### PR TITLE
Add encrypted SecretStore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@
 # NOTE: keep comments on their own lines. systemd's EnvironmentFile treats `#` as a
 # comment only at the start of a line — an inline `# ...` after a value becomes part of
 # the value and breaks parsing.
+# --- SECRETS ---
+# Production path: run `clawd secrets seal` once to encrypt these into <stateRoot>/secrets.enc
+# (key in <stateRoot>/secret.key, mode 0600 — keep it OUT of your state-root backup boundary), then
+# you may remove the two plaintext lines below. If EITHER secrets.enc OR secret.key exists, the
+# encrypted backend is REQUIRED (no silent env fallback). Leaving these set uses the warned dev
+# fallback (plaintext on disk).
 CLAW_TELEGRAM_BOT_TOKEN=123456:replace-with-BotFather-token
 # comma-separated numeric Telegram user IDs, e.g. 12345678 (empty is allowed — onboarding still boots)
 CLAW_ALLOWLIST=
@@ -15,7 +21,7 @@ CLAW_POLL_TIMEOUT=30
 # LLM provider (OpenAI-compatible Chat Completions endpoint)
 CLAW_LLM_BASE_URL=https://api.anthropic.com/v1
 CLAW_LLM_MODEL=claude-sonnet-4-6
-# optional; leave blank for local servers that need no auth
+# optional; leave blank for local servers that need no auth. Part of the sealed secrets (see above).
 CLAW_LLM_API_KEY=
 # max_tokens field name sent to the provider: max_completion_tokens or max_tokens
 CLAW_LLM_MAX_TOKENS_FIELD=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ swift-claw — a persistent, always-on, **single-owner personal AI assistant** c
 
 ## Read first (authoritative)
 
