### PR TITLE
feat: add per-session lane lifecycle

### DIFF
--- a/Sources/ClawAgent/SessionActor.swift
+++ b/Sources/ClawAgent/SessionActor.swift
@@ -1,36 +1,36 @@
 /// Per-session FIFO lane. Actor isolation protects bookkeeping; the stored Task chain serializes
 /// complete turn bodies across their suspension points.
 public actor SessionActor {
-  private var tail: Task<Void, Never>?
-  private var inFlight: [Int64: Task<Void, Never>] = [:]
+  private var lastEnqueuedTask: Task<Void, Never>?
+  private var inFlightTasks: [Int64: Task<Void, Never>] = [:]
 
   public init() {}
 
   public func enqueue(runId: Int64, _ work: @Sendable @escaping () async -> Void) {
-    let previous = tail
+    let previous = lastEnqueuedTask
     let task = Task {
       _ = await previous?.value
       await work()
       self.finish(runId: runId)
     }
-    tail = task
-    inFlight[runId] = task
+    lastEnqueuedTask = task
+    inFlightTasks[runId] = task
   }
 
   public func cancel(runId: Int64) {
-    inFlight[runId]?.cancel()
+    inFlightTasks[runId]?.cancel()
   }
 
   public func cancelAll() {
-    for task in inFlight.values {
+    for task in inFlightTasks.values {
       task.cancel()
     }
   }
 
   private func finish(runId: Int64) {
-    inFlight[runId] = nil
-    if inFlight.isEmpty {
-      tail = nil
+    inFlightTasks[runId] = nil
+    if inFlightTasks.isEmpty {
+      lastEnqueuedTask = nil
     }
   }
 }

--- a/Sources/ClawAgent/SessionActor.swift
+++ b/Sources/ClawAgent/SessionActor.swift
@@ -1,0 +1,56 @@
+/// Per-session FIFO lane. Actor isolation protects bookkeeping; the stored Task chain serializes
+/// complete turn bodies across their suspension points.
+public actor SessionActor {
+  private var tail: Task<Void, Never>?
+  private var inFlight: [Int64: Task<Void, Never>] = [:]
+
+  public init() {}
+
+  public func enqueue(runId: Int64, _ work: @Sendable @escaping () async -> Void) {
+    let previous = tail
+    let task = Task {
+      _ = await previous?.value
+      await work()
+      self.finish(runId: runId)
+    }
+    tail = task
+    inFlight[runId] = task
+  }
+
+  public func cancel(runId: Int64) {
+    inFlight[runId]?.cancel()
+  }
+
+  public func cancelAll() {
+    for task in inFlight.values {
+      task.cancel()
+    }
+  }
+
+  private func finish(runId: Int64) {
+    inFlight[runId] = nil
+    if inFlight.isEmpty {
+      tail = nil
+    }
+  }
+}
+
+public actor SessionLaneRegistry {
+  private var actors: [Int64: SessionActor] = [:]
+
+  public init() {}
+
+  public func actor(for sessionId: Int64) -> SessionActor {
+    if let existing = actors[sessionId] {
+      return existing
+    }
+
+    let created = SessionActor()
+    actors[sessionId] = created
+    return created
+  }
+
+  public var count: Int {
+    actors.count
+  }
+}

--- a/Sources/ClawCore/Persistence.swift
+++ b/Sources/ClawCore/Persistence.swift
@@ -1,10 +1,27 @@
 import Foundation
 
 public enum RunState: String, Sendable, Equatable {
+  /// Persisted after the inbound message and run are created atomically, before lane execution.
   case pending = "PENDING"
+  /// Persisted when the session lane successfully picks up the turn.
   case running = "RUNNING"
+  /// Terminal success: the assistant reply and outbox rows committed atomically.
   case done = "DONE"
+  /// Terminal failure: the turn could not complete and should not be picked up again.
   case failed = "FAILED"
+  /// Terminal cancellation requested by `/stop`.
+  case cancelled = "CANCELLED"
+  /// Terminal cancellation requested by `/new`; queued turns are superseded too.
+  case superseded = "SUPERSEDED"
+}
+
+/// The two command-owned reasons for terminating a live run.
+///
+/// This is intentionally narrower than `RunState`: callers cannot accidentally request an
+/// unrelated terminal state such as `.done` or `.failed`.
+public enum CancelReason: Sendable, Equatable {
+  case cancelled
+  case superseded
 }
 
 public enum Provenance: String, Sendable, Equatable {
@@ -69,11 +86,21 @@ public struct ClaimResult: Sendable, Equatable {
   public let newlyClaimed: Bool
   public let sessionId: Int64?
   public let messageId: Int64?
+  public let runId: Int64?
+  public let triggerMessageId: Int64?
 
-  public init(newlyClaimed: Bool, sessionId: Int64?, messageId: Int64?) {
+  public init(
+    newlyClaimed: Bool,
+    sessionId: Int64?,
+    messageId: Int64?,
+    runId: Int64?,
+    triggerMessageId: Int64?
+  ) {
     self.newlyClaimed = newlyClaimed
     self.sessionId = sessionId
     self.messageId = messageId
+    self.runId = runId
+    self.triggerMessageId = triggerMessageId
   }
 }
 

--- a/Sources/ClawCore/Persistence.swift
+++ b/Sources/ClawCore/Persistence.swift
@@ -24,6 +24,16 @@ public enum CancelReason: Sendable, Equatable {
   case superseded
 }
 
+/// Outcome of a commit attempt at the run-store seam.
+public enum RunCommitResult: Sendable, Equatable {
+  /// The run was still RUNNING and the terminal state plus owner-visible side effects committed.
+  case committed
+  /// Cancellation/supersede had already won; provider usage was still durably recorded.
+  case usageRecordedAfterTerminal
+  /// The run was not in a state where this commit owns any side effect.
+  case ignored
+}
+
 public enum Provenance: String, Sendable, Equatable {
   case trusted
   case untrusted
@@ -224,6 +234,28 @@ public struct AssistantTurn: Sendable, Equatable {
     self.content = content
     self.usage = usage
     self.chunks = chunks
+  }
+}
+
+public struct DegradedTurn: Sendable, Equatable {
+  public let runId: Int64
+  public let sessionId: Int64
+  public let chatId: Int64
+  public let usage: ProviderUsage?
+  public let chunk: OutboxChunk
+
+  public init(
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    usage: ProviderUsage?,
+    chunk: OutboxChunk
+  ) {
+    self.runId = runId
+    self.sessionId = sessionId
+    self.chatId = chatId
+    self.usage = usage
+    self.chunk = chunk
   }
 }
 

--- a/Sources/ClawCore/RunFSM.swift
+++ b/Sources/ClawCore/RunFSM.swift
@@ -1,26 +1,46 @@
 /// The events that can move a run through its lifecycle. Distinct from `RunState` (the persisted
 /// column) so the legality of a transition lives in one reducer rather than scattered across stores.
 public enum RunEvent: Sendable, Equatable {
+  /// The session lane starts a durable PENDING run.
   case pickUp
+  /// The assistant reply, usage, and outbox rows commit successfully.
   case complete
   /// Raised by a terminal/exhausted/timeout outcome *or* the boot sweep over an orphaned run.
   case fail
+  /// `/stop` terminates a pending or running turn.
+  case cancel
+  /// `/new` terminates the running turn and any queued turns from the old conversation window.
+  case supersede
 }
 
-/// The run lifecycle reducer — the single source of truth for which `(state, event)` pairs are
-/// legal. Canonical for Inc 1 (the stores still apply their transitions directly in SQL); the Inc 2
-/// per-session lane routes its state changes through this so an illegal pair can't be persisted.
+/// The run lifecycle reducer: the single source of truth for legal state changes.
 public enum RunFSM {
-  /// Returns the next state for a legal transition, or `nil` for an illegal one. There is **no
-  /// default arm that invents a state** — an unrecognized pair is a programmer error the caller must
-  /// handle, not silently swallow.
+  /// Returns the next state for a legal transition, or `nil` when the store must perform no write.
+  ///
+  /// Every state/event pair is explicit so adding a future state or event produces a compiler
+  /// reminder to revisit the lifecycle rules.
   public static func reduce(state: RunState, on event: RunEvent) -> RunState? {
     switch (state, event) {
-    case (.pending, .pickUp): .running
-    case (.running, .complete): .done
-    case (.running, .fail): .failed
-    case (.pending, .fail): .failed
-    default: nil
+    case (.pending, .pickUp):
+      .running
+    case (.pending, .fail):
+      .failed
+    case (.pending, .cancel):
+      .cancelled
+    case (.pending, .supersede):
+      .superseded
+    case (.running, .complete):
+      .done
+    case (.running, .fail):
+      .failed
+    case (.running, .cancel):
+      .cancelled
+    case (.running, .supersede):
+      .superseded
+    case (.pending, .complete), (.running, .pickUp):
+      nil
+    case (.done, _), (.failed, _), (.cancelled, _), (.superseded, _):
+      nil
     }
   }
 }

--- a/Sources/ClawCore/Stores.swift
+++ b/Sources/ClawCore/Stores.swift
@@ -36,8 +36,11 @@ public protocol RunStore: Sendable {
   /// PENDING → RUNNING through `RunFSM`; false means the run is absent or no longer pending.
   func pickUp(runId: Int64, now: Date) throws -> Bool
   /// F6 atomicity: assistant message + run→DONE + provider_usage + outbox chunk(s) in ONE txn,
-  /// committed before any send. No-ops unless the run is RUNNING.
-  func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws
+  /// committed before any send. If cancellation/supersede already won, records usage only.
+  func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws -> RunCommitResult
+  /// Failure/degradation commit: provider_usage + run→FAILED + degradation outbox in ONE txn.
+  /// If cancellation/supersede already won, records usage when present but writes no reply.
+  func commitDegradedTurn(_ turn: DegradedTurn, now: Date) throws -> RunCommitResult
   /// RUNNING → FAILED through `RunFSM`; no-ops unless the run is RUNNING.
   func failRun(runId: Int64, now: Date) throws
   /// Terminates the current RUNNING turn for `/stop`; returns the affected run, if any.

--- a/Sources/ClawCore/Stores.swift
+++ b/Sources/ClawCore/Stores.swift
@@ -19,21 +19,32 @@ public protocol UpdateCursorStore: Sendable {
 
 public protocol SessionMessageStore: Sendable {
   func loadOrCreateSession(sessionKey: String, now: Date) throws -> Int64
-  /// Fused F4 transaction: claim the `update_id` and (only if newly claimed) upsert the session +
-  /// insert the user message in ONE `db.write`. Returns `newlyClaimed` + the new ids.
+  /// Fused transaction: claim the update, upsert the session, insert the user message, create the
+  /// PENDING run, and stamp its trigger message in one write. Duplicates create nothing.
   func claimAndPersistInbound(_ inbound: InboundMessage) throws -> ClaimResult
-  /// Most-recent `limit` messages, returned **oldest-first** for context assembly.
-  func loadRecentMessages(sessionId: Int64, limit: Int) throws -> [StoredMessage]
+  /// Context returned oldest-first and bounded to the message this run is answering.
+  func loadContext(
+    sessionId: Int64,
+    throughMessageId: Int64,
+    limit: Int
+  ) throws -> [StoredMessage]
+  /// Advances the `/new` context boundary to the latest message and clears session taint.
+  func resetWindowAndDetaint(sessionId: Int64, now: Date) throws
 }
 
 public protocol RunStore: Sendable {
-  func createRun(sessionId: Int64, now: Date) throws -> Int64
+  /// PENDING → RUNNING through `RunFSM`; false means the run is absent or no longer pending.
+  func pickUp(runId: Int64, now: Date) throws -> Bool
   /// F6 atomicity: assistant message + run→DONE + provider_usage + outbox chunk(s) in ONE txn,
-  /// committed BEFORE any send.
+  /// committed before any send. No-ops unless the run is RUNNING.
   func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws
+  /// RUNNING → FAILED through `RunFSM`; no-ops unless the run is RUNNING.
   func failRun(runId: Int64, now: Date) throws
-  /// Boot sweep (F22): flip every `RUNNING` row → `FAILED`; for any that delivered nothing,
-  /// enqueue a PENDING degradation outbox row and return it for logging.
+  /// Terminates the current RUNNING turn for `/stop`; returns the affected run, if any.
+  func cancelActiveRun(sessionId: Int64, reason: CancelReason, now: Date) throws -> Int64?
+  /// Terminates RUNNING and queued PENDING turns for `/new`.
+  func supersedeSessionRuns(sessionId: Int64, now: Date) throws -> [Int64]
+  /// Boot sweep: fail every orphaned PENDING/RUNNING run and enqueue degradation when needed.
   func reconcileRunsAtBoot(now: Date, degradationText: String) throws -> [DegradationReply]
   /// Snapshot of run-table health: in-flight count, age of oldest running run, last
   /// success/failure timestamps, and count of consecutive failures at the head of the table.
@@ -50,6 +61,14 @@ public protocol UsageStore: Sendable {
 
 public protocol OutboxStore: Sendable {
   func claimOutbound(
+    runId: Int64,
+    stepIndex: Int,
+    chatId: Int64,
+    payload: String,
+    payloadHash: String
+  ) throws -> Bool
+  /// Claims a degradation reply only while the owning run is still RUNNING.
+  func claimOutboundIfRunActive(
     runId: Int64,
     stepIndex: Int,
     chatId: Int64,

--- a/Sources/ClawData/ClawDatabase.swift
+++ b/Sources/ClawData/ClawDatabase.swift
@@ -119,6 +119,14 @@ public enum ClawDatabase {
         table.column("session_id", .integer)
       }
     }
+    migrator.registerMigration("v3") { db in
+      try db.alter(table: "sessions") { table in
+        table.add(column: "window_start_message_id", .integer).notNull().defaults(to: 0)
+      }
+      try db.alter(table: "runs") { table in
+        table.add(column: "trigger_message_id", .integer)
+      }
+    }
     return migrator
   }
 

--- a/Sources/ClawData/OutboxStoreGRDB.swift
+++ b/Sources/ClawData/OutboxStoreGRDB.swift
@@ -28,6 +28,39 @@ public struct OutboxStoreGRDB: OutboxStore {
         ),
         now: Date()
       )
+    }
+  }
+
+  public func claimOutboundIfRunActive(
+    runId: Int64,
+    stepIndex: Int,
+    chatId: Int64,
+    payload: String,
+    payloadHash: String
+  ) throws -> Bool {
+    try writer.writeMapping { db in
+      try db.execute(
+        sql: """
+          INSERT OR IGNORE INTO outbound_deliveries(
+            run_id, step_index, chat_id, dedup_key, payload, payload_hash, status, created_ts
+          )
+          SELECT ?, ?, ?, ?, ?, ?, 'PENDING', ?
+          WHERE EXISTS (
+            SELECT 1 FROM runs WHERE id = ? AND state = ?
+          )
+          """,
+        arguments: [
+          runId,
+          stepIndex,
+          chatId,
+          "\(runId):\(stepIndex)",
+          payload,
+          payloadHash,
+          Date(),
+          runId,
+          RunState.running.rawValue,
+        ]
+      )
       return db.changesCount > 0
     }
   }

--- a/Sources/ClawData/RunStoreGRDB.swift
+++ b/Sources/ClawData/RunStoreGRDB.swift
@@ -72,17 +72,29 @@ public struct RunStoreGRDB: RunStore {
     }
   }
 
-  public func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws {
+  public func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws -> RunCommitResult {
     try writer.writeMapping { db in
-      guard
-        let nextState = try Self.transitionRun(
+      guard let currentState = try Self.currentRunState(db, runId: turn.runId) else {
+        return .ignored
+      }
+
+      guard currentState == .running else {
+        return try Self.recordTerminalUsageIfNeeded(
           db,
-          runId: turn.runId,
-          event: .complete,
+          usage: turn.usage,
+          state: currentState,
           now: now
         )
-      else {
-        return
+      }
+
+      let nextState = try Self.transitionRun(
+        db,
+        runId: turn.runId,
+        event: .complete,
+        now: now
+      )
+      guard let nextState else {
+        return .ignored
       }
 
       let usage = turn.usage
@@ -117,6 +129,41 @@ public struct RunStoreGRDB: RunStore {
       for chunk in turn.chunks {
         _ = try Self.insertOutbox(db, runId: turn.runId, chunk: chunk, now: now)
       }
+
+      return .committed
+    }
+  }
+
+  public func commitDegradedTurn(_ turn: DegradedTurn, now: Date) throws -> RunCommitResult {
+    try writer.writeMapping { db in
+      guard let currentState = try Self.currentRunState(db, runId: turn.runId) else {
+        return .ignored
+      }
+
+      guard currentState == .running else {
+        if let usage = turn.usage {
+          return try Self.recordTerminalUsageIfNeeded(
+            db,
+            usage: usage,
+            state: currentState,
+            now: now
+          )
+        }
+        return .ignored
+      }
+
+      guard try Self.transitionRun(db, runId: turn.runId, event: .fail, now: now) != nil else {
+        return .ignored
+      }
+
+      if let usage = turn.usage {
+        try Self.insertUsage(db, usage)
+        try Self.updateRunUsage(db, usage: usage, now: now)
+      }
+
+      _ = try Self.insertOutbox(db, runId: turn.runId, chunk: turn.chunk, now: now)
+
+      return .committed
     }
   }
 
@@ -236,15 +283,8 @@ public struct RunStoreGRDB: RunStore {
     event: RunEvent,
     now: Date
   ) throws -> RunState? {
-    let rawState = try String.fetchOne(
-      db,
-      sql: "SELECT state FROM runs WHERE id = ?",
-      arguments: [runId]
-    )
-
     guard
-      let rawState,
-      let state = RunState(rawValue: rawState),
+      let state = try currentRunState(db, runId: runId),
       let nextState = RunFSM.reduce(state: state, on: event)
     else {
       return nil
@@ -256,6 +296,20 @@ public struct RunStoreGRDB: RunStore {
     )
 
     return nextState
+  }
+
+  private static func currentRunState(_ db: Database, runId: Int64) throws -> RunState? {
+    let rawState = try String.fetchOne(
+      db,
+      sql: "SELECT state FROM runs WHERE id = ?",
+      arguments: [runId]
+    )
+
+    guard let rawState else {
+      return nil
+    }
+
+    return RunState(rawValue: rawState)
   }
 
   static func insertUsage(_ db: Database, _ usage: ProviderUsage) throws {
@@ -275,6 +329,48 @@ public struct RunStoreGRDB: RunStore {
         usage.costSource.rawValue,
         usage.isEstimated,
         usage.ts,
+      ]
+    )
+  }
+
+  private static func recordTerminalUsageIfNeeded(
+    _ db: Database,
+    usage: ProviderUsage,
+    state: RunState,
+    now: Date
+  ) throws -> RunCommitResult {
+    guard state == .cancelled || state == .superseded else {
+      return .ignored
+    }
+
+    let existingRows =
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM provider_usage WHERE run_id = ?",
+        arguments: [usage.runId]
+      ) ?? 0
+    guard existingRows == 0 else {
+      return .ignored
+    }
+
+    try insertUsage(db, usage)
+    try updateRunUsage(db, usage: usage, now: now)
+
+    return .usageRecordedAfterTerminal
+  }
+
+  private static func updateRunUsage(_ db: Database, usage: ProviderUsage, now: Date) throws {
+    try db.execute(
+      sql: """
+        UPDATE runs SET updated_ts = ?, input_tokens = ?, output_tokens = ?, cost_usd = ?
+        WHERE id = ?
+        """,
+      arguments: [
+        now,
+        usage.promptTokens,
+        usage.completionTokens,
+        usage.costUSD,
+        usage.runId,
       ]
     )
   }

--- a/Sources/ClawData/RunStoreGRDB.swift
+++ b/Sources/ClawData/RunStoreGRDB.swift
@@ -9,20 +9,78 @@ public struct RunStoreGRDB: RunStore {
     self.writer = writer
   }
 
-  public func createRun(sessionId: Int64, now: Date) throws -> Int64 {
+  public func pickUp(runId: Int64, now: Date) throws -> Bool {
     try writer.writeMapping { db in
-      try db.execute(
+      try Self.transitionRun(db, runId: runId, event: .pickUp, now: now) != nil
+    }
+  }
+
+  public func cancelActiveRun(
+    sessionId: Int64,
+    reason: CancelReason,
+    now: Date
+  ) throws -> Int64? {
+    try writer.writeMapping { db in
+      let runId = try Int64.fetchOne(
+        db,
         sql: """
-          INSERT INTO runs(session_id, state, created_ts, updated_ts) VALUES (?, ?, ?, ?)
+          SELECT id FROM runs
+          WHERE session_id = ? AND state = ?
+          ORDER BY id DESC
+          LIMIT 1
           """,
-        arguments: [sessionId, RunState.running.rawValue, now, now]
+        arguments: [sessionId, RunState.running.rawValue]
       )
-      return db.lastInsertedRowID
+      guard let runId else {
+        return nil
+      }
+
+      let event: RunEvent = reason == .cancelled ? .cancel : .supersede
+      guard try Self.transitionRun(db, runId: runId, event: event, now: now) != nil else {
+        return nil
+      }
+
+      return runId
+    }
+  }
+
+  public func supersedeSessionRuns(sessionId: Int64, now: Date) throws -> [Int64] {
+    try writer.writeMapping { db in
+      let rows = try Row.fetchAll(
+        db,
+        sql: """
+          SELECT id FROM runs
+          WHERE session_id = ? AND state IN (?, ?)
+          ORDER BY id ASC
+          """,
+        arguments: [sessionId, RunState.pending.rawValue, RunState.running.rawValue]
+      )
+
+      var affected: [Int64] = []
+      for row in rows {
+        let runId: Int64 = row["id"]
+        if try Self.transitionRun(db, runId: runId, event: .supersede, now: now) != nil {
+          affected.append(runId)
+        }
+      }
+
+      return affected
     }
   }
 
   public func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws {
     try writer.writeMapping { db in
+      guard
+        let nextState = try Self.transitionRun(
+          db,
+          runId: turn.runId,
+          event: .complete,
+          now: now
+        )
+      else {
+        return
+      }
+
       let usage = turn.usage
       try db.execute(
         sql: """
@@ -42,7 +100,7 @@ public struct RunStoreGRDB: RunStore {
         sql:
           "UPDATE runs SET state = ?, updated_ts = ?, input_tokens = ?, output_tokens = ?, cost_usd = ? WHERE id = ?",
         arguments: [
-          RunState.done.rawValue,
+          nextState.rawValue,
           now,
           usage.promptTokens,
           usage.completionTokens,
@@ -59,10 +117,7 @@ public struct RunStoreGRDB: RunStore {
 
   public func failRun(runId: Int64, now: Date) throws {
     try writer.writeMapping { db in
-      try db.execute(
-        sql: "UPDATE runs SET state = ?, updated_ts = ? WHERE id = ?",
-        arguments: [RunState.failed.rawValue, now, runId]
-      )
+      _ = try Self.transitionRun(db, runId: runId, event: .fail, now: now)
     }
   }
 
@@ -72,28 +127,31 @@ public struct RunStoreGRDB: RunStore {
         db,
         sql: """
           SELECT r.id AS run_id, s.session_key AS session_key FROM runs r
-          JOIN sessions s ON s.id = r.session_id WHERE r.state = ?
+          JOIN sessions s ON s.id = r.session_id
+          WHERE r.state IN (?, ?)
+          ORDER BY r.id ASC
           """,
-        arguments: [RunState.running.rawValue]
+        arguments: [RunState.pending.rawValue, RunState.running.rawValue]
       )
 
       var replies: [DegradationReply] = []
       for row in stale {
         let runId: Int64 = row["run_id"]
-        try db.execute(
-          sql: "UPDATE runs SET state = ?, updated_ts = ? WHERE id = ?",
-          arguments: [RunState.failed.rawValue, now, runId]
-        )
-        let delivered =
+        guard try Self.transitionRun(db, runId: runId, event: .fail, now: now) != nil else {
+          continue
+        }
+
+        let sentCount =
           try Int.fetchOne(
             db,
-            sql: "SELECT COUNT(*) FROM outbound_deliveries WHERE run_id = ?",
+            sql: """
+              SELECT COUNT(*) FROM outbound_deliveries
+              WHERE run_id = ? AND status = 'SENT'
+              """,
             arguments: [runId]
           ) ?? 0
-        // A delivered run committed its reply before the crash; the dispatcher resends it.
-        // An undelivered run left the owner in silence — enqueue the degradation reply.
         guard
-          delivered == 0,
+          sentCount == 0,
           let chatId = SessionKey.chatId(from: row["session_key"])
         else {
           continue
@@ -105,9 +163,9 @@ public struct RunStoreGRDB: RunStore {
           payload: degradationText,
           payloadHash: ContentHash.fnv1a(degradationText)
         )
-        try Self.insertOutbox(db, runId: runId, chunk: chunk, now: now)
-
-        replies.append(DegradationReply(chatId: chatId, runId: runId, text: degradationText))
+        if try Self.insertOutbox(db, runId: runId, chunk: chunk, now: now) {
+          replies.append(DegradationReply(chatId: chatId, runId: runId, text: degradationText))
+        }
       }
 
       return replies
@@ -116,18 +174,19 @@ public struct RunStoreGRDB: RunStore {
 
   public func runsHealth(now: Date) throws -> RunsHealth {
     try writer.readMapping { db in
+      let activeStates = [RunState.pending.rawValue, RunState.running.rawValue]
       let inFlight =
         try Int.fetchOne(
           db,
-          sql: "SELECT COUNT(*) FROM runs WHERE state = ?",
-          arguments: [RunState.running.rawValue]
+          sql: "SELECT COUNT(*) FROM runs WHERE state IN (?, ?)",
+          arguments: StatementArguments(activeStates)
         ) ?? 0
 
       let oldestRunAgeSeconds: Double? =
         try Date.fetchOne(
           db,
-          sql: "SELECT MIN(created_ts) FROM runs WHERE state = ?",
-          arguments: [RunState.running.rawValue]
+          sql: "SELECT MIN(created_ts) FROM runs WHERE state IN (?, ?)",
+          arguments: StatementArguments(activeStates)
         ).map { now.timeIntervalSince($0) }
 
       let lastFailedAt = try Date.fetchOne(
@@ -163,6 +222,35 @@ public struct RunStoreGRDB: RunStore {
     }
   }
 
+  @discardableResult
+  private static func transitionRun(
+    _ db: Database,
+    runId: Int64,
+    event: RunEvent,
+    now: Date
+  ) throws -> RunState? {
+    let rawState = try String.fetchOne(
+      db,
+      sql: "SELECT state FROM runs WHERE id = ?",
+      arguments: [runId]
+    )
+
+    guard
+      let rawState,
+      let state = RunState(rawValue: rawState),
+      let nextState = RunFSM.reduce(state: state, on: event)
+    else {
+      return nil
+    }
+
+    try db.execute(
+      sql: "UPDATE runs SET state = ?, updated_ts = ? WHERE id = ?",
+      arguments: [nextState.rawValue, now, runId]
+    )
+
+    return nextState
+  }
+
   static func insertUsage(_ db: Database, _ usage: ProviderUsage) throws {
     try db.execute(
       sql: """
@@ -184,7 +272,13 @@ public struct RunStoreGRDB: RunStore {
     )
   }
 
-  static func insertOutbox(_ db: Database, runId: Int64, chunk: OutboxChunk, now: Date) throws {
+  @discardableResult
+  static func insertOutbox(
+    _ db: Database,
+    runId: Int64,
+    chunk: OutboxChunk,
+    now: Date
+  ) throws -> Bool {
     try db.execute(
       sql: """
         INSERT OR IGNORE INTO outbound_deliveries(run_id, step_index, chat_id, dedup_key, payload,
@@ -201,5 +295,6 @@ public struct RunStoreGRDB: RunStore {
         now,
       ]
     )
+    return db.changesCount > 0
   }
 }

--- a/Sources/ClawData/RunStoreGRDB.swift
+++ b/Sources/ClawData/RunStoreGRDB.swift
@@ -35,7 +35,11 @@ public struct RunStoreGRDB: RunStore {
         return nil
       }
 
-      let event: RunEvent = reason == .cancelled ? .cancel : .supersede
+      let event: RunEvent =
+        switch reason {
+        case .cancelled: .cancel
+        case .superseded: .supersede
+        }
       guard try Self.transitionRun(db, runId: runId, event: event, now: now) != nil else {
         return nil
       }
@@ -109,8 +113,9 @@ public struct RunStoreGRDB: RunStore {
         ]
       )
       try Self.insertUsage(db, usage)
+
       for chunk in turn.chunks {
-        try Self.insertOutbox(db, runId: turn.runId, chunk: chunk, now: now)
+        _ = try Self.insertOutbox(db, runId: turn.runId, chunk: chunk, now: now)
       }
     }
   }
@@ -121,7 +126,10 @@ public struct RunStoreGRDB: RunStore {
     }
   }
 
-  public func reconcileRunsAtBoot(now: Date, degradationText: String) throws -> [DegradationReply] {
+  public func reconcileRunsAtBoot(
+    now: Date,
+    degradationText: String
+  ) throws -> [DegradationReply] {
     try writer.writeMapping { db in
       let stale = try Row.fetchAll(
         db,
@@ -222,7 +230,6 @@ public struct RunStoreGRDB: RunStore {
     }
   }
 
-  @discardableResult
   private static func transitionRun(
     _ db: Database,
     runId: Int64,
@@ -272,7 +279,6 @@ public struct RunStoreGRDB: RunStore {
     )
   }
 
-  @discardableResult
   static func insertOutbox(
     _ db: Database,
     runId: Int64,

--- a/Sources/ClawData/SessionMessageStoreGRDB.swift
+++ b/Sources/ClawData/SessionMessageStoreGRDB.swift
@@ -24,7 +24,13 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
       )
 
       guard newlyClaimed else {
-        return ClaimResult(newlyClaimed: false, sessionId: nil, messageId: nil)
+        return ClaimResult(
+          newlyClaimed: false,
+          sessionId: nil,
+          messageId: nil,
+          runId: nil,
+          triggerMessageId: nil
+        )
       }
 
       let sessionId = try Self.upsertSession(db, sessionKey: inbound.sessionKey, now: inbound.ts)
@@ -37,33 +43,86 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
           """,
         arguments: [sessionId, inbound.text, inbound.ts]
       )
+      let messageId = db.lastInsertedRowID
+
+      try db.execute(
+        sql: """
+          INSERT INTO runs(session_id, state, created_ts, updated_ts, trigger_message_id)
+          VALUES (?, ?, ?, ?, ?)
+          """,
+        arguments: [
+          sessionId,
+          RunState.pending.rawValue,
+          inbound.ts,
+          inbound.ts,
+          messageId,
+        ]
+      )
+      let runId = db.lastInsertedRowID
 
       return ClaimResult(
         newlyClaimed: true,
         sessionId: sessionId,
-        messageId: db.lastInsertedRowID
+        messageId: messageId,
+        runId: runId,
+        triggerMessageId: messageId
       )
     }
   }
 
-  public func loadRecentMessages(sessionId: Int64, limit: Int) throws -> [StoredMessage] {
+  public func loadContext(
+    sessionId: Int64,
+    throughMessageId: Int64,
+    limit: Int
+  ) throws -> [StoredMessage] {
     try writer.readMapping { db in
-      // Most-recent `limit` by (ts, id) DESC, then reversed to oldest-first for context assembly.
+      // Limit the newest eligible rows first, then restore chronological order for the model.
       let rows = try Row.fetchAll(
         db,
         sql: """
-          SELECT role, content, provenance FROM messages
-          WHERE session_id = ? ORDER BY ts DESC, id DESC LIMIT ?
+          SELECT role, content, provenance FROM (
+            SELECT m.id, m.role, m.content, m.provenance
+            FROM messages m
+            JOIN sessions s ON s.id = m.session_id
+            WHERE m.session_id = ?
+              AND m.id > s.window_start_message_id
+              AND m.id <= ?
+            ORDER BY m.id DESC
+            LIMIT ?
+          )
+          ORDER BY id ASC
           """,
-        arguments: [sessionId, limit]
+        arguments: [sessionId, throughMessageId, limit]
       )
-      return rows.reversed().map { row in
+
+      return rows.map { row in
         StoredMessage(
           role: MessageRole(rawValue: row["role"]) ?? .user,
           content: row["content"],
           provenance: Provenance(rawValue: row["provenance"]) ?? .trusted
         )
       }
+    }
+  }
+
+  public func resetWindowAndDetaint(sessionId: Int64, now: Date) throws {
+    try writer.writeMapping { db in
+      // The boundary and detaint must move atomically so `/new` cannot expose a mixed session state.
+      let boundary =
+        try Int64.fetchOne(
+          db,
+          sql: "SELECT COALESCE(MAX(id), 0) FROM messages WHERE session_id = ?",
+          arguments: [sessionId]
+        ) ?? 0
+
+      try db.execute(
+        sql: """
+          UPDATE sessions
+          SET window_start_message_id = ?, tainted = 0, updated_ts = ?
+          WHERE id = ?
+          """,
+        arguments: [boundary, now, sessionId]
+      )
     }
   }
 

--- a/Sources/ClawGateway/MessageRouter.swift
+++ b/Sources/ClawGateway/MessageRouter.swift
@@ -1,3 +1,4 @@
+import ClawAgent
 import ClawCore
 import Foundation
 import Logging
@@ -21,6 +22,7 @@ public struct MessageRouter: Sendable {
   private let accessControl: AccessControl
   private let transport: any TelegramTransport
   private let turnRunner: any TurnDispatching
+  private let lanes: SessionLaneRegistry
   private let logger: Logger
 
   public init(
@@ -29,6 +31,7 @@ public struct MessageRouter: Sendable {
     accessControl: AccessControl,
     transport: any TelegramTransport,
     turnRunner: any TurnDispatching,
+    lanes: SessionLaneRegistry,
     logger: Logger
   ) {
     self.processed = processed
@@ -36,6 +39,7 @@ public struct MessageRouter: Sendable {
     self.accessControl = accessControl
     self.transport = transport
     self.turnRunner = turnRunner
+    self.lanes = lanes
     self.logger = logger
   }
 
@@ -81,10 +85,8 @@ public struct MessageRouter: Sendable {
     }
   }
 
-  /// The real §4 turn path: fuse claim+persist in one write, then dispatch the run. A full disk on
-  /// either the persist or the run's first write surfaces as the storage-full path; every other run
-  /// error is already degraded in-band (the reply is enqueued), so it's logged and swallowed — the
-  /// update is durably claimed, so re-polling it would only redeliver a duplicate.
+  /// Fuses claim + persistence, then enqueues the durable run and returns without awaiting it.
+  /// Persistence failure prevents cursor advancement; background turn failures are logged in-band.
   private func dispatchTurn(
     rawUpdate: RawUpdate,
     message: IncomingMessage,
@@ -110,19 +112,30 @@ public struct MessageRouter: Sendable {
       return .transientFailure
     }
 
-    guard claim.newlyClaimed, let sessionId = claim.sessionId else {
+    guard
+      claim.newlyClaimed,
+      let sessionId = claim.sessionId,
+      let runId = claim.runId,
+      let triggerMessageId = claim.triggerMessageId
+    else {
       logger.debug("duplicate update \(rawUpdate.updateId), skipping")
       return .skipped
     }
 
-    do {
-      try await turnRunner.run(sessionId: sessionId, chatId: message.chatId)
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      // The run degrades every other failure in-band (reply already enqueued), so there's nothing
-      // to recover here; the claimed update should still advance.
-      logger.error("turn run error (handled in-band) for update \(rawUpdate.updateId): \(error)")
+    let lane = await lanes.actor(for: sessionId)
+    await lane.enqueue(runId: runId) { [turnRunner, logger] in
+      do {
+        try await turnRunner.run(
+          runId: runId,
+          sessionId: sessionId,
+          chatId: message.chatId,
+          triggerMessageId: triggerMessageId
+        )
+      } catch StoreError.diskFull {
+        logger.error("turn \(runId) stopped by storage full after enqueue")
+      } catch {
+        logger.error("turn run error (handled in-band) for update \(rawUpdate.updateId): \(error)")
+      }
     }
 
     return .processed

--- a/Sources/ClawGateway/TurnRunner.swift
+++ b/Sources/ClawGateway/TurnRunner.swift
@@ -19,7 +19,6 @@ public struct TurnRunner: TurnDispatching {
   private let sessionMessages: any SessionMessageStore
   private let runs: any RunStore
   private let usageStore: any UsageStore
-  private let outbox: any OutboxStore
   private let audit: any AuditLog
   private let agent: AgentRuntime
   private let budget: RunBudget
@@ -39,7 +38,6 @@ public struct TurnRunner: TurnDispatching {
     sessionMessages: any SessionMessageStore,
     runs: any RunStore,
     usageStore: any UsageStore,
-    outbox: any OutboxStore,
     audit: any AuditLog,
     agent: AgentRuntime,
     budget: RunBudget,
@@ -52,7 +50,6 @@ public struct TurnRunner: TurnDispatching {
     self.sessionMessages = sessionMessages
     self.runs = runs
     self.usageStore = usageStore
-    self.outbox = outbox
     self.audit = audit
     self.agent = agent
     self.budget = budget
@@ -135,38 +132,46 @@ public struct TurnRunner: TurnDispatching {
         usage: usage,
         chunks: outboxChunks(for: content, chatId: chatId)
       )
-      try runs.commitAssistantTurn(turn, now: committedAt)
-      try audit.appendAudit(
-        turnAudit(
-          action: .turnCompleted,
-          runId: runId,
-          sessionId: sessionId,
-          resultSize: content.utf8.count,
-          at: committedAt
-        )
-      )
-      notifyOutbox()
-      await notifyDailyCapIfTripped(chatId: chatId, runId: runId, sessionId: sessionId)
-    case .degraded(let degradationKind, let usage):
-      if let usage {
-        try usageStore.recordUsage(usage)
-      }
 
-      try degradeAndFail(
+      let commitResult = try runs.commitAssistantTurn(turn, now: committedAt)
+      switch commitResult {
+      case .committed:
+        try audit.appendAudit(
+          turnAudit(
+            action: .turnCompleted,
+            runId: runId,
+            sessionId: sessionId,
+            resultSize: content.utf8.count,
+            at: committedAt
+          )
+        )
+        notifyOutbox()
+        await notifyDailyCapIfTripped(chatId: chatId, runId: runId, sessionId: sessionId)
+      case .usageRecordedAfterTerminal:
+        await notifyDailyCapIfTripped(chatId: chatId, runId: runId, sessionId: sessionId)
+      case .ignored:
+        return
+      }
+    case .degraded(let degradationKind, let usage):
+      let commitResult = try commitDegradation(
         runId: runId,
         sessionId: sessionId,
         chatId: chatId,
+        usage: usage,
         message: Degradation.message(for: degradationKind),
         action: .turnDegraded,
         decision: degradationKind.rawValue,
         at: committedAt
       )
-      await notifyDailyCapIfTripped(chatId: chatId, runId: runId, sessionId: sessionId)
+      if commitResult != .ignored {
+        await notifyDailyCapIfTripped(chatId: chatId, runId: runId, sessionId: sessionId)
+      }
     case .budgetStopped(let cap):
-      try degradeAndFail(
+      _ = try commitDegradation(
         runId: runId,
         sessionId: sessionId,
         chatId: chatId,
+        usage: nil,
         message: Degradation.budget(cap: cap),
         action: .turnBudgetStopped,
         decision: cap,
@@ -175,30 +180,39 @@ public struct TurnRunner: TurnDispatching {
     }
   }
 
-  /// The shared failure tail: enqueue the degradation reply, then fail the run, then audit. The
-  /// enqueue precedes `failRun` so a crash between them leaves a PENDING reply for boot reconcile
-  /// to deliver (F22) rather than losing it.
-  private func degradeAndFail(  // swiftlint:disable:this function_parameter_count
+  /// The shared failure tail. The store owns the run-state arbitration and writes usage, FAILED,
+  /// and the degradation outbox row in one transaction so `/stop`/`/new` cannot interleave.
+  private func commitDegradation(  // swiftlint:disable:this function_parameter_count
     runId: Int64,
     sessionId: Int64,
     chatId: Int64,
+    usage: ProviderUsage?,
     message: String,
     action: AuditAction,
     decision: String,
     at committedAt: Date
-  ) throws {
-    let claimed = try outbox.claimOutboundIfRunActive(
-      runId: runId,
+  ) throws -> RunCommitResult {
+    let chunk = OutboxChunk(
       stepIndex: 0,
       chatId: chatId,
       payload: message,
       payloadHash: ContentHash.fnv1a(message)
     )
-    guard claimed else {
-      return
+
+    let commitResult = try runs.commitDegradedTurn(
+      DegradedTurn(
+        runId: runId,
+        sessionId: sessionId,
+        chatId: chatId,
+        usage: usage,
+        chunk: chunk
+      ),
+      now: committedAt
+    )
+    guard commitResult == .committed else {
+      return commitResult
     }
 
-    try runs.failRun(runId: runId, now: committedAt)
     try audit.appendAudit(
       turnAudit(
         action: action,
@@ -209,6 +223,8 @@ public struct TurnRunner: TurnDispatching {
       )
     )
     notifyOutbox()
+
+    return commitResult
   }
 
   /// Post-commit daily kill-switch. Reads today's totals (durable, from `provider_usage`) and asks

--- a/Sources/ClawGateway/TurnRunner.swift
+++ b/Sources/ClawGateway/TurnRunner.swift
@@ -5,13 +5,16 @@ import Logging
 
 /// Injected behind a protocol so the router/poller tests stay decoupled from the real provider.
 public protocol TurnDispatching: Sendable {
-  func run(sessionId: Int64, chatId: Int64) async throws
+  func run(
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    triggerMessageId: Int64
+  ) async throws
 }
 
-/// Orchestrates one inline turn at the gateway boundary: create the run, assemble context, hand it
-/// to the agent, then persist the outcome. The agent never throws (every failure is a `TurnResult`),
-/// so the only error `run` propagates is `StoreError.diskFull` — the router maps that to the
-/// storage-full path; every other failure is degraded in-band and enqueued (never silence).
+/// Picks up a durable PENDING run, assembles its trigger-bounded context, executes the agent, and
+/// persists the outcome.
 public struct TurnRunner: TurnDispatching {
   private let sessionMessages: any SessionMessageStore
   private let runs: any RunStore
@@ -60,12 +63,29 @@ public struct TurnRunner: TurnDispatching {
     self.logger = logger
   }
 
-  public func run(sessionId: Int64, chatId: Int64) async throws {
-    let now = Date()
-    let runId = try runs.createRun(sessionId: sessionId, now: now)
+  public func run(
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    triggerMessageId: Int64
+  ) async throws {
+    guard !Task.isCancelled else {
+      return
+    }
 
-    let history = try sessionMessages.loadRecentMessages(
+    let now = Date()
+    guard try runs.pickUp(runId: runId, now: now) else {
+      logger.debug("run \(runId) was not pending at pickup; skipping turn")
+      return
+    }
+
+    guard !Task.isCancelled else {
+      return
+    }
+
+    let history = try sessionMessages.loadContext(
       sessionId: sessionId,
+      throughMessageId: triggerMessageId,
       limit: Self.historyLimit
     )
     let (todayTokens, todayUSD) = try usageStore.todayTokensAndCost(now: now)
@@ -167,16 +187,17 @@ public struct TurnRunner: TurnDispatching {
     decision: String,
     at committedAt: Date
   ) throws {
-    // The `newlyClaimed` result is ignored: the dedup key is `runId:stepIndex`, and each turn gets
-    // a fresh `runId`, so this first chunk always inserts — a `false` here would mean a duplicate
-    // delivery, which can't occur for a brand-new run.
-    _ = try outbox.claimOutbound(
+    let claimed = try outbox.claimOutboundIfRunActive(
       runId: runId,
       stepIndex: 0,
       chatId: chatId,
       payload: message,
       payloadHash: ContentHash.fnv1a(message)
     )
+    guard claimed else {
+      return
+    }
+
     try runs.failRun(runId: runId, now: committedAt)
     try audit.appendAudit(
       turnAudit(

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -129,6 +129,7 @@ struct RunCommand: AsyncParsableCommand {
     // the dispatcher to drain the rows it just enqueued.
     let outboxSignal = OutboxSignal()
     let breaker = BudgetBreaker(budget: config.budget)
+    let lanes = SessionLaneRegistry()
     let turnRunner = TurnRunner(
       sessionMessages: stores.sessionMessages,
       runs: stores.runs,
@@ -149,6 +150,7 @@ struct RunCommand: AsyncParsableCommand {
       accessControl: AccessControl(allowlist: stores.allowlist),
       transport: transport,
       turnRunner: turnRunner,
+      lanes: lanes,
       logger: logger
     )
     let poller = TelegramPollerService(

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -134,7 +134,6 @@ struct RunCommand: AsyncParsableCommand {
       sessionMessages: stores.sessionMessages,
       runs: stores.runs,
       usageStore: stores.usage,
-      outbox: stores.outbox,
       audit: stores.audit,
       agent: agent,
       budget: config.budget,

--- a/Tests/ClawAgentTests/SessionActorTests.swift
+++ b/Tests/ClawAgentTests/SessionActorTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+
+@testable import ClawAgent
+
+@Suite struct SessionActorTests {
+  actor Recorder {
+    private var events: [String] = []
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func append(_ event: String) {
+      events.append(event)
+      for continuation in continuations {
+        continuation.resume()
+      }
+      continuations.removeAll()
+    }
+
+    func snapshot() -> [String] {
+      events
+    }
+
+    func waitForCount(_ count: Int) async {
+      while events.count < count {
+        await withCheckedContinuation { continuation in
+          continuations.append(continuation)
+        }
+      }
+    }
+  }
+
+  @Test func queuedWorkRunsFifoAndDoesNotInterleave() async {
+    // given
+    let lane = SessionActor()
+    let recorder = Recorder()
+
+    // when
+    await lane.enqueue(runId: 1) {
+      await recorder.append("a-start")
+      try? await Task.sleep(for: .milliseconds(20))
+      await recorder.append("a-end")
+    }
+    await lane.enqueue(runId: 2) {
+      await recorder.append("b-start")
+      await recorder.append("b-end")
+    }
+    await recorder.waitForCount(4)
+
+    // then
+    #expect(await recorder.snapshot() == ["a-start", "a-end", "b-start", "b-end"])
+  }
+
+  @Test func cancelledQueuedTaskStillReachesWorkBodyForDatabaseSelfAbort() async {
+    // given
+    let lane = SessionActor()
+    let recorder = Recorder()
+
+    // when
+    await lane.enqueue(runId: 1) {
+      try? await Task.sleep(for: .milliseconds(20))
+      await recorder.append("a")
+    }
+    await lane.enqueue(runId: 2) {
+      await recorder.append(Task.isCancelled ? "b-cancelled" : "b-running")
+    }
+    await lane.cancel(runId: 2)
+    await recorder.waitForCount(2)
+
+    // then
+    #expect(await recorder.snapshot() == ["a", "b-cancelled"])
+  }
+
+  @Test func registryReusesActorsPerSession() async {
+    // given
+    let registry = SessionLaneRegistry()
+
+    // when
+    let first = await registry.actor(for: 1)
+    let again = await registry.actor(for: 1)
+    let second = await registry.actor(for: 2)
+
+    // then
+    #expect(first === again)
+    #expect(first !== second)
+    #expect(await registry.count == 2)
+  }
+}

--- a/Tests/ClawCoreTests/RunFSMTests.swift
+++ b/Tests/ClawCoreTests/RunFSMTests.swift
@@ -2,24 +2,24 @@ import Testing
 
 @testable import ClawCore
 
-/// The run lifecycle is a small reducer: `RunFSM.reduce` is the single source of truth for which
-/// `(state, event)` pairs are legal. These tests pin the Inc 1 transition table and prove that an
-/// illegal pair returns `nil` rather than silently defaulting to some state.
 @Suite struct RunFSMTests {
-  /// One row of the legal transition table: applying `event` to `state` must yield `expected`.
   private struct Transition {
     let state: RunState
     let event: RunEvent
     let expected: RunState
   }
 
-  @Test func legalInc1Transitions() {
-    // given — every transition the Inc 1 lifecycle is allowed to make
+  @Test func legalTransitions() {
+    // given
     let legal = [
       Transition(state: .pending, event: .pickUp, expected: .running),
+      Transition(state: .pending, event: .fail, expected: .failed),
+      Transition(state: .pending, event: .cancel, expected: .cancelled),
+      Transition(state: .pending, event: .supersede, expected: .superseded),
       Transition(state: .running, event: .complete, expected: .done),
       Transition(state: .running, event: .fail, expected: .failed),
-      Transition(state: .pending, event: .fail, expected: .failed),
+      Transition(state: .running, event: .cancel, expected: .cancelled),
+      Transition(state: .running, event: .supersede, expected: .superseded),
     ]
 
     for transition in legal {
@@ -32,11 +32,14 @@ import Testing
   }
 
   @Test func illegalTransitionsHaveNoDefaultArm() {
-    // given — pairs that must never move the state (no default arm hides them)
+    // given
     let illegal: [(state: RunState, event: RunEvent)] = [
-      (.done, .complete),  // a finished run can't complete again
-      (.failed, .pickUp),  // a failed run can't be picked back up
-      (.done, .fail),  // a finished run can't be failed
+      (.done, .complete),
+      (.failed, .pickUp),
+      (.cancelled, .complete),
+      (.superseded, .fail),
+      (.pending, .complete),
+      (.running, .pickUp),
     ]
 
     for transition in illegal {

--- a/Tests/ClawDataTests/OutboxStoreTests.swift
+++ b/Tests/ClawDataTests/OutboxStoreTests.swift
@@ -5,32 +5,52 @@ import Testing
 @testable import ClawData
 
 @Suite struct OutboxStoreTests {
-  private func fixture() throws -> (OutboxStoreGRDB, Int64) {
+  private struct Fixture {
+    let outbox: OutboxStoreGRDB
+    let runs: RunStoreGRDB
+    let sessionId: Int64
+    let runId: Int64
+  }
+
+  private func fixture() throws -> Fixture {
     let queue = try ClawDatabase.makeInMemoryQueue()
     try ClawDatabase.migrate(queue)
     let sessions = SessionMessageStoreGRDB(writer: queue)
-    let sessionId = try sessions.loadOrCreateSession(
-      sessionKey: SessionKey.telegramDM(chatId: 42),
-      now: Date()
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: 42),
+        chatId: 42,
+        userId: 42,
+        text: "seed",
+        isEdited: false,
+        ts: Date()
+      )
     )
-    let runId = try RunStoreGRDB(writer: queue).createRun(sessionId: sessionId, now: Date())
-    return (OutboxStoreGRDB(writer: queue), runId)
+    let sessionId = try #require(claim.sessionId)
+    let runId = try #require(claim.runId)
+    return Fixture(
+      outbox: OutboxStoreGRDB(writer: queue),
+      runs: RunStoreGRDB(writer: queue),
+      sessionId: sessionId,
+      runId: runId
+    )
   }
 
   @Test func claimIsIdempotentOnTheDeterministicKey() throws {
     // given
-    let (outbox, runId) = try fixture()
+    let env = try fixture()
 
     // when — the same run_id:step_index claimed twice
-    let first = try outbox.claimOutbound(
-      runId: runId,
+    let first = try env.outbox.claimOutbound(
+      runId: env.runId,
       stepIndex: 0,
       chatId: 42,
       payload: "p",
       payloadHash: "h"
     )
-    let second = try outbox.claimOutbound(
-      runId: runId,
+    let second = try env.outbox.claimOutbound(
+      runId: env.runId,
       stepIndex: 0,
       chatId: 42,
       payload: "p",
@@ -40,14 +60,14 @@ import Testing
     // then — INSERT OR IGNORE dedups; one PENDING row
     #expect(first)
     #expect(second == false)
-    #expect(try outbox.pendingOutbound().count == 1)
+    #expect(try env.outbox.pendingOutbound().count == 1)
   }
 
   @Test func markSentRemovesRowFromPending() throws {
     // given
-    let (outbox, runId) = try fixture()
-    let claimed = try outbox.claimOutbound(
-      runId: runId,
+    let env = try fixture()
+    let claimed = try env.outbox.claimOutbound(
+      runId: env.runId,
       stepIndex: 0,
       chatId: 42,
       payload: "p",
@@ -56,9 +76,54 @@ import Testing
     #expect(claimed)
 
     // when
-    try outbox.markSent(runId: runId, stepIndex: 0, telegramMessageId: 555, now: Date())
+    try env.outbox.markSent(
+      runId: env.runId,
+      stepIndex: 0,
+      telegramMessageId: 555,
+      now: Date()
+    )
 
     // then
-    #expect(try outbox.pendingOutbound().isEmpty)
+    #expect(try env.outbox.pendingOutbound().isEmpty)
+  }
+
+  @Test func activeClaimOnlyInsertsForRunningRun() throws {
+    // given
+    let env = try fixture()
+
+    // when / then
+    #expect(
+      try env.outbox.claimOutboundIfRunActive(
+        runId: env.runId,
+        stepIndex: 0,
+        chatId: 42,
+        payload: "pending",
+        payloadHash: "p"
+      ) == false
+    )
+    #expect(try env.runs.pickUp(runId: env.runId, now: Date()))
+    #expect(
+      try env.outbox.claimOutboundIfRunActive(
+        runId: env.runId,
+        stepIndex: 0,
+        chatId: 42,
+        payload: "running",
+        payloadHash: "r"
+      )
+    )
+    _ = try env.runs.cancelActiveRun(
+      sessionId: env.sessionId,
+      reason: .cancelled,
+      now: Date()
+    )
+    #expect(
+      try env.outbox.claimOutboundIfRunActive(
+        runId: env.runId,
+        stepIndex: 1,
+        chatId: 42,
+        payload: "cancelled",
+        payloadHash: "c"
+      ) == false
+    )
   }
 }

--- a/Tests/ClawDataTests/PersistenceSchemaMigrationTests.swift
+++ b/Tests/ClawDataTests/PersistenceSchemaMigrationTests.swift
@@ -49,4 +49,40 @@ import Testing
         && (dbErr.message?.contains("FOREIGN KEY") ?? false)
     }
   }
+
+  @Test func migrationV3AddsLaneLifecycleColumns() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+
+    // when
+    try ClawDatabase.migrate(queue)
+
+    // then
+    let sessionColumns = try queue.read { db in
+      try Row.fetchAll(db, sql: "PRAGMA table_info(sessions)")
+    }
+    let runColumns = try queue.read { db in
+      try Row.fetchAll(db, sql: "PRAGMA table_info(runs)")
+    }
+
+    let windowColumn = try #require(
+      sessionColumns.first { row in
+        let name: String = row["name"]
+        return name == "window_start_message_id"
+      }
+    )
+    let windowNotNull: Int = windowColumn["notnull"]
+    let windowDefault: String = windowColumn["dflt_value"]
+    #expect(windowNotNull == 1)
+    #expect(windowDefault == "0")
+
+    let triggerColumn = try #require(
+      runColumns.first { row in
+        let name: String = row["name"]
+        return name == "trigger_message_id"
+      }
+    )
+    let triggerNotNull: Int = triggerColumn["notnull"]
+    #expect(triggerNotNull == 0)
+  }
 }

--- a/Tests/ClawDataTests/RunStoreTests.swift
+++ b/Tests/ClawDataTests/RunStoreTests.swift
@@ -147,7 +147,7 @@ import Testing
     #expect(try env.runs.pickUp(runId: queuedRunId, now: Date()) == false)
   }
 
-  @Test func commitAndFailNoOpWhenRunIsTerminal() throws {
+  @Test func assistantCommitAfterSupersedeRecordsUsageOnly() throws {
     // given
     let env = try fixture()
     _ = try env.runs.supersedeSessionRuns(sessionId: env.sessionId, now: Date())
@@ -161,7 +161,7 @@ import Testing
     )
 
     // when
-    try env.runs.commitAssistantTurn(turn, now: Date())
+    let result = try env.runs.commitAssistantTurn(turn, now: Date())
     try env.runs.failRun(runId: env.seedRunId, now: Date())
 
     // then
@@ -186,7 +186,8 @@ import Testing
         try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM messages WHERE role = 'assistant'")
       }
     )
-    #expect(usageCount == 0)
+    #expect(result == .usageRecordedAfterTerminal)
+    #expect(usageCount == 1)
     #expect(assistantCount == 0)
   }
 
@@ -205,7 +206,7 @@ import Testing
     )
 
     // when
-    try env.runs.commitAssistantTurn(turn, now: Date())
+    let result = try env.runs.commitAssistantTurn(turn, now: Date())
 
     // then
     let assistantCount = try #require(
@@ -224,6 +225,7 @@ import Testing
       }
     )
     #expect(state == RunState.done.rawValue)
+    #expect(result == .committed)
     #expect(try env.outbox.pendingOutbound().count == 1)
     let (tokens, _) = try env.usage.todayTokensAndCost(now: Date())
     #expect(tokens == 30)
@@ -308,7 +310,9 @@ import Testing
 
     // when / then — the commit throws and writes NOTHING: no assistant message, run still RUNNING,
     // no provider_usage (F6 atomicity — all four side effects share one transaction)
-    #expect(throws: (any Error).self) { try env.runs.commitAssistantTurn(turn, now: Date()) }
+    #expect(throws: (any Error).self) {
+      _ = try env.runs.commitAssistantTurn(turn, now: Date())
+    }
     let assistantCount = try #require(
       try env.queue.read { db in
         try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM messages WHERE role = 'assistant'")

--- a/Tests/ClawDataTests/RunStoreTests.swift
+++ b/Tests/ClawDataTests/RunStoreTests.swift
@@ -13,23 +13,34 @@ import Testing
     let usage: UsageStoreGRDB
     let outbox: OutboxStoreGRDB
     let sessionId: Int64
+    let seedRunId: Int64
   }
 
   private func fixture() throws -> Fixture {
     let queue = try ClawDatabase.makeInMemoryQueue()
     try ClawDatabase.migrate(queue)
     let sessions = SessionMessageStoreGRDB(writer: queue)
-    let sessionId = try sessions.loadOrCreateSession(
-      sessionKey: SessionKey.telegramDM(chatId: 42),
-      now: Date()
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: 42),
+        chatId: 42,
+        userId: 42,
+        text: "hi",
+        isEdited: false,
+        ts: Date()
+      )
     )
+    let sessionId = try #require(claim.sessionId)
+    let seedRunId = try #require(claim.runId)
     return Fixture(
       queue: queue,
       sessions: sessions,
       runs: RunStoreGRDB(writer: queue),
       usage: UsageStoreGRDB(writer: queue),
       outbox: OutboxStoreGRDB(writer: queue),
-      sessionId: sessionId
+      sessionId: sessionId,
+      seedRunId: seedRunId
     )
   }
 
@@ -47,10 +58,143 @@ import Testing
     )
   }
 
+  @Test func pickUpMovesPendingRunToRunningOnce() throws {
+    // given
+    let env = try fixture()
+
+    // when
+    let first = try env.runs.pickUp(runId: env.seedRunId, now: Date())
+    let second = try env.runs.pickUp(runId: env.seedRunId, now: Date())
+
+    // then
+    #expect(first)
+    #expect(second == false)
+    let state = try #require(
+      try env.queue.read { db in
+        try String.fetchOne(
+          db,
+          sql: "SELECT state FROM runs WHERE id = ?",
+          arguments: [env.seedRunId]
+        )
+      }
+    )
+    #expect(state == RunState.running.rawValue)
+  }
+
+  @Test func cancelActiveRunOnlyCancelsRunningRun() throws {
+    // given
+    let env = try fixture()
+    #expect(
+      try env.runs.cancelActiveRun(
+        sessionId: env.sessionId,
+        reason: .cancelled,
+        now: Date()
+      ) == nil
+    )
+    #expect(try env.runs.pickUp(runId: env.seedRunId, now: Date()))
+
+    // when
+    let cancelled = try env.runs.cancelActiveRun(
+      sessionId: env.sessionId,
+      reason: .cancelled,
+      now: Date()
+    )
+
+    // then
+    #expect(cancelled == env.seedRunId)
+    let state = try #require(
+      try env.queue.read { db in
+        try String.fetchOne(
+          db,
+          sql: "SELECT state FROM runs WHERE id = ?",
+          arguments: [env.seedRunId]
+        )
+      }
+    )
+    #expect(state == RunState.cancelled.rawValue)
+  }
+
+  @Test func supersedeSessionRunsTerminatesRunningAndQueuedRuns() throws {
+    // given
+    let env = try fixture()
+    #expect(try env.runs.pickUp(runId: env.seedRunId, now: Date()))
+    let queued = try env.sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 2,
+        sessionKey: SessionKey.telegramDM(chatId: 42),
+        chatId: 42,
+        userId: 42,
+        text: "queued",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let queuedRunId = try #require(queued.runId)
+
+    // when
+    let superseded = try env.runs.supersedeSessionRuns(sessionId: env.sessionId, now: Date())
+
+    // then
+    #expect(superseded == [env.seedRunId, queuedRunId])
+    let states = try env.queue.read { db in
+      try String.fetchAll(
+        db,
+        sql: "SELECT state FROM runs WHERE id IN (?, ?) ORDER BY id ASC",
+        arguments: [env.seedRunId, queuedRunId]
+      )
+    }
+    #expect(states == [RunState.superseded.rawValue, RunState.superseded.rawValue])
+    #expect(try env.runs.pickUp(runId: queuedRunId, now: Date()) == false)
+  }
+
+  @Test func commitAndFailNoOpWhenRunIsTerminal() throws {
+    // given
+    let env = try fixture()
+    _ = try env.runs.supersedeSessionRuns(sessionId: env.sessionId, now: Date())
+    let turn = AssistantTurn(
+      runId: env.seedRunId,
+      sessionId: env.sessionId,
+      chatId: 42,
+      content: "answer",
+      usage: usage(runId: env.seedRunId, sessionId: env.sessionId),
+      chunks: [OutboxChunk(stepIndex: 0, chatId: 42, payload: "answer", payloadHash: "h")]
+    )
+
+    // when
+    try env.runs.commitAssistantTurn(turn, now: Date())
+    try env.runs.failRun(runId: env.seedRunId, now: Date())
+
+    // then
+    let state = try #require(
+      try env.queue.read { db in
+        try String.fetchOne(
+          db,
+          sql: "SELECT state FROM runs WHERE id = ?",
+          arguments: [env.seedRunId]
+        )
+      }
+    )
+    #expect(state == RunState.superseded.rawValue)
+    #expect(try env.outbox.pendingOutbound().isEmpty)
+    let usageCount = try #require(
+      try env.queue.read { db in
+        try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM provider_usage")
+      }
+    )
+    let assistantCount = try #require(
+      try env.queue.read { db in
+        try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM messages WHERE role = 'assistant'")
+      }
+    )
+    #expect(usageCount == 0)
+    #expect(assistantCount == 0)
+  }
+
   @Test func commitAssistantTurnWritesMessageDoneUsageAndOutboxTogether() throws {
     // given
     let env = try fixture()
-    let runId = try env.runs.createRun(sessionId: env.sessionId, now: Date())
+    let runId = env.seedRunId
+    #expect(try env.runs.pickUp(runId: runId, now: Date()))
     let turn = AssistantTurn(
       runId: runId,
       sessionId: env.sessionId,
@@ -63,11 +207,17 @@ import Testing
     // when
     try env.runs.commitAssistantTurn(turn, now: Date())
 
-    // then — assistant message persisted, run DONE, usage + one PENDING outbox row
-    let history = try env.sessions.loadRecentMessages(sessionId: env.sessionId, limit: 10)
-    #expect(
-      history.contains(StoredMessage(role: .assistant, content: "answer", provenance: .trusted))
+    // then
+    let assistantCount = try #require(
+      try env.queue.read { db in
+        try Int.fetchOne(
+          db,
+          sql: "SELECT COUNT(*) FROM messages WHERE run_id = ? AND role = 'assistant'",
+          arguments: [runId]
+        )
+      }
     )
+    #expect(assistantCount == 1)
     let state = try #require(
       try env.queue.read { db in
         try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [runId])
@@ -79,29 +229,41 @@ import Testing
     #expect(tokens == 30)
   }
 
-  @Test func reconcileFlipsRunningToFailedAndEnqueuesDegradationWhenNothingDelivered() throws {
-    // given — a run left RUNNING with no outbox row (the crash-mid-call window)
+  @Test func reconcileFlipsPendingAndRunningToFailed() throws {
+    // given
     let env = try fixture()
-    let runId = try env.runs.createRun(sessionId: env.sessionId, now: Date())
+    let pendingRunId = env.seedRunId
+    let runningClaim = try env.sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 2,
+        sessionKey: SessionKey.telegramDM(chatId: 42),
+        chatId: 42,
+        userId: 42,
+        text: "running",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let runningRunId = try #require(runningClaim.runId)
+    #expect(try env.runs.pickUp(runId: runningRunId, now: Date()))
 
     // when
     let replies = try env.runs.reconcileRunsAtBoot(now: Date(), degradationText: "didn't finish")
 
     // then
-    let state = try #require(
-      try env.queue.read { db in
-        try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [runId])
-      }
-    )
-    #expect(state == RunState.failed.rawValue)
-    #expect(replies == [DegradationReply(chatId: 42, runId: runId, text: "didn't finish")])
-    #expect(try env.outbox.pendingOutbound().count == 1)  // degradation reply enqueued
+    let states = try env.queue.read { db in
+      try String.fetchAll(db, sql: "SELECT state FROM runs ORDER BY id ASC")
+    }
+    #expect(states == [RunState.failed.rawValue, RunState.failed.rawValue])
+    #expect(Set(replies.map(\.runId)) == Set([pendingRunId, runningRunId]))
+    #expect(try env.outbox.pendingOutbound().count == 2)
   }
 
   @Test func reconcileDoesNotEnqueueWhenARunAlreadyDelivered() throws {
-    // given — a RUNNING run that already has an outbox row (reply was committed pre-crash)
+    // given
     let env = try fixture()
-    let runId = try env.runs.createRun(sessionId: env.sessionId, now: Date())
+    let runId = env.seedRunId
+    #expect(try env.runs.pickUp(runId: runId, now: Date()))
     _ = try env.outbox.claimOutbound(
       runId: runId,
       stepIndex: 0,
@@ -109,18 +271,26 @@ import Testing
       payload: "x",
       payloadHash: "h"
     )
+    try env.outbox.markSent(runId: runId, stepIndex: 0, telegramMessageId: 1001, now: Date())
 
     // when
     let replies = try env.runs.reconcileRunsAtBoot(now: Date(), degradationText: "didn't finish")
 
-    // then — flipped to FAILED but no new degradation reply
+    // then
     #expect(replies.isEmpty)
+    let state = try #require(
+      try env.queue.read { db in
+        try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [runId])
+      }
+    )
+    #expect(state == RunState.failed.rawValue)
   }
 
   @Test func commitAssistantTurnRollsBackEntirelyWhenTheOutboxInsertAborts() throws {
-    // given — a run, plus a trigger that aborts the outbox INSERT mid-commit
+    // given
     let env = try fixture()
-    let runId = try env.runs.createRun(sessionId: env.sessionId, now: Date())
+    let runId = env.seedRunId
+    #expect(try env.runs.pickUp(runId: runId, now: Date()))
     try env.queue.write { db in
       try db.execute(
         sql:

--- a/Tests/ClawDataTests/RunsHealthTests.swift
+++ b/Tests/ClawDataTests/RunsHealthTests.swift
@@ -6,6 +6,7 @@ import Testing
 
 @Suite struct RunsHealthTests {
   private struct Fixture {
+    let sessions: SessionMessageStoreGRDB
     let store: RunStoreGRDB
     let usage: UsageStoreGRDB
     let sessionId: Int64
@@ -20,10 +21,31 @@ import Testing
       now: Date()
     )
     return Fixture(
+      sessions: sessions,
       store: RunStoreGRDB(writer: queue),
       usage: UsageStoreGRDB(writer: queue),
       sessionId: sessionId
     )
+  }
+
+  private func seedPendingRun(
+    sessions: SessionMessageStoreGRDB,
+    updateId: Int64,
+    chatId: Int64 = 1,
+    ts: Date
+  ) throws -> Int64 {
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: updateId,
+        sessionKey: SessionKey.telegramDM(chatId: chatId),
+        chatId: chatId,
+        userId: chatId,
+        text: "seed",
+        isEdited: false,
+        ts: ts
+      )
+    )
+    return try #require(claim.runId)
   }
 
   private func seedUsage(
@@ -49,15 +71,21 @@ import Testing
   }
 
   private func commitDone(
-    store: RunStoreGRDB,
-    sessionId: Int64,
+    fixture: Fixture,
+    updateId: Int64,
     chatId: Int64,
     now: Date
   ) throws {
-    let runId = try store.createRun(sessionId: sessionId, now: now)
+    let runId = try seedPendingRun(
+      sessions: fixture.sessions,
+      updateId: updateId,
+      chatId: chatId,
+      ts: now
+    )
+    #expect(try fixture.store.pickUp(runId: runId, now: now))
     let usage = ProviderUsage(
       runId: runId,
-      sessionId: sessionId,
+      sessionId: fixture.sessionId,
       model: "m",
       promptTokens: 10,
       completionTokens: 5,
@@ -66,10 +94,10 @@ import Testing
       isEstimated: false,
       ts: now
     )
-    try store.commitAssistantTurn(
+    try fixture.store.commitAssistantTurn(
       AssistantTurn(
         runId: runId,
-        sessionId: sessionId,
+        sessionId: fixture.sessionId,
         chatId: chatId,
         content: "hi",
         usage: usage,
@@ -80,22 +108,39 @@ import Testing
   }
 
   @Test func reportsInFlightAndTrailingFailures() throws {
-    // given — seed: 1 DONE, 2 FAILED, 1 RUNNING (insertion order = ascending id)
+    // given — seed: 1 DONE, 2 FAILED, 1 PENDING (insertion order = ascending id)
     let fix = try makeFixture()
     let store = fix.store
-    let sid = fix.sessionId
     let base = Date(timeIntervalSinceReferenceDate: 0)
 
-    try commitDone(store: store, sessionId: sid, chatId: 2, now: base)
+    try commitDone(
+      fixture: fix,
+      updateId: 1,
+      chatId: 1,
+      now: base
+    )
 
-    let failed1 = try store.createRun(sessionId: sid, now: base.addingTimeInterval(2))
+    let failed1 = try seedPendingRun(
+      sessions: fix.sessions,
+      updateId: 2,
+      ts: base.addingTimeInterval(2)
+    )
+    #expect(try store.pickUp(runId: failed1, now: base.addingTimeInterval(2)))
     try store.failRun(runId: failed1, now: base.addingTimeInterval(3))
 
-    let failed2 = try store.createRun(sessionId: sid, now: base.addingTimeInterval(4))
+    let failed2 = try seedPendingRun(
+      sessions: fix.sessions,
+      updateId: 3,
+      ts: base.addingTimeInterval(4)
+    )
+    #expect(try store.pickUp(runId: failed2, now: base.addingTimeInterval(4)))
     try store.failRun(runId: failed2, now: base.addingTimeInterval(5))
 
-    // RUNNING — left open (simulates in-flight); created at base+6
-    _ = try store.createRun(sessionId: sid, now: base.addingTimeInterval(6))
+    _ = try seedPendingRun(
+      sessions: fix.sessions,
+      updateId: 4,
+      ts: base.addingTimeInterval(6)
+    )
 
     let now = base.addingTimeInterval(10)
 
@@ -104,7 +149,7 @@ import Testing
 
     // then
     #expect(health.inFlight == 1)
-    // RUNNING run created at base+6, now = base+10 → age = 4 s
+    // PENDING run created at base+6, now = base+10 → age = 4 s
     let age = try #require(health.oldestRunAgeSeconds)
     #expect(age == 4)
     // DONE updated at base+1; last FAILED updated at base+5
@@ -112,7 +157,7 @@ import Testing
     #expect(successAt == base.addingTimeInterval(1))
     let failedAt = try #require(health.lastFailedAt)
     #expect(failedAt == base.addingTimeInterval(5))
-    // Most-recent run (highest id) is RUNNING — streak is 0
+    // Most-recent run (highest id) is PENDING — streak is 0
     #expect(health.consecutiveFailures == 0)
   }
 
@@ -120,13 +165,22 @@ import Testing
     // given — seed: 1 DONE then 3 FAILED (no newer run)
     let fix = try makeFixture()
     let store = fix.store
-    let sid = fix.sessionId
     let base = Date(timeIntervalSinceReferenceDate: 0)
 
-    try commitDone(store: store, sessionId: sid, chatId: 3, now: base)
+    try commitDone(
+      fixture: fix,
+      updateId: 1,
+      chatId: 1,
+      now: base
+    )
 
-    for offset in stride(from: 2.0, through: 6.0, by: 2.0) {
-      let runId = try store.createRun(sessionId: sid, now: base.addingTimeInterval(offset))
+    for (index, offset) in stride(from: 2.0, through: 6.0, by: 2.0).enumerated() {
+      let runId = try seedPendingRun(
+        sessions: fix.sessions,
+        updateId: Int64(index + 2),
+        ts: base.addingTimeInterval(offset)
+      )
+      #expect(try store.pickUp(runId: runId, now: base.addingTimeInterval(offset)))
       try store.failRun(runId: runId, now: base.addingTimeInterval(offset + 1))
     }
 
@@ -143,18 +197,33 @@ import Testing
     // newest-first: FAILED(4), DONE(3), FAILED(2), FAILED(1) → streak = 1
     let fix = try makeFixture()
     let store = fix.store
-    let sid = fix.sessionId
     let base = Date(timeIntervalSinceReferenceDate: 0)
 
-    let run1 = try store.createRun(sessionId: sid, now: base)
+    let run1 = try seedPendingRun(sessions: fix.sessions, updateId: 1, ts: base)
+    #expect(try store.pickUp(runId: run1, now: base))
     try store.failRun(runId: run1, now: base.addingTimeInterval(1))
 
-    let run2 = try store.createRun(sessionId: sid, now: base.addingTimeInterval(2))
+    let run2 = try seedPendingRun(
+      sessions: fix.sessions,
+      updateId: 2,
+      ts: base.addingTimeInterval(2)
+    )
+    #expect(try store.pickUp(runId: run2, now: base.addingTimeInterval(2)))
     try store.failRun(runId: run2, now: base.addingTimeInterval(3))
 
-    try commitDone(store: store, sessionId: sid, chatId: 4, now: base.addingTimeInterval(4))
+    try commitDone(
+      fixture: fix,
+      updateId: 3,
+      chatId: 1,
+      now: base.addingTimeInterval(4)
+    )
 
-    let run4 = try store.createRun(sessionId: sid, now: base.addingTimeInterval(6))
+    let run4 = try seedPendingRun(
+      sessions: fix.sessions,
+      updateId: 4,
+      ts: base.addingTimeInterval(6)
+    )
+    #expect(try store.pickUp(runId: run4, now: base.addingTimeInterval(6)))
     try store.failRun(runId: run4, now: base.addingTimeInterval(7))
 
     // when
@@ -184,13 +253,12 @@ import Testing
   @Test func costSourceMixCountsTodayRowsBySource() throws {
     // given
     let fix = try makeFixture()
-    let store = fix.store
     let usage = fix.usage
     let sessionId = fix.sessionId
     let now = Date()
 
-    let runId1 = try store.createRun(sessionId: sessionId, now: now)
-    let runId2 = try store.createRun(sessionId: sessionId, now: now)
+    let runId1 = try seedPendingRun(sessions: fix.sessions, updateId: 1, ts: now)
+    let runId2 = try seedPendingRun(sessions: fix.sessions, updateId: 2, ts: now)
     try seedUsage(usage, runId: runId1, sessionId: sessionId, source: .providerReturned, now: now)
     try seedUsage(usage, runId: runId2, sessionId: sessionId, source: .heuristic, now: now)
 

--- a/Tests/ClawDataTests/RunsHealthTests.swift
+++ b/Tests/ClawDataTests/RunsHealthTests.swift
@@ -94,7 +94,7 @@ import Testing
       isEstimated: false,
       ts: now
     )
-    try fixture.store.commitAssistantTurn(
+    _ = try fixture.store.commitAssistantTurn(
       AssistantTurn(
         runId: runId,
         sessionId: fixture.sessionId,

--- a/Tests/ClawDataTests/SessionMessageStoreTests.swift
+++ b/Tests/ClawDataTests/SessionMessageStoreTests.swift
@@ -24,9 +24,11 @@ import Testing
     )
   }
 
-  @Test func claimAndPersistInsertsClaimSessionAndMessageAtomically() throws {
+  @Test func claimAndPersistCreatesPendingRunBoundToTriggerMessage() throws {
     // given
-    let store = try freshStore()
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let store = SessionMessageStoreGRDB(writer: queue)
 
     // when
     let result = try store.claimAndPersistInbound(inbound(updateId: 1, text: "hello"))
@@ -34,8 +36,33 @@ import Testing
     // then
     #expect(result.newlyClaimed)
     let sessionId = try #require(result.sessionId)
-    let history = try store.loadRecentMessages(sessionId: sessionId, limit: 10)
+    let messageId = try #require(result.messageId)
+    let runId = try #require(result.runId)
+    let triggerMessageId = try #require(result.triggerMessageId)
+    #expect(triggerMessageId == messageId)
+
+    let history = try store.loadContext(
+      sessionId: sessionId,
+      throughMessageId: triggerMessageId,
+      limit: 10
+    )
     #expect(history == [StoredMessage(role: .user, content: "hello", provenance: .trusted)])
+
+    let run = try #require(
+      try queue.read { db in
+        try Row.fetchOne(
+          db,
+          sql: "SELECT session_id, state, trigger_message_id FROM runs WHERE id = ?",
+          arguments: [runId]
+        )
+      }
+    )
+    let persistedSessionId: Int64 = run["session_id"]
+    let state: String = run["state"]
+    let persistedTriggerMessageId: Int64 = run["trigger_message_id"]
+    #expect(persistedSessionId == sessionId)
+    #expect(state == RunState.pending.rawValue)
+    #expect(persistedTriggerMessageId == messageId)
   }
 
   @Test func duplicateUpdateIsNotReclaimedAndPersistsNothingNew() throws {
@@ -51,22 +78,62 @@ import Testing
     #expect(again.sessionId == nil)
   }
 
-  @Test func recentMessagesAreOldestFirstWithinLimit() throws {
+  @Test func loadContextIsOldestFirstWithinLimitAndTriggerBound() throws {
     // given
     let store = try freshStore()
+    var claims: [ClaimResult] = []
     for index in 1...5 {
-      _ = try store.claimAndPersistInbound(inbound(updateId: Int64(index), text: "m\(index)"))
+      claims.append(
+        try store.claimAndPersistInbound(inbound(updateId: Int64(index), text: "m\(index)"))
+      )
     }
-    let sessionId = try store.loadOrCreateSession(
-      sessionKey: SessionKey.telegramDM(chatId: 42),
-      now: Date()
-    )
+    let sessionId = try #require(claims.last?.sessionId)
+    let throughMessageId = try #require(claims[3].triggerMessageId)
 
     // when
-    let history = try store.loadRecentMessages(sessionId: sessionId, limit: 3)
+    let history = try store.loadContext(
+      sessionId: sessionId,
+      throughMessageId: throughMessageId,
+      limit: 3
+    )
 
-    // then — the three most recent, oldest-first
-    #expect(history.map(\.content) == ["m3", "m4", "m5"])
+    // then — bounded through m4, so m5 is invisible to m4's turn.
+    #expect(history.map(\.content) == ["m2", "m3", "m4"])
+  }
+
+  @Test func resetWindowAndDetaintExcludesEarlierHistory() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let store = SessionMessageStoreGRDB(writer: queue)
+    let first = try store.claimAndPersistInbound(inbound(updateId: 1, text: "before"))
+    let sessionId = try #require(first.sessionId)
+    try queue.write { db in
+      try db.execute(sql: "UPDATE sessions SET tainted = 1 WHERE id = ?", arguments: [sessionId])
+    }
+
+    // when
+    try store.resetWindowAndDetaint(sessionId: sessionId, now: Date())
+    let second = try store.claimAndPersistInbound(inbound(updateId: 2, text: "after"))
+    let triggerMessageId = try #require(second.triggerMessageId)
+    let history = try store.loadContext(
+      sessionId: sessionId,
+      throughMessageId: triggerMessageId,
+      limit: 10
+    )
+
+    // then
+    #expect(history.map(\.content) == ["after"])
+    let tainted = try #require(
+      try queue.read { db in
+        try Int.fetchOne(
+          db,
+          sql: "SELECT tainted FROM sessions WHERE id = ?",
+          arguments: [sessionId]
+        )
+      }
+    )
+    #expect(tainted == 0)
   }
 
   @Test func claimAndPersistRollsBackEntirelyWhenTheMessageInsertAborts() throws {
@@ -96,5 +163,34 @@ import Testing
     )
     #expect(claims == 0)
     #expect(sessions == 0)
+  }
+
+  @Test func claimAndPersistRollsBackEntirelyWhenTheRunInsertAborts() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    try queue.write { db in
+      try db.execute(
+        sql: "CREATE TRIGGER boom BEFORE INSERT ON runs BEGIN SELECT RAISE(ABORT, 'boom'); END"
+      )
+    }
+    let store = SessionMessageStoreGRDB(writer: queue)
+
+    // when / then
+    #expect(throws: (any Error).self) {
+      try store.claimAndPersistInbound(inbound(updateId: 1, text: "hi"))
+    }
+    let counts = try queue.read { db in
+      (
+        claims: try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM processed_updates") ?? -1,
+        sessions: try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM sessions") ?? -1,
+        messages: try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM messages") ?? -1,
+        runs: try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM runs") ?? -1
+      )
+    }
+    #expect(counts.claims == 0)
+    #expect(counts.sessions == 0)
+    #expect(counts.messages == 0)
+    #expect(counts.runs == 0)
   }
 }

--- a/Tests/ClawDataTests/UsageStoreTests.swift
+++ b/Tests/ClawDataTests/UsageStoreTests.swift
@@ -10,11 +10,19 @@ import Testing
     let queue = try ClawDatabase.makeInMemoryQueue()
     try ClawDatabase.migrate(queue)
     let sessions = SessionMessageStoreGRDB(writer: queue)
-    let sessionId = try sessions.loadOrCreateSession(
-      sessionKey: SessionKey.telegramDM(chatId: 42),
-      now: Date()
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: 42),
+        chatId: 42,
+        userId: 42,
+        text: "seed",
+        isEdited: false,
+        ts: Date()
+      )
     )
-    let runId = try RunStoreGRDB(writer: queue).createRun(sessionId: sessionId, now: Date())
+    let sessionId = try #require(claim.sessionId)
+    let runId = try #require(claim.runId)
     let usage = UsageStoreGRDB(writer: queue)
     let now = Date()
     try usage.recordUsage(

--- a/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
+++ b/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
@@ -21,12 +21,32 @@ actor RecordingProvider: LLMProvider {
   }
 
   private let outcome: Outcome
-  private(set) var lastMessageCount = 0
+  private let blocksFirstCall: Bool
+  private(set) var requests: [[ChatMessage]] = []
+  private var requestContinuations: [CheckedContinuation<Void, Never>] = []
+  private var firstCallRelease: CheckedContinuation<Void, Never>?
 
-  init(_ outcome: Outcome) { self.outcome = outcome }
+  init(_ outcome: Outcome, blocksFirstCall: Bool = false) {
+    self.outcome = outcome
+    self.blocksFirstCall = blocksFirstCall
+  }
+
+  var lastMessageCount: Int {
+    requests.last?.count ?? 0
+  }
 
   func complete(request: ChatRequest) async throws -> ChatResponse {
-    lastMessageCount = request.messages.count
+    requests.append(request.messages)
+    for continuation in requestContinuations {
+      continuation.resume()
+    }
+    requestContinuations.removeAll()
+    if blocksFirstCall && requests.count == 1 {
+      await withCheckedContinuation { continuation in
+        firstCallRelease = continuation
+      }
+    }
+
     switch outcome {
     case .respond(let answer):
       return ChatResponse(
@@ -39,13 +59,40 @@ actor RecordingProvider: LLMProvider {
       throw error
     }
   }
+
+  func waitForRequestCount(_ count: Int) async {
+    while requests.count < count {
+      await withCheckedContinuation { continuation in
+        requestContinuations.append(continuation)
+      }
+    }
+  }
+
+  func releaseFirstCall() {
+    firstCallRelease?.resume()
+    firstCallRelease = nil
+  }
+}
+
+actor Gate {
+  private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+  func wait() async {
+    await withCheckedContinuation { continuation in
+      releaseContinuation = continuation
+    }
+  }
+
+  func release() {
+    releaseContinuation?.resume()
+    releaseContinuation = nil
+  }
 }
 
 // MARK: - Stack
 
-/// The full inline-turn wiring over one `DatabaseWriter`: `router.handle` runs a turn and commits
-/// (without sending); `dispatcher.drainOnce()` then delivers the PENDING outbox rows. Both the stores
-/// and the raw `writer` are exposed so tests can assert durable state directly.
+/// The full lane-dispatched wiring over one `DatabaseWriter`: `router.handle` persists and enqueues;
+/// the lane commits without sending, then `dispatcher.drainOnce()` delivers PENDING outbox rows.
 struct Stack {
   let router: MessageRouter
   let dispatcher: OutboxDispatcher
@@ -59,15 +106,16 @@ struct Stack {
   let outbox: OutboxStoreGRDB
   let cursor: UpdateCursorStoreGRDB
   let chatId: Int64
+  let lanes: SessionLaneRegistry
 }
 
-/// Assembles the production inline-turn stack over `writer`, seeding `chatId` onto the allowlist and
-/// scripting the provider with `outcome`. The caller owns `writer` (an in-memory queue for most tests,
-/// a file pool for the restart test) and must have migrated it first.
+/// Assembles the production lane stack over `writer`, seeding `chatId` onto the allowlist and
+/// scripting the provider with `outcome`.
 func makeStack(
   writer: any DatabaseWriter,
   allow chatId: Int64 = 42,
-  outcome: RecordingProvider.Outcome
+  outcome: RecordingProvider.Outcome,
+  blocksFirstProviderCall: Bool = false
 ) throws -> Stack {
   let allowlist = AllowlistStoreGRDB(writer: writer)
   try allowlist.seedAllowlist(userIds: [chatId])
@@ -80,9 +128,10 @@ func makeStack(
   let outbox = OutboxStoreGRDB(writer: writer)
   let audit = AuditLogGRDB(writer: writer)
 
-  let provider = RecordingProvider(outcome)
+  let provider = RecordingProvider(outcome, blocksFirstCall: blocksFirstProviderCall)
   let transport = RecordingTransport()
   let signal = OutboxSignal()
+  let lanes = SessionLaneRegistry()
   let logger = Logger(label: "inc1-acceptance")
 
   let agent = AgentRuntime(
@@ -118,6 +167,7 @@ func makeStack(
     accessControl: AccessControl(allowlist: allowlist),
     transport: transport,
     turnRunner: turnRunner,
+    lanes: lanes,
     logger: logger
   )
 
@@ -140,7 +190,8 @@ func makeStack(
     usage: usage,
     outbox: outbox,
     cursor: cursor,
-    chatId: chatId
+    chatId: chatId,
+    lanes: lanes
   )
 }
 
@@ -161,6 +212,38 @@ func makeStack(
     }
   }
 
+  private func runStates(_ writer: any DatabaseWriter) throws -> [String] {
+    try writer.read { db in
+      try String.fetchAll(db, sql: "SELECT state FROM runs ORDER BY id ASC")
+    }
+  }
+
+  private func waitForRunStates(
+    _ writer: any DatabaseWriter,
+    expected: [String]
+  ) async throws {
+    for _ in 0..<100 {
+      if try runStates(writer) == expected {
+        return
+      }
+      try await Task.sleep(for: .milliseconds(10))
+    }
+    #expect(try runStates(writer) == expected)
+  }
+
+  private func waitForPendingOutboxCount(
+    _ outbox: OutboxStoreGRDB,
+    count: Int
+  ) async throws {
+    for _ in 0..<100 {
+      if try outbox.pendingOutbound().count == count {
+        return
+      }
+      try await Task.sleep(for: .milliseconds(10))
+    }
+    #expect(try outbox.pendingOutbound().count == count)
+  }
+
   // MARK: - Tests
 
   /// §1: a real answer is persisted across the whole spine and committed BEFORE any send — the turn
@@ -172,10 +255,11 @@ func makeStack(
     try ClawDatabase.migrate(queue)
     let stack = try makeStack(writer: queue, outcome: .respond("stub answer"))
 
-    // when — route one allowlisted message: the turn runs inline and commits, but sends nothing
+    // when — route one allowlisted message, then wait for the queued turn to commit
     let outcome = await stack.router.handle(
       rawUpdate: textUpdate(id: 1, from: stack.chatId, text: "hello")
     )
+    try await waitForRunStates(queue, expected: [RunState.done.rawValue])
 
     // then — everything is durable, nothing is on the wire yet
     #expect(outcome == .processed)
@@ -206,7 +290,13 @@ func makeStack(
 
     // when — two sequential turns from the same chat (distinct update ids)
     await stack.router.handle(rawUpdate: textUpdate(id: 1, from: stack.chatId, text: "first"))
+    try await waitForRunStates(queue, expected: [RunState.done.rawValue])
     await stack.router.handle(rawUpdate: textUpdate(id: 2, from: stack.chatId, text: "second"))
+    await stack.provider.waitForRequestCount(2)
+    try await waitForRunStates(
+      queue,
+      expected: [RunState.done.rawValue, RunState.done.rawValue]
+    )
 
     // then — the second call's request carried the full prior history plus the system prompt
     #expect(await stack.provider.lastMessageCount == 4)
@@ -226,6 +316,8 @@ func makeStack(
 
     // when
     await stack.router.handle(rawUpdate: textUpdate(id: 1, from: stack.chatId, text: "hello"))
+    try await waitForRunStates(queue, expected: [RunState.failed.rawValue])
+    try await waitForPendingOutboxCount(stack.outbox, count: 1)
     await stack.dispatcher.drainOnce()
 
     // then — the run failed but the owner was told, never left silent
@@ -255,7 +347,7 @@ func makeStack(
       )
     )
     let seedSession = try #require(seedClaim.sessionId)
-    let seedRun = try stack.runs.createRun(sessionId: seedSession, now: Date())
+    let seedRun = try #require(seedClaim.runId)
     try stack.usage.recordUsage(
       ProviderUsage(
         runId: seedRun,
@@ -269,9 +361,15 @@ func makeStack(
         ts: Date()
       )
     )
+    _ = try stack.runs.supersedeSessionRuns(sessionId: seedSession, now: Date())
 
     // when — an allowlisted turn arrives with the cap already met
     await stack.router.handle(rawUpdate: textUpdate(id: 1, from: stack.chatId, text: "hello"))
+    try await waitForRunStates(
+      queue,
+      expected: [RunState.superseded.rawValue, RunState.failed.rawValue]
+    )
+    try await waitForPendingOutboxCount(stack.outbox, count: 1)
     await stack.dispatcher.drainOnce()
 
     // then — the gate refused pre-call (provider never invoked), the run failed, and the owner was told
@@ -298,6 +396,7 @@ func makeStack(
       try ClawDatabase.migrate(pool)
       let stack = try makeStack(writer: pool, outcome: .respond("stub answer"))
       await stack.router.handle(rawUpdate: textUpdate(id: 100, from: stack.chatId, text: "hello"))
+      try await waitForRunStates(pool, expected: [RunState.done.rawValue])
       try stack.cursor.advanceCursor(to: 100)
     }
 
@@ -309,9 +408,68 @@ func makeStack(
       sessionKey: sessionKey,
       now: Date()
     )
-    let history = try reopened.sessionMessages.loadRecentMessages(sessionId: sessionId, limit: 50)
+    let history = try reopened.sessionMessages.loadContext(
+      sessionId: sessionId,
+      throughMessageId: .max,
+      limit: 50
+    )
     #expect(history.contains { $0.role == .user && $0.content == "hello" })
     #expect(history.contains { $0.role == .assistant && $0.content == "stub answer" })
+  }
+
+  @Test func twoQuickMessagesRunFifoAndFirstContextExcludesSecond() async throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let stack = try makeStack(
+      writer: queue,
+      outcome: .respond("stub answer"),
+      blocksFirstProviderCall: true
+    )
+    let sessionId = try stack.sessionMessages.loadOrCreateSession(
+      sessionKey: SessionKey.telegramDM(chatId: stack.chatId),
+      now: Date()
+    )
+    let lane = await stack.lanes.actor(for: sessionId)
+    let gate = Gate()
+    await lane.enqueue(runId: -1) {
+      await gate.wait()
+    }
+
+    // when
+    let firstOutcome = await stack.router.handle(
+      rawUpdate: textUpdate(id: 1, from: stack.chatId, text: "first")
+    )
+    let secondOutcome = await stack.router.handle(
+      rawUpdate: textUpdate(id: 2, from: stack.chatId, text: "second")
+    )
+    #expect(firstOutcome == .processed)
+    #expect(secondOutcome == .processed)
+    #expect(await stack.provider.requests.isEmpty)
+    await gate.release()
+    await stack.provider.waitForRequestCount(1)
+    #expect(await stack.provider.requests.count == 1)
+    await stack.provider.releaseFirstCall()
+    await stack.provider.waitForRequestCount(2)
+    try await waitForRunStates(
+      queue,
+      expected: [RunState.done.rawValue, RunState.done.rawValue]
+    )
+
+    // then
+    let requests = await stack.provider.requests
+    let firstContents = requests[0].map(\.content)
+    let secondContents = requests[1].map(\.content)
+    #expect(firstContents.contains("first"))
+    #expect(firstContents.contains("second") == false)
+    #expect(secondContents.contains("second"))
+    let assistantRunIds = try await queue.read { db in
+      try Int64.fetchAll(
+        db,
+        sql: "SELECT run_id FROM messages WHERE role = 'assistant' ORDER BY id ASC"
+      )
+    }
+    #expect(assistantRunIds == [1, 2])
   }
 }
 // swiftlint:enable function_body_length

--- a/Tests/ClawGatewayTests/MessageRouterTests.swift
+++ b/Tests/ClawGatewayTests/MessageRouterTests.swift
@@ -1,3 +1,4 @@
+import ClawAgent
 import ClawCore
 import ClawData
 import Foundation
@@ -14,7 +15,14 @@ struct FullSessions: SessionMessageStore {
   func claimAndPersistInbound(_ inbound: InboundMessage) throws -> ClaimResult {
     throw StoreError.diskFull
   }
-  func loadRecentMessages(sessionId: Int64, limit: Int) throws -> [StoredMessage] { [] }
+  func loadContext(
+    sessionId: Int64,
+    throughMessageId: Int64,
+    limit: Int
+  ) throws -> [StoredMessage] {
+    []
+  }
+  func resetWindowAndDetaint(sessionId: Int64, now: Date) throws {}
 }
 
 @Suite struct MessageRouterTests {
@@ -40,6 +48,7 @@ struct FullSessions: SessionMessageStore {
       accessControl: AccessControl(allowlist: allowlist),
       transport: transport,
       turnRunner: dispatcher,
+      lanes: SessionLaneRegistry(),
       logger: Logger(label: "test")
     )
 
@@ -57,6 +66,7 @@ struct FullSessions: SessionMessageStore {
 
     // when
     let outcome = await harness.router.handle(rawUpdate: textUpdate(id: 1, from: 42, text: "hello"))
+    await harness.dispatcher.waitForCalls(atLeast: 1)
 
     // then — a turn was dispatched, nothing was sent directly, and the user message was persisted
     #expect(outcome == .processed)
@@ -64,8 +74,12 @@ struct FullSessions: SessionMessageStore {
     #expect(calls.count == 1)
     let sent = await harness.transport.sent
     #expect(sent.isEmpty)
-    let sessionId = try #require(calls.first?.sessionId)
-    let history = try harness.sessionMessages.loadRecentMessages(sessionId: sessionId, limit: 50)
+    let firstCall = try #require(calls.first)
+    let history = try harness.sessionMessages.loadContext(
+      sessionId: firstCall.sessionId,
+      throughMessageId: firstCall.triggerMessageId,
+      limit: 50
+    )
     #expect(history.contains { $0.role == .user && $0.content == "hello" })
   }
 
@@ -75,6 +89,7 @@ struct FullSessions: SessionMessageStore {
 
     // when — the same update_id arrives twice
     await harness.router.handle(rawUpdate: textUpdate(id: 1, from: 42, text: "hi"))
+    await harness.dispatcher.waitForCalls(atLeast: 1)
     await harness.router.handle(rawUpdate: textUpdate(id: 1, from: 42, text: "hi"))
 
     // then — the fused claim dedups, so only one turn runs
@@ -165,6 +180,7 @@ struct FullSessions: SessionMessageStore {
       accessControl: AccessControl(allowlist: allowlist),
       transport: transport,
       turnRunner: FakeTurnRunner(),
+      lanes: SessionLaneRegistry(),
       logger: Logger(label: "test")
     )
 

--- a/Tests/ClawGatewayTests/OutboxDispatcherTests.swift
+++ b/Tests/ClawGatewayTests/OutboxDispatcherTests.swift
@@ -27,6 +27,22 @@ private struct MarkSentFailingOutbox: OutboxStore {
     )
   }
 
+  func claimOutboundIfRunActive(
+    runId: Int64,
+    stepIndex: Int,
+    chatId: Int64,
+    payload: String,
+    payloadHash: String
+  ) throws -> Bool {
+    try base.claimOutboundIfRunActive(
+      runId: runId,
+      stepIndex: stepIndex,
+      chatId: chatId,
+      payload: payload,
+      payloadHash: payloadHash
+    )
+  }
+
   func markSent(runId: Int64, stepIndex: Int, telegramMessageId: Int64, now: Date) throws {
     throw StoreError.diskFull
   }

--- a/Tests/ClawGatewayTests/TelegramPollerServiceTests.swift
+++ b/Tests/ClawGatewayTests/TelegramPollerServiceTests.swift
@@ -1,3 +1,4 @@
+import ClawAgent
 import ClawCore
 import ClawData
 import Foundation
@@ -5,6 +6,38 @@ import Logging
 import Testing
 
 @testable import ClawGateway
+
+private actor BlockingTurnRunner: TurnDispatching {
+  private(set) var callCount = 0
+  private var started: CheckedContinuation<Void, Never>?
+  private var release: CheckedContinuation<Void, Never>?
+
+  func run(
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    triggerMessageId: Int64
+  ) async throws {
+    callCount += 1
+    started?.resume()
+    started = nil
+    await withCheckedContinuation { continuation in
+      release = continuation
+    }
+  }
+
+  func waitUntilStarted() async {
+    guard callCount == 0 else { return }
+    await withCheckedContinuation { continuation in
+      started = continuation
+    }
+  }
+
+  func finish() {
+    release?.resume()
+    release = nil
+  }
+}
 
 @Suite struct TelegramPollerServiceTests {
   private struct Stack {
@@ -38,6 +71,7 @@ import Testing
       accessControl: AccessControl(allowlist: allowlist),
       transport: transport,
       turnRunner: dispatcher,
+      lanes: SessionLaneRegistry(),
       logger: Logger(label: "test")
     )
     let cursor = UpdateCursorStoreGRDB(writer: queue)
@@ -82,6 +116,44 @@ import Testing
 
     // then
     try await task.value  // returns promptly, no throw
+  }
+
+  @Test func cursorAdvancesAfterEnqueueWithoutWaitingForTurnCompletion() async throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let allowlist = AllowlistStoreGRDB(writer: queue)
+    try allowlist.seedAllowlist(userIds: [42])
+    let transport = RecordingTransport(batches: [[textUpdate(id: 100, from: 42, text: "hi")]])
+    let runner = BlockingTurnRunner()
+    let router = MessageRouter(
+      processed: ProcessedUpdateStoreGRDB(writer: queue),
+      sessionMessages: SessionMessageStoreGRDB(writer: queue),
+      accessControl: AccessControl(allowlist: allowlist),
+      transport: transport,
+      turnRunner: runner,
+      lanes: SessionLaneRegistry(),
+      logger: Logger(label: "test")
+    )
+    let cursor = UpdateCursorStoreGRDB(writer: queue)
+    let poller = TelegramPollerService(
+      transport: transport,
+      router: router,
+      cursor: cursor,
+      pollTimeout: 0,
+      logger: Logger(label: "test")
+    )
+
+    // when
+    let task = Task { try await poller.run() }
+    await runner.waitUntilStarted()
+    await transport.waitForPolls(atLeast: 2)
+
+    // then
+    #expect(try cursor.loadCursor() == 100)
+    await runner.finish()
+    task.cancel()
+    try await task.value
   }
 
   @Test func poisonUpdateAdvancesCursorPastIt() async throws {

--- a/Tests/ClawGatewayTests/TestSupport.swift
+++ b/Tests/ClawGatewayTests/TestSupport.swift
@@ -9,14 +9,46 @@ import Testing
 /// Records the turns the router dispatches (and optionally throws a scripted error) so router/poller
 /// tests stay decoupled from the real provider/persistence.
 actor FakeTurnRunner: TurnDispatching {
-  private(set) var calls: [(sessionId: Int64, chatId: Int64)] = []
+  struct Call: Sendable, Equatable {
+    let runId: Int64
+    let sessionId: Int64
+    let chatId: Int64
+    let triggerMessageId: Int64
+  }
+
+  private(set) var calls: [Call] = []
   private let error: (any Error)?
+  private var continuations: [CheckedContinuation<Void, Never>] = []
 
   init(error: (any Error)? = nil) { self.error = error }
 
-  func run(sessionId: Int64, chatId: Int64) async throws {
-    calls.append((sessionId, chatId))
+  func run(
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    triggerMessageId: Int64
+  ) async throws {
+    calls.append(
+      Call(
+        runId: runId,
+        sessionId: sessionId,
+        chatId: chatId,
+        triggerMessageId: triggerMessageId
+      )
+    )
+    for continuation in continuations {
+      continuation.resume()
+    }
+    continuations.removeAll()
     if let error { throw error }
+  }
+
+  func waitForCalls(atLeast count: Int) async {
+    while calls.count < count {
+      await withCheckedContinuation { continuation in
+        continuations.append(continuation)
+      }
+    }
   }
 }
 
@@ -182,9 +214,9 @@ func makeSeededFixture() throws -> SeededFixture {
       ts: Date()
     )
   )
-  let sessionId = try #require(claim.sessionId)
+  let runId = try #require(claim.runId)
   let runs = RunStoreGRDB(writer: queue)
-  let runId = try runs.createRun(sessionId: sessionId, now: Date())
+  #expect(try runs.pickUp(runId: runId, now: Date()))
   return SeededFixture(
     outbox: OutboxStoreGRDB(writer: queue),
     runs: runs,

--- a/Tests/ClawGatewayTests/TurnRunnerTests.swift
+++ b/Tests/ClawGatewayTests/TurnRunnerTests.swift
@@ -18,10 +18,12 @@ actor StubLLMProvider: LLMProvider {
   }
 
   private let outcome: Outcome
+  private(set) var callCount = 0
 
   init(_ outcome: Outcome) { self.outcome = outcome }
 
   func complete(request: ChatRequest) async throws -> ChatResponse {
+    callCount += 1
     switch outcome {
     case .respond(let response): return response
     case .fail(let error): throw error
@@ -35,9 +37,11 @@ struct NoopTyping: TypingIndicator {
 
 /// A `RunStore` whose first write reports a full disk, to exercise the storage-full rethrow.
 struct DiskFullRuns: RunStore {
-  func createRun(sessionId: Int64, now: Date) throws -> Int64 { throw StoreError.diskFull }
+  func pickUp(runId: Int64, now: Date) throws -> Bool { throw StoreError.diskFull }
   func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws {}
   func failRun(runId: Int64, now: Date) throws {}
+  func cancelActiveRun(sessionId: Int64, reason: CancelReason, now: Date) throws -> Int64? { nil }
+  func supersedeSessionRuns(sessionId: Int64, now: Date) throws -> [Int64] { [] }
   func reconcileRunsAtBoot(now: Date, degradationText: String) throws -> [DegradationReply] { [] }
   func runsHealth(now: Date) throws -> RunsHealth {
     RunsHealth(
@@ -58,6 +62,9 @@ struct DiskFullRuns: RunStore {
     let outbox: OutboxStoreGRDB
     let sessionId: Int64
     let chatId: Int64
+    let runId: Int64
+    let triggerMessageId: Int64
+    let provider: StubLLMProvider
   }
 
   private func makeEnv(
@@ -86,9 +93,12 @@ struct DiskFullRuns: RunStore {
       )
     )
     let sessionId = try #require(claim.sessionId)
+    let runId = try #require(claim.runId)
+    let triggerMessageId = try #require(claim.triggerMessageId)
 
+    let provider = StubLLMProvider(agentOutcome)
     let agent = AgentRuntime(
-      provider: StubLLMProvider(agentOutcome),
+      provider: provider,
       typingIndicator: NoopTyping(),
       costResolver: CostResolver(
         priceTable: .empty,
@@ -118,7 +128,10 @@ struct DiskFullRuns: RunStore {
       sessionMessages: sessionMessages,
       outbox: outbox,
       sessionId: sessionId,
-      chatId: chatId
+      chatId: chatId,
+      runId: runId,
+      triggerMessageId: triggerMessageId,
+      provider: provider
     )
   }
 
@@ -142,12 +155,24 @@ struct DiskFullRuns: RunStore {
     let env = try makeEnv(agentOutcome: .respond(okResponse(content: "Hello there")))
 
     // when
-    try await env.runner.run(sessionId: env.sessionId, chatId: env.chatId)
+    try await env.runner.run(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: env.chatId,
+      triggerMessageId: env.triggerMessageId
+    )
 
     // then
     #expect(try latestRunState(env.queue) == "DONE")
-    let history = try env.sessionMessages.loadRecentMessages(sessionId: env.sessionId, limit: 50)
-    #expect(history.contains { $0.role == .assistant && $0.content == "Hello there" })
+    let persistedAssistantCount = try await env.queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM messages WHERE run_id = ? AND content = ?",
+        arguments: [env.runId, "Hello there"]
+      )
+    }
+    let assistantCount = try #require(persistedAssistantCount)
+    #expect(assistantCount == 1)
     let pending = try env.outbox.pendingOutbound()
     #expect(pending.count == 1)
     let firstPending = try #require(pending.first)
@@ -159,7 +184,12 @@ struct DiskFullRuns: RunStore {
     let env = try makeEnv(agentOutcome: .fail(.terminal(status: 400, message: "bad request")))
 
     // when
-    try await env.runner.run(sessionId: env.sessionId, chatId: env.chatId)
+    try await env.runner.run(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: env.chatId,
+      triggerMessageId: env.triggerMessageId
+    )
 
     // then
     #expect(try latestRunState(env.queue) == "FAILED")
@@ -178,7 +208,34 @@ struct DiskFullRuns: RunStore {
 
     // when / then — only StoreError.diskFull may propagate out of run
     await #expect(throws: StoreError.diskFull) {
-      try await env.runner.run(sessionId: env.sessionId, chatId: env.chatId)
+      try await env.runner.run(
+        runId: env.runId,
+        sessionId: env.sessionId,
+        chatId: env.chatId,
+        triggerMessageId: env.triggerMessageId
+      )
     }
+  }
+
+  @Test func supersededRunSelfAbortsBeforeProviderCall() async throws {
+    // given
+    let env = try makeEnv(agentOutcome: .respond(okResponse(content: "should not run")))
+    _ = try RunStoreGRDB(writer: env.queue).supersedeSessionRuns(
+      sessionId: env.sessionId,
+      now: Date()
+    )
+
+    // when
+    try await env.runner.run(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: env.chatId,
+      triggerMessageId: env.triggerMessageId
+    )
+
+    // then
+    #expect(await env.provider.callCount == 0)
+    #expect(try latestRunState(env.queue) == RunState.superseded.rawValue)
+    #expect(try env.outbox.pendingOutbound().isEmpty)
   }
 }

--- a/Tests/ClawGatewayTests/TurnRunnerTests.swift
+++ b/Tests/ClawGatewayTests/TurnRunnerTests.swift
@@ -35,10 +35,91 @@ struct NoopTyping: TypingIndicator {
   func sendTyping(chatId: Int64) async {}
 }
 
+/// Delegates to the real run store but flips the active run to CANCELLED immediately before the
+/// assistant commit, modeling `/stop` winning after the provider returned usage.
+struct CancellingBeforeAssistantCommitRuns: RunStore {
+  let base: RunStoreGRDB
+  let sessionId: Int64
+
+  func pickUp(runId: Int64, now: Date) throws -> Bool {
+    try base.pickUp(runId: runId, now: now)
+  }
+
+  func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws -> RunCommitResult {
+    _ = try base.cancelActiveRun(sessionId: sessionId, reason: .cancelled, now: now)
+    return try base.commitAssistantTurn(turn, now: now)
+  }
+
+  func commitDegradedTurn(_ turn: DegradedTurn, now: Date) throws -> RunCommitResult {
+    try base.commitDegradedTurn(turn, now: now)
+  }
+
+  func failRun(runId: Int64, now: Date) throws {
+    try base.failRun(runId: runId, now: now)
+  }
+
+  func cancelActiveRun(sessionId: Int64, reason: CancelReason, now: Date) throws -> Int64? {
+    try base.cancelActiveRun(sessionId: sessionId, reason: reason, now: now)
+  }
+
+  func supersedeSessionRuns(sessionId: Int64, now: Date) throws -> [Int64] {
+    try base.supersedeSessionRuns(sessionId: sessionId, now: now)
+  }
+
+  func reconcileRunsAtBoot(now: Date, degradationText: String) throws -> [DegradationReply] {
+    try base.reconcileRunsAtBoot(now: now, degradationText: degradationText)
+  }
+
+  func runsHealth(now: Date) throws -> RunsHealth {
+    try base.runsHealth(now: now)
+  }
+}
+
+/// Delegates to the real run store but flips the active run to CANCELLED immediately before the
+/// degradation commit, modeling `/stop` winning after the runtime produced a degradation result.
+struct CancellingBeforeDegradedCommitRuns: RunStore {
+  let base: RunStoreGRDB
+  let sessionId: Int64
+
+  func pickUp(runId: Int64, now: Date) throws -> Bool {
+    try base.pickUp(runId: runId, now: now)
+  }
+
+  func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws -> RunCommitResult {
+    try base.commitAssistantTurn(turn, now: now)
+  }
+
+  func commitDegradedTurn(_ turn: DegradedTurn, now: Date) throws -> RunCommitResult {
+    _ = try base.cancelActiveRun(sessionId: sessionId, reason: .cancelled, now: now)
+    return try base.commitDegradedTurn(turn, now: now)
+  }
+
+  func failRun(runId: Int64, now: Date) throws {
+    try base.failRun(runId: runId, now: now)
+  }
+
+  func cancelActiveRun(sessionId: Int64, reason: CancelReason, now: Date) throws -> Int64? {
+    try base.cancelActiveRun(sessionId: sessionId, reason: reason, now: now)
+  }
+
+  func supersedeSessionRuns(sessionId: Int64, now: Date) throws -> [Int64] {
+    try base.supersedeSessionRuns(sessionId: sessionId, now: now)
+  }
+
+  func reconcileRunsAtBoot(now: Date, degradationText: String) throws -> [DegradationReply] {
+    try base.reconcileRunsAtBoot(now: now, degradationText: degradationText)
+  }
+
+  func runsHealth(now: Date) throws -> RunsHealth {
+    try base.runsHealth(now: now)
+  }
+}
+
 /// A `RunStore` whose first write reports a full disk, to exercise the storage-full rethrow.
 struct DiskFullRuns: RunStore {
   func pickUp(runId: Int64, now: Date) throws -> Bool { throw StoreError.diskFull }
-  func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws {}
+  func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws -> RunCommitResult { .ignored }
+  func commitDegradedTurn(_ turn: DegradedTurn, now: Date) throws -> RunCommitResult { .ignored }
   func failRun(runId: Int64, now: Date) throws {}
   func cancelActiveRun(sessionId: Int64, reason: CancelReason, now: Date) throws -> Int64? { nil }
   func supersedeSessionRuns(sessionId: Int64, now: Date) throws -> [Int64] { [] }
@@ -69,7 +150,8 @@ struct DiskFullRuns: RunStore {
 
   private func makeEnv(
     agentOutcome: StubLLMProvider.Outcome,
-    runs: (any RunStore)? = nil
+    runs: (any RunStore)? = nil,
+    runsFactory: ((DatabaseQueue, Int64) -> any RunStore)? = nil
   ) throws -> Env {
     let queue = try ClawDatabase.makeInMemoryQueue()
     try ClawDatabase.migrate(queue)
@@ -111,7 +193,7 @@ struct DiskFullRuns: RunStore {
 
     let runner = TurnRunner(
       sessionMessages: sessionMessages,
-      runs: runs ?? RunStoreGRDB(writer: queue),
+      runs: runsFactory?(queue, sessionId) ?? runs ?? RunStoreGRDB(writer: queue),
       usageStore: usage,
       outbox: outbox,
       audit: audit,
@@ -237,5 +319,80 @@ struct DiskFullRuns: RunStore {
     #expect(await env.provider.callCount == 0)
     #expect(try latestRunState(env.queue) == RunState.superseded.rawValue)
     #expect(try env.outbox.pendingOutbound().isEmpty)
+  }
+
+  @Test func completedUsageSurvivesWhenStopWinsBeforeAssistantCommit() async throws {
+    // given
+    let env = try makeEnv(
+      agentOutcome: .respond(okResponse(content: "must not send")),
+      runsFactory: { queue, sessionId in
+        CancellingBeforeAssistantCommitRuns(
+          base: RunStoreGRDB(writer: queue),
+          sessionId: sessionId
+        )
+      }
+    )
+
+    // when
+    try await env.runner.run(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: env.chatId,
+      triggerMessageId: env.triggerMessageId
+    )
+
+    // then
+    let state = try #require(
+      try await env.queue.read { db in
+        try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [env.runId])
+      }
+    )
+    let usageCount = try #require(
+      try await env.queue.read { db in
+        try Int.fetchOne(
+          db,
+          sql: "SELECT COUNT(*) FROM provider_usage WHERE run_id = ?",
+          arguments: [env.runId]
+        )
+      }
+    )
+    let assistantCount = try #require(
+      try await env.queue.read { db in
+        try Int.fetchOne(
+          db,
+          sql: "SELECT COUNT(*) FROM messages WHERE run_id = ? AND role = 'assistant'",
+          arguments: [env.runId]
+        )
+      }
+    )
+    #expect(state == RunState.cancelled.rawValue)
+    #expect(usageCount == 1)
+    #expect(assistantCount == 0)
+    #expect(try env.outbox.pendingOutbound().isEmpty)
+  }
+
+  @Test func degradationReplyIsNotLeftPendingWhenStopWinsBeforeFailCommit() async throws {
+    // given
+    let raced = try makeEnv(
+      agentOutcome: .fail(.terminal(status: 400, message: "bad request")),
+      runsFactory: { queue, sessionId in
+        CancellingBeforeDegradedCommitRuns(
+          base: RunStoreGRDB(writer: queue),
+          sessionId: sessionId
+        )
+      }
+    )
+
+    // when
+    try await raced.runner.run(
+      runId: raced.runId,
+      sessionId: raced.sessionId,
+      chatId: raced.chatId,
+      triggerMessageId: raced.triggerMessageId
+    )
+
+    // then
+    #expect(try latestRunState(raced.queue) == RunState.cancelled.rawValue)
+    #expect(try raced.outbox.pendingOutbound().isEmpty)
   }
 }


### PR DESCRIPTION
## What changed
- Adds a per-session lane lifecycle in `SessionActor`.
- Threads lane-aware persistence through run state, message routing, outbox handling, and turn execution.
- Expands coverage for persistence, migration, FIFO turn handling, and retry paths.

## Why
Swift actor isolation does not serialize work across `await`. This branch chains each session turn through a stored task so the lane stays ordered while the turn waits on I/O.

## Impact
Turns for the same session no longer interleave. Session state, run state, and outbound messages now move through one ordered path.

## Validation
- `swift test`