### PR TITLE
feat: /stop and /new command routing

### DIFF
--- a/Sources/ClawCore/Command.swift
+++ b/Sources/ClawCore/Command.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Telegram text command classification. Only a leading slash-token is authoritative; slash text
+/// later in the message remains ordinary user content.
+public enum Command: Sendable, Equatable {
+  case start
+  case stop
+  case new
+  case plain(String)
+
+  public static func parse(_ text: String, botUsername: String?) -> Command {
+    guard text.first == "/" else {
+      return .plain(text)
+    }
+
+    let tokenEnd = text.firstIndex(where: { $0.isWhitespace }) ?? text.endIndex
+    let token = text[..<tokenEnd]
+    let commandBody = token.dropFirst()
+    guard commandBody.isEmpty == false else {
+      return .plain(text)
+    }
+
+    let pieces = commandBody.split(
+      separator: "@",
+      maxSplits: 1,
+      omittingEmptySubsequences: false
+    )
+    guard let rawName = pieces.first, rawName.isEmpty == false else {
+      return .plain(text)
+    }
+
+    if pieces.count == 2 {
+      guard
+        let botUsername,
+        pieces[1].caseInsensitiveCompare(botUsername) == .orderedSame
+      else {
+        return .plain(text)
+      }
+    }
+
+    switch String(rawName).lowercased() {
+    case "start":
+      return .start
+    case "stop":
+      return .stop
+    case "new":
+      return .new
+    default:
+      return .plain(text)
+    }
+  }
+}