+- Before starting any task → read learned preferences and behavioral rules at `/Users/jetbrains/.claude/projects/-Users-jetbrains-Developer-swift-claw/memory/MEMORY.md`, then open any topic files relevant to the task.
 - Before implementing or changing the design → **`docs/ARCHITECTURE.md` is the NORMATIVE technical spec**; where it and anything else disagree, it wins.
 - Product scope, phasing, success criteria → `docs/PRD.md`.
 - Cited background research → `docs/research/`.

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.21.0"),
+    .package(url: "https://github.com/apple/swift-crypto.git", from: "4.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.11.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
@@ -17,6 +18,13 @@ let package = Package(
   ],
   targets: [
     .target(name: "ClawCore"),
+    .target(
+      name: "ClawSecrets",
+      dependencies: [
+        "ClawCore",
+        .product(name: "Crypto", package: "swift-crypto"),
+      ]
+    ),
     .target(
       name: "ClawData",
       dependencies: [
@@ -51,13 +59,21 @@ let package = Package(
     .executableTarget(
       name: "clawd",
       dependencies: [
-        "ClawCore", "ClawData", "ClawTelegram", "ClawGateway", "ClawLLM", "ClawAgent",
+        "ClawCore", "ClawData", "ClawSecrets", "ClawTelegram", "ClawGateway", "ClawLLM",
+        "ClawAgent",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "Logging", package: "swift-log"),
       ]
     ),
     .testTarget(name: "ClawCoreTests", dependencies: ["ClawCore"]),
+    .testTarget(
+      name: "ClawSecretsTests",
+      dependencies: [
+        "ClawSecrets", "ClawCore",
+        .product(name: "Crypto", package: "swift-crypto"),
+      ]
+    ),
     .testTarget(name: "ClawDataTests", dependencies: ["ClawData", "ClawCore"]),
     .testTarget(name: "ClawTelegramTests", dependencies: ["ClawTelegram", "ClawCore"]),
     .testTarget(name: "ClawLLMTests", dependencies: ["ClawLLM", "ClawCore"]),

--- a/Sources/ClawCore/AppConfig.swift
+++ b/Sources/ClawCore/AppConfig.swift
@@ -2,13 +2,11 @@ import Foundation
 
 public struct AppConfig: Sendable, Equatable {
   enum EnvKey {
-    static let botToken = "CLAW_TELEGRAM_BOT_TOKEN"
     static let allowlist = "CLAW_ALLOWLIST"
     static let stateRoot = "CLAW_STATE_ROOT"
     static let pollTimeout = "CLAW_POLL_TIMEOUT"
     static let llmBaseURL = "CLAW_LLM_BASE_URL"
     static let llmModel = "CLAW_LLM_MODEL"
-    static let llmApiKey = "CLAW_LLM_API_KEY"
     static let llmMaxTokensField = "CLAW_LLM_MAX_TOKENS_FIELD"
     static let llmMaxTokens = "CLAW_LLM_MAX_TOKENS"
     static let perRunUSD = "CLAW_PER_RUN_USD"
@@ -28,7 +26,6 @@ public struct AppConfig: Sendable, Equatable {
 
   private static let stateRootPermissions = 0o700
 
-  public let botToken: String
   public let allowlist: Set<Int64>
   public let stateRoot: URL
   public let pollTimeoutSeconds: Int
@@ -36,14 +33,12 @@ public struct AppConfig: Sendable, Equatable {
   public let budget: RunBudget
 
   public init(
-    botToken: String,
     allowlist: Set<Int64>,
     stateRoot: URL,
     pollTimeoutSeconds: Int,
     llm: LLMConfig,
     budget: RunBudget
   ) {
-    self.botToken = botToken
     self.allowlist = allowlist
     self.stateRoot = stateRoot
     self.pollTimeoutSeconds = pollTimeoutSeconds
@@ -51,24 +46,18 @@ public struct AppConfig: Sendable, Equatable {
     self.budget = budget
   }
 
-  /// Loads and validates config from the environment, throwing `ConfigError` on a missing token,
-  /// a non-numeric allowlist entry, an uncreatable state root, or missing/invalid LLM settings.
-  /// An empty allowlist is allowed so onboarding can still boot.
+  /// Loads and validates non-secret config from the environment. Secrets (the bot token / LLM key)
+  /// are loaded separately via `SecretStore` and injected at the composition root. An empty
+  /// allowlist is allowed so onboarding can still boot.
   public static func load(environment env: [String: String]) throws -> AppConfig {
-    guard let botToken = env[EnvKey.botToken], !botToken.isEmpty else {
-      throw ConfigError.missingBotToken
-    }
-
     let allowlist = try parseAllowlist(from: env[EnvKey.allowlist])
     let stateRoot = try createStateRootURL(for: env[EnvKey.stateRoot])
     let pollTimeoutSeconds =
       env[EnvKey.pollTimeout].flatMap(Int.init) ?? EnvDefaults.pollTimeoutSeconds
-    // Parsed last so a missing LLM key never preempts the bot-token / allowlist errors.
     let llm = try parseLLMConfig(from: env)
     let budget = try parseBudget(from: env, llm: llm)
 
     return AppConfig(
-      botToken: botToken,
       allowlist: allowlist,
       stateRoot: stateRoot,
       pollTimeoutSeconds: pollTimeoutSeconds,
@@ -93,8 +82,6 @@ public struct AppConfig: Sendable, Equatable {
       throw ConfigError.missingLLMModel
     }
 
-    let apiKey = env[EnvKey.llmApiKey] ?? ""
-
     let rawField = env[EnvKey.llmMaxTokensField]?.trimmingCharacters(in: .whitespaces) ?? ""
     let maxTokensField: MaxTokensField
     if rawField.isEmpty {
@@ -118,7 +105,7 @@ public struct AppConfig: Sendable, Equatable {
     return LLMConfig(
       baseURL: baseURL,
       model: model,
-      apiKey: apiKey,
+      apiKey: "",  // injected at the composition root from Secrets (LLMConfig.withAPIKey)
       maxTokensField: maxTokensField,
       maxOutputTokens: maxOutputTokens,
       retryBudget: EnvDefaults.retryBudget,

--- a/Sources/ClawCore/Errors.swift
+++ b/Sources/ClawCore/Errors.swift
@@ -8,7 +8,6 @@ public enum ClawExitCode: Int32, Sendable {
 }
 
 public enum ConfigError: Error, Sendable, Equatable {
-  case missingBotToken
   case invalidAllowlist(String)
   case unwritableStateRoot(String)
   case missingLLMBaseURL
@@ -19,7 +18,6 @@ public enum ConfigError: Error, Sendable, Equatable {
 
   public var exitCode: Int32 {
     switch self {
-    case .missingBotToken: ClawExitCode.secretLoadFailed.rawValue
     case .invalidAllowlist: ClawExitCode.configInvalid.rawValue
     case .unwritableStateRoot: ClawExitCode.configInvalid.rawValue
     case .missingLLMBaseURL: ClawExitCode.configInvalid.rawValue

--- a/Sources/ClawCore/LLM.swift
+++ b/Sources/ClawCore/LLM.swift
@@ -125,6 +125,22 @@ public struct LLMConfig: Sendable, Equatable {
   }
 }
 
+extension LLMConfig {
+  /// Returns a copy with the runtime secret injected. `AppConfig` carries no key (it's a secret);
+  /// the composition root combines the non-secret LLM config with `Secrets.llmApiKey`.
+  public func withAPIKey(_ apiKey: String) -> LLMConfig {
+    LLMConfig(
+      baseURL: baseURL,
+      model: model,
+      apiKey: apiKey,
+      maxTokensField: maxTokensField,
+      maxOutputTokens: maxOutputTokens,
+      retryBudget: retryBudget,
+      requestTimeoutSeconds: requestTimeoutSeconds
+    )
+  }
+}
+
 // MARK: - Pricing
 
 /// Per-million-token USD prices for one model — the normalized `Prices.json` schema.

--- a/Sources/ClawCore/SecretStore.swift
+++ b/Sources/ClawCore/SecretStore.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// The secrets seam. Secrets load **once at startup** into an immutable `Sendable` value so they
+/// cross actor/task boundaries freely (impl-grounding §3.5). The concrete stores live in `ClawSecrets`.
+public protocol SecretStore: Sendable {
+  func loadSecrets() throws -> Secrets
+}
+
+/// The loaded secrets. These values feed the **existing** exact-value redactors in `TelegramClient`
+/// (the bot token) and `OpenAICompatibleProvider` (the API key) — no new redaction mechanism.
+public struct Secrets: Sendable, Equatable {
+  public let telegramBotToken: String
+  public let llmApiKey: String?
+
+  public init(telegramBotToken: String, llmApiKey: String?) {
+    self.telegramBotToken = telegramBotToken
+    self.llmApiKey = llmApiKey
+  }
+}
+
+/// State-root-relative filenames the encrypted backend owns. Shared so the resolver's existence
+/// checks and the `secrets seal` subcommand name the same files the store reads.
+public enum SecretFile {
+  public static let envelope = "secrets.enc"
+  public static let key = "secret.key"
+}
+
+/// Every secret-load failure is non-retryable and exits 11 — distinct from a config error so the
+/// supervisor backs off instead of hot-looping (`ClawExitCode.secretLoadFailed`).
+public enum SecretStoreError: Error, Sendable, Equatable {
+  case missingTelegramToken
+  case keyFileInsecure(String)
+  case malformedEnvelope
+  case decryptionFailed
+  case unreadable(String)
+
+  public var exitCode: Int32 { ClawExitCode.secretLoadFailed.rawValue }
+}

--- a/Sources/ClawSecrets/EncryptedFileSecretStore.swift
+++ b/Sources/ClawSecrets/EncryptedFileSecretStore.swift
@@ -17,6 +17,8 @@ public struct EncryptedFileSecretStore: SecretStore {
   /// dispatches on it AND authenticates it.
   static let envelopeVersion: UInt8 = 1
   static let keyByteCount = 32  // 256-bit symmetric key
+  static let keyFilePermissions: UInt32 = 0o600  // owner read/write only
+  static let permissionBitsMask: UInt32 = 0o777  // strips file-type bits from st_mode
 
   private let keyURL: URL
   private let envelopeURL: URL
@@ -130,7 +132,7 @@ public struct EncryptedFileSecretStore: SecretStore {
 
     let key = SymmetricKey(size: .bits256)
     let keyData = key.withUnsafeBytes { Data($0) }
-    let descriptor = open(url.path, O_WRONLY | O_CREAT | O_EXCL, 0o600)
+    let descriptor = open(url.path, O_WRONLY | O_CREAT | O_EXCL, mode_t(keyFilePermissions))
 
     guard descriptor >= 0 else {
       throw SecretStoreError.keyFileInsecure(
@@ -148,11 +150,64 @@ public struct EncryptedFileSecretStore: SecretStore {
     return key
   }
 
-  /// Minimal open for Task 02; Task 03 hardens it (O_NOFOLLOW + regular-file + owner + 0600).
+  // MARK: - Key-file security policy
+
+  /// The fstat-derived facts the policy checks. Factored out so owner/file-type/mode rules are
+  /// table-testable with synthetic values — there is no portable way to chown to a foreign uid
+  /// unprivileged, so that case is covered by `validateKeyMetadata` rather than an integration test.
+  struct KeyFileMetadata: Sendable, Equatable {
+    let isRegularFile: Bool
+    let permissionBits: UInt32  // st_mode & permissionBitsMask
+    let ownerUID: uid_t
+  }
+
+  static func validateKeyMetadata(_ metadata: KeyFileMetadata, expectedUID: uid_t) throws {
+    guard metadata.isRegularFile else {
+      throw SecretStoreError.keyFileInsecure("\(SecretFile.key) is not a regular file")
+    }
+    guard metadata.permissionBits == keyFilePermissions else {
+      throw SecretStoreError.keyFileInsecure("\(SecretFile.key) must be mode 0600")
+    }
+    guard metadata.ownerUID == expectedUID else {
+      throw SecretStoreError.keyFileInsecure("\(SecretFile.key) not owned by the daemon uid")
+    }
+  }
+
   static func openKey(at url: URL) throws -> SymmetricKey {
-    guard let data = try? Data(contentsOf: url), data.count == keyByteCount else {
+    let descriptor = open(url.path, O_RDONLY | O_NOFOLLOW)
+    guard descriptor >= 0 else {
+      throw SecretStoreError.keyFileInsecure(
+        "open \(SecretFile.key): \(String(cString: strerror(errno)))"
+      )
+    }
+    defer { close(descriptor) }
+
+    var status = stat()
+    guard fstat(descriptor, &status) == 0 else {
+      throw SecretStoreError.keyFileInsecure("fstat \(SecretFile.key)")
+    }
+
+    // `st_mode` is UInt16 on Darwin and UInt32 on Linux; normalize to UInt32 for both.
+    let mode = UInt32(status.st_mode)
+    try validateKeyMetadata(
+      KeyFileMetadata(
+        isRegularFile: (mode & UInt32(S_IFMT)) == UInt32(S_IFREG),
+        permissionBits: mode & permissionBitsMask,
+        ownerUID: status.st_uid
+      ),
+      expectedUID: getuid()
+    )
+
+    let data = FileHandle(
+      fileDescriptor: descriptor,
+      closeOnDealloc: false
+    )
+    .readDataToEndOfFile()
+
+    guard data.count == keyByteCount else {
       throw SecretStoreError.keyFileInsecure("key must be \(keyByteCount) bytes")
     }
+
     return SymmetricKey(data: data)
   }
 }

--- a/Sources/ClawSecrets/EncryptedFileSecretStore.swift
+++ b/Sources/ClawSecrets/EncryptedFileSecretStore.swift
@@ -1,0 +1,158 @@
+import ClawCore
+import Crypto
+import Foundation
+
+#if canImport(Glibc)
+  import Glibc
+#else
+  import Darwin
+#endif
+
+/// Encrypted-at-rest secrets over swift-crypto AES-GCM. The on-disk envelope is
+/// `[1-byte version] + AES.GCM.SealedBox.combined` (12-byte random nonce ‖ ciphertext ‖ 16-byte tag);
+/// the version byte is bound as **AEAD associated data**, so it can't be swapped without failing
+/// authentication. The 256-bit key is 32 random bytes in `secret.key` (safe-opened in Task 03).
+public struct EncryptedFileSecretStore: SecretStore {
+  /// Current envelope version. Single-version today; bound as AAD so a future multi-version world
+  /// dispatches on it AND authenticates it.
+  static let envelopeVersion: UInt8 = 1
+  static let keyByteCount = 32  // 256-bit symmetric key
+
+  private let keyURL: URL
+  private let envelopeURL: URL
+
+  public init(stateRoot: URL) {
+    keyURL = stateRoot.appendingPathComponent(SecretFile.key)
+    envelopeURL = stateRoot.appendingPathComponent(SecretFile.envelope)
+  }
+
+  // MARK: - SecretStore
+
+  public func loadSecrets() throws -> Secrets {
+    let key = try Self.openKey(at: keyURL)
+
+    guard
+      let envelope = try? Data(contentsOf: envelopeURL),
+      !envelope.isEmpty
+    else {
+      throw SecretStoreError.unreadable(SecretFile.envelope)
+    }
+
+    let plaintext = try Self.openEnvelope(envelope, key: key)
+
+    return try Self.decode(plaintext)
+  }
+
+  // MARK: - Sealing (used by `clawd secrets seal`)
+
+  /// Generates `secret.key` (0600, `O_EXCL`) if missing, then writes the versioned `secrets.enc`.
+  public static func seal(_ secrets: Secrets, stateRoot: URL) throws {
+    let keyURL = stateRoot.appendingPathComponent(SecretFile.key)
+    let envelopeURL = stateRoot.appendingPathComponent(SecretFile.envelope)
+
+    let key = try ensureKey(at: keyURL)
+
+    let envelope = try sealEnvelope(encode(secrets), key: key)
+    try envelope.write(to: envelopeURL, options: .atomic)
+  }
+
+  // MARK: - AES-GCM envelope
+
+  static func sealEnvelope(_ plaintext: Data, key: SymmetricKey) throws -> Data {
+    let associatedData = Data([envelopeVersion])
+    let sealedBox = try AES.GCM.seal(plaintext, using: key, authenticating: associatedData)
+
+    guard let combined = sealedBox.combined else {
+      throw SecretStoreError.malformedEnvelope
+    }
+
+    return associatedData + combined
+  }
+
+  static func openEnvelope(_ envelope: Data, key: SymmetricKey) throws -> Data {
+    guard let version = envelope.first, version == envelopeVersion else {
+      throw SecretStoreError.malformedEnvelope
+    }
+
+    let associatedData = Data([version])
+
+    do {
+      let sealedBox = try AES.GCM.SealedBox(combined: Data(envelope.dropFirst()))
+      return try AES.GCM.open(sealedBox, using: key, authenticating: associatedData)
+    } catch {
+      throw SecretStoreError.decryptionFailed
+    }
+  }
+
+  // MARK: - Plaintext JSON map
+
+  /// The JSON shape stored inside the encrypted envelope.
+  private struct Payload: Codable {
+    let telegramBotToken: String
+    let llmApiKey: String?
+
+    enum CodingKeys: String, CodingKey {
+      case telegramBotToken = "telegram_bot_token"
+      case llmApiKey = "llm_api_key"
+    }
+  }
+
+  static func encode(_ secrets: Secrets) throws -> Data {
+    let payload = Payload(
+      telegramBotToken: secrets.telegramBotToken,
+      llmApiKey: secrets.llmApiKey
+    )
+    return try JSONEncoder().encode(payload)
+  }
+
+  static func decode(_ data: Data) throws -> Secrets {
+    guard let payload = try? JSONDecoder().decode(Payload.self, from: data) else {
+      throw SecretStoreError.malformedEnvelope
+    }
+
+    guard !payload.telegramBotToken.isEmpty else {
+      throw SecretStoreError.missingTelegramToken
+    }
+    let apiKey = payload.llmApiKey.flatMap { $0.isEmpty ? nil : $0 }
+
+    return Secrets(
+      telegramBotToken: payload.telegramBotToken,
+      llmApiKey: apiKey
+    )
+  }
+
+  // MARK: - Key file
+
+  static func ensureKey(at url: URL) throws -> SymmetricKey {
+    if FileManager.default.fileExists(atPath: url.path) {
+      return try openKey(at: url)
+    }
+
+    let key = SymmetricKey(size: .bits256)
+    let keyData = key.withUnsafeBytes { Data($0) }
+    let descriptor = open(url.path, O_WRONLY | O_CREAT | O_EXCL, 0o600)
+
+    guard descriptor >= 0 else {
+      throw SecretStoreError.keyFileInsecure(
+        "create \(SecretFile.key): \(String(cString: strerror(errno)))"
+      )
+    }
+    defer { close(descriptor) }
+
+    try FileHandle(
+      fileDescriptor: descriptor,
+      closeOnDealloc: false
+    )
+    .write(contentsOf: keyData)
+
+    return key
+  }
+
+  /// Minimal open for Task 02; Task 03 hardens it (O_NOFOLLOW + regular-file + owner + 0600).
+  static func openKey(at url: URL) throws -> SymmetricKey {
+    guard let data = try? Data(contentsOf: url), data.count == keyByteCount else {
+      throw SecretStoreError.keyFileInsecure("key must be \(keyByteCount) bytes")
+    }
+    return SymmetricKey(data: data)
+  }
+}

--- a/Sources/ClawSecrets/EnvSecretStore.swift
+++ b/Sources/ClawSecrets/EnvSecretStore.swift
@@ -1,0 +1,45 @@
+import ClawCore
+import Foundation
+
+/// The §15-sanctioned dev fallback: reads the plaintext env vars (Inc 1 behavior) and **warns
+/// loudly** that secrets are plaintext. Selected only when no encrypted artifact exists (resolver).
+public struct EnvSecretStore: SecretStore {
+  public enum EnvKey {
+    public static let botToken = "CLAW_TELEGRAM_BOT_TOKEN"
+    public static let llmApiKey = "CLAW_LLM_API_KEY"
+  }
+
+  private let environment: [String: String]
+  private let warn: @Sendable (String) -> Void
+
+  public init(
+    environment: [String: String],
+    warn: @escaping @Sendable (String) -> Void = EnvSecretStore.defaultWarn
+  ) {
+    self.environment = environment
+    self.warn = warn
+  }
+
+  public func loadSecrets() throws -> Secrets {
+    guard let botToken = environment[EnvKey.botToken], !botToken.isEmpty else {
+      throw SecretStoreError.missingTelegramToken
+    }
+
+    warn(
+      "secrets are PLAINTEXT in environment variables — run `clawd secrets seal` for encrypted-at-rest storage"
+    )
+
+    let apiKey = environment[EnvKey.llmApiKey].flatMap { $0.isEmpty ? nil : $0 }
+
+    return Secrets(
+      telegramBotToken: botToken,
+      llmApiKey: apiKey
+    )
+  }
+
+  /// Writes to stderr — used as the default warn so the daemon always emits the warning
+  /// even when no custom handler is injected.
+  public static let defaultWarn: @Sendable (String) -> Void = { message in
+    FileHandle.standardError.write(Data(("WARN: " + message + "\n").utf8))
+  }
+}

--- a/Sources/ClawSecrets/SecretStoreResolver.swift
+++ b/Sources/ClawSecrets/SecretStoreResolver.swift
@@ -77,12 +77,19 @@ extension SecretStoreResolver {
     stateRoot: URL,
     environment: [String: String]
   ) -> SecretsDoctorResult {
-    let resolution = resolve(stateRoot: stateRoot, environment: environment, warn: { _ in })
+    let resolution = resolve(
+      stateRoot: stateRoot,
+      environment: environment,
+      warn: { _ in }
+    )
+
     do {
       _ = try resolution.store.loadSecrets()
       switch resolution.backend {
-      case .encrypted: return SecretsDoctorResult(value: "backend=encrypted", ok: true)
-      case .env: return SecretsDoctorResult(value: "backend=env (WARN: plaintext)", ok: true)
+      case .encrypted:
+        return SecretsDoctorResult(value: "backend=encrypted", ok: true)
+      case .env:
+        return SecretsDoctorResult(value: "backend=env (WARN: plaintext)", ok: true)
       }
     } catch {
       return SecretsDoctorResult(value: "FAIL: \(error)", ok: false)

--- a/Sources/ClawSecrets/SecretStoreResolver.swift
+++ b/Sources/ClawSecrets/SecretStoreResolver.swift
@@ -1,0 +1,58 @@
+import ClawCore
+import Foundation
+
+#if canImport(Glibc)
+  import Glibc
+#else
+  import Darwin
+#endif
+
+/// Which backend was selected — surfaced to doctor.
+public enum SecretBackend: String, Sendable, Equatable {
+  case encrypted
+  case env
+}
+
+public struct ResolvedSecretStore: Sendable {
+  public let store: any SecretStore
+  public let backend: SecretBackend
+
+  public init(store: any SecretStore, backend: SecretBackend) {
+    self.store = store
+    self.backend = backend
+  }
+}
+
+/// Fail-closed backend selection (spec §3.2, review #9). If **either** `secrets.enc` or `secret.key`
+/// is present, the encrypted backend is **required** (both must exist and decrypt, else exit 11) — we
+/// never silently fall back to env when an encrypted setup is partially present. The env fallback
+/// (+ warn) is used **only** when *neither* encrypted artifact exists.
+public enum SecretStoreResolver {
+  public static func resolve(
+    stateRoot: URL,
+    environment: [String: String],
+    warn: @escaping @Sendable (String) -> Void = EnvSecretStore.defaultWarn
+  ) -> ResolvedSecretStore {
+    let hasKey = entryExists(at: stateRoot.appendingPathComponent(SecretFile.key))
+    let hasEnvelope = entryExists(at: stateRoot.appendingPathComponent(SecretFile.envelope))
+
+    if hasKey || hasEnvelope {
+      return ResolvedSecretStore(
+        store: EncryptedFileSecretStore(stateRoot: stateRoot),
+        backend: .encrypted
+      )
+    }
+
+    return ResolvedSecretStore(
+      store: EnvSecretStore(environment: environment, warn: warn),
+      backend: .env
+    )
+  }
+
+  /// `lstat` (not `stat` / `FileManager.fileExists`) so a dangling symlink counts as present —
+  /// a broken symlink entry still forces the encrypted backend rather than a silent env fallback.
+  private static func entryExists(at url: URL) -> Bool {
+    var status = stat()
+    return lstat(url.path, &status) == 0
+  }
+}

--- a/Sources/ClawSecrets/SecretStoreResolver.swift
+++ b/Sources/ClawSecrets/SecretStoreResolver.swift
@@ -56,3 +56,36 @@ public enum SecretStoreResolver {
     return lstat(url.path, &status) == 0
   }
 }
+
+// MARK: - Doctor row
+
+/// The doctor "secrets" row: backend label + an `ok` flag, computed by a **real decrypt without
+/// booting**. Used by `doctor --check-config` to validate decrypt early.
+public struct SecretsDoctorResult: Sendable, Equatable {
+  public let value: String
+  public let ok: Bool
+
+  public init(value: String, ok: Bool) {
+    self.value = value
+    self.ok = ok
+  }
+}
+
+extension SecretStoreResolver {
+  /// Resolves the backend and performs a real `loadSecrets()` (no daemon boot).
+  public static func doctorRow(
+    stateRoot: URL,
+    environment: [String: String]
+  ) -> SecretsDoctorResult {
+    let resolution = resolve(stateRoot: stateRoot, environment: environment, warn: { _ in })
+    do {
+      _ = try resolution.store.loadSecrets()
+      switch resolution.backend {
+      case .encrypted: return SecretsDoctorResult(value: "backend=encrypted", ok: true)
+      case .env: return SecretsDoctorResult(value: "backend=env (WARN: plaintext)", ok: true)
+      }
+    } catch {
+      return SecretsDoctorResult(value: "FAIL: \(error)", ok: false)
+    }
+  }
+}

--- a/Sources/clawd/Clawd.swift
+++ b/Sources/clawd/Clawd.swift
@@ -6,7 +6,7 @@ struct Clawd: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "clawd",
     abstract: "swift-claw — single-owner Telegram assistant daemon.",
-    subcommands: [RunCommand.self, DoctorCommand.self],
+    subcommands: [RunCommand.self, DoctorCommand.self, SecretsCommand.self],
     defaultSubcommand: RunCommand.self
   )
 }

--- a/Sources/clawd/Clawd.swift
+++ b/Sources/clawd/Clawd.swift
@@ -6,7 +6,11 @@ struct Clawd: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "clawd",
     abstract: "swift-claw — single-owner Telegram assistant daemon.",
-    subcommands: [RunCommand.self, DoctorCommand.self, SecretsCommand.self],
+    subcommands: [
+      RunCommand.self,
+      DoctorCommand.self,
+      SecretsCommand.self,
+    ],
     defaultSubcommand: RunCommand.self
   )
 }

--- a/Sources/clawd/Subcommands/DoctorCommand.swift
+++ b/Sources/clawd/Subcommands/DoctorCommand.swift
@@ -42,12 +42,14 @@ struct DoctorCommand: AsyncParsableCommand {
 
     if checkConfig {
       emit(report)
+
       if !secretsRow.ok {
         throw ExitCode(ClawExitCode.secretLoadFailed.rawValue)
       }
       if !report.ok {
         throw ExitCode(ClawExitCode.configInvalid.rawValue)
       }
+
       return
     }
 
@@ -69,24 +71,28 @@ struct DoctorCommand: AsyncParsableCommand {
     }
 
     // Best-effort connectivity check (only if a token is available).
-    if let secrets = try? SecretStoreResolver.resolve(
+    let secretStore = SecretStoreResolver.resolve(
       stateRoot: config.stateRoot,
       environment: ProcessInfo.processInfo.environment
-    ).store.loadSecrets() {
+    ).store
+    if let secrets = try? secretStore.loadSecrets() {
       let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
       let transport = TelegramClient(
         token: secrets.telegramBotToken,
         http: AsyncHTTPExecutor(client: httpClient)
       )
+
       if let identity = try? await transport.getMe() {
         report.add(key: "telegram.bot", value: identity.username ?? "id:\(identity.id)")
       } else {
         report.add(key: "telegram.bot", value: "unreachable", ok: false)
       }
+
       try? await httpClient.shutdown()
     }
 
     emit(report)
+
     if !secretsRow.ok {
       throw ExitCode(ClawExitCode.secretLoadFailed.rawValue)
     }

--- a/Sources/clawd/Subcommands/DoctorCommand.swift
+++ b/Sources/clawd/Subcommands/DoctorCommand.swift
@@ -3,6 +3,7 @@ import AsyncHTTPClient
 import ClawCore
 import ClawData
 import ClawGateway
+import ClawSecrets
 import ClawTelegram
 import Foundation
 
@@ -33,8 +34,17 @@ struct DoctorCommand: AsyncParsableCommand {
     report.add(key: "config", value: "OK")
     report.add(key: "config.max_tokens", value: "\(config.llm.maxOutputTokens)")
 
+    let secretsRow = SecretStoreResolver.doctorRow(
+      stateRoot: config.stateRoot,
+      environment: ProcessInfo.processInfo.environment
+    )
+    report.add(key: "secrets", value: secretsRow.value, ok: secretsRow.ok)
+
     if checkConfig {
       emit(report)
+      if !secretsRow.ok {
+        throw ExitCode(ClawExitCode.secretLoadFailed.rawValue)
+      }
       if !report.ok {
         throw ExitCode(ClawExitCode.configInvalid.rawValue)
       }
@@ -58,20 +68,28 @@ struct DoctorCommand: AsyncParsableCommand {
       report.add(key: "db.writable", value: "false: \(error)", ok: false)
     }
 
-    // Best-effort connectivity check.
-    let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
-    let transport = TelegramClient(
-      token: config.botToken,
-      http: AsyncHTTPExecutor(client: httpClient)
-    )
-    if let identity = try? await transport.getMe() {
-      report.add(key: "telegram.bot", value: identity.username ?? "id:\(identity.id)")
-    } else {
-      report.add(key: "telegram.bot", value: "unreachable", ok: false)
+    // Best-effort connectivity check (only if a token is available).
+    if let secrets = try? SecretStoreResolver.resolve(
+      stateRoot: config.stateRoot,
+      environment: ProcessInfo.processInfo.environment
+    ).store.loadSecrets() {
+      let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
+      let transport = TelegramClient(
+        token: secrets.telegramBotToken,
+        http: AsyncHTTPExecutor(client: httpClient)
+      )
+      if let identity = try? await transport.getMe() {
+        report.add(key: "telegram.bot", value: identity.username ?? "id:\(identity.id)")
+      } else {
+        report.add(key: "telegram.bot", value: "unreachable", ok: false)
+      }
+      try? await httpClient.shutdown()
     }
-    try? await httpClient.shutdown()
 
     emit(report)
+    if !secretsRow.ok {
+      throw ExitCode(ClawExitCode.secretLoadFailed.rawValue)
+    }
     if !report.ok {
       throw ExitCode.failure
     }

--- a/Sources/clawd/Subcommands/DoctorCommand.swift
+++ b/Sources/clawd/Subcommands/DoctorCommand.swift
@@ -8,7 +8,10 @@ import ClawTelegram
 import Foundation
 
 struct DoctorCommand: AsyncParsableCommand {
-  static let configuration = CommandConfiguration(abstract: "Run health self-checks.")
+  static let configuration = CommandConfiguration(
+    commandName: "doctor",
+    abstract: "Run health self-checks."
+  )
 
   @Flag(
     name: .customLong("check-config"),

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -11,7 +11,10 @@ import Foundation
 import Logging
 
 struct RunCommand: AsyncParsableCommand {
-  static let configuration = CommandConfiguration(abstract: "Start the daemon.")
+  static let configuration = CommandConfiguration(
+    commandName: "run",
+    abstract: "Start the daemon."
+  )
 
   func run() async throws {
     let logger = Logger(label: "clawd")

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -5,6 +5,7 @@ import ClawCore
 import ClawData
 import ClawGateway
 import ClawLLM
+import ClawSecrets
 import ClawTelegram
 import Foundation
 import Logging
@@ -15,6 +16,7 @@ struct RunCommand: AsyncParsableCommand {
   func run() async throws {
     let logger = Logger(label: "clawd")
     let config = try Self.loadConfigOrExit()
+    let secrets = try Self.loadSecretsOrExit(config: config)
 
     // Single-instance guard — held until the process exits (defer covers the graceful path).
     let lockPath = config.stateRoot.appendingPathComponent(StateFile.lock).path
@@ -53,7 +55,13 @@ struct RunCommand: AsyncParsableCommand {
     let httpClient = HTTPClient(eventLoopGroupProvider: .singleton, configuration: httpConfig)
     let executor = AsyncHTTPExecutor(client: httpClient)
 
-    let daemon = makeDaemon(config: config, stores: stores, executor: executor, logger: logger)
+    let daemon = makeDaemon(
+      config: config,
+      secrets: secrets,
+      stores: stores,
+      executor: executor,
+      logger: logger
+    )
 
     logger.info("clawd starting (owners allowlisted: \(config.allowlist.count))")
     var runFailure: Error?
@@ -84,16 +92,36 @@ struct RunCommand: AsyncParsableCommand {
     }
   }
 
+  /// Loads secrets via the fail-closed resolver; a secret-load failure exits 11 (non-retryable).
+  private static func loadSecretsOrExit(config: AppConfig) throws -> Secrets {
+    let resolution = SecretStoreResolver.resolve(
+      stateRoot: config.stateRoot,
+      environment: ProcessInfo.processInfo.environment
+    )
+    do {
+      return try resolution.store.loadSecrets()
+    } catch let error as SecretStoreError {
+      FileHandle.standardError.write(Data("secret error: \(error)\n".utf8))
+      throw ExitCode(error.exitCode)
+    }
+  }
+
   /// Builds the service graph: the OpenAI-compatible provider + agent feed a `TurnRunner`, which
   /// the router dispatches from the poller. Both Telegram and the LLM share the injected executor.
   private func makeDaemon(
     config: AppConfig,
+    secrets: Secrets,
     stores: ClawStores,
     executor: AsyncHTTPExecutor,
     logger: Logger
   ) -> Daemon {
-    let transport = TelegramClient(token: config.botToken, http: executor)
-    let agent = makeAgent(config: config, executor: executor, transport: transport)
+    let transport = TelegramClient(token: secrets.telegramBotToken, http: executor)
+    let agent = makeAgent(
+      config: config,
+      secrets: secrets,
+      executor: executor,
+      transport: transport
+    )
     // Created before the TurnRunner so its notifyOutbox closure can capture it: each commit pokes
     // the dispatcher to drain the rows it just enqueued.
     let outboxSignal = OutboxSignal()
@@ -145,11 +173,12 @@ struct RunCommand: AsyncParsableCommand {
   /// composition root reads as "build the agent → feed the turn runner → register the services".
   private func makeAgent(
     config: AppConfig,
+    secrets: Secrets,
     executor: AsyncHTTPExecutor,
     transport: TelegramClient
   ) -> AgentRuntime {
     let provider = OpenAICompatibleProvider(
-      config: config.llm,
+      config: config.llm.withAPIKey(secrets.llmApiKey ?? ""),
       http: executor,
       sleep: { try await Task.sleep(for: .seconds($0)) },
       jitter: { Double.random(in: 0...$0) }

--- a/Sources/clawd/Subcommands/SecretsCommand.swift
+++ b/Sources/clawd/Subcommands/SecretsCommand.swift
@@ -31,7 +31,10 @@ struct SecretsCommand: AsyncParsableCommand {
       let secrets: Secrets
       do {
         // Suppress the plaintext warning — reading plaintext to encrypt it is the intent here.
-        secrets = try EnvSecretStore(environment: environment, warn: { _ in }).loadSecrets()
+        secrets = try EnvSecretStore(
+          environment: environment,
+          warn: { _ in }
+        ).loadSecrets()
       } catch let error as SecretStoreError {
         FileHandle.standardError.write(Data("secrets seal: \(error)\n".utf8))
         throw ExitCode(error.exitCode)

--- a/Sources/clawd/Subcommands/SecretsCommand.swift
+++ b/Sources/clawd/Subcommands/SecretsCommand.swift
@@ -1,0 +1,59 @@
+import ArgumentParser
+import ClawCore
+import ClawSecrets
+import Foundation
+
+struct SecretsCommand: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "secrets",
+    abstract: "Manage encrypted-at-rest secrets.",
+    subcommands: [Seal.self]
+  )
+
+  /// Reads the plaintext env secrets and encrypts them into `<stateRoot>/secrets.enc`, generating
+  /// `secret.key` (0600) if missing. Uses the same env file the daemon reads (it already carries the
+  /// non-secret LLM config needed to resolve the state root).
+  struct Seal: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+      abstract: "Encrypt the env secrets into <stateRoot>/secrets.enc."
+    )
+
+    func run() async throws {
+      let environment = ProcessInfo.processInfo.environment
+      let config: AppConfig
+      do {
+        config = try AppConfig.load(environment: environment)
+      } catch let error as ConfigError {
+        FileHandle.standardError.write(Data("secrets seal: config error: \(error)\n".utf8))
+        throw ExitCode(error.exitCode)
+      }
+
+      let secrets: Secrets
+      do {
+        // Suppress the plaintext warning — reading plaintext to encrypt it is the intent here.
+        secrets = try EnvSecretStore(environment: environment, warn: { _ in }).loadSecrets()
+      } catch let error as SecretStoreError {
+        FileHandle.standardError.write(Data("secrets seal: \(error)\n".utf8))
+        throw ExitCode(error.exitCode)
+      }
+
+      do {
+        try EncryptedFileSecretStore.seal(secrets, stateRoot: config.stateRoot)
+      } catch {
+        FileHandle.standardError.write(Data("secrets seal failed: \(error)\n".utf8))
+        throw ExitCode(ClawExitCode.secretLoadFailed.rawValue)
+      }
+
+      let envelopePath = config.stateRoot.appendingPathComponent(SecretFile.envelope).path
+      let keyPath = config.stateRoot.appendingPathComponent(SecretFile.key).path
+      // swiftlint:disable:next no_print_in_production
+      print(
+        """
+        Sealed secrets → \(envelopePath)
+        Key → \(keyPath) (mode 0600 — keep this OUTSIDE your state-root backup boundary)
+        You may now remove the plaintext CLAW_TELEGRAM_BOT_TOKEN / CLAW_LLM_API_KEY from the env.
+        """
+      )
+    }
+  }
+}

--- a/Tests/ClawCoreTests/AppConfigTests.swift
+++ b/Tests/ClawCoreTests/AppConfigTests.swift
@@ -7,18 +7,17 @@ import Testing
   private typealias EnvKey = AppConfig.EnvKey
 
   /// Adds the LLM keys every successful `load` now requires, unless the base already sets them.
+  /// No secret keys here — the bot token / LLM key load via `SecretStore`, not `AppConfig`.
   private func envWithLLM(_ base: [String: String]) -> [String: String] {
     base.merging([
       EnvKey.llmBaseURL: "http://localhost:1234/v1",
       EnvKey.llmModel: "gpt-4o",
-      EnvKey.llmApiKey: "sk-test",
     ]) { existing, _ in existing }
   }
 
   @Test func loadsValidConfig() throws {
     // given
     let env = envWithLLM([
-      EnvKey.botToken: "123:abc",
       EnvKey.allowlist: "42, 99",
       EnvKey.stateRoot: NSTemporaryDirectory(),
       EnvKey.pollTimeout: "20",
@@ -28,55 +27,38 @@ import Testing
     let config = try AppConfig.load(environment: env)
 
     // then
-    #expect(config.botToken == "123:abc")
     #expect(config.allowlist == [42, 99])
     #expect(config.pollTimeoutSeconds == 20)
     #expect(config.llm.model == "gpt-4o")
+    #expect(config.llm.apiKey.isEmpty)  // the secret is injected at the root, not parsed here
   }
 
   @Test(arguments: [
     (
-      "missingBotToken",
-      envWithLLM: true,
-      overrides: [:],
-      omitKeys: [EnvKey.botToken],
-      expectedError: ConfigError.missingBotToken
-    ),
-    (
       "missingLLMBaseURL",
       envWithLLM: false,
       overrides: [EnvKey.llmModel: "gpt-4o"],
-      omitKeys: [],
       expectedError: ConfigError.missingLLMBaseURL
     ),
     (
       "invalidAllowlist",
       envWithLLM: true,
       overrides: [EnvKey.allowlist: "42, notanumber"],
-      omitKeys: [],
       expectedError: ConfigError.invalidAllowlist("notanumber")
     ),
   ]) func missingOrInvalidConfigFieldThrows(
     description: String,
     envWithLLM: Bool,
     overrides: [String: String],
-    omitKeys: [String],
     expectedError: ConfigError
   ) {
     // given
-    var env = [
-      EnvKey.botToken: "t",
-      EnvKey.stateRoot: NSTemporaryDirectory(),
-    ]
+    var env = [EnvKey.stateRoot: NSTemporaryDirectory()]
     if envWithLLM {
       env[EnvKey.llmBaseURL] = "http://localhost:1234/v1"
       env[EnvKey.llmModel] = "gpt-4o"
-      env[EnvKey.llmApiKey] = "sk-test"
     }
     env.merge(overrides) { _, new in new }
-    for key in omitKeys {
-      env.removeValue(forKey: key)
-    }
 
     // then
     #expect(throws: expectedError) {
@@ -86,10 +68,7 @@ import Testing
 
   @Test func emptyAllowlistIsAllowed() throws {
     // given
-    let env = envWithLLM([
-      EnvKey.botToken: "t",
-      EnvKey.stateRoot: NSTemporaryDirectory(),
-    ])
+    let env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
 
     // when
     let config = try AppConfig.load(environment: env)
@@ -100,10 +79,7 @@ import Testing
 
   @Test func defaultsPollTimeoutTo30() throws {
     // given
-    let env = envWithLLM([
-      EnvKey.botToken: "t",
-      EnvKey.stateRoot: NSTemporaryDirectory(),
-    ])
+    let env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
 
     // when
     let config = try AppConfig.load(environment: env)
@@ -114,8 +90,8 @@ import Testing
 
   @Test func blankStateRootFallsBackToHomeDefaultNotCwd() throws {
     // given — copying .env.example verbatim leaves CLAW_STATE_ROOT blank
-    let blankEnv = envWithLLM([EnvKey.botToken: "t", EnvKey.stateRoot: "   "])
-    let omittedEnv = envWithLLM([EnvKey.botToken: "t"])
+    let blankEnv = envWithLLM([EnvKey.stateRoot: "   "])
+    let omittedEnv = envWithLLM([:])
 
     // when
     let fromBlank = try AppConfig.load(environment: blankEnv)
@@ -129,10 +105,7 @@ import Testing
 
   @Test func loadsLLMConfigWithDefaults() throws {
     // given — only the required LLM keys, no field/max-tokens overrides
-    let env = envWithLLM([
-      EnvKey.botToken: "t",
-      EnvKey.stateRoot: NSTemporaryDirectory(),
-    ])
+    let env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
 
     // when
     let config = try AppConfig.load(environment: env)
@@ -144,10 +117,7 @@ import Testing
 
   @Test func maxTokensFieldOverrideParses() throws {
     // given
-    var env = envWithLLM([
-      EnvKey.botToken: "t",
-      EnvKey.stateRoot: NSTemporaryDirectory(),
-    ])
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
     env[EnvKey.llmMaxTokensField] = "max_tokens"
 
     // when
@@ -159,10 +129,7 @@ import Testing
 
   @Test func perDayUSDOverrideParses() throws {
     // given
-    var env = envWithLLM([
-      EnvKey.botToken: "t",
-      EnvKey.stateRoot: NSTemporaryDirectory(),
-    ])
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
     env[EnvKey.perDayUSD] = "5"
 
     // when
@@ -174,10 +141,7 @@ import Testing
 
   @Test func budgetDefaultsMirrorRunBudgetAndLLM() throws {
     // given
-    let env = envWithLLM([
-      EnvKey.botToken: "t",
-      EnvKey.stateRoot: NSTemporaryDirectory(),
-    ])
+    let env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
 
     // when
     let config = try AppConfig.load(environment: env)
@@ -190,15 +154,26 @@ import Testing
 
   @Test func invalidBudgetValueThrows() {
     // given
-    var env = envWithLLM([
-      EnvKey.botToken: "t",
-      EnvKey.stateRoot: NSTemporaryDirectory(),
-    ])
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
     env[EnvKey.perRunUSD] = "-1"
 
     // when / then
     #expect(throws: ConfigError.invalidBudget("-1")) {
       try AppConfig.load(environment: env)
     }
+  }
+
+  @Test func withAPIKeyInjectsSecretWithoutMutatingTheRest() throws {
+    // given
+    let env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    let config = try AppConfig.load(environment: env)
+
+    // when
+    let withKey = config.llm.withAPIKey("sk-injected")
+
+    // then
+    #expect(withKey.apiKey == "sk-injected")
+    #expect(withKey.model == config.llm.model)
+    #expect(withKey.baseURL == config.llm.baseURL)
   }
 }

--- a/Tests/ClawCoreTests/ErrorTests.swift
+++ b/Tests/ClawCoreTests/ErrorTests.swift
@@ -26,7 +26,6 @@ import Testing
 
   @Test func configErrorMapsToExitCode() {
     // then
-    #expect(ConfigError.missingBotToken.exitCode == ClawExitCode.secretLoadFailed.rawValue)
     #expect(ConfigError.invalidAllowlist("bad").exitCode == ClawExitCode.configInvalid.rawValue)
     #expect(ConfigError.unwritableStateRoot("/x").exitCode == ClawExitCode.configInvalid.rawValue)
   }

--- a/Tests/ClawSecretsTests/EncryptedFileSecretStoreTests.swift
+++ b/Tests/ClawSecretsTests/EncryptedFileSecretStoreTests.swift
@@ -1,0 +1,124 @@
+import ClawCore
+import Crypto
+import Foundation
+import Testing
+
+@testable import ClawSecrets
+
+@Suite struct EncryptedFileSecretStoreTests {
+  /// A fresh, unique state root per test so the suite stays parallel-safe.
+  private func makeStateRoot() throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("claw-secrets-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  @Test func sealThenLoadRoundTrips() throws {
+    // given
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    let original = Secrets(telegramBotToken: "123:abc", llmApiKey: "sk-secret")
+
+    // when
+    try EncryptedFileSecretStore.seal(original, stateRoot: stateRoot)
+    let loaded = try EncryptedFileSecretStore(stateRoot: stateRoot).loadSecrets()
+
+    // then
+    #expect(loaded == original)
+  }
+
+  @Test func sealedEnvelopeContainsNoPlaintextToken() throws {
+    // given
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    let token = "123:super-secret-token"
+
+    // when
+    try EncryptedFileSecretStore.seal(
+      Secrets(telegramBotToken: token, llmApiKey: nil),
+      stateRoot: stateRoot
+    )
+    let envelope = try Data(
+      contentsOf: stateRoot.appendingPathComponent(SecretFile.envelope)
+    )
+
+    // then — the token's bytes never appear in the ciphertext at rest.
+    #expect(envelope.range(of: Data(token.utf8)) == nil)
+  }
+
+  @Test func tamperedCiphertextFailsClosed() throws {
+    // given
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    try EncryptedFileSecretStore.seal(
+      Secrets(telegramBotToken: "123:abc", llmApiKey: nil),
+      stateRoot: stateRoot
+    )
+    let envelopeURL = stateRoot.appendingPathComponent(SecretFile.envelope)
+    var bytes = try Data(contentsOf: envelopeURL)
+
+    // when — flip a byte deep in the ciphertext (past the version + nonce).
+    bytes[bytes.count - 1] ^= 0xFF
+    try bytes.write(to: envelopeURL)
+
+    // then
+    #expect(throws: SecretStoreError.self) {
+      try EncryptedFileSecretStore(stateRoot: stateRoot).loadSecrets()
+    }
+  }
+
+  @Test func tamperedVersionByteFailsClosed() throws {
+    // given
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    try EncryptedFileSecretStore.seal(
+      Secrets(telegramBotToken: "123:abc", llmApiKey: nil),
+      stateRoot: stateRoot
+    )
+    let envelopeURL = stateRoot.appendingPathComponent(SecretFile.envelope)
+    var bytes = try Data(contentsOf: envelopeURL)
+
+    // when — set the version byte to an UNSUPPORTED value.
+    bytes[0] = 0x99
+    try bytes.write(to: envelopeURL)
+
+    // then — the version guard rejects an unknown version before AES-GCM (fail-closed dispatch).
+    #expect(throws: SecretStoreError.self) {
+      try EncryptedFileSecretStore(stateRoot: stateRoot).loadSecrets()
+    }
+  }
+
+  @Test func envelopeAuthenticatedUnderDifferentVersionFailsAuthentication() throws {
+    // given — a valid on-disk version byte (1, supported) but ciphertext authenticated under a
+    // DIFFERENT associated-data byte. This proves the version byte is bound as AEAD AAD: the reader
+    // passes the version guard, then authentication fails because the AAD it uses ([1]) differs
+    // from the AAD the box was sealed with ([2]). Built by hand with a key we control.
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    let keyData = Data(repeating: 0x11, count: EncryptedFileSecretStore.keyByteCount)
+    let keyURL = stateRoot.appendingPathComponent(SecretFile.key)
+    try keyData.write(to: keyURL)
+    try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: keyURL.path)
+
+    let payload = try JSONEncoder().encode(["telegram_bot_token": "123:abc"])
+    let sealed = try AES.GCM.seal(
+      payload,
+      using: SymmetricKey(data: keyData),
+      authenticating: Data([2])  // AAD = version 2 …
+    )
+    let combined = try #require(sealed.combined)
+    let envelope = Data([1]) + combined  // … but the on-disk version byte claims 1
+    try envelope.write(to: stateRoot.appendingPathComponent(SecretFile.envelope))
+
+    // then
+    #expect(throws: SecretStoreError.self) {
+      try EncryptedFileSecretStore(stateRoot: stateRoot).loadSecrets()
+    }
+  }
+}

--- a/Tests/ClawSecretsTests/EnvSecretStoreTests.swift
+++ b/Tests/ClawSecretsTests/EnvSecretStoreTests.swift
@@ -1,0 +1,96 @@
+import ClawCore
+import Foundation
+import Testing
+
+@testable import ClawSecrets
+
+@Suite struct EnvSecretStoreTests {
+  private typealias EnvKey = EnvSecretStore.EnvKey
+
+  /// A concurrency-safe test spy for the `@Sendable` warn closure. A `@Sendable` closure may not
+  /// capture-and-mutate a local `var` under Swift 6 strict concurrency, so the recorder is a
+  /// lock-guarded reference type the closure captures by reference.
+  private final class WarningSpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private var messages: [String] = []
+
+    func record(_ message: String) {
+      lock.lock()
+      defer { lock.unlock() }
+      messages.append(message)
+    }
+
+    var recorded: [String] {
+      lock.lock()
+      defer { lock.unlock() }
+      return messages
+    }
+  }
+
+  @Test func loadsTokenAndKeyFromEnvironment() throws {
+    // given
+    let store = EnvSecretStore(
+      environment: [EnvKey.botToken: "123:abc", EnvKey.llmApiKey: "sk-test"],
+      warn: { _ in }
+    )
+
+    // when
+    let secrets = try store.loadSecrets()
+
+    // then
+    #expect(secrets.telegramBotToken == "123:abc")
+    #expect(secrets.llmApiKey == "sk-test")
+  }
+
+  @Test func missingTokenFailsClosed() {
+    // given
+    let store = EnvSecretStore(environment: [:], warn: { _ in })
+
+    // when / then
+    #expect(throws: SecretStoreError.missingTelegramToken) {
+      try store.loadSecrets()
+    }
+  }
+
+  @Test func blankApiKeyBecomesNil() throws {
+    // given
+    let store = EnvSecretStore(
+      environment: [EnvKey.botToken: "123:abc", EnvKey.llmApiKey: ""],
+      warn: { _ in }
+    )
+
+    // when
+    let secrets = try store.loadSecrets()
+
+    // then — local servers need no key; a blank value is nil, not "".
+    #expect(secrets.llmApiKey == nil)
+  }
+
+  @Test func loadWarnsThatSecretsArePlaintext() throws {
+    // given
+    let spy = WarningSpy()
+    let store = EnvSecretStore(
+      environment: [EnvKey.botToken: "123:abc"],
+      warn: { spy.record($0) }
+    )
+
+    // when
+    _ = try store.loadSecrets()
+
+    // then — the env fallback must warn loudly on every load.
+    #expect(spy.recorded.count == 1)
+    #expect(spy.recorded.first?.contains("PLAINTEXT") == true)
+  }
+
+  @Test(arguments: [
+    SecretStoreError.missingTelegramToken,
+    SecretStoreError.keyFileInsecure("x"),
+    SecretStoreError.malformedEnvelope,
+    SecretStoreError.decryptionFailed,
+    SecretStoreError.unreadable("x"),
+  ]) func everySecretErrorMapsToExit11(error: SecretStoreError) {
+    // then — a secret-load failure is non-retryable and exits 11 (acceptance #5/#11).
+    #expect(error.exitCode == ClawExitCode.secretLoadFailed.rawValue)
+    #expect(error.exitCode == 11)
+  }
+}

--- a/Tests/ClawSecretsTests/KeyFileSecurityTests.swift
+++ b/Tests/ClawSecretsTests/KeyFileSecurityTests.swift
@@ -1,0 +1,144 @@
+import ClawCore
+import Foundation
+import Testing
+
+@testable import ClawSecrets
+
+#if canImport(Glibc)
+  import Glibc
+#else
+  import Darwin
+#endif
+
+@Suite struct KeyFileSecurityTests {
+  private func makeStateRoot() throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("claw-keysec-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  private func writeKey(at url: URL, mode: Int) throws {
+    try Data(repeating: 0xAB, count: EncryptedFileSecretStore.keyByteCount).write(to: url)
+    try FileManager.default.setAttributes([.posixPermissions: mode], ofItemAtPath: url.path)
+  }
+
+  @Test func acceptsRegularOwned0600Key() throws {
+    // given
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    let keyURL = stateRoot.appendingPathComponent(SecretFile.key)
+    try writeKey(at: keyURL, mode: 0o600)
+
+    // when / then — a well-formed key opens without throwing.
+    #expect(throws: Never.self) {
+      _ = try EncryptedFileSecretStore.openKey(at: keyURL)
+    }
+  }
+
+  @Test func rejectsWorldReadableKey() throws {
+    // given
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    let keyURL = stateRoot.appendingPathComponent(SecretFile.key)
+    try writeKey(at: keyURL, mode: 0o644)
+
+    // when / then
+    #expect(throws: SecretStoreError.self) {
+      _ = try EncryptedFileSecretStore.openKey(at: keyURL)
+    }
+  }
+
+  @Test func rejectsSymlinkedKey() throws {
+    // given — a symlink whose target is a valid 0600 key; O_NOFOLLOW must still refuse it.
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    let realKey = stateRoot.appendingPathComponent("real.key")
+    try writeKey(at: realKey, mode: 0o600)
+    let linkURL = stateRoot.appendingPathComponent(SecretFile.key)
+    try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: realKey)
+
+    // when / then
+    #expect(throws: SecretStoreError.self) {
+      _ = try EncryptedFileSecretStore.openKey(at: linkURL)
+    }
+  }
+
+  @Test func rejectsWrongLengthKey() throws {
+    // given
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    let keyURL = stateRoot.appendingPathComponent(SecretFile.key)
+    try Data(repeating: 0xAB, count: 16).write(to: keyURL)
+    try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: keyURL.path)
+
+    // when / then
+    #expect(throws: SecretStoreError.self) {
+      _ = try EncryptedFileSecretStore.openKey(at: keyURL)
+    }
+  }
+
+  @Test func rejectsNonRegularKey() throws {
+    // given — a directory standing in for secret.key; open succeeds but fstat reports a non-regular
+    // file, so the metadata policy must reject it before any read.
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    let keyURL = stateRoot.appendingPathComponent(SecretFile.key)
+    try FileManager.default.createDirectory(at: keyURL, withIntermediateDirectories: false)
+
+    // when / then
+    #expect(throws: SecretStoreError.self) {
+      _ = try EncryptedFileSecretStore.openKey(at: keyURL)
+    }
+  }
+
+  // Owner mismatch and file-type are validated through the pure policy seam, because there is no
+  // portable way to chown to a foreign uid unprivileged. (Automates acceptance #5's "wrong-owner".)
+  @Test(arguments: [
+    (
+      name: "non-regular", isRegular: false, perms: UInt32(0o600), ownerDelta: UInt32(0),
+      throws: true
+    ),
+    (
+      name: "world-readable", isRegular: true, perms: UInt32(0o644), ownerDelta: UInt32(0),
+      throws: true
+    ),
+    (
+      name: "wrong-owner", isRegular: true, perms: UInt32(0o600), ownerDelta: UInt32(1),
+      throws: true
+    ),
+    (
+      name: "regular-0600-owned", isRegular: true, perms: UInt32(0o600), ownerDelta: UInt32(0),
+      throws: false
+    ),
+  ]) func keyMetadataPolicy(
+    name: String,
+    isRegular: Bool,
+    perms: UInt32,
+    ownerDelta: UInt32,
+    throws expectThrow: Bool
+  ) {
+    // given
+    let metadata = EncryptedFileSecretStore.KeyFileMetadata(
+      isRegularFile: isRegular,
+      permissionBits: perms,
+      ownerUID: getuid() &+ ownerDelta
+    )
+
+    // when / then
+    if expectThrow {
+      #expect(throws: SecretStoreError.self) {
+        try EncryptedFileSecretStore.validateKeyMetadata(metadata, expectedUID: getuid())
+      }
+    } else {
+      #expect(throws: Never.self) {
+        try EncryptedFileSecretStore.validateKeyMetadata(metadata, expectedUID: getuid())
+      }
+    }
+  }
+}

--- a/Tests/ClawSecretsTests/SecretStoreResolverTests.swift
+++ b/Tests/ClawSecretsTests/SecretStoreResolverTests.swift
@@ -1,0 +1,107 @@
+import ClawCore
+import Foundation
+import Testing
+
+@testable import ClawSecrets
+
+@Suite struct SecretStoreResolverTests {
+  private typealias EnvKey = EnvSecretStore.EnvKey
+
+  private func makeStateRoot() throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("claw-resolve-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  @Test func picksEnvWhenNoEncryptedArtifacts() throws {
+    // given — neither secrets.enc nor secret.key exists.
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    // when
+    let resolution = SecretStoreResolver.resolve(
+      stateRoot: stateRoot,
+      environment: [EnvKey.botToken: "123:abc"],
+      warn: { _ in }
+    )
+
+    // then
+    #expect(resolution.backend == .env)
+    #expect(try resolution.store.loadSecrets().telegramBotToken == "123:abc")
+  }
+
+  @Test func picksEncryptedWhenSealed() throws {
+    // given
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    try EncryptedFileSecretStore.seal(
+      Secrets(telegramBotToken: "123:abc", llmApiKey: nil),
+      stateRoot: stateRoot
+    )
+
+    // when
+    let resolution = SecretStoreResolver.resolve(
+      stateRoot: stateRoot,
+      environment: [:],
+      warn: { _ in }
+    )
+
+    // then
+    #expect(resolution.backend == .encrypted)
+    #expect(try resolution.store.loadSecrets().telegramBotToken == "123:abc")
+  }
+
+  @Test func envelopeWithoutKeyFailsClosedNeverFallsBackToEnv() throws {
+    // given — a partial encrypted setup: secrets.enc present, secret.key missing, env token set.
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    try EncryptedFileSecretStore.seal(
+      Secrets(telegramBotToken: "123:abc", llmApiKey: nil),
+      stateRoot: stateRoot
+    )
+    try FileManager.default.removeItem(
+      at: stateRoot.appendingPathComponent(SecretFile.key)
+    )
+
+    // when — selection must require encrypted (it exists partially), not fall back to env.
+    let resolution = SecretStoreResolver.resolve(
+      stateRoot: stateRoot,
+      environment: [EnvKey.botToken: "999:env-token"],
+      warn: { _ in }
+    )
+
+    // then
+    #expect(resolution.backend == .encrypted)
+    #expect(throws: SecretStoreError.self) {
+      try resolution.store.loadSecrets()  // never returns the env token
+    }
+  }
+
+  @Test func danglingKeySymlinkForcesEncryptedNotEnv() throws {
+    // given — secret.key is a BROKEN symlink (its target was never created) and an env token is set.
+    // `FileManager.fileExists` follows symlinks and reports a broken one as absent (fail-open);
+    // an `lstat`-based check sees the entry and must force the encrypted backend (fail-closed).
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    let keyURL = stateRoot.appendingPathComponent(SecretFile.key)
+    let missingTarget = stateRoot.appendingPathComponent("gone.key")
+    try FileManager.default.createSymbolicLink(at: keyURL, withDestinationURL: missingTarget)
+
+    // when
+    let resolution = SecretStoreResolver.resolve(
+      stateRoot: stateRoot,
+      environment: [EnvKey.botToken: "999:env-token"],
+      warn: { _ in }
+    )
+
+    // then — a present (if broken) artifact entry requires encrypted; never the env token.
+    #expect(resolution.backend == .encrypted)
+    #expect(throws: SecretStoreError.self) {
+      try resolution.store.loadSecrets()
+    }
+  }
+}

--- a/Tests/ClawSecretsTests/SecretsDoctorRowTests.swift
+++ b/Tests/ClawSecretsTests/SecretsDoctorRowTests.swift
@@ -18,6 +18,7 @@ import Testing
     // given
     let stateRoot = try makeStateRoot()
     defer { try? FileManager.default.removeItem(at: stateRoot) }
+
     try EncryptedFileSecretStore.seal(
       Secrets(telegramBotToken: "123:abc", llmApiKey: nil),
       stateRoot: stateRoot
@@ -51,6 +52,7 @@ import Testing
     // given — secrets.enc present, key missing → decrypt fails.
     let stateRoot = try makeStateRoot()
     defer { try? FileManager.default.removeItem(at: stateRoot) }
+
     try EncryptedFileSecretStore.seal(
       Secrets(telegramBotToken: "123:abc", llmApiKey: nil),
       stateRoot: stateRoot

--- a/Tests/ClawSecretsTests/SecretsDoctorRowTests.swift
+++ b/Tests/ClawSecretsTests/SecretsDoctorRowTests.swift
@@ -1,0 +1,67 @@
+import ClawCore
+import Foundation
+import Testing
+
+@testable import ClawSecrets
+
+@Suite struct SecretsDoctorRowTests {
+  private typealias EnvKey = EnvSecretStore.EnvKey
+
+  private func makeStateRoot() throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("claw-doctor-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  @Test func reportsEncryptedOkAfterDecrypt() throws {
+    // given
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+    try EncryptedFileSecretStore.seal(
+      Secrets(telegramBotToken: "123:abc", llmApiKey: nil),
+      stateRoot: stateRoot
+    )
+
+    // when — validates a real decrypt without booting the daemon.
+    let row = SecretStoreResolver.doctorRow(stateRoot: stateRoot, environment: [:])
+
+    // then
+    #expect(row.ok)
+    #expect(row.value == "backend=encrypted")
+  }
+
+  @Test func reportsEnvWarning() throws {
+    // given
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    // when
+    let row = SecretStoreResolver.doctorRow(
+      stateRoot: stateRoot,
+      environment: [EnvKey.botToken: "123:abc"]
+    )
+
+    // then
+    #expect(row.ok)
+    #expect(row.value == "backend=env (WARN: plaintext)")
+  }
+
+  @Test func reportsFailWhenEncryptedSetupIsBroken() throws {
+    // given — secrets.enc present, key missing → decrypt fails.
+    let stateRoot = try makeStateRoot()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+    try EncryptedFileSecretStore.seal(
+      Secrets(telegramBotToken: "123:abc", llmApiKey: nil),
+      stateRoot: stateRoot
+    )
+    try FileManager.default.removeItem(at: stateRoot.appendingPathComponent(SecretFile.key))
+
+    // when
+    let row = SecretStoreResolver.doctorRow(stateRoot: stateRoot, environment: [:])
+
+    // then
+    #expect(!row.ok)
+    #expect(row.value.hasPrefix("FAIL:"))
+  }
+}

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -1,0 +1,145 @@
+# Local Development Guide
+
+Day-to-day commands for building, running, and operating `clawd` locally.
+
+---
+
+## Prerequisites
+
+`clawd` reads config from environment variables. The file `~/.swift-claw/clawd.env`
+holds those variables but is never loaded automatically — you source it before each
+invocation. Get in the habit of doing this at the start of a dev session:
+
+```bash
+set -a && source ~/.swift-claw/clawd.env && set +a
+```
+
+All commands below assume a sourced shell unless noted.
+
+---
+
+## Build
+
+```bash
+swift build
+```
+
+The debug binary lands at `.build/debug/clawd`. For a release build:
+
+```bash
+swift build -c release
+```
+
+---
+
+## Lint
+
+```bash
+scripts/lint.sh --fix   # auto-apply swift-format + swiftlint fixes
+scripts/lint.sh         # verify; must pass before committing
+```
+
+CI runs the check step. Fix before pushing.
+
+---
+
+## Tests
+
+```bash
+swift test                                    # full suite
+swift test --filter SuiteName/testName       # single test
+```
+
+Tests follow Given-When-Then. Check `// given` / `// when` / `// then` sections
+when reading failures.
+
+---
+
+## Doctor
+
+Checks config validity, secrets, database, and Telegram connectivity:
+
+```bash
+set -a && source ~/.swift-claw/clawd.env && set +a
+.build/debug/clawd doctor
+```
+
+Config-and-secrets only (no DB or network):
+
+```bash
+.build/debug/clawd doctor --check-config
+```
+
+Machine-readable output:
+
+```bash
+.build/debug/clawd doctor --json
+```
+
+Healthy output shows `OK` on `config` and `backend=encrypted` (or
+`backend=env (WARN: plaintext)` before sealing).
+
+---
+
+## Secrets
+
+### Seal (first-time setup)
+
+Reads `CLAW_TELEGRAM_BOT_TOKEN` and `CLAW_LLM_API_KEY` from the environment
+and writes two files under `~/.swift-claw/`:
+
+- `secrets.enc` — encrypted envelope
+- `secret.key` — AES key (mode 0600)
+
+```bash
+set -a && source ~/.swift-claw/clawd.env && set +a
+.build/debug/clawd secrets seal
+```
+
+After sealing, remove the two secret lines from `clawd.env`:
+
+```
+# delete or blank these after sealing:
+CLAW_TELEGRAM_BOT_TOKEN=...
+CLAW_LLM_API_KEY=...
+```
+
+Keep the non-secret config (`CLAW_LLM_BASE_URL`, `CLAW_LLM_MODEL`, etc.).
+
+### How the daemon picks up secrets
+
+Once `secrets.enc` and `secret.key` exist in the state root, the resolver
+uses the encrypted backend automatically. No extra env var needed. If either
+file is present but broken, the daemon refuses to start rather than falling
+back to plaintext env.
+
+Verify with `doctor`: look for `secrets: backend=encrypted`.
+
+---
+
+## Run
+
+```bash
+set -a && source ~/.swift-claw/clawd.env && set +a
+.build/debug/clawd run
+```
+
+The daemon long-polls Telegram, routes messages, and runs LLM turns.
+Stop with `Ctrl-C`. A second instance against the same state root will
+exit immediately (lock guard).
+
+---
+
+## State root
+
+Default: `~/.swift-claw/`. Contents:
+
+| File          | Purpose                       |
+| ------------- | ----------------------------- |
+| `claw.sqlite` | Main database (WAL mode)      |
+| `clawd.env`   | Non-secret config             |
+| `clawd.lock`  | Single-instance lock          |
+| `secrets.enc` | Encrypted secrets envelope    |
+| `secret.key`  | AES key (keep out of backups) |
+
+Override the state root with `CLAW_STATE_ROOT` for isolated test setups.


### PR DESCRIPTION
## Summary
- add the `SecretStore` domain seam and a warned environment fallback
- add AES-GCM encrypted file storage with safe key-file validation and fail-closed backend selection
- split secrets from `AppConfig`, wire startup and doctor checks, and add `clawd secrets seal`
- restore the documented `clawd run` and `clawd doctor` command names

## Why
Increment 2 requires production secrets to be encrypted at rest instead of parsed as plaintext application configuration. The daemon now resolves and loads secrets once at startup while retaining an explicit warned environment fallback for development.

## Impact
- production deployments can seal Telegram and optional LLM credentials into `secrets.enc`
- partial or invalid encrypted setups fail closed with exit code 11
- `doctor --check-config` validates a real decrypt without booting the daemon
- existing non-secret configuration and exact-value redaction paths remain intact

## Validation
- `scripts/lint.sh`
- `swift test` (170 tests)
