### PR TITLE
Add ClawWorkspace loader and skills scanner

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f96c843b67b27cf582c45c374e8faef87a800407d0e210a577ccee595fe33cd0",
+  "originHash" : "77e020aad7ce4604fe4e1570755feb3b6e8afe2843e8cd4fad76106740ae8497",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
-        "version" : "5.4.0"
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dfdddf73e643563e1b8d7621e171e703a71cf8c50d76ad4968234ecae0d99801",
+  "originHash" : "f96c843b67b27cf582c45c374e8faef87a800407d0e210a577ccee595fe33cd0",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -215,6 +215,15 @@
       "state" : {
         "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
         "version" : "1.7.2"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
+        "version" : "5.4.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.21.0"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "4.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.11.0"),
-    .package(url: "https://github.com/jpsim/Yams.git", from: "5.1.0"),
+    .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.2"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.21.0"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "4.0.0"),
     .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.11.0"),
+    .package(url: "https://github.com/jpsim/Yams.git", from: "5.1.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
@@ -30,6 +31,13 @@ let package = Package(
       dependencies: [
         "ClawCore",
         .product(name: "GRDB", package: "GRDB.swift"),
+      ]
+    ),
+    .target(
+      name: "ClawWorkspace",
+      dependencies: [
+        "ClawCore",
+        .product(name: "Yams", package: "Yams"),
       ]
     ),
     .target(
@@ -75,6 +83,7 @@ let package = Package(
       ]
     ),
     .testTarget(name: "ClawDataTests", dependencies: ["ClawData", "ClawCore"]),
+    .testTarget(name: "ClawWorkspaceTests", dependencies: ["ClawWorkspace", "ClawCore"]),
     .testTarget(
       name: "ClawTelegramTests",
       dependencies: [

--- a/Sources/ClawWorkspace/FileSystemWorkspace.swift
+++ b/Sources/ClawWorkspace/FileSystemWorkspace.swift
@@ -1,0 +1,45 @@
+import ClawCore
+import Foundation
+
+/// Pure workspace file I/O and parsing (spec §3, §6). No budget, LLM, or config knowledge: per-file
+/// grapheme caps arrive as a parameter and the caller decides how to react to each `LoadedFile`.
+public protocol WorkspaceReading: Sendable {
+  /// Loads a fixed workspace file in the grapheme domain. A missing file returns `.missing`, an
+  /// undecodable file `.unreadable`, an over-cap file `.overCap` (no consumable text), and never
+  /// throws. `maxGraphemes` nil means no cap.
+  func load(_ file: WorkspaceFile, maxGraphemes: Int?) -> LoadedFile
+}
+
+public struct FileSystemWorkspace: WorkspaceReading {
+  public let root: URL
+
+  public init(root: URL) {
+    self.root = root
+  }
+
+  public func load(_ file: WorkspaceFile, maxGraphemes: Int?) -> LoadedFile {
+    loadFile(at: root.appendingPathComponent(file.relativePath), maxGraphemes: maxGraphemes)
+  }
+
+  /// Shared read + outcome classification for any single file path.
+  func loadFile(at fileURL: URL, maxGraphemes: Int?) -> LoadedFile {
+    let fileManager = FileManager.default
+
+    guard fileManager.fileExists(atPath: fileURL.path) else {
+      return .missing
+    }
+
+    guard let rawData = try? Data(contentsOf: fileURL),
+      let text = String(data: rawData, encoding: .utf8)
+    else {
+      return LoadedFile(outcome: .unreadable, text: "", graphemeCount: 0)
+    }
+
+    let graphemeCount = text.count
+    if let cap = maxGraphemes, graphemeCount > cap {
+      return LoadedFile(outcome: .overCap, text: "", graphemeCount: graphemeCount)
+    }
+
+    return LoadedFile(outcome: .present, text: text, graphemeCount: graphemeCount)
+  }
+}

--- a/Sources/ClawWorkspace/FileSystemWorkspace.swift
+++ b/Sources/ClawWorkspace/FileSystemWorkspace.swift
@@ -8,6 +8,10 @@ public protocol WorkspaceReading: Sendable {
   /// undecodable file `.unreadable`, an over-cap file `.overCap` (no consumable text), and never
   /// throws. `maxGraphemes` nil means no cap.
   func load(_ file: WorkspaceFile, maxGraphemes: Int?) -> LoadedFile
+
+  /// Loads a dated daily log `memory/<day>.md`, where `day` is a `YYYY-MM-DD` stem. A stem that is
+  /// not `YYYY-MM-DD`, or a missing file, returns `.missing`. Same outcome rules as `load`.
+  func loadDailyLog(day: String, maxGraphemes: Int?) -> LoadedFile
 }
 
 public struct FileSystemWorkspace: WorkspaceReading {
@@ -19,6 +23,34 @@ public struct FileSystemWorkspace: WorkspaceReading {
 
   public func load(_ file: WorkspaceFile, maxGraphemes: Int?) -> LoadedFile {
     loadFile(at: root.appendingPathComponent(file.relativePath), maxGraphemes: maxGraphemes)
+  }
+
+  public func loadDailyLog(day: String, maxGraphemes: Int?) -> LoadedFile {
+    guard Self.isDayStem(day) else {
+      return .missing
+    }
+
+    let fileURL =
+      root
+      .appendingPathComponent("memory", isDirectory: true)
+      .appendingPathComponent("\(day).md")
+    return loadFile(at: fileURL, maxGraphemes: maxGraphemes)
+  }
+
+  /// True only for a `YYYY-MM-DD` stem (four digits, two, two). Rejects path separators and `..`.
+  private static func isDayStem(_ day: String) -> Bool {
+    let parts = day.split(separator: "-", omittingEmptySubsequences: false)
+    let expectedLengths = [4, 2, 2]
+    guard parts.count == expectedLengths.count else {
+      return false
+    }
+
+    for (part, length) in zip(parts, expectedLengths) {
+      guard part.count == length, part.allSatisfy({ ("0"..."9").contains($0) }) else {
+        return false
+      }
+    }
+    return true
   }
 
   /// Shared read + outcome classification for any single file path.

--- a/Sources/ClawWorkspace/FileSystemWorkspace.swift
+++ b/Sources/ClawWorkspace/FileSystemWorkspace.swift
@@ -24,6 +24,9 @@ public protocol WorkspaceReading: Sendable {
 }
 
 public struct FileSystemWorkspace: WorkspaceReading {
+  private static let skillsDirectoryName = "skills"
+  private static let skillManifestName = "SKILL.md"
+
   public let root: URL
 
   public init(root: URL) {
@@ -90,9 +93,6 @@ public struct FileSystemWorkspace: WorkspaceReading {
 
     return SkillScanResult(descriptors: descriptors, warnings: warnings)
   }
-
-  private static let skillsDirectoryName = "skills"
-  private static let skillManifestName = "SKILL.md"
 
   /// Extracts the leading `---`-fenced YAML block, keeping only string-valued keys. Returns nil when
   /// there is no opening/closing fence or the block is not a parseable string map.

--- a/Sources/ClawWorkspace/FileSystemWorkspace.swift
+++ b/Sources/ClawWorkspace/FileSystemWorkspace.swift
@@ -8,7 +8,7 @@ public protocol WorkspaceReading: Sendable {
   /// Loads a fixed workspace file in the grapheme domain. A missing file returns `.missing`, an
   /// undecodable file `.unreadable`, an over-cap file `.overCap` (no consumable text), and never
   /// throws. `maxGraphemes` nil means no cap.
-  func load(_ file: WorkspaceFile, maxGraphemes: Int?) -> LoadedFile
+  func load(file: WorkspaceFile, maxGraphemes: Int?) -> LoadedFile
 
   /// Loads a dated daily log `memory/<day>.md`, where `day` is a `YYYY-MM-DD` stem. A stem that is
   /// not `YYYY-MM-DD`, or a missing file, returns `.missing`. Same outcome rules as `load`.
@@ -30,7 +30,7 @@ public struct FileSystemWorkspace: WorkspaceReading {
     self.root = root
   }
 
-  public func load(_ file: WorkspaceFile, maxGraphemes: Int?) -> LoadedFile {
+  public func load(file: WorkspaceFile, maxGraphemes: Int?) -> LoadedFile {
     loadFile(at: root.appendingPathComponent(file.relativePath), maxGraphemes: maxGraphemes)
   }
 

--- a/Sources/ClawWorkspace/FileSystemWorkspace.swift
+++ b/Sources/ClawWorkspace/FileSystemWorkspace.swift
@@ -1,5 +1,6 @@
 import ClawCore
 import Foundation
+import Yams
 
 /// Pure workspace file I/O and parsing (spec §3, §6). No budget, LLM, or config knowledge: per-file
 /// grapheme caps arrive as a parameter and the caller decides how to react to each `LoadedFile`.
@@ -12,6 +13,14 @@ public protocol WorkspaceReading: Sendable {
   /// Loads a dated daily log `memory/<day>.md`, where `day` is a `YYYY-MM-DD` stem. A stem that is
   /// not `YYYY-MM-DD`, or a missing file, returns `.missing`. Same outcome rules as `load`.
   func loadDailyLog(day: String, maxGraphemes: Int?) -> LoadedFile
+
+  /// Scans `skills/<name>/SKILL.md` and returns one `SkillDescriptor` per skill whose frontmatter
+  /// has a non-empty `name` and `description`, plus a `WorkspaceWarning` for each present-but-unusable
+  /// manifest. A missing `skills/` directory or a subdirectory with no `SKILL.md` is skipped without
+  /// a warning; a `skills/` directory that exists but cannot be listed yields
+  /// `.unreadableSkillsDirectory` (§12). Never a half-entry, never a crash. Descriptors are sorted by
+  /// directory name.
+  func scanSkills() -> SkillScanResult
 }
 
 public struct FileSystemWorkspace: WorkspaceReading {
@@ -35,6 +44,90 @@ public struct FileSystemWorkspace: WorkspaceReading {
       .appendingPathComponent("memory", isDirectory: true)
       .appendingPathComponent("\(day).md")
     return loadFile(at: fileURL, maxGraphemes: maxGraphemes)
+  }
+
+  public func scanSkills() -> SkillScanResult {
+    let fileManager = FileManager.default
+    let skillsRoot = root.appendingPathComponent(Self.skillsDirectoryName, isDirectory: true)
+
+    guard fileManager.fileExists(atPath: skillsRoot.path) else {
+      return SkillScanResult(descriptors: [], warnings: [])  // no skills/ dir: normal, silent
+    }
+
+    guard
+      let entries = try? fileManager.contentsOfDirectory(
+        at: skillsRoot,
+        includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles]
+      )
+    else {
+      // skills/ exists but cannot be listed: a §12 context-read failure, not a missing directory.
+      return SkillScanResult(descriptors: [], warnings: [.unreadableSkillsDirectory])
+    }
+
+    var descriptors: [SkillDescriptor] = []
+    var warnings: [WorkspaceWarning] = []
+
+    for subdir in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+      let manifestURL = subdir.appendingPathComponent(Self.skillManifestName)
+
+      guard fileManager.fileExists(atPath: manifestURL.path) else {
+        continue  // not a skill directory: normal, no warning
+      }
+
+      guard
+        let manifestText = try? String(contentsOf: manifestURL, encoding: .utf8),
+        let frontmatter = Self.frontmatter(in: manifestText),
+        let name = frontmatter["name"], name.isEmpty == false,
+        let description = frontmatter["description"], description.isEmpty == false
+      else {
+        warnings.append(.invalidSkillManifest(skill: subdir.lastPathComponent))
+        continue
+      }
+
+      descriptors.append(SkillDescriptor(name: name, description: description, directory: subdir))
+    }
+
+    return SkillScanResult(descriptors: descriptors, warnings: warnings)
+  }
+
+  private static let skillsDirectoryName = "skills"
+  private static let skillManifestName = "SKILL.md"
+
+  /// Extracts the leading `---`-fenced YAML block, keeping only string-valued keys. Returns nil when
+  /// there is no opening/closing fence or the block is not a parseable string map.
+  private static func frontmatter(in text: String) -> [String: String]? {
+    let lines = text.components(separatedBy: "\n")
+    guard lines.first?.trimmingCharacters(in: .whitespacesAndNewlines) == "---" else {
+      return nil
+    }
+
+    var yamlLines: [String] = []
+    var didCloseFence = false
+    for line in lines.dropFirst() {
+      if line.trimmingCharacters(in: .whitespacesAndNewlines) == "---" {
+        didCloseFence = true
+        break
+      }
+      yamlLines.append(line)
+    }
+
+    guard didCloseFence else {
+      return nil
+    }
+
+    let yaml = yamlLines.joined(separator: "\n")
+    guard let parsed = (try? Yams.load(yaml: yaml)) as? [String: Any] else {
+      return nil
+    }
+
+    var result: [String: String] = [:]
+    for (key, value) in parsed {
+      if let stringValue = value as? String {
+        result[key] = stringValue
+      }
+    }
+    return result
   }
 
   /// True only for a `YYYY-MM-DD` stem (four digits, two, two). Rejects path separators and `..`.

--- a/Sources/ClawWorkspace/LoadedFile.swift
+++ b/Sources/ClawWorkspace/LoadedFile.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// The result of loading a workspace file in the grapheme domain (spec §6, §6.1, §12).
+public struct LoadedFile: Sendable, Equatable {
+  /// What happened, so the caller can apply the right policy. `ClawWorkspace` decides none of it:
+  /// `.present` -> usable; `.overCap` -> omit + owner notice (§6.1); `.missing` -> omit silently
+  /// (normal, §6); `.unreadable` -> omit + log (§12).
+  public enum Outcome: Sendable, Equatable {
+    case present
+    case overCap
+    case missing
+    case unreadable
+  }
+
+  public let outcome: Outcome
+
+  /// File content for `.present`. Empty for every other outcome - in particular `.overCap` returns
+  /// no text so a caller can never accidentally inject a truncated hand-curated file
+  /// (`ARCHITECTURE.md` §9.3: "ERROR, never silent truncation").
+  public let text: String
+
+  /// Original grapheme length before any cap check. Non-zero on `.present` and `.overCap`; drives
+  /// the §6.1 "N/cap" owner notice. Zero on `.missing`/`.unreadable`.
+  public let graphemeCount: Int
+
+  public init(outcome: Outcome, text: String, graphemeCount: Int) {
+    self.outcome = outcome
+    self.text = text
+    self.graphemeCount = graphemeCount
+  }
+
+  /// A file that does not exist: normal, omit silently, never throws (spec §6).
+  public static let missing = LoadedFile(outcome: .missing, text: "", graphemeCount: 0)
+}

--- a/Sources/ClawWorkspace/SkillScanResult.swift
+++ b/Sources/ClawWorkspace/SkillScanResult.swift
@@ -1,0 +1,25 @@
+import ClawCore
+import Foundation
+
+/// A non-fatal diagnostic from a workspace scan, for the consuming layer to log (spec §6.2, §12).
+/// `ClawWorkspace` is pure I/O and owns no logger.
+public enum WorkspaceWarning: Sendable, Equatable {
+  /// `skills/<skill>/SKILL.md` exists but is unusable (no `---` fence, malformed YAML, or missing
+  /// `name`/`description`).
+  case invalidSkillManifest(skill: String)
+
+  /// `skills/` exists but could not be listed (a §12 context-read failure, distinct from a missing
+  /// `skills/` directory, which is normal and silent).
+  case unreadableSkillsDirectory
+}
+
+/// The result of scanning `skills/`: the valid descriptors plus any skip warnings.
+public struct SkillScanResult: Sendable, Equatable {
+  public let descriptors: [SkillDescriptor]
+  public let warnings: [WorkspaceWarning]
+
+  public init(descriptors: [SkillDescriptor], warnings: [WorkspaceWarning]) {
+    self.descriptors = descriptors
+    self.warnings = warnings
+  }
+}

--- a/Sources/ClawWorkspace/WorkspaceFile.swift
+++ b/Sources/ClawWorkspace/WorkspaceFile.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// The fixed workspace files Increment 3a loads by name (spec §6). Dated daily logs
+/// The fixed workspace files load by name (spec §6). Dated daily logs
 /// (`memory/YYYY-MM-DD.md`) have dynamic names and load via `WorkspaceReading.loadDailyLog`, so they
 /// are deliberately not cases here. `HEARTBEAT.md` is out of 3a scope (Inc 4).
 public enum WorkspaceFile: String, Sendable, Equatable, CaseIterable {

--- a/Sources/ClawWorkspace/WorkspaceFile.swift
+++ b/Sources/ClawWorkspace/WorkspaceFile.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// The fixed workspace files Increment 3a loads by name (spec §6). Dated daily logs
+/// (`memory/YYYY-MM-DD.md`) have dynamic names and load via `WorkspaceReading.loadDailyLog`, so they
+/// are deliberately not cases here. `HEARTBEAT.md` is out of 3a scope (Inc 4).
+public enum WorkspaceFile: String, Sendable, Equatable, CaseIterable {
+  case soul = "SOUL.md"
+  case agents = "AGENTS.md"
+  case tools = "TOOLS.md"
+  case user = "USER.md"
+  case memory = "MEMORY.md"
+
+  /// Path relative to the workspace root.
+  public var relativePath: String { rawValue }
+}

--- a/Tests/ClawWorkspaceTests/Support/WorkspaceTestSupport.swift
+++ b/Tests/ClawWorkspaceTests/Support/WorkspaceTestSupport.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Creates a unique, empty temporary workspace root. The caller removes it in a `defer`.
+func makeTemporaryRoot() throws -> URL {
+  let root = FileManager.default.temporaryDirectory
+    .appendingPathComponent("claw-workspace-tests", isDirectory: true)
+    .appendingPathComponent(UUID().uuidString, isDirectory: true)
+  try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+  return root
+}
+
+/// Writes a UTF-8 file at `relativePath` under `root`, creating intermediate directories.
+func writeFile(atRelativePath relativePath: String, content: String, under root: URL) throws {
+  let fileURL = root.appendingPathComponent(relativePath)
+  try FileManager.default.createDirectory(
+    at: fileURL.deletingLastPathComponent(),
+    withIntermediateDirectories: true
+  )
+  try content.write(to: fileURL, atomically: true, encoding: .utf8)
+}
+
+/// Writes raw bytes at `relativePath` under `root` (used to create an invalid-UTF-8 file).
+func writeRawFile(atRelativePath relativePath: String, bytes: [UInt8], under root: URL) throws {
+  let fileURL = root.appendingPathComponent(relativePath)
+  try FileManager.default.createDirectory(
+    at: fileURL.deletingLastPathComponent(),
+    withIntermediateDirectories: true
+  )
+  try Data(bytes).write(to: fileURL)
+}
+
+/// Writes `skills/<name>/SKILL.md` under `root`, creating intermediate directories.
+func writeSkill(named name: String, manifest: String, under root: URL) throws {
+  try writeFile(atRelativePath: "skills/\(name)/SKILL.md", content: manifest, under: root)
+}

--- a/Tests/ClawWorkspaceTests/WorkspaceDailyLogTests.swift
+++ b/Tests/ClawWorkspaceTests/WorkspaceDailyLogTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+
+@testable import ClawWorkspace
+
+@Suite struct WorkspaceDailyLogTests {
+  @Test func presentDailyLogLoadsFromMemorySubdirectory() throws {
+    // given
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try writeFile(
+      atRelativePath: "memory/2026-06-29.md",
+      content: "today the owner shipped 3a",
+      under: root
+    )
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let loaded = workspace.loadDailyLog(day: "2026-06-29", maxGraphemes: nil)
+
+    // then
+    #expect(loaded.outcome == .present)
+    #expect(loaded.text == "today the owner shipped 3a")
+  }
+
+  @Test func missingDailyLogLoadsAsMissing() throws {
+    // given
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let loaded = workspace.loadDailyLog(day: "2026-06-29", maxGraphemes: nil)
+
+    // then
+    #expect(loaded == .missing)
+  }
+
+  @Test func malformedDayStemLoadsAsMissingAndCannotTraverse() throws {
+    // given - a non YYYY-MM-DD stem, including a traversal attempt, must not read any file.
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try writeFile(atRelativePath: "MEMORY.md", content: "secret", under: root)
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let badStem = workspace.loadDailyLog(day: "not-a-date", maxGraphemes: nil)
+    let traversal = workspace.loadDailyLog(day: "../../MEMORY", maxGraphemes: nil)
+
+    // then
+    #expect(badStem == .missing)
+    #expect(traversal == .missing)
+  }
+}

--- a/Tests/ClawWorkspaceTests/WorkspaceLoaderTests.swift
+++ b/Tests/ClawWorkspaceTests/WorkspaceLoaderTests.swift
@@ -11,7 +11,7 @@ import Testing
     let workspace = FileSystemWorkspace(root: root)
 
     // when
-    let loaded = workspace.load(.memory, maxGraphemes: 2_200)
+    let loaded = workspace.load(file: .memory, maxGraphemes: 2_200)
 
     // then
     #expect(loaded == .missing)
@@ -25,7 +25,7 @@ import Testing
     let workspace = FileSystemWorkspace(root: root)
 
     // when
-    let loaded = workspace.load(.user, maxGraphemes: 1_375)
+    let loaded = workspace.load(file: .user, maxGraphemes: 1_375)
 
     // then
     #expect(loaded.outcome == .present)
@@ -42,7 +42,7 @@ import Testing
     let workspace = FileSystemWorkspace(root: root)
 
     // when
-    let loaded = workspace.load(.memory, maxGraphemes: 4)
+    let loaded = workspace.load(file: .memory, maxGraphemes: 4)
 
     // then
     #expect(loaded.outcome == .overCap)
@@ -59,7 +59,7 @@ import Testing
     let workspace = FileSystemWorkspace(root: root)
 
     // when - cap 5 exceeds the 4 grapheme clusters but is below the 8 scalars.
-    let loaded = workspace.load(.memory, maxGraphemes: 5)
+    let loaded = workspace.load(file: .memory, maxGraphemes: 5)
 
     // then - grapheme counting keeps it present; scalar counting would have tripped .overCap.
     #expect(loaded.outcome == .present)
@@ -76,7 +76,7 @@ import Testing
     let workspace = FileSystemWorkspace(root: root)
 
     // when
-    let loaded = workspace.load(.soul, maxGraphemes: nil)
+    let loaded = workspace.load(file: .soul, maxGraphemes: nil)
 
     // then
     #expect(loaded.outcome == .present)
@@ -91,7 +91,7 @@ import Testing
     let workspace = FileSystemWorkspace(root: root)
 
     // when
-    let loaded = workspace.load(.memory, maxGraphemes: 2_200)
+    let loaded = workspace.load(file: .memory, maxGraphemes: 2_200)
 
     // then - distinct from .missing so Plan 5 can log it (§12), not treat it as a normal empty.
     #expect(loaded.outcome == .unreadable)

--- a/Tests/ClawWorkspaceTests/WorkspaceLoaderTests.swift
+++ b/Tests/ClawWorkspaceTests/WorkspaceLoaderTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+
+@testable import ClawWorkspace
+
+@Suite struct WorkspaceLoaderTests {
+  @Test func missingFileLoadsAsMissingAndNeverThrows() throws {
+    // given
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let loaded = workspace.load(.memory, maxGraphemes: 2_200)
+
+    // then
+    #expect(loaded == .missing)
+  }
+
+  @Test func presentFileUnderCapLoadsFullText() throws {
+    // given
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try writeFile(atRelativePath: "USER.md", content: "owner profile", under: root)
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let loaded = workspace.load(.user, maxGraphemes: 1_375)
+
+    // then
+    #expect(loaded.outcome == .present)
+    #expect(loaded.text == "owner profile")
+    #expect(loaded.graphemeCount == 13)
+  }
+
+  @Test func overCapFileReportsOriginalCountButYieldsNoConsumableText() throws {
+    // given
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let content = String(repeating: "x", count: 10)
+    try writeFile(atRelativePath: "MEMORY.md", content: content, under: root)
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let loaded = workspace.load(.memory, maxGraphemes: 4)
+
+    // then
+    #expect(loaded.outcome == .overCap)
+    #expect(loaded.graphemeCount == 10)
+    #expect(loaded.text.isEmpty)
+  }
+
+  @Test func capCountsGraphemeClustersNotUnicodeScalars() throws {
+    // given - each "e\u{0301}" is one grapheme cluster made of two scalars: 4 clusters, 8 scalars.
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let content = String(repeating: "e\u{0301}", count: 4)
+    try writeFile(atRelativePath: "MEMORY.md", content: content, under: root)
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when - cap 5 exceeds the 4 grapheme clusters but is below the 8 scalars.
+    let loaded = workspace.load(.memory, maxGraphemes: 5)
+
+    // then - grapheme counting keeps it present; scalar counting would have tripped .overCap.
+    #expect(loaded.outcome == .present)
+    #expect(loaded.graphemeCount == 4)
+    #expect(loaded.text.unicodeScalars.count == 8)
+  }
+
+  @Test func nilCapLoadsFullTextRegardlessOfSize() throws {
+    // given
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let content = String(repeating: "soul ", count: 1_000)
+    try writeFile(atRelativePath: "SOUL.md", content: content, under: root)
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let loaded = workspace.load(.soul, maxGraphemes: nil)
+
+    // then
+    #expect(loaded.outcome == .present)
+    #expect(loaded.text == content)
+  }
+
+  @Test func presentButUndecodableFileLoadsAsUnreadable() throws {
+    // given - invalid UTF-8 bytes force a decode failure on an existing file.
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try writeRawFile(atRelativePath: "MEMORY.md", bytes: [0xFF, 0xFF, 0xFF], under: root)
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let loaded = workspace.load(.memory, maxGraphemes: 2_200)
+
+    // then - distinct from .missing so Plan 5 can log it (§12), not treat it as a normal empty.
+    #expect(loaded.outcome == .unreadable)
+    #expect(loaded.text.isEmpty)
+    #expect(loaded.graphemeCount == 0)
+  }
+}

--- a/Tests/ClawWorkspaceTests/WorkspaceSkillsScannerTests.swift
+++ b/Tests/ClawWorkspaceTests/WorkspaceSkillsScannerTests.swift
@@ -1,0 +1,191 @@
+import ClawCore
+import Foundation
+import Testing
+
+@testable import ClawWorkspace
+
+@Suite struct WorkspaceSkillsScannerTests {
+  private static let validManifest = """
+    ---
+    name: summarize
+    description: Summarize owner-provided text.
+    ---
+    # Summarize
+
+    Body content the index ignores.
+    """
+
+  @Test func missingSkillsDirectoryYieldsEmptyResult() throws {
+    // given
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let result = workspace.scanSkills()
+
+    // then
+    #expect(result.descriptors.isEmpty)
+    #expect(result.warnings.isEmpty)
+  }
+
+  @Test func unlistableSkillsDirectoryWarnsAndIsDistinctFromMissing() throws {
+    // given - "skills" exists as a regular file, so listing it as a directory reliably fails.
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try writeFile(atRelativePath: "skills", content: "not a directory", under: root)
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let result = workspace.scanSkills()
+
+    // then - a failed listing warns (§12 log + omit), unlike a missing dir which is silent.
+    #expect(result.descriptors.isEmpty)
+    #expect(result.warnings == [.unreadableSkillsDirectory])
+  }
+
+  @Test func validManifestBecomesDescriptorWithNameDescriptionAndDirectory() throws {
+    // given
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try writeSkill(named: "summarize", manifest: Self.validManifest, under: root)
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let result = workspace.scanSkills()
+
+    // then
+    #expect(result.warnings.isEmpty)
+    let descriptor = try #require(result.descriptors.first)
+    #expect(descriptor.name == "summarize")
+    #expect(descriptor.description == "Summarize owner-provided text.")
+    #expect(descriptor.directory.lastPathComponent == "summarize")
+  }
+
+  @Test func subdirectoryWithoutManifestIsSkippedSilently() throws {
+    // given
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let emptySkillDir =
+      root
+      .appendingPathComponent("skills", isDirectory: true)
+      .appendingPathComponent("empty", isDirectory: true)
+    try FileManager.default.createDirectory(at: emptySkillDir, withIntermediateDirectories: true)
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let result = workspace.scanSkills()
+
+    // then - a non-skill directory is normal, not a warning.
+    #expect(result.descriptors.isEmpty)
+    #expect(result.warnings.isEmpty)
+  }
+
+  @Test func manifestMissingDescriptionIsSkippedWithWarning() throws {
+    // given
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let manifest = """
+      ---
+      name: partial
+      ---
+      body
+      """
+    try writeSkill(named: "partial", manifest: manifest, under: root)
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let result = workspace.scanSkills()
+
+    // then
+    #expect(result.descriptors.isEmpty)
+    #expect(result.warnings == [.invalidSkillManifest(skill: "partial")])
+  }
+
+  @Test func manifestWithoutFrontmatterFenceIsSkippedWithWarning() throws {
+    // given
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let manifest = "# Just a heading\n\nNo frontmatter here."
+    try writeSkill(named: "nofence", manifest: manifest, under: root)
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let result = workspace.scanSkills()
+
+    // then
+    #expect(result.descriptors.isEmpty)
+    #expect(result.warnings == [.invalidSkillManifest(skill: "nofence")])
+  }
+
+  @Test func malformedFrontmatterYamlIsSkippedWithWarning() throws {
+    // given - an unterminated flow sequence makes the YAML block unparseable.
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let manifest = """
+      ---
+      name: [unterminated
+      description: x
+      ---
+      body
+      """
+    try writeSkill(named: "broken", manifest: manifest, under: root)
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let result = workspace.scanSkills()
+
+    // then
+    #expect(result.descriptors.isEmpty)
+    #expect(result.warnings == [.invalidSkillManifest(skill: "broken")])
+  }
+
+  @Test func extraFrontmatterKeysAreIgnored() throws {
+    // given
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let manifest = """
+      ---
+      name: rich
+      description: Rich skill.
+      version: 3
+      tags: [a, b]
+      ---
+      body
+      """
+    try writeSkill(named: "rich", manifest: manifest, under: root)
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let result = workspace.scanSkills()
+
+    // then
+    #expect(result.warnings.isEmpty)
+    let descriptor = try #require(result.descriptors.first)
+    #expect(descriptor.name == "rich")
+    #expect(descriptor.description == "Rich skill.")
+  }
+
+  @Test func multipleSkillsAreReturnedInDirectoryNameOrder() throws {
+    // given
+    let root = try makeTemporaryRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    try writeSkill(
+      named: "bravo",
+      manifest: "---\nname: bravo\ndescription: Second.\n---\n",
+      under: root
+    )
+    try writeSkill(
+      named: "alpha",
+      manifest: "---\nname: alpha\ndescription: First.\n---\n",
+      under: root
+    )
+    let workspace = FileSystemWorkspace(root: root)
+
+    // when
+    let names = workspace.scanSkills().descriptors.map(\.name)
+
+    // then
+    #expect(names == ["alpha", "bravo"])
+  }
+}

--- a/Tests/ClawWorkspaceTests/WorkspaceValuesTests.swift
+++ b/Tests/ClawWorkspaceTests/WorkspaceValuesTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+
+@testable import ClawWorkspace
+
+@Suite struct WorkspaceValuesTests {
+  @Test func workspaceFileRelativePathsMatchKnownFilenames() {
+    // given / when / then
+    #expect(WorkspaceFile.soul.relativePath == "SOUL.md")
+    #expect(WorkspaceFile.agents.relativePath == "AGENTS.md")
+    #expect(WorkspaceFile.tools.relativePath == "TOOLS.md")
+    #expect(WorkspaceFile.user.relativePath == "USER.md")
+    #expect(WorkspaceFile.memory.relativePath == "MEMORY.md")
+  }
+
+  @Test func workspaceFileEnumeratesEveryFixedFileInOrder() {
+    // given / when
+    let paths = WorkspaceFile.allCases.map(\.relativePath)
+
+    // then
+    #expect(paths == ["SOUL.md", "AGENTS.md", "TOOLS.md", "USER.md", "MEMORY.md"])
+  }
+
+  @Test func missingLoadedFileIsEmptyZeroLengthWithMissingOutcome() {
+    // given / when
+    let missing = LoadedFile.missing
+
+    // then
+    #expect(missing.outcome == .missing)
+    #expect(missing.text.isEmpty)
+    #expect(missing.graphemeCount == 0)
+  }
+}


### PR DESCRIPTION
Adds a new `ClawWorkspace` library: pure file-I/O plus parsing with no budget/LLM/config knowledge (spec §3).

## What's included

- **`WorkspaceFile`** — typed `CaseIterable` vocabulary for the fixed workspace files (SOUL/AGENTS/TOOLS/USER/MEMORY); no magic-string paths. `HEARTBEAT.md` and daily logs are deliberately not cases.
- **`LoadedFile`** — outcome-typed load result (`.present` / `.overCap` / `.missing` / `.unreadable`) carrying the original `graphemeCount`. A missing file never throws; an over-cap hand-curated file is **omitted, never silently truncated** (`.overCap` yields no consumable text — ARCHITECTURE.md §9.3); an undecodable file is `.unreadable`, distinct from `.missing` so the caller can log it (§12).
- **`FileSystemWorkspace` / `WorkspaceReading`** — the concrete loader behind a `Sendable` protocol seam, with:
  - `load(_:maxGraphemes:)` — fixed-file loader, grapheme-domain cap (`String.count`), `nil` cap = no cap.
  - `loadDailyLog(day:maxGraphemes:)` — dated `memory/YYYY-MM-DD.md` logs; the `YYYY-MM-DD` stem validator doubles as the path-traversal guard.
  - `scanSkills()` — scans `skills/<name>/SKILL.md` Yams frontmatter into `SkillDescriptor`s plus typed `WorkspaceWarning`s (missing dir → silent; unlistable dir → `.unreadableSkillsDirectory`; present-but-unusable manifest → `.invalidSkillManifest`).
- **`SkillScanResult` / `WorkspaceWarning`** — typed scan result; `ClawWorkspace` owns no logger, so it returns warnings for the consuming layer to log.
- Adds the `Yams` dependency (`Package.swift` + `Package.resolved`) and the `ClawWorkspace` / `ClawWorkspaceTests` targets.

## Verification

- Built task-by-task with TDD; each task passed an independent spec + quality review.
- Full package suite: **290 tests / 60 suites passing**.
- `scripts/lint.sh` gate: ok.
- Whole-branch review verdict: ready to merge.

## Notes

- The `.unreadable` classification uses an explicit `Data` read + `String(data:encoding:.utf8)` nil-check (the plan's sanctioned fallback) to guarantee strict UTF-8 rejection rather than relying on `String(contentsOf:)` toolchain behavior.
- Daily-log load path is wired but has no caller in 3a — it ships ready for the increment that injects daily logs.