--- a/Sources/ClawCore/Persistence.swift
+++ b/Sources/ClawCore/Persistence.swift
@@ -277,6 +277,8 @@ public enum AuditAction: String, Sendable, Equatable {
   case turnDegraded = "turn_degraded"
   case turnBudgetStopped = "turn_budget_stopped"
   case budgetTripped = "budget_tripped"
+  case turnCancelled = "turn_cancelled"
+  case turnSuperseded = "turn_superseded"
 }
 
 public struct AuditEvent: Sendable, Equatable {

--- a/Sources/ClawCore/Stores.swift
+++ b/Sources/ClawCore/Stores.swift
@@ -12,6 +12,39 @@ public protocol ProcessedUpdateStore: Sendable {
   func claimUpdate(updateId: Int64) throws -> Bool
 }
 
+public struct StopCommandResult: Sendable, Equatable {
+  public let newlyClaimed: Bool
+  public let sessionId: Int64?
+  public let cancelledRunId: Int64?
+
+  public init(newlyClaimed: Bool, sessionId: Int64?, cancelledRunId: Int64?) {
+    self.newlyClaimed = newlyClaimed
+    self.sessionId = sessionId
+    self.cancelledRunId = cancelledRunId
+  }
+}
+
+public struct NewCommandResult: Sendable, Equatable {
+  public let newlyClaimed: Bool
+  public let sessionId: Int64?
+  public let supersededRunIds: [Int64]
+
+  public init(newlyClaimed: Bool, sessionId: Int64?, supersededRunIds: [Int64]) {
+    self.newlyClaimed = newlyClaimed
+    self.sessionId = sessionId
+    self.supersededRunIds = supersededRunIds
+  }
+}
+
+public protocol CommandStore: Sendable {
+  /// Atomic `/stop`: claim update + resolve session + RUNNING→CANCELLED + audit in one write.
+  func applyStop(updateId: Int64, sessionKey: String, now: Date) throws -> StopCommandResult
+
+  /// Atomic `/new`: claim update + resolve session + RUNNING/PENDING→SUPERSEDED +
+  /// resetWindowAndDetaint + audit in one write.
+  func applyNew(updateId: Int64, sessionKey: String, now: Date) throws -> NewCommandResult
+}
+
 public protocol UpdateCursorStore: Sendable {
   func loadCursor() throws -> Int64?
   func advanceCursor(to updateId: Int64) throws

--- a/Sources/ClawData/AuditLogGRDB.swift
+++ b/Sources/ClawData/AuditLogGRDB.swift
@@ -11,23 +11,27 @@ public struct AuditLogGRDB: AuditLog {
 
   public func appendAudit(_ event: AuditEvent) throws {
     try writer.writeMapping { db in
-      try db.execute(
-        sql: """
-          INSERT INTO audit_events(ts, actor, action, tool, args_redacted, result_size, decision, run_id, session_id)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-          """,
-        arguments: [
-          event.ts,
-          event.actor.rawValue,
-          event.action.rawValue,
-          event.tool,
-          event.argsRedacted,
-          event.resultSize,
-          event.decision,
-          event.runId,
-          event.sessionId,
-        ]
-      )
+      try Self.insertAudit(db, event)
     }
+  }
+
+  static func insertAudit(_ db: Database, _ event: AuditEvent) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO audit_events(ts, actor, action, tool, args_redacted, result_size, decision, run_id, session_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+      arguments: [
+        event.ts,
+        event.actor.rawValue,
+        event.action.rawValue,
+        event.tool,
+        event.argsRedacted,
+        event.resultSize,
+        event.decision,
+        event.runId,
+        event.sessionId,
+      ]
+    )
   }
 }

--- a/Sources/ClawData/ClawStores.swift
+++ b/Sources/ClawData/ClawStores.swift
@@ -5,6 +5,7 @@ import ClawCore
 public struct ClawStores: Sendable {
   public let allowlist: any AllowlistStore
   public let processed: any ProcessedUpdateStore
+  public let commands: any CommandStore
   public let cursor: any UpdateCursorStore
   public let sessionMessages: any SessionMessageStore
   public let runs: any RunStore
@@ -15,6 +16,7 @@ public struct ClawStores: Sendable {
   public init(
     allowlist: any AllowlistStore,
     processed: any ProcessedUpdateStore,
+    commands: any CommandStore,
     cursor: any UpdateCursorStore,
     sessionMessages: any SessionMessageStore,
     runs: any RunStore,
@@ -24,6 +26,7 @@ public struct ClawStores: Sendable {
   ) {
     self.allowlist = allowlist
     self.processed = processed
+    self.commands = commands
     self.cursor = cursor
     self.sessionMessages = sessionMessages
     self.runs = runs
@@ -41,6 +44,7 @@ extension ClawDatabase {
     return ClawStores(
       allowlist: AllowlistStoreGRDB(writer: pool),
       processed: ProcessedUpdateStoreGRDB(writer: pool),
+      commands: CommandStoreGRDB(writer: pool),
       cursor: UpdateCursorStoreGRDB(writer: pool),
       sessionMessages: SessionMessageStoreGRDB(writer: pool),
       runs: RunStoreGRDB(writer: pool),

--- a/Sources/ClawData/CommandStoreGRDB.swift
+++ b/Sources/ClawData/CommandStoreGRDB.swift
@@ -40,18 +40,11 @@ public struct CommandStoreGRDB: CommandStore {
         sessionKey: sessionKey,
         now: now
       )
-      let runId = try Int64.fetchOne(
-        db,
-        sql: """
-          SELECT id FROM runs
-          WHERE session_id = ? AND state = ?
-          ORDER BY id DESC
-          LIMIT 1
-          """,
-        arguments: [sessionId, RunState.running.rawValue]
-      )
+      let runId = try RunStoreGRDB.fetchActiveRunId(db, sessionId: sessionId)
+
       let cancelledRunId: Int64?
-      if let runId, try Self.transitionRun(db, runId: runId, event: .cancel, now: now) != nil {
+      if let runId,
+        try RunStoreGRDB.transitionRun(db, runId: runId, event: .cancel, now: now) != nil {
         cancelledRunId = runId
       } else {
         cancelledRunId = nil
@@ -100,25 +93,9 @@ public struct CommandStoreGRDB: CommandStore {
         sessionKey: sessionKey,
         now: now
       )
-      let rows = try Row.fetchAll(
-        db,
-        sql: """
-          SELECT id FROM runs
-          WHERE session_id = ? AND state IN (?, ?)
-          ORDER BY id ASC
-          """,
-        arguments: [sessionId, RunState.pending.rawValue, RunState.running.rawValue]
-      )
+      let supersededRunIds = try RunStoreGRDB.supersedeRuns(db, sessionId: sessionId, now: now)
 
-      var supersededRunIds: [Int64] = []
-      for row in rows {
-        let runId: Int64 = row["id"]
-        if try Self.transitionRun(db, runId: runId, event: .supersede, now: now) != nil {
-          supersededRunIds.append(runId)
-        }
-      }
-
-      try Self.resetWindowAndDetaint(db, sessionId: sessionId, now: now)
+      try SessionMessageStoreGRDB.resetWindowAndDetaint(db, sessionId: sessionId, now: now)
       try Self.insertNewAudits(db, sessionId: sessionId, runIds: supersededRunIds, now: now)
 
       return NewCommandResult(
@@ -127,21 +104,6 @@ public struct CommandStoreGRDB: CommandStore {
         supersededRunIds: supersededRunIds
       )
     }
-  }
-
-  private static func resetWindowAndDetaint(_ db: Database, sessionId: Int64, now: Date) throws {
-    try db.execute(
-      sql: """
-        UPDATE sessions
-        SET window_start_message_id = (
-          SELECT COALESCE(MAX(messages.id), 0) FROM messages WHERE messages.session_id = ?
-        ),
-        tainted = 0,
-        updated_ts = ?
-        WHERE id = ?
-        """,
-      arguments: [sessionId, now, sessionId]
-    )
   }
 
   private static func insertNewAudits(
@@ -179,40 +141,5 @@ public struct CommandStoreGRDB: CommandStore {
         )
       )
     }
-  }
-
-  private static func transitionRun(
-    _ db: Database,
-    runId: Int64,
-    event: RunEvent,
-    now: Date
-  ) throws -> RunState? {
-    guard
-      let state = try currentRunState(db, runId: runId),
-      let nextState = RunFSM.reduce(state: state, on: event)
-    else {
-      return nil
-    }
-
-    try db.execute(
-      sql: "UPDATE runs SET state = ?, updated_ts = ? WHERE id = ?",
-      arguments: [nextState.rawValue, now, runId]
-    )
-
-    return nextState
-  }
-
-  private static func currentRunState(_ db: Database, runId: Int64) throws -> RunState? {
-    let rawState = try String.fetchOne(
-      db,
-      sql: "SELECT state FROM runs WHERE id = ?",
-      arguments: [runId]
-    )
-
-    guard let rawState else {
-      return nil
-    }
-
-    return RunState(rawValue: rawState)
   }
 }

--- a/Sources/ClawData/CommandStoreGRDB.swift
+++ b/Sources/ClawData/CommandStoreGRDB.swift
@@ -1,0 +1,218 @@
+import ClawCore
+import Foundation
+import GRDB
+
+public struct CommandStoreGRDB: CommandStore {
+  private let writer: any DatabaseWriter
+  private let afterClaimForTesting: @Sendable () throws -> Void
+
+  public init(writer: any DatabaseWriter) {
+    self.init(writer: writer, afterClaimForTesting: {})
+  }
+
+  init(
+    writer: any DatabaseWriter,
+    afterClaimForTesting: @Sendable @escaping () throws -> Void
+  ) {
+    self.writer = writer
+    self.afterClaimForTesting = afterClaimForTesting
+  }
+
+  public func applyStop(
+    updateId: Int64,
+    sessionKey: String,
+    now: Date
+  ) throws -> StopCommandResult {
+    try writer.writeMapping { db in
+      let newlyClaimed = try ProcessedUpdateStoreGRDB.claimUpdate(
+        db: db,
+        updateId: updateId,
+        claimedAt: now
+      )
+      guard newlyClaimed else {
+        return StopCommandResult(newlyClaimed: false, sessionId: nil, cancelledRunId: nil)
+      }
+
+      try afterClaimForTesting()
+
+      let sessionId = try SessionMessageStoreGRDB.upsertSession(
+        db,
+        sessionKey: sessionKey,
+        now: now
+      )
+      let runId = try Int64.fetchOne(
+        db,
+        sql: """
+          SELECT id FROM runs
+          WHERE session_id = ? AND state = ?
+          ORDER BY id DESC
+          LIMIT 1
+          """,
+        arguments: [sessionId, RunState.running.rawValue]
+      )
+      let cancelledRunId: Int64?
+      if let runId, try Self.transitionRun(db, runId: runId, event: .cancel, now: now) != nil {
+        cancelledRunId = runId
+      } else {
+        cancelledRunId = nil
+      }
+
+      try AuditLogGRDB.insertAudit(
+        db,
+        AuditEvent(
+          actor: .owner,
+          action: .turnCancelled,
+          argsRedacted: "/stop",
+          decision: cancelledRunId == nil ? "nothing_to_stop" : "cancelled",
+          runId: cancelledRunId,
+          sessionId: sessionId,
+          ts: now
+        )
+      )
+
+      return StopCommandResult(
+        newlyClaimed: true,
+        sessionId: sessionId,
+        cancelledRunId: cancelledRunId
+      )
+    }
+  }
+
+  public func applyNew(
+    updateId: Int64,
+    sessionKey: String,
+    now: Date
+  ) throws -> NewCommandResult {
+    try writer.writeMapping { db in
+      let newlyClaimed = try ProcessedUpdateStoreGRDB.claimUpdate(
+        db: db,
+        updateId: updateId,
+        claimedAt: now
+      )
+      guard newlyClaimed else {
+        return NewCommandResult(newlyClaimed: false, sessionId: nil, supersededRunIds: [])
+      }
+
+      try afterClaimForTesting()
+
+      let sessionId = try SessionMessageStoreGRDB.upsertSession(
+        db,
+        sessionKey: sessionKey,
+        now: now
+      )
+      let rows = try Row.fetchAll(
+        db,
+        sql: """
+          SELECT id FROM runs
+          WHERE session_id = ? AND state IN (?, ?)
+          ORDER BY id ASC
+          """,
+        arguments: [sessionId, RunState.pending.rawValue, RunState.running.rawValue]
+      )
+
+      var supersededRunIds: [Int64] = []
+      for row in rows {
+        let runId: Int64 = row["id"]
+        if try Self.transitionRun(db, runId: runId, event: .supersede, now: now) != nil {
+          supersededRunIds.append(runId)
+        }
+      }
+
+      try Self.resetWindowAndDetaint(db, sessionId: sessionId, now: now)
+      try Self.insertNewAudits(db, sessionId: sessionId, runIds: supersededRunIds, now: now)
+
+      return NewCommandResult(
+        newlyClaimed: true,
+        sessionId: sessionId,
+        supersededRunIds: supersededRunIds
+      )
+    }
+  }
+
+  private static func resetWindowAndDetaint(_ db: Database, sessionId: Int64, now: Date) throws {
+    try db.execute(
+      sql: """
+        UPDATE sessions
+        SET window_start_message_id = (
+          SELECT COALESCE(MAX(messages.id), 0) FROM messages WHERE messages.session_id = ?
+        ),
+        tainted = 0,
+        updated_ts = ?
+        WHERE id = ?
+        """,
+      arguments: [sessionId, now, sessionId]
+    )
+  }
+
+  private static func insertNewAudits(
+    _ db: Database,
+    sessionId: Int64,
+    runIds: [Int64],
+    now: Date
+  ) throws {
+    guard !runIds.isEmpty else {
+      try AuditLogGRDB.insertAudit(
+        db,
+        AuditEvent(
+          actor: .owner,
+          action: .turnSuperseded,
+          argsRedacted: "/new",
+          decision: "fresh_window",
+          sessionId: sessionId,
+          ts: now
+        )
+      )
+      return
+    }
+
+    for runId in runIds {
+      try AuditLogGRDB.insertAudit(
+        db,
+        AuditEvent(
+          actor: .owner,
+          action: .turnSuperseded,
+          argsRedacted: "/new",
+          decision: "superseded",
+          runId: runId,
+          sessionId: sessionId,
+          ts: now
+        )
+      )
+    }
+  }
+
+  private static func transitionRun(
+    _ db: Database,
+    runId: Int64,
+    event: RunEvent,
+    now: Date
+  ) throws -> RunState? {
+    guard
+      let state = try currentRunState(db, runId: runId),
+      let nextState = RunFSM.reduce(state: state, on: event)
+    else {
+      return nil
+    }
+
+    try db.execute(
+      sql: "UPDATE runs SET state = ?, updated_ts = ? WHERE id = ?",
+      arguments: [nextState.rawValue, now, runId]
+    )
+
+    return nextState
+  }
+
+  private static func currentRunState(_ db: Database, runId: Int64) throws -> RunState? {
+    let rawState = try String.fetchOne(
+      db,
+      sql: "SELECT state FROM runs WHERE id = ?",
+      arguments: [runId]
+    )
+
+    guard let rawState else {
+      return nil
+    }
+
+    return RunState(rawValue: rawState)
+  }
+}

--- a/Sources/ClawData/CommandStoreGRDB.swift
+++ b/Sources/ClawData/CommandStoreGRDB.swift
@@ -42,13 +42,14 @@ public struct CommandStoreGRDB: CommandStore {
       )
       let runId = try RunStoreGRDB.fetchActiveRunId(db, sessionId: sessionId)
 
-      let cancelledRunId: Int64?
-      if let runId,
-        try RunStoreGRDB.transitionRun(db, runId: runId, event: .cancel, now: now) != nil {
-        cancelledRunId = runId
-      } else {
-        cancelledRunId = nil
-      }
+      // swift-format-ignore
+      let cancelledRunId: Int64? =
+        if let runId,
+          try RunStoreGRDB.transitionRun(db, runId: runId, event: .cancel, now: now) != nil {
+          runId
+        } else {
+          nil
+        }
 
       try AuditLogGRDB.insertAudit(
         db,

--- a/Sources/ClawData/RunStoreGRDB.swift
+++ b/Sources/ClawData/RunStoreGRDB.swift
@@ -21,17 +21,7 @@ public struct RunStoreGRDB: RunStore {
     now: Date
   ) throws -> Int64? {
     try writer.writeMapping { db in
-      let runId = try Int64.fetchOne(
-        db,
-        sql: """
-          SELECT id FROM runs
-          WHERE session_id = ? AND state = ?
-          ORDER BY id DESC
-          LIMIT 1
-          """,
-        arguments: [sessionId, RunState.running.rawValue]
-      )
-      guard let runId else {
+      guard let runId = try Self.fetchActiveRunId(db, sessionId: sessionId) else {
         return nil
       }
 
@@ -50,25 +40,7 @@ public struct RunStoreGRDB: RunStore {
 
   public func supersedeSessionRuns(sessionId: Int64, now: Date) throws -> [Int64] {
     try writer.writeMapping { db in
-      let rows = try Row.fetchAll(
-        db,
-        sql: """
-          SELECT id FROM runs
-          WHERE session_id = ? AND state IN (?, ?)
-          ORDER BY id ASC
-          """,
-        arguments: [sessionId, RunState.pending.rawValue, RunState.running.rawValue]
-      )
-
-      var affected: [Int64] = []
-      for row in rows {
-        let runId: Int64 = row["id"]
-        if try Self.transitionRun(db, runId: runId, event: .supersede, now: now) != nil {
-          affected.append(runId)
-        }
-      }
-
-      return affected
+      try Self.supersedeRuns(db, sessionId: sessionId, now: now)
     }
   }
 
@@ -277,7 +249,42 @@ public struct RunStoreGRDB: RunStore {
     }
   }
 
-  private static func transitionRun(
+  static func fetchActiveRunId(_ db: Database, sessionId: Int64) throws -> Int64? {
+    try Int64.fetchOne(
+      db,
+      sql: """
+        SELECT id FROM runs
+        WHERE session_id = ? AND state = ?
+        ORDER BY id DESC
+        LIMIT 1
+        """,
+      arguments: [sessionId, RunState.running.rawValue]
+    )
+  }
+
+  static func supersedeRuns(_ db: Database, sessionId: Int64, now: Date) throws -> [Int64] {
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT id FROM runs
+        WHERE session_id = ? AND state IN (?, ?)
+        ORDER BY id ASC
+        """,
+      arguments: [sessionId, RunState.pending.rawValue, RunState.running.rawValue]
+    )
+
+    var affected: [Int64] = []
+    for row in rows {
+      let runId: Int64 = row["id"]
+      if try transitionRun(db, runId: runId, event: .supersede, now: now) != nil {
+        affected.append(runId)
+      }
+    }
+
+    return affected
+  }
+
+  static func transitionRun(
     _ db: Database,
     runId: Int64,
     event: RunEvent,

--- a/Sources/ClawData/SessionMessageStoreGRDB.swift
+++ b/Sources/ClawData/SessionMessageStoreGRDB.swift
@@ -107,23 +107,29 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
 
   public func resetWindowAndDetaint(sessionId: Int64, now: Date) throws {
     try writer.writeMapping { db in
-      // The boundary and detaint must move atomically so `/new` cannot expose a mixed session state.
-      let boundary =
-        try Int64.fetchOne(
-          db,
-          sql: "SELECT COALESCE(MAX(id), 0) FROM messages WHERE session_id = ?",
-          arguments: [sessionId]
-        ) ?? 0
-
-      try db.execute(
-        sql: """
-          UPDATE sessions
-          SET window_start_message_id = ?, tainted = 0, updated_ts = ?
-          WHERE id = ?
-          """,
-        arguments: [boundary, now, sessionId]
-      )
+      try Self.resetWindowAndDetaint(db, sessionId: sessionId, now: now)
     }
+  }
+
+  /// Resets the context window boundary to the current message high-water mark and clears the
+  /// taint flag atomically. Reused inside existing transactions (e.g. `CommandStoreGRDB`).
+  static func resetWindowAndDetaint(_ db: Database, sessionId: Int64, now: Date) throws {
+    // The boundary and detaint must move atomically so `/new` cannot expose a mixed session state.
+    let boundary =
+      try Int64.fetchOne(
+        db,
+        sql: "SELECT COALESCE(MAX(id), 0) FROM messages WHERE session_id = ?",
+        arguments: [sessionId]
+      ) ?? 0
+
+    try db.execute(
+      sql: """
+        UPDATE sessions
+        SET window_start_message_id = ?, tainted = 0, updated_ts = ?
+        WHERE id = ?
+        """,
+      arguments: [boundary, now, sessionId]
+    )
   }
 
   /// Upsert keyed on `session_key`; returns the row id. Reused inside `claimAndPersistInbound`'s

--- a/Sources/ClawGateway/CommandReplies.swift
+++ b/Sources/ClawGateway/CommandReplies.swift
@@ -1,0 +1,6 @@
+public enum CommandReplies {
+  public static let stopped = "Stopped."
+  public static let nothingToStop = "Nothing to stop."
+  public static let freshConversation =
+    "Started a fresh conversation — earlier context cleared."
+}

--- a/Sources/ClawGateway/MessageRouter.swift
+++ b/Sources/ClawGateway/MessageRouter.swift
@@ -19,6 +19,8 @@ public enum HandleOutcome: Sendable, Equatable {
 public struct MessageRouter: Sendable {
   private let processed: any ProcessedUpdateStore
   private let sessionMessages: any SessionMessageStore
+  private let commands: any CommandStore
+  private let botUsername: String?
   private let accessControl: AccessControl
   private let transport: any TelegramTransport
   private let turnRunner: any TurnDispatching
@@ -28,6 +30,8 @@ public struct MessageRouter: Sendable {
   public init(
     processed: any ProcessedUpdateStore,
     sessionMessages: any SessionMessageStore,
+    commands: any CommandStore,
+    botUsername: String?,
     accessControl: AccessControl,
     transport: any TelegramTransport,
     turnRunner: any TurnDispatching,
@@ -36,6 +40,8 @@ public struct MessageRouter: Sendable {
   ) {
     self.processed = processed
     self.sessionMessages = sessionMessages
+    self.commands = commands
+    self.botUsername = botUsername
     self.accessControl = accessControl
     self.transport = transport
     self.turnRunner = turnRunner
@@ -56,33 +62,116 @@ public struct MessageRouter: Sendable {
     let isAllowed = accessControl.isAllowed(userId: message.userId)
 
     switch message.content {
-    case .text(let text) where Self.isStart(text):
-      // Onboarding stays a direct reply for both tiers: the owner gets the welcome; a stranger gets
-      // THEIR own id to request access (never the allowlist, never a turn).
-      let reply = isAllowed ? Self.welcomeText : Self.unauthorizedStartText(userId: message.userId)
-      return await sendCanned(
-        rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: reply
-      )
     case .text(let text):
-      guard isAllowed else {
+      switch Command.parse(text, botUsername: botUsername) {
+      case .start:
+        // Onboarding stays a direct reply for both tiers: the owner gets the welcome; a stranger
+        // gets THEIR own id to request access (never the allowlist, never a turn).
+        let reply =
+          isAllowed ? Self.welcomeText : Self.unauthorizedStartText(userId: message.userId)
         return await sendCanned(
           rawUpdate: rawUpdate,
           chatId: message.chatId,
-          text: Self.privateBotText
+          text: reply
+        )
+      case .stop:
+        guard isAllowed else {
+          return await sendCanned(
+            rawUpdate: rawUpdate,
+            chatId: message.chatId,
+            text: Self.privateBotText
+          )
+        }
+        return await handleStop(rawUpdate: rawUpdate, message: message)
+      case .new:
+        guard isAllowed else {
+          return await sendCanned(
+            rawUpdate: rawUpdate,
+            chatId: message.chatId,
+            text: Self.privateBotText
+          )
+        }
+        return await handleNew(rawUpdate: rawUpdate, message: message)
+      case .plain(let plainText):
+        guard isAllowed else {
+          return await sendCanned(
+            rawUpdate: rawUpdate,
+            chatId: message.chatId,
+            text: Self.privateBotText
+          )
+        }
+        return await dispatchTurn(
+          rawUpdate: rawUpdate,
+          message: message,
+          text: plainText
         )
       }
-      return await dispatchTurn(
-        rawUpdate: rawUpdate,
-        message: message,
-        text: text
-      )
     case .unsupported(let kind):
       // Never reveal capabilities to a stranger; the owner gets a specific "can't read X yet".
       let reply = isAllowed ? "I can't read \(kind) yet." : Self.privateBotText
       return await sendCanned(rawUpdate: rawUpdate, chatId: message.chatId, text: reply)
     }
+  }
+
+  private func handleStop(rawUpdate: RawUpdate, message: IncomingMessage) async -> HandleOutcome {
+    let result: StopCommandResult
+    do {
+      result = try commands.applyStop(
+        updateId: rawUpdate.updateId,
+        sessionKey: SessionKey.telegramDM(chatId: message.chatId),
+        now: Date()
+      )
+    } catch StoreError.diskFull {
+      return await storageFull(chatId: message.chatId)
+    } catch {
+      logger.error("stop command failed for update \(rawUpdate.updateId): \(error)")
+      return .transientFailure
+    }
+
+    guard result.newlyClaimed else {
+      logger.debug("duplicate update \(rawUpdate.updateId), skipping")
+      return .skipped
+    }
+
+    if let sessionId = result.sessionId, let runId = result.cancelledRunId {
+      let lane = await lanes.actor(for: sessionId)
+      await lane.cancel(runId: runId)
+    }
+
+    let reply = result.cancelledRunId == nil ? CommandReplies.nothingToStop : CommandReplies.stopped
+    return await sendCommandAck(rawUpdate: rawUpdate, chatId: message.chatId, text: reply)
+  }
+
+  private func handleNew(rawUpdate: RawUpdate, message: IncomingMessage) async -> HandleOutcome {
+    let result: NewCommandResult
+    do {
+      result = try commands.applyNew(
+        updateId: rawUpdate.updateId,
+        sessionKey: SessionKey.telegramDM(chatId: message.chatId),
+        now: Date()
+      )
+    } catch StoreError.diskFull {
+      return await storageFull(chatId: message.chatId)
+    } catch {
+      logger.error("new command failed for update \(rawUpdate.updateId): \(error)")
+      return .transientFailure
+    }
+
+    guard result.newlyClaimed else {
+      logger.debug("duplicate update \(rawUpdate.updateId), skipping")
+      return .skipped
+    }
+
+    if let sessionId = result.sessionId {
+      let lane = await lanes.actor(for: sessionId)
+      await lane.cancelAll()
+    }
+
+    return await sendCommandAck(
+      rawUpdate: rawUpdate,
+      chatId: message.chatId,
+      text: CommandReplies.freshConversation
+    )
   }
 
   /// Fuses claim + persistence, then enqueues the durable run and returns without awaiting it.
@@ -141,6 +230,19 @@ public struct MessageRouter: Sendable {
     return .processed
   }
 
+  private func sendCommandAck(
+    rawUpdate: RawUpdate,
+    chatId: Int64,
+    text: String
+  ) async -> HandleOutcome {
+    do {
+      _ = try await transport.sendMessage(chatId: chatId, text: text)
+    } catch {
+      logger.error("command ack send failed for update \(rawUpdate.updateId): \(error)")
+    }
+    return .processed
+  }
+
   /// A direct canned reply, deduped via `claimUpdate` so a redelivery doesn't double-send it.
   private func sendCanned(
     rawUpdate: RawUpdate,
@@ -187,9 +289,5 @@ public struct MessageRouter: Sendable {
     """
     This is a private bot. Your Telegram user ID is \(userId). Ask the owner to add it to the allowlist.
     """
-  }
-
-  private static func isStart(_ text: String) -> Bool {
-    text == "/start" || text.hasPrefix("/start ") || text.hasPrefix("/start@")
   }
 }

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -58,7 +58,7 @@ struct RunCommand: AsyncParsableCommand {
     let httpClient = HTTPClient(eventLoopGroupProvider: .singleton, configuration: httpConfig)
     let executor = AsyncHTTPExecutor(client: httpClient)
 
-    let daemon = makeDaemon(
+    let daemon = await makeDaemon(
       config: config,
       secrets: secrets,
       stores: stores,
@@ -117,8 +117,9 @@ struct RunCommand: AsyncParsableCommand {
     stores: ClawStores,
     executor: AsyncHTTPExecutor,
     logger: Logger
-  ) -> Daemon {
+  ) async -> Daemon {
     let transport = TelegramClient(token: secrets.telegramBotToken, http: executor)
+    let botUsername = await fetchBotUsername(transport: transport, logger: logger)
     let agent = makeAgent(
       config: config,
       secrets: secrets,
@@ -146,6 +147,8 @@ struct RunCommand: AsyncParsableCommand {
     let router = MessageRouter(
       processed: stores.processed,
       sessionMessages: stores.sessionMessages,
+      commands: stores.commands,
+      botUsername: botUsername,
       accessControl: AccessControl(allowlist: stores.allowlist),
       transport: transport,
       turnRunner: turnRunner,
@@ -170,6 +173,17 @@ struct RunCommand: AsyncParsableCommand {
       bootReconcile: bootReconcile(stores: stores, logger: logger),
       logger: logger
     )
+  }
+
+  private func fetchBotUsername(transport: TelegramClient, logger: Logger) async -> String? {
+    do {
+      return try await transport.getMe().username
+    } catch {
+      logger.warning(
+        "failed to fetch bot identity; command mentions will require bare commands: \(error)"
+      )
+      return nil
+    }
   }
 
   /// Assembles the LLM agent stack: the OpenAI-compatible provider, the offline-first cost resolver,

--- a/Tests/ClawCoreTests/CommandTests.swift
+++ b/Tests/ClawCoreTests/CommandTests.swift
@@ -1,0 +1,56 @@
+import Testing
+
+@testable import ClawCore
+
+@Suite struct CommandTests {
+  @Test(arguments: [
+    ("/start", Command.start),
+    ("/START please", .start),
+    ("/stop", .stop),
+    ("/stop now", .stop),
+    ("/new", .new),
+    ("/new fresh please", .new),
+    ("/stop@claw_bot", .stop),
+    ("/STOP@CLAW_BOT now", .stop),
+  ])
+  func leadingSlashCommandsParse(text: String, expected: Command) {
+    // given
+    let botUsername = "claw_bot"
+
+    // when
+    let command = Command.parse(text, botUsername: botUsername)
+
+    // then
+    #expect(command == expected)
+  }
+
+  @Test(arguments: [
+    "tell me about /stop",
+    " /stop",
+    "/stop@some_other_bot",
+    "/stop@",
+    "/unknown",
+    "/",
+  ])
+  func nonMatchingSlashTextStaysPlain(text: String) {
+    // given
+    let botUsername = "claw_bot"
+
+    // when
+    let command = Command.parse(text, botUsername: botUsername)
+
+    // then
+    #expect(command == .plain(text))
+  }
+
+  @Test func botSuffixRequiresKnownMatchingUsername() {
+    // given
+    let text = "/new@claw_bot"
+
+    // when
+    let command = Command.parse(text, botUsername: nil)
+
+    // then
+    #expect(command == .plain(text))
+  }
+}

--- a/Tests/ClawDataTests/CommandStoreTests.swift
+++ b/Tests/ClawDataTests/CommandStoreTests.swift
@@ -1,0 +1,248 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct CommandStoreTests {
+  private struct Fixture {
+    let queue: DatabaseQueue
+    let sessions: SessionMessageStoreGRDB
+    let runs: RunStoreGRDB
+    let commands: CommandStoreGRDB
+    let sessionKey: String
+    let sessionId: Int64
+    let firstRunId: Int64
+  }
+
+  private struct InjectedCrash: Error {}
+
+  private func fixture() throws -> Fixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let sessionKey = SessionKey.telegramDM(chatId: 42)
+    let firstClaim = try sessions.claimAndPersistInbound(
+      inbound(updateId: 1, sessionKey: sessionKey, text: "first")
+    )
+    let sessionId = try #require(firstClaim.sessionId)
+    let firstRunId = try #require(firstClaim.runId)
+
+    return Fixture(
+      queue: queue,
+      sessions: sessions,
+      runs: RunStoreGRDB(writer: queue),
+      commands: CommandStoreGRDB(writer: queue),
+      sessionKey: sessionKey,
+      sessionId: sessionId,
+      firstRunId: firstRunId
+    )
+  }
+
+  private func inbound(updateId: Int64, sessionKey: String, text: String) -> InboundMessage {
+    InboundMessage(
+      updateId: updateId,
+      sessionKey: sessionKey,
+      chatId: 42,
+      userId: 42,
+      text: text,
+      isEdited: false,
+      ts: Date(timeIntervalSince1970: Double(updateId))
+    )
+  }
+
+  @Test func stopCancelsOnlyRunningRunAndAuditsCancellation() throws {
+    // given
+    let env = try fixture()
+    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)))
+    let queued = try env.sessions.claimAndPersistInbound(
+      inbound(updateId: 2, sessionKey: env.sessionKey, text: "queued")
+    )
+    let queuedRunId = try #require(queued.runId)
+    let now = Date(timeIntervalSince1970: 100)
+
+    // when
+    let result = try env.commands.applyStop(updateId: 100, sessionKey: env.sessionKey, now: now)
+
+    // then
+    #expect(
+      result
+        == StopCommandResult(
+          newlyClaimed: true,
+          sessionId: env.sessionId,
+          cancelledRunId: env.firstRunId
+        )
+    )
+    let states = try runStates(env.queue)
+    #expect(states[env.firstRunId] == RunState.cancelled.rawValue)
+    #expect(states[queuedRunId] == RunState.pending.rawValue)
+    #expect(try processedCount(env.queue, updateId: 100) == 1)
+    #expect(try messageCount(env.queue, content: "/stop") == 0)
+
+    let audits = try auditRows(env.queue)
+    #expect(audits.count == 1)
+    let audit = try #require(audits.first)
+    #expect(audit["actor"] as String == AuditActor.owner.rawValue)
+    #expect(audit["action"] as String == AuditAction.turnCancelled.rawValue)
+    #expect(audit["args_redacted"] as String == "/stop")
+    #expect(audit["decision"] as String == "cancelled")
+    #expect(audit["run_id"] as Int64? == env.firstRunId)
+    #expect(audit["session_id"] as Int64? == env.sessionId)
+  }
+
+  @Test func newSupersedesActiveRunsResetsWindowDetaintsAndAudits() throws {
+    // given
+    let env = try fixture()
+    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)))
+    let queued = try env.sessions.claimAndPersistInbound(
+      inbound(updateId: 2, sessionKey: env.sessionKey, text: "queued")
+    )
+    let queuedRunId = try #require(queued.runId)
+    try env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE sessions SET tainted = 1, window_start_message_id = 0 WHERE id = ?",
+        arguments: [env.sessionId]
+      )
+    }
+    let latestMessageId = try #require(
+      try env.queue.read { db in
+        try Int64.fetchOne(
+          db,
+          sql: "SELECT MAX(id) FROM messages WHERE session_id = ?",
+          arguments: [env.sessionId]
+        )
+      }
+    )
+    let now = Date(timeIntervalSince1970: 200)
+
+    // when
+    let result = try env.commands.applyNew(updateId: 200, sessionKey: env.sessionKey, now: now)
+
+    // then
+    #expect(
+      result
+        == NewCommandResult(
+          newlyClaimed: true,
+          sessionId: env.sessionId,
+          supersededRunIds: [env.firstRunId, queuedRunId]
+        )
+    )
+    let states = try runStates(env.queue)
+    #expect(states[env.firstRunId] == RunState.superseded.rawValue)
+    #expect(states[queuedRunId] == RunState.superseded.rawValue)
+    let session = try #require(
+      try env.queue.read { db in
+        try Row.fetchOne(
+          db,
+          sql: "SELECT window_start_message_id, tainted, updated_ts FROM sessions WHERE id = ?",
+          arguments: [env.sessionId]
+        )
+      }
+    )
+    #expect(session["window_start_message_id"] as Int64 == latestMessageId)
+    #expect(session["tainted"] as Bool == false)
+    #expect(session["updated_ts"] as Date == now)
+    #expect(try messageCount(env.queue, content: "/new") == 0)
+
+    let audits = try auditRows(env.queue)
+    #expect(audits.count == 2)
+    #expect(
+      audits.map { $0["action"] as String } == [
+        AuditAction.turnSuperseded.rawValue, AuditAction.turnSuperseded.rawValue,
+      ]
+    )
+    #expect(audits.map { $0["decision"] as String } == ["superseded", "superseded"])
+    #expect(audits.map { $0["args_redacted"] as String } == ["/new", "/new"])
+    #expect(audits.map { $0["run_id"] as Int64? } == [env.firstRunId, queuedRunId])
+  }
+
+  @Test func duplicateCommandDoesNotRepeatEffects() throws {
+    // given
+    let env = try fixture()
+    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)))
+    let now = Date(timeIntervalSince1970: 300)
+    let first = try env.commands.applyStop(updateId: 300, sessionKey: env.sessionKey, now: now)
+
+    // when
+    let duplicate = try env.commands.applyStop(updateId: 300, sessionKey: env.sessionKey, now: now)
+
+    // then
+    #expect(first.cancelledRunId == env.firstRunId)
+    #expect(
+      duplicate == StopCommandResult(newlyClaimed: false, sessionId: nil, cancelledRunId: nil)
+    )
+    #expect(try processedCount(env.queue, updateId: 300) == 1)
+    #expect(try auditRows(env.queue).count == 1)
+    let states = try runStates(env.queue)
+    #expect(states[env.firstRunId] == RunState.cancelled.rawValue)
+  }
+
+  @Test func crashAfterClaimRollsBackClaimAndAllowsRetry() throws {
+    // given
+    let env = try fixture()
+    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)))
+    let crashingStore = CommandStoreGRDB(
+      writer: env.queue,
+      afterClaimForTesting: { throw InjectedCrash() }
+    )
+    let now = Date(timeIntervalSince1970: 400)
+
+    // when
+    #expect(throws: InjectedCrash.self) {
+      try crashingStore.applyStop(updateId: 400, sessionKey: env.sessionKey, now: now)
+    }
+
+    // then
+    #expect(try processedCount(env.queue, updateId: 400) == 0)
+    #expect(try runStates(env.queue)[env.firstRunId] == RunState.running.rawValue)
+
+    let retry = try env.commands.applyStop(updateId: 400, sessionKey: env.sessionKey, now: now)
+    #expect(retry.cancelledRunId == env.firstRunId)
+    #expect(try processedCount(env.queue, updateId: 400) == 1)
+    #expect(try runStates(env.queue)[env.firstRunId] == RunState.cancelled.rawValue)
+  }
+
+  private func runStates(_ queue: DatabaseQueue) throws -> [Int64: String] {
+    try queue.read { db in
+      let rows = try Row.fetchAll(db, sql: "SELECT id, state FROM runs")
+      return Dictionary(
+        uniqueKeysWithValues: rows.map { row in (row["id"] as Int64, row["state"] as String) }
+      )
+    }
+  }
+
+  private func processedCount(_ queue: DatabaseQueue, updateId: Int64) throws -> Int {
+    try queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM processed_updates WHERE update_id = ?",
+        arguments: [updateId]
+      ) ?? 0
+    }
+  }
+
+  private func messageCount(_ queue: DatabaseQueue, content: String) throws -> Int {
+    try queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM messages WHERE content = ?",
+        arguments: [content]
+      ) ?? 0
+    }
+  }
+
+  private func auditRows(_ queue: DatabaseQueue) throws -> [Row] {
+    try queue.read { db in
+      try Row.fetchAll(
+        db,
+        sql: """
+          SELECT actor, action, args_redacted, decision, run_id, session_id
+          FROM audit_events
+          ORDER BY id ASC
+          """
+      )
+    }
+  }
+}

--- a/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
+++ b/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
@@ -123,6 +123,7 @@ func makeStack(
   let processed = ProcessedUpdateStoreGRDB(writer: writer)
   let cursor = UpdateCursorStoreGRDB(writer: writer)
   let sessionMessages = SessionMessageStoreGRDB(writer: writer)
+  let commands = CommandStoreGRDB(writer: writer)
   let runs = RunStoreGRDB(writer: writer)
   let usage = UsageStoreGRDB(writer: writer)
   let outbox = OutboxStoreGRDB(writer: writer)
@@ -163,6 +164,8 @@ func makeStack(
   let router = MessageRouter(
     processed: processed,
     sessionMessages: sessionMessages,
+    commands: commands,
+    botUsername: "claw_bot",
     accessControl: AccessControl(allowlist: allowlist),
     transport: transport,
     turnRunner: turnRunner,

--- a/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
+++ b/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
@@ -74,6 +74,47 @@ actor RecordingProvider: LLMProvider {
   }
 }
 
+actor StopNewProvider: LLMProvider {
+  private(set) var requests: [[ChatMessage]] = []
+  private var requestContinuations: [(count: Int, continuation: CheckedContinuation<Void, Never>)] =
+    []
+
+  func complete(request: ChatRequest) async throws -> ChatResponse {
+    requests.append(request.messages)
+    resumeRequestContinuations()
+
+    if requests.count == 1 {
+      while !Task.isCancelled {
+        try await Task.sleep(for: .milliseconds(5))
+      }
+      throw CancellationError()
+    }
+
+    return ChatResponse(
+      content: "fresh reply",
+      finishReason: "stop",
+      usage: ChatUsage(promptTokens: 10, completionTokens: 5, totalTokens: 15),
+      costFromProvider: 0.0021
+    )
+  }
+
+  func waitForRequestCount(_ count: Int) async {
+    guard requests.count < count else { return }
+    await withCheckedContinuation { continuation in
+      requestContinuations.append((count: count, continuation: continuation))
+    }
+  }
+
+  private func resumeRequestContinuations() {
+    let currentCount = requests.count
+    let ready = requestContinuations.filter { $0.count <= currentCount }
+    requestContinuations.removeAll { $0.count <= currentCount }
+    for waiter in ready {
+      waiter.continuation.resume()
+    }
+  }
+}
+
 actor Gate {
   private var releaseContinuation: CheckedContinuation<Void, Never>?
 
@@ -107,6 +148,16 @@ struct Stack {
   let cursor: UpdateCursorStoreGRDB
   let chatId: Int64
   let lanes: SessionLaneRegistry
+}
+
+struct StopNewStack {
+  let router: MessageRouter
+  let transport: RecordingTransport
+  let provider: StopNewProvider
+  let signal: OutboxSignal
+  let writer: any DatabaseWriter
+  let outbox: OutboxStoreGRDB
+  let chatId: Int64
 }
 
 /// Assembles the production lane stack over `writer`, seeding `chatId` onto the allowlist and
@@ -197,6 +248,76 @@ func makeStack(
   )
 }
 
+func makeStopNewStack(
+  writer: any DatabaseWriter,
+  allow chatId: Int64 = 42
+) throws -> StopNewStack {
+  let allowlist = AllowlistStoreGRDB(writer: writer)
+  try allowlist.seedAllowlist(userIds: [chatId])
+
+  let processed = ProcessedUpdateStoreGRDB(writer: writer)
+  let sessionMessages = SessionMessageStoreGRDB(writer: writer)
+  let commands = CommandStoreGRDB(writer: writer)
+  let runs = RunStoreGRDB(writer: writer)
+  let usage = UsageStoreGRDB(writer: writer)
+  let outbox = OutboxStoreGRDB(writer: writer)
+  let audit = AuditLogGRDB(writer: writer)
+
+  let provider = StopNewProvider()
+  let transport = RecordingTransport()
+  let signal = OutboxSignal()
+  let lanes = SessionLaneRegistry()
+  let logger = Logger(label: "stop-new-acceptance")
+
+  let agent = AgentRuntime(
+    provider: provider,
+    typingIndicator: NoopTyping(),
+    costResolver: CostResolver(
+      priceTable: .empty,
+      referenceUSDPerToken: RunBudget.default.referenceUSDPerToken
+    ),
+    budget: .default,
+    model: "gpt-4o",
+    sleep: { try await Task.sleep(for: $0) }
+  )
+
+  let turnRunner = TurnRunner(
+    sessionMessages: sessionMessages,
+    runs: runs,
+    usageStore: usage,
+    audit: audit,
+    agent: agent,
+    budget: .default,
+    systemPrompt: SystemPrompt.minimal,
+    notifyOutbox: { signal.poke() },
+    breaker: BudgetBreaker(budget: .default),
+    transport: transport,
+    logger: logger
+  )
+
+  let router = MessageRouter(
+    processed: processed,
+    sessionMessages: sessionMessages,
+    commands: commands,
+    botUsername: "claw_bot",
+    accessControl: AccessControl(allowlist: allowlist),
+    transport: transport,
+    turnRunner: turnRunner,
+    lanes: lanes,
+    logger: logger
+  )
+
+  return StopNewStack(
+    router: router,
+    transport: transport,
+    provider: provider,
+    signal: signal,
+    writer: writer,
+    outbox: outbox,
+    chatId: chatId
+  )
+}
+
 @Suite struct LLMTurnPersistenceAcceptanceTests {
   // MARK: - Durable-state probes
 
@@ -218,6 +339,11 @@ func makeStack(
     try writer.read { db in
       try String.fetchAll(db, sql: "SELECT state FROM runs ORDER BY id ASC")
     }
+  }
+
+  private func waitForOutboxPoke(_ signal: OutboxSignal) async {
+    var iterator = signal.notifications.makeAsyncIterator()
+    _ = await iterator.next()
   }
 
   private func waitForRunStates(
@@ -472,6 +598,86 @@ func makeStack(
       )
     }
     #expect(assistantRunIds == [1, 2])
+  }
+
+  @Test func stopMidTurnCancelsRunAndNextPlainMessageStillReplies() async throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let stack = try makeStopNewStack(writer: queue)
+
+    // when
+    let firstOutcome = await stack.router.handle(
+      rawUpdate: textUpdate(id: 1, from: stack.chatId, text: "before stop")
+    )
+    await stack.provider.waitForRequestCount(1)
+    let stopOutcome = await stack.router.handle(
+      rawUpdate: textUpdate(id: 2, from: stack.chatId, text: "/stop")
+    )
+    let afterStopOutcome = await stack.router.handle(
+      rawUpdate: textUpdate(id: 3, from: stack.chatId, text: "after stop")
+    )
+    await stack.provider.waitForRequestCount(2)
+    await waitForOutboxPoke(stack.signal)
+
+    // then
+    #expect(firstOutcome == .processed)
+    #expect(stopOutcome == .processed)
+    #expect(afterStopOutcome == .processed)
+    #expect(
+      try runStates(queue) == [
+        RunState.cancelled.rawValue,
+        RunState.done.rawValue,
+      ]
+    )
+    #expect(await stack.transport.sent.contains { $0.text == CommandReplies.stopped })
+    #expect(try stack.outbox.pendingOutbound().map(\.payload) == ["fresh reply"])
+  }
+
+  @Test func newSupersedesRunningAndQueuedRunsAndClearsContextWindow() async throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let stack = try makeStopNewStack(writer: queue)
+
+    // when
+    let firstOutcome = await stack.router.handle(
+      rawUpdate: textUpdate(id: 1, from: stack.chatId, text: "before one")
+    )
+    await stack.provider.waitForRequestCount(1)
+    let secondOutcome = await stack.router.handle(
+      rawUpdate: textUpdate(id: 2, from: stack.chatId, text: "before two")
+    )
+    let newOutcome = await stack.router.handle(
+      rawUpdate: textUpdate(id: 3, from: stack.chatId, text: "/new")
+    )
+    let afterNewOutcome = await stack.router.handle(
+      rawUpdate: textUpdate(id: 4, from: stack.chatId, text: "after new")
+    )
+    await stack.provider.waitForRequestCount(2)
+    await waitForOutboxPoke(stack.signal)
+
+    // then
+    #expect(firstOutcome == .processed)
+    #expect(secondOutcome == .processed)
+    #expect(newOutcome == .processed)
+    #expect(afterNewOutcome == .processed)
+    #expect(
+      try runStates(queue) == [
+        RunState.superseded.rawValue,
+        RunState.superseded.rawValue,
+        RunState.done.rawValue,
+      ]
+    )
+    #expect(await stack.transport.sent.contains { $0.text == CommandReplies.freshConversation })
+
+    let requests = await stack.provider.requests
+    #expect(requests.count == 2)
+    let secondRequestContent = requests[1].map(\.content)
+    #expect(secondRequestContent.contains("after new"))
+    #expect(secondRequestContent.contains("before one") == false)
+    #expect(secondRequestContent.contains("before two") == false)
+    #expect(try stack.outbox.pendingOutbound().map(\.payload) == ["fresh reply"])
   }
 }
 // swiftlint:enable function_body_length

--- a/Tests/ClawGatewayTests/MessageRouterTests.swift
+++ b/Tests/ClawGatewayTests/MessageRouterTests.swift
@@ -275,6 +275,66 @@ struct FullSessions: SessionMessageStore {
     #expect(try runStates(queue)[runId] == RunState.cancelled.rawValue)
   }
 
+  @Test func failedNewAckDoesNotUndoCommittedEffect() async throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let allowlist = AllowlistStoreGRDB(writer: queue)
+    try allowlist.seedAllowlist(userIds: [42])
+    let sessionMessages = SessionMessageStoreGRDB(writer: queue)
+    let runs = RunStoreGRDB(writer: queue)
+    let firstClaim = try sessionMessages.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 60,
+        sessionKey: SessionKey.telegramDM(chatId: 42),
+        chatId: 42,
+        userId: 42,
+        text: "running",
+        isEdited: false,
+        ts: Date(timeIntervalSince1970: 60)
+      )
+    )
+    let runningRunId = try #require(firstClaim.runId)
+    #expect(try runs.pickUp(runId: runningRunId, now: Date(timeIntervalSince1970: 61)))
+    let secondClaim = try sessionMessages.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 61,
+        sessionKey: SessionKey.telegramDM(chatId: 42),
+        chatId: 42,
+        userId: 42,
+        text: "queued",
+        isEdited: false,
+        ts: Date(timeIntervalSince1970: 61)
+      )
+    )
+    let queuedRunId = try #require(secondClaim.runId)
+    let transport = RecordingTransport(sendError: .transport("ack down"))
+    let dispatcher = FakeTurnRunner()
+    let router = MessageRouter(
+      processed: ProcessedUpdateStoreGRDB(writer: queue),
+      sessionMessages: sessionMessages,
+      commands: CommandStoreGRDB(writer: queue),
+      botUsername: "claw_bot",
+      accessControl: AccessControl(allowlist: allowlist),
+      transport: transport,
+      turnRunner: dispatcher,
+      lanes: SessionLaneRegistry(),
+      logger: Logger(label: "test")
+    )
+
+    // when
+    let outcome = await router.handle(rawUpdate: textUpdate(id: 62, from: 42, text: "/new"))
+
+    // then
+    #expect(outcome == .processed)
+    #expect(await transport.sendAttempts == 1)
+    #expect(await dispatcher.calls.isEmpty)
+    #expect(try messageCount(queue, content: "/new") == 0)
+    let states = try runStates(queue)
+    #expect(states[runningRunId] == RunState.superseded.rawValue)
+    #expect(states[queuedRunId] == RunState.superseded.rawValue)
+  }
+
   @Test func unsupportedMediaGetsFriendlyReply() async throws {
     // given
     let harness = try makeHarness(allowed: [42])

--- a/Tests/ClawGatewayTests/MessageRouterTests.swift
+++ b/Tests/ClawGatewayTests/MessageRouterTests.swift
@@ -2,6 +2,7 @@ import ClawAgent
 import ClawCore
 import ClawData
 import Foundation
+import GRDB
 import Logging
 import Testing
 
@@ -31,6 +32,14 @@ struct FullSessions: SessionMessageStore {
     let transport: RecordingTransport
     let dispatcher: FakeTurnRunner
     let sessionMessages: SessionMessageStoreGRDB
+    let runs: RunStoreGRDB
+    let queue: DatabaseQueue
+  }
+
+  private struct SeededRun {
+    let sessionId: Int64
+    let runId: Int64
+    let messageId: Int64
   }
 
   private func makeHarness(allowed: [Int64]) throws -> Harness {
@@ -42,9 +51,12 @@ struct FullSessions: SessionMessageStore {
     let transport = RecordingTransport()
     let dispatcher = FakeTurnRunner()
     let sessionMessages = SessionMessageStoreGRDB(writer: queue)
+    let runs = RunStoreGRDB(writer: queue)
     let router = MessageRouter(
       processed: ProcessedUpdateStoreGRDB(writer: queue),
       sessionMessages: sessionMessages,
+      commands: CommandStoreGRDB(writer: queue),
+      botUsername: "claw_bot",
       accessControl: AccessControl(allowlist: allowlist),
       transport: transport,
       turnRunner: dispatcher,
@@ -56,7 +68,9 @@ struct FullSessions: SessionMessageStore {
       router: router,
       transport: transport,
       dispatcher: dispatcher,
-      sessionMessages: sessionMessages
+      sessionMessages: sessionMessages,
+      runs: runs,
+      queue: queue
     )
   }
 
@@ -141,6 +155,126 @@ struct FullSessions: SessionMessageStore {
     #expect(await harness.dispatcher.calls.isEmpty)
   }
 
+  @Test func allowlistedStopCancelsActiveRunAndSendsStopped() async throws {
+    // given
+    let harness = try makeHarness(allowed: [42])
+    let seeded = try seedPendingRun(harness, updateId: 10, text: "working")
+    #expect(try harness.runs.pickUp(runId: seeded.runId, now: Date(timeIntervalSince1970: 10)))
+
+    // when
+    let outcome = await harness.router.handle(
+      rawUpdate: textUpdate(id: 11, from: 42, text: "/stop")
+    )
+
+    // then
+    #expect(outcome == .processed)
+    let sent = await harness.transport.sent
+    #expect(sent.map(\.text) == [CommandReplies.stopped])
+    #expect(await harness.dispatcher.calls.isEmpty)
+    #expect(try messageCount(harness.queue, content: "/stop") == 0)
+    #expect(try runStates(harness.queue)[seeded.runId] == RunState.cancelled.rawValue)
+  }
+
+  @Test func allowlistedStopWithNoActiveRunSendsNothingToStop() async throws {
+    // given
+    let harness = try makeHarness(allowed: [42])
+
+    // when
+    let outcome = await harness.router.handle(
+      rawUpdate: textUpdate(id: 20, from: 42, text: "/stop")
+    )
+
+    // then
+    #expect(outcome == .processed)
+    let sent = await harness.transport.sent
+    #expect(sent.map(\.text) == [CommandReplies.nothingToStop])
+    #expect(await harness.dispatcher.calls.isEmpty)
+  }
+
+  @Test func allowlistedNewForThisBotSendsFreshAckAndDoesNotDispatch() async throws {
+    // given
+    let harness = try makeHarness(allowed: [42])
+
+    // when
+    let outcome = await harness.router.handle(
+      rawUpdate: textUpdate(id: 30, from: 42, text: "/new@claw_bot")
+    )
+
+    // then
+    #expect(outcome == .processed)
+    let sent = await harness.transport.sent
+    #expect(sent.map(\.text) == [CommandReplies.freshConversation])
+    #expect(await harness.dispatcher.calls.isEmpty)
+  }
+
+  @Test func newForSomeOtherBotIsPlainTextAndDispatchesTurn() async throws {
+    // given
+    let harness = try makeHarness(allowed: [42])
+
+    // when
+    let outcome = await harness.router.handle(
+      rawUpdate: textUpdate(id: 40, from: 42, text: "/new@some_other_bot")
+    )
+    await harness.dispatcher.waitForCalls(atLeast: 1)
+
+    // then
+    #expect(outcome == .processed)
+    #expect(await harness.transport.sent.isEmpty)
+    let calls = await harness.dispatcher.calls
+    let firstCall = try #require(calls.first)
+    let history = try harness.sessionMessages.loadContext(
+      sessionId: firstCall.sessionId,
+      throughMessageId: firstCall.triggerMessageId,
+      limit: 50
+    )
+    #expect(history.contains { $0.role == .user && $0.content == "/new@some_other_bot" })
+  }
+
+  @Test func commandAckFailureStillProcessesAndKeepsDurableStopEffect() async throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let allowlist = AllowlistStoreGRDB(writer: queue)
+    try allowlist.seedAllowlist(userIds: [42])
+    let sessionMessages = SessionMessageStoreGRDB(writer: queue)
+    let runs = RunStoreGRDB(writer: queue)
+    let claim = try sessionMessages.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 50,
+        sessionKey: SessionKey.telegramDM(chatId: 42),
+        chatId: 42,
+        userId: 42,
+        text: "working",
+        isEdited: false,
+        ts: Date(timeIntervalSince1970: 50)
+      )
+    )
+    let runId = try #require(claim.runId)
+    #expect(try runs.pickUp(runId: runId, now: Date(timeIntervalSince1970: 51)))
+    let transport = RecordingTransport(sendError: .transport("ack down"))
+    let dispatcher = FakeTurnRunner()
+    let router = MessageRouter(
+      processed: ProcessedUpdateStoreGRDB(writer: queue),
+      sessionMessages: sessionMessages,
+      commands: CommandStoreGRDB(writer: queue),
+      botUsername: "claw_bot",
+      accessControl: AccessControl(allowlist: allowlist),
+      transport: transport,
+      turnRunner: dispatcher,
+      lanes: SessionLaneRegistry(),
+      logger: Logger(label: "test")
+    )
+
+    // when
+    let outcome = await router.handle(rawUpdate: textUpdate(id: 52, from: 42, text: "/stop"))
+
+    // then
+    #expect(outcome == .processed)
+    #expect(await transport.sendAttempts == 1)
+    #expect(await dispatcher.calls.isEmpty)
+    #expect(try runStates(queue)[runId] == RunState.cancelled.rawValue)
+  }
+
   @Test func unsupportedMediaGetsFriendlyReply() async throws {
     // given
     let harness = try makeHarness(allowed: [42])
@@ -177,6 +311,8 @@ struct FullSessions: SessionMessageStore {
     let router = MessageRouter(
       processed: ProcessedUpdateStoreGRDB(writer: queue),
       sessionMessages: FullSessions(),
+      commands: CommandStoreGRDB(writer: queue),
+      botUsername: "claw_bot",
       accessControl: AccessControl(allowlist: allowlist),
       transport: transport,
       turnRunner: FakeTurnRunner(),
@@ -191,5 +327,47 @@ struct FullSessions: SessionMessageStore {
     #expect(outcome == .storageFull)
     let sent = await transport.sent
     #expect(sent.contains { $0.text == Degradation.storageFull })
+  }
+
+  private func seedPendingRun(
+    _ harness: Harness,
+    updateId: Int64,
+    text: String
+  ) throws -> SeededRun {
+    let claim = try harness.sessionMessages.claimAndPersistInbound(
+      InboundMessage(
+        updateId: updateId,
+        sessionKey: SessionKey.telegramDM(chatId: 42),
+        chatId: 42,
+        userId: 42,
+        text: text,
+        isEdited: false,
+        ts: Date(timeIntervalSince1970: Double(updateId))
+      )
+    )
+    return SeededRun(
+      sessionId: try #require(claim.sessionId),
+      runId: try #require(claim.runId),
+      messageId: try #require(claim.triggerMessageId)
+    )
+  }
+
+  private func runStates(_ queue: DatabaseQueue) throws -> [Int64: String] {
+    try queue.read { db in
+      let rows = try Row.fetchAll(db, sql: "SELECT id, state FROM runs")
+      return Dictionary(
+        uniqueKeysWithValues: rows.map { row in (row["id"] as Int64, row["state"] as String) }
+      )
+    }
+  }
+
+  private func messageCount(_ queue: DatabaseQueue, content: String) throws -> Int {
+    try queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM messages WHERE content = ?",
+        arguments: [content]
+      ) ?? 0
+    }
   }
 }

--- a/Tests/ClawGatewayTests/TelegramPollerServiceTests.swift
+++ b/Tests/ClawGatewayTests/TelegramPollerServiceTests.swift
@@ -68,6 +68,8 @@ private actor BlockingTurnRunner: TurnDispatching {
     let router = MessageRouter(
       processed: ProcessedUpdateStoreGRDB(writer: queue),
       sessionMessages: SessionMessageStoreGRDB(writer: queue),
+      commands: CommandStoreGRDB(writer: queue),
+      botUsername: "claw_bot",
       accessControl: AccessControl(allowlist: allowlist),
       transport: transport,
       turnRunner: dispatcher,
@@ -129,6 +131,8 @@ private actor BlockingTurnRunner: TurnDispatching {
     let router = MessageRouter(
       processed: ProcessedUpdateStoreGRDB(writer: queue),
       sessionMessages: SessionMessageStoreGRDB(writer: queue),
+      commands: CommandStoreGRDB(writer: queue),
+      botUsername: "claw_bot",
       accessControl: AccessControl(allowlist: allowlist),
       transport: transport,
       turnRunner: runner,


### PR DESCRIPTION
## Summary

- Adds `Command` enum with a `parse(_:botUsername:)` method that classifies leading slash tokens and ignores bot-qualified commands addressed to other bots.
- Adds `CommandStoreGRDB` with atomic idempotency via `ProcessedUpdateStoreGRDB`: `/stop` cancels the active run and creates a fresh session in one transaction; `/new` resets the session without touching the run.
- Routes `/stop` and `/new` through `MessageRouter`, wiring the store into `RunCommand` bootstrap.
- Adds acceptance tests covering duplicate-update deduplication, concurrent `/stop` races, and the full `/new` session-reset flow.

## Test plan

- [x] `swift test --filter CommandTests` — `Command.parse` cases including bot-qualified, bare slash, unknown commands
- [x] `swift test --filter CommandStoreTests` — atomic stop/new, idempotency, race deduplication
- [x] `swift test --filter MessageRouterTests` — routing for `/stop`, `/new`, plain text
- [x] `swift test --filter LLMTurnPersistenceAcceptanceTests` — end-to-end turn persistence with stop/new interleaved
- [x] `scripts/lint.sh` passes