### PR TITLE
Wire context assembler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
       dependencies: ["ClawCore"],
       resources: [.copy("Pricing/Prices.json")]
     ),
-    .target(name: "ClawAgent", dependencies: ["ClawCore"]),
+    .target(name: "ClawAgent", dependencies: ["ClawCore", "ClawWorkspace"]),
     .target(
       name: "ClawGateway",
       dependencies: [
@@ -68,7 +68,7 @@ let package = Package(
       name: "clawd",
       dependencies: [
         "ClawCore", "ClawData", "ClawSecrets", "ClawTelegram", "ClawGateway", "ClawLLM",
-        "ClawAgent",
+        "ClawAgent", "ClawWorkspace",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "Logging", package: "swift-log"),
@@ -96,10 +96,12 @@ let package = Package(
       ]
     ),
     .testTarget(name: "ClawLLMTests", dependencies: ["ClawLLM", "ClawCore"]),
-    .testTarget(name: "ClawAgentTests", dependencies: ["ClawAgent", "ClawCore"]),
+    .testTarget(name: "ClawAgentTests", dependencies: ["ClawAgent", "ClawCore", "ClawWorkspace"]),
     .testTarget(
       name: "ClawGatewayTests",
-      dependencies: ["ClawGateway", "ClawCore", "ClawData", "ClawAgent", "ClawTelegram"]
+      dependencies: [
+        "ClawGateway", "ClawCore", "ClawData", "ClawAgent", "ClawTelegram", "ClawWorkspace",
+      ]
     ),
   ]
 )

--- a/Sources/ClawAgent/Context/BudgetFitter.swift
+++ b/Sources/ClawAgent/Context/BudgetFitter.swift
@@ -2,10 +2,12 @@ import ClawCore
 import Foundation
 
 public struct SectionUnit: Sendable, Equatable {
+  public let id: String
   public let content: String
   public let canTruncate: Bool
 
-  public init(content: String, canTruncate: Bool) {
+  public init(id: String = "", content: String, canTruncate: Bool) {
+    self.id = id
     self.content = content
     self.canTruncate = canTruncate
   }
@@ -36,6 +38,43 @@ public struct FittableSection: Sendable, Equatable, Identifiable {
   }
 }
 
+public struct FittedSection: Sendable, Equatable, Identifiable {
+  public let id: ContextRowID
+  public let tier: ContextTier
+  public let priority: ContextPriority
+  public let truncatable: Bool
+  public let cap: Int?
+  public let units: [SectionUnit]
+
+  public var content: String {
+    Self.render(units: units)
+  }
+
+  public var section: Section {
+    Section(
+      id: id,
+      tier: tier,
+      priority: priority,
+      truncatable: truncatable,
+      cap: cap,
+      content: content
+    )
+  }
+
+  fileprivate init(source: FittableSection, units: [SectionUnit]) {
+    id = source.id
+    tier = source.tier
+    priority = source.priority
+    truncatable = source.truncatable
+    cap = source.cap
+    self.units = units
+  }
+
+  private static func render(units: [SectionUnit]) -> String {
+    units.map(\.content).joined(separator: "\n")
+  }
+}
+
 public enum BudgetFitterError: Error, Equatable {
   case nonTruncatableRowsExceedInputCap(required: Int, cap: Int)
 }
@@ -47,6 +86,13 @@ public enum BudgetFitter {
     _ sections: [FittableSection],
     budget: ContextBudget
   ) throws -> [Section] {
+    try fitWithUnits(sections, budget: budget).map(\.section)
+  }
+
+  public static func fitWithUnits(
+    _ sections: [FittableSection],
+    budget: ContextBudget
+  ) throws -> [FittedSection] {
     let ordered = sections.sorted { first, second in
       first.priority < second.priority
     }
@@ -88,24 +134,10 @@ public enum BudgetFitter {
     }
 
     let fixedSections = nonTruncatable.map { section in
-      Section(
-        id: section.id,
-        tier: section.tier,
-        priority: section.priority,
-        truncatable: section.truncatable,
-        cap: section.cap,
-        content: render(units: section.units)
-      )
+      FittedSection(source: section, units: section.units)
     }
     let fittedSections = fittedRows.map { row in
-      Section(
-        id: row.source.id,
-        tier: row.source.tier,
-        priority: row.source.priority,
-        truncatable: row.source.truncatable,
-        cap: row.source.cap,
-        content: row.content
-      )
+      FittedSection(source: row.source, units: row.units)
     }
 
     return (fixedSections + fittedSections).sorted { first, second in
@@ -118,7 +150,7 @@ public enum BudgetFitter {
       return nil
     }
 
-    var kept = [String]()
+    var kept: [SectionUnit] = []
     var used = 0
 
     for unit in section.units {
@@ -126,12 +158,15 @@ public enum BudgetFitter {
       let wholeCount = separatorCount + unit.content.count
 
       if used + wholeCount <= maxCount {
-        kept.append(unit.content)
+        kept.append(unit)
         used += wholeCount
         continue
       }
 
       guard unit.canTruncate else {
+        if section.id == .history {
+          break
+        }
         continue
       }
 
@@ -142,7 +177,9 @@ public enum BudgetFitter {
 
       let prefixCount = available - truncationMarker.count
       let prefix = String(unit.content.prefix(prefixCount))
-      kept.append(prefix + truncationMarker)
+      kept.append(
+        SectionUnit(id: unit.id, content: prefix + truncationMarker, canTruncate: unit.canTruncate)
+      )
       break
     }
 
@@ -150,7 +187,7 @@ public enum BudgetFitter {
       return nil
     }
 
-    return FittedRow(source: section, content: kept.joined(separator: "\n"))
+    return FittedRow(source: section, units: kept)
   }
 
   private static func renderedCount(_ section: FittableSection) -> Int {
@@ -164,5 +201,9 @@ public enum BudgetFitter {
 
 private struct FittedRow: Equatable {
   let source: FittableSection
-  let content: String
+  let units: [SectionUnit]
+
+  var content: String {
+    units.map(\.content).joined(separator: "\n")
+  }
 }

--- a/Sources/ClawAgent/Context/BudgetFitter.swift
+++ b/Sources/ClawAgent/Context/BudgetFitter.swift
@@ -108,6 +108,10 @@ public enum BudgetFitter {
     }
 
     let residual = budget.inputCapGraphemes - required
+    // The newest history unit is kept even when it alone exceeds the residual (see `fittedRow`),
+    // so the squeezed total can legitimately overshoot the residual by this floor.
+    let historyFloorCount =
+      ordered.first { section in section.id == .history }?.units.first?.content.count ?? 0
     let cappedRows = truncatable.compactMap { section -> FittedRow? in
       let maxCount = min(section.cap ?? Int.max, renderedCount(section))
       return fittedRow(for: section, maxCount: maxCount)
@@ -130,7 +134,7 @@ public enum BudgetFitter {
         }
       }
       cappedTotal = fittedRows.map(\.content.count).reduce(0, +)
-      precondition(cappedTotal <= residual)
+      precondition(cappedTotal <= max(residual, historyFloorCount))
     }
 
     let fixedSections = nonTruncatable.map { section in
@@ -146,7 +150,13 @@ public enum BudgetFitter {
   }
 
   private static func fittedRow(for section: FittableSection, maxCount: Int) -> FittedRow? {
-    guard maxCount > 0 else {
+    // The newest history unit is the current turn; it is non-droppable even when it alone
+    // exceeds the budget, so the model always sees the message it is answering. Flooring the
+    // budget at its size means it is admitted whole on the first iteration; later units still
+    // obey the contiguous newest-first stop rule.
+    let historyFloor = section.id == .history ? (section.units.first?.content.count ?? 0) : 0
+    let effectiveMax = max(maxCount, historyFloor)
+    guard effectiveMax > 0 else {
       return nil
     }
 
@@ -157,7 +167,7 @@ public enum BudgetFitter {
       let separatorCount = kept.isEmpty ? 0 : 1
       let wholeCount = separatorCount + unit.content.count
 
-      if used + wholeCount <= maxCount {
+      if used + wholeCount <= effectiveMax {
         kept.append(unit)
         used += wholeCount
         continue
@@ -170,7 +180,7 @@ public enum BudgetFitter {
         continue
       }
 
-      let available = maxCount - used - separatorCount
+      let available = effectiveMax - used - separatorCount
       guard available >= truncationMarker.count + 1 else {
         continue
       }

--- a/Sources/ClawAgent/Context/BudgetFitter.swift
+++ b/Sources/ClawAgent/Context/BudgetFitter.swift
@@ -47,7 +47,7 @@ public struct FittedSection: Sendable, Equatable, Identifiable {
   public let units: [SectionUnit]
 
   public var content: String {
-    Self.render(units: units)
+    renderUnits(units)
   }
 
   public var section: Section {
@@ -62,16 +62,12 @@ public struct FittedSection: Sendable, Equatable, Identifiable {
   }
 
   fileprivate init(source: FittableSection, units: [SectionUnit]) {
-    id = source.id
-    tier = source.tier
-    priority = source.priority
-    truncatable = source.truncatable
-    cap = source.cap
+    self.id = source.id
+    self.tier = source.tier
+    self.priority = source.priority
+    self.truncatable = source.truncatable
+    self.cap = source.cap
     self.units = units
-  }
-
-  private static func render(units: [SectionUnit]) -> String {
-    units.map(\.content).joined(separator: "\n")
   }
 }
 
@@ -201,11 +197,7 @@ public enum BudgetFitter {
   }
 
   private static func renderedCount(_ section: FittableSection) -> Int {
-    render(units: section.units).count
-  }
-
-  private static func render(units: [SectionUnit]) -> String {
-    units.map(\.content).joined(separator: "\n")
+    renderUnits(section.units).count
   }
 }
 
@@ -214,6 +206,10 @@ private struct FittedRow: Equatable {
   let units: [SectionUnit]
 
   var content: String {
-    units.map(\.content).joined(separator: "\n")
+    renderUnits(units)
   }
+}
+
+private func renderUnits(_ units: [SectionUnit]) -> String {
+  units.map(\.content).joined(separator: "\n")
 }

--- a/Sources/ClawAgent/Context/ContextBuilder.swift
+++ b/Sources/ClawAgent/Context/ContextBuilder.swift
@@ -8,11 +8,13 @@ public struct ContextBuilder: Sendable {
   public static let recallInjectionLimit = 5
 
   private let systemPrompt: String
+
   private let workspace: any WorkspaceReading
   private let memoryStore: any MemoryStore
   private let retriever: any Retriever
   private let recallCutoff: any RecallCutoff
   private let budget: ContextBudget
+
   private let now: @Sendable () -> Date
   private let warn: @Sendable (String) -> Void
 
@@ -41,6 +43,7 @@ public struct ContextBuilder: Sendable {
     sessionId: Int64
   ) throws -> BuildResult {
     var ownerNotices: [String] = []
+
     let fixedSections = buildFixedSections(ownerNotices: &ownerNotices)
     let residual = residualAfterFixedSections(fixedSections)
     let truncatableSections = buildTruncatableSections(
@@ -129,7 +132,9 @@ public struct ContextBuilder: Sendable {
       let loaded = workspace.load(file: file, maxGraphemes: cap)
       switch loaded.outcome {
       case .present:
-        guard loaded.text.isEmpty == false else { return nil }
+        guard loaded.text.isEmpty == false else {
+          return nil
+        }
         return SectionUnit(
           id: file.relativePath,
           content: "## \(file.relativePath)\n\(loaded.text)",
@@ -137,9 +142,10 @@ public struct ContextBuilder: Sendable {
         )
       case .overCap:
         if let cap {
-          let notice =
-            "⚠ `\(file.relativePath)` is \(loaded.graphemeCount)/\(cap) "
-            + "— edit it to trim; left out this turn."
+          let notice = """
+            ⚠ `\(file.relativePath)` is \(loaded.graphemeCount)/\(cap) \
+            — edit it to trim; left out this turn.
+            """
           ownerNotices.append(notice)
         } else {
           warn("Workspace file \(file.relativePath) exceeded an uncapped load")
@@ -153,7 +159,10 @@ public struct ContextBuilder: Sendable {
       }
     }
 
-    guard units.isEmpty == false else { return nil }
+    guard units.isEmpty == false else {
+      return nil
+    }
+
     return section(id: id, units: units)
   }
 
@@ -162,7 +171,9 @@ public struct ContextBuilder: Sendable {
     residual: Int
   ) -> FittableSection? {
     let cap = cap(for: .memoryItems, residual: residual)
-    guard cap > 0 else { return nil }
+    guard cap > 0 else {
+      return nil
+    }
 
     let fetched: [MemoryItem]
     do {
@@ -183,7 +194,11 @@ public struct ContextBuilder: Sendable {
     let units = ranked.map { item in
       SectionUnit(id: "memory-\(item.id)", content: item.text, canTruncate: false)
     }
-    guard units.isEmpty == false else { return nil }
+
+    guard units.isEmpty == false else {
+      return nil
+    }
+
     return section(id: .memoryItems, cap: cap, units: units)
   }
 
@@ -195,7 +210,11 @@ public struct ContextBuilder: Sendable {
     let units = snapshot.history.enumerated().reversed().map { index, message in
       SectionUnit(id: "history-\(index)", content: message.content, canTruncate: false)
     }
-    guard units.isEmpty == false else { return nil }
+
+    guard units.isEmpty == false else {
+      return nil
+    }
+
     return section(id: .history, cap: cap, units: units)
   }
 
@@ -205,7 +224,11 @@ public struct ContextBuilder: Sendable {
     residual: Int
   ) -> FittableSection? {
     let cap = cap(for: .recall, residual: residual)
-    guard cap > 0, let query = latestUserMessage(in: snapshot.history) else { return nil }
+    guard cap > 0,
+      let query = latestUserMessage(in: snapshot.history)
+    else {
+      return nil
+    }
 
     let hits: [RecallHit]
     do {
@@ -224,16 +247,24 @@ public struct ContextBuilder: Sendable {
     let selected = recallCutoff.select(hits: hits, limit: Self.recallInjectionLimit)
     let units = selected.compactMap { hit -> SectionUnit? in
       let content = cappedRecallContent(hit.content)
-      guard content.isEmpty == false else { return nil }
+      guard content.isEmpty == false else {
+        return nil
+      }
       return SectionUnit(id: "recall-\(hit.id)", content: content, canTruncate: true)
     }
-    guard units.isEmpty == false else { return nil }
+
+    guard units.isEmpty == false else {
+      return nil
+    }
+
     return section(id: .recall, cap: cap, units: units)
   }
 
   private func skillsSection(residual: Int) -> FittableSection? {
     let cap = cap(for: .skills, residual: residual)
-    guard cap > 0 else { return nil }
+    guard cap > 0 else {
+      return nil
+    }
 
     let scan = workspace.scanSkills()
     for warning in scan.warnings {
@@ -247,7 +278,10 @@ public struct ContextBuilder: Sendable {
         canTruncate: false
       )
     }
-    guard units.isEmpty == false else { return nil }
+    guard units.isEmpty == false else {
+      return nil
+    }
+
     return section(id: .skills, cap: cap, units: units)
   }
 
@@ -295,7 +329,10 @@ public struct ContextBuilder: Sendable {
       fitted
       .filter { section in section.tier == .untrustedLabeled }
       .map { section in
-        LabeledContextFactory.make(label: label(for: section.id), content: section.content).render()
+        LabeledContextFactory.make(
+          label: label(for: section.id),
+          content: section.content
+        ).render()
       }
       .joined(separator: "\n\n")
     if untrusted.isEmpty == false {
@@ -316,7 +353,9 @@ public struct ContextBuilder: Sendable {
 
     let keptIDs = Set(historySection.units.map(\.id))
     return snapshot.history.enumerated().compactMap { index, message in
-      guard keptIDs.contains("history-\(index)") else { return nil }
+      guard keptIDs.contains("history-\(index)") else {
+        return nil
+      }
       return ChatMessage(role: message.role, content: message.content)
     }
   }
@@ -335,11 +374,14 @@ public struct ContextBuilder: Sendable {
     guard content.count > budget.recallHitCap else {
       return content
     }
+
     let marker = BudgetFitter.truncationMarker
     guard budget.recallHitCap > marker.count else {
       return ""
     }
+
     let prefixCount = budget.recallHitCap - marker.count
+
     return String(content.prefix(prefixCount)) + marker
   }
 

--- a/Sources/ClawAgent/Context/ContextBuilder.swift
+++ b/Sources/ClawAgent/Context/ContextBuilder.swift
@@ -36,40 +36,6 @@ public struct ContextBuilder: Sendable {
     self.warn = warn
   }
 
-  public static func assemble(
-    systemPrompt: String,
-    history: [StoredMessage],
-    inputCapGraphemes: Int
-  ) -> [ChatMessage] {
-    var inputCappedMessages = [StoredMessage]()
-    inputCappedMessages.reserveCapacity(history.count)
-
-    var isBudgetExhausted = false
-    var budget = inputCapGraphemes - systemPrompt.count
-
-    for (index, message) in history.reversed().enumerated() {
-      budget -= message.content.count
-
-      if budget < 0 && index > 0 {
-        isBudgetExhausted = true
-        break
-      }
-
-      inputCappedMessages.append(message)
-    }
-
-    let budgetExhaustedMarker = "\n\n[…earlier conversation truncated]"
-    let systemMessage = ChatMessage(
-      role: .system,
-      content: isBudgetExhausted ? systemPrompt + budgetExhaustedMarker : systemPrompt
-    )
-
-    return [systemMessage]
-      + inputCappedMessages.reversed().map { message in
-        ChatMessage(role: message.role, content: message.content)
-      }
-  }
-
   public func assemble(
     snapshot: SessionContextSnapshot,
     sessionId: Int64

--- a/Sources/ClawAgent/Context/ContextBuilder.swift
+++ b/Sources/ClawAgent/Context/ContextBuilder.swift
@@ -7,6 +7,8 @@ public struct ContextBuilder: Sendable {
   public static let recallCandidateLimit = 20
   public static let recallInjectionLimit = 5
 
+  private static let historyTruncatedMarker = "\n\n[…earlier conversation truncated]"
+
   private let systemPrompt: String
 
   private let workspace: any WorkspaceReading
@@ -318,11 +320,15 @@ public struct ContextBuilder: Sendable {
     fitted: [FittedSection],
     snapshot: SessionContextSnapshot
   ) -> [ChatMessage] {
+    let historyMessages = fittedHistoryMessages(fitted: fitted, snapshot: snapshot)
+    let historyWasTruncated = historyMessages.count < snapshot.history.count
+
     let systemContent =
       fitted
       .filter { section in section.tier == .system }
       .map(\.content)
       .joined(separator: "\n\n")
+      + (historyWasTruncated ? Self.historyTruncatedMarker : "")
     var messages = [ChatMessage(role: .system, content: systemContent)]
 
     let untrusted =
@@ -339,7 +345,7 @@ public struct ContextBuilder: Sendable {
       messages.append(ChatMessage(role: .user, content: untrusted))
     }
 
-    messages.append(contentsOf: fittedHistoryMessages(fitted: fitted, snapshot: snapshot))
+    messages.append(contentsOf: historyMessages)
     return messages
   }
 

--- a/Sources/ClawAgent/Context/ContextBuilder.swift
+++ b/Sources/ClawAgent/Context/ContextBuilder.swift
@@ -188,9 +188,10 @@ public struct ContextBuilder: Sendable {
   }
 
   private func historySection(snapshot: SessionContextSnapshot, residual: Int) -> FittableSection? {
+    // No `cap > 0` early-return: even when fixed sections leave a zero residual, the newest
+    // history unit (the current turn) must reach the fitter, which keeps it as a non-droppable
+    // floor so the model always sees the message it is answering.
     let cap = cap(for: .history, residual: residual)
-    guard cap > 0 else { return nil }
-
     let units = snapshot.history.enumerated().reversed().map { index, message in
       SectionUnit(id: "history-\(index)", content: message.content, canTruncate: false)
     }

--- a/Sources/ClawAgent/Context/ContextBuilder.swift
+++ b/Sources/ClawAgent/Context/ContextBuilder.swift
@@ -1,16 +1,41 @@
 import ClawCore
+import ClawWorkspace
 import Foundation
 
-/// Greedy-by-priority §9 context assembly (grapheme domain). The system prompt is always the
-/// first message and is never dropped; recent history is kept newest-first until the grapheme
-/// cap is reached, then restored to chronological order. When older history was dropped, a
-/// literal truncation marker is appended to the system prompt content.
-public enum ContextBuilder {
-  /// - Parameters:
-  ///   - systemPrompt: the trusted built-in prompt (Inc 1) — never dropped.
-  ///   - history: session messages, oldest-first.
-  ///   - inputCapGraphemes: the §9 grapheme budget for the whole context.
-  /// - Returns: `[system] + fitting history`, in chronological order.
+public struct ContextBuilder: Sendable {
+  public static let memoryFetchLimit = 100
+  public static let recallCandidateLimit = 20
+  public static let recallInjectionLimit = 5
+
+  private let systemPrompt: String
+  private let workspace: any WorkspaceReading
+  private let memoryStore: any MemoryStore
+  private let retriever: any Retriever
+  private let recallCutoff: any RecallCutoff
+  private let budget: ContextBudget
+  private let now: @Sendable () -> Date
+  private let warn: @Sendable (String) -> Void
+
+  public init(
+    systemPrompt: String,
+    workspace: any WorkspaceReading,
+    memoryStore: any MemoryStore,
+    retriever: any Retriever,
+    recallCutoff: any RecallCutoff = CandidateCapRecallCutoff(),
+    budget: ContextBudget,
+    now: @escaping @Sendable () -> Date = Date.init,
+    warn: @escaping @Sendable (String) -> Void = { _ in }
+  ) {
+    self.systemPrompt = systemPrompt
+    self.workspace = workspace
+    self.memoryStore = memoryStore
+    self.retriever = retriever
+    self.recallCutoff = recallCutoff
+    self.budget = budget
+    self.now = now
+    self.warn = warn
+  }
+
   public static func assemble(
     systemPrompt: String,
     history: [StoredMessage],
@@ -22,8 +47,6 @@ public enum ContextBuilder {
     var isBudgetExhausted = false
     var budget = inputCapGraphemes - systemPrompt.count
 
-    // Walk newest → oldest. The newest message (index 0) is the current user turn, kept
-    // unconditionally even if it alone exceeds the budget; older messages are dropped to fit.
     for (index, message) in history.reversed().enumerated() {
       budget -= message.content.count
 
@@ -41,12 +64,346 @@ public enum ContextBuilder {
       content: isBudgetExhausted ? systemPrompt + budgetExhaustedMarker : systemPrompt
     )
 
-    return [systemMessage] + inputCappedMessages.reversed().map(ChatMessage.init)
+    return [systemMessage]
+      + inputCappedMessages.reversed().map { message in
+        ChatMessage(role: message.role, content: message.content)
+      }
   }
-}
 
-extension ChatMessage {
-  init(_ stored: StoredMessage) {
-    self.init(role: stored.role, content: stored.content)
+  public func assemble(
+    snapshot: SessionContextSnapshot,
+    sessionId: Int64
+  ) throws -> BuildResult {
+    var ownerNotices: [String] = []
+    let fixedSections = buildFixedSections(ownerNotices: &ownerNotices)
+    let residual = residualAfterFixedSections(fixedSections)
+    let truncatableSections = buildTruncatableSections(
+      snapshot: snapshot,
+      sessionId: sessionId,
+      residual: residual
+    )
+
+    let fitted = try BudgetFitter.fitWithUnits(
+      fixedSections + truncatableSections,
+      budget: budget
+    )
+    let messages = renderMessages(fitted: fitted, snapshot: snapshot)
+
+    return BuildResult(
+      messages: messages,
+      ownerNotices: ownerNotices,
+      hasPrivateDataAccess: hasPrivateDataAccess(fitted)
+    )
+  }
+
+  private func buildFixedSections(ownerNotices: inout [String]) -> [FittableSection] {
+    [
+      section(
+        id: .policy,
+        units: [
+          SectionUnit(
+            id: "policy",
+            content: systemPrompt,
+            canTruncate: false
+          )
+        ]
+      ),
+      workspaceSection(
+        id: .systemWorkspace,
+        files: [.soul, .agents],
+        cap: nil,
+        ownerNotices: &ownerNotices
+      ),
+      workspaceSection(id: .tools, files: [.tools], cap: nil, ownerNotices: &ownerNotices),
+      section(
+        id: .metadata,
+        units: [
+          SectionUnit(
+            id: "metadata-time",
+            content: "Current time: \(Self.iso8601(now()))",
+            canTruncate: false
+          )
+        ]
+      ),
+      workspaceSection(
+        id: .userFile,
+        files: [.user],
+        cap: budget.userFileCap,
+        ownerNotices: &ownerNotices
+      ),
+      workspaceSection(
+        id: .memoryFile,
+        files: [.memory],
+        cap: budget.memoryFileCap,
+        ownerNotices: &ownerNotices
+      ),
+    ].compactMap { $0 }
+  }
+
+  private func buildTruncatableSections(
+    snapshot: SessionContextSnapshot,
+    sessionId: Int64,
+    residual: Int
+  ) -> [FittableSection] {
+    [
+      memoryItemsSection(snapshot: snapshot, residual: residual),
+      historySection(snapshot: snapshot, residual: residual),
+      recallSection(snapshot: snapshot, sessionId: sessionId, residual: residual),
+      skillsSection(residual: residual),
+    ].compactMap { $0 }
+  }
+
+  private func workspaceSection(
+    id: ContextRowID,
+    files: [WorkspaceFile],
+    cap: Int?,
+    ownerNotices: inout [String]
+  ) -> FittableSection? {
+    let units = files.compactMap { file -> SectionUnit? in
+      let loaded = workspace.load(file: file, maxGraphemes: cap)
+      switch loaded.outcome {
+      case .present:
+        guard loaded.text.isEmpty == false else { return nil }
+        return SectionUnit(
+          id: file.relativePath,
+          content: "## \(file.relativePath)\n\(loaded.text)",
+          canTruncate: false
+        )
+      case .overCap:
+        if let cap {
+          let notice =
+            "⚠ `\(file.relativePath)` is \(loaded.graphemeCount)/\(cap) "
+            + "— edit it to trim; left out this turn."
+          ownerNotices.append(notice)
+        } else {
+          warn("Workspace file \(file.relativePath) exceeded an uncapped load")
+        }
+        return nil
+      case .missing:
+        return nil
+      case .unreadable:
+        warn("Workspace file \(file.relativePath) could not be read")
+        return nil
+      }
+    }
+
+    guard units.isEmpty == false else { return nil }
+    return section(id: id, units: units)
+  }
+
+  private func memoryItemsSection(
+    snapshot: SessionContextSnapshot,
+    residual: Int
+  ) -> FittableSection? {
+    let cap = cap(for: .memoryItems, residual: residual)
+    guard cap > 0 else { return nil }
+
+    let fetched: [MemoryItem]
+    do {
+      fetched = try memoryStore.fetchRanked(
+        excludeSensitive: snapshot.isTainted,
+        limit: Self.memoryFetchLimit
+      )
+    } catch {
+      warn("memory_items read failed: \(error)")
+      return nil
+    }
+
+    let ranked = MemoryRanker.rank(
+      items: fetched,
+      excludeSensitive: snapshot.isTainted,
+      cap: cap
+    )
+    let units = ranked.map { item in
+      SectionUnit(id: "memory-\(item.id)", content: item.text, canTruncate: false)
+    }
+    guard units.isEmpty == false else { return nil }
+    return section(id: .memoryItems, cap: cap, units: units)
+  }
+
+  private func historySection(snapshot: SessionContextSnapshot, residual: Int) -> FittableSection? {
+    let cap = cap(for: .history, residual: residual)
+    guard cap > 0 else { return nil }
+
+    let units = snapshot.history.enumerated().reversed().map { index, message in
+      SectionUnit(id: "history-\(index)", content: message.content, canTruncate: false)
+    }
+    guard units.isEmpty == false else { return nil }
+    return section(id: .history, cap: cap, units: units)
+  }
+
+  private func recallSection(
+    snapshot: SessionContextSnapshot,
+    sessionId: Int64,
+    residual: Int
+  ) -> FittableSection? {
+    let cap = cap(for: .recall, residual: residual)
+    guard cap > 0, let query = latestUserMessage(in: snapshot.history) else { return nil }
+
+    let hits: [RecallHit]
+    do {
+      hits = try retriever.searchRelevantMessages(
+        query: query,
+        currentSessionId: sessionId,
+        windowStartMessageId: snapshot.windowStartMessageId,
+        excludedMessageIds: snapshot.historyMessageIds,
+        limit: Self.recallCandidateLimit
+      )
+    } catch {
+      warn("message recall failed: \(error)")
+      return nil
+    }
+
+    let selected = recallCutoff.select(hits: hits, limit: Self.recallInjectionLimit)
+    let units = selected.compactMap { hit -> SectionUnit? in
+      let content = cappedRecallContent(hit.content)
+      guard content.isEmpty == false else { return nil }
+      return SectionUnit(id: "recall-\(hit.id)", content: content, canTruncate: true)
+    }
+    guard units.isEmpty == false else { return nil }
+    return section(id: .recall, cap: cap, units: units)
+  }
+
+  private func skillsSection(residual: Int) -> FittableSection? {
+    let cap = cap(for: .skills, residual: residual)
+    guard cap > 0 else { return nil }
+
+    let scan = workspace.scanSkills()
+    for warning in scan.warnings {
+      warn("skills scan warning: \(warning)")
+    }
+
+    let units = scan.descriptors.map { descriptor in
+      SectionUnit(
+        id: "skill-\(descriptor.name)",
+        content: "- \(descriptor.name): \(descriptor.description)",
+        canTruncate: false
+      )
+    }
+    guard units.isEmpty == false else { return nil }
+    return section(id: .skills, cap: cap, units: units)
+  }
+
+  private func section(
+    id: ContextRowID,
+    cap: Int? = nil,
+    units: [SectionUnit]
+  ) -> FittableSection {
+    let spec = spec(for: id)
+    return FittableSection(
+      id: spec.id,
+      tier: spec.tier,
+      priority: spec.priority,
+      truncatable: spec.truncatable,
+      cap: cap ?? spec.cap.resolve(in: budget, residualGraphemes: nil),
+      units: units
+    )
+  }
+
+  private func cap(for id: ContextRowID, residual: Int) -> Int {
+    spec(for: id).cap.resolve(in: budget, residualGraphemes: residual) ?? Int.max
+  }
+
+  private func residualAfterFixedSections(_ sections: [FittableSection]) -> Int {
+    let required =
+      sections
+      .filter { section in !section.truncatable }
+      .map { section in section.units.map(\.content).joined(separator: "\n").count }
+      .reduce(0, +)
+    return max(0, budget.inputCapGraphemes - required)
+  }
+
+  private func renderMessages(
+    fitted: [FittedSection],
+    snapshot: SessionContextSnapshot
+  ) -> [ChatMessage] {
+    let systemContent =
+      fitted
+      .filter { section in section.tier == .system }
+      .map(\.content)
+      .joined(separator: "\n\n")
+    var messages = [ChatMessage(role: .system, content: systemContent)]
+
+    let untrusted =
+      fitted
+      .filter { section in section.tier == .untrustedLabeled }
+      .map { section in
+        LabeledContextFactory.make(label: label(for: section.id), content: section.content).render()
+      }
+      .joined(separator: "\n\n")
+    if untrusted.isEmpty == false {
+      messages.append(ChatMessage(role: .user, content: untrusted))
+    }
+
+    messages.append(contentsOf: fittedHistoryMessages(fitted: fitted, snapshot: snapshot))
+    return messages
+  }
+
+  private func fittedHistoryMessages(
+    fitted: [FittedSection],
+    snapshot: SessionContextSnapshot
+  ) -> [ChatMessage] {
+    guard let historySection = fitted.first(where: { section in section.id == .history }) else {
+      return []
+    }
+
+    let keptIDs = Set(historySection.units.map(\.id))
+    return snapshot.history.enumerated().compactMap { index, message in
+      guard keptIDs.contains("history-\(index)") else { return nil }
+      return ChatMessage(role: message.role, content: message.content)
+    }
+  }
+
+  private func hasPrivateDataAccess(_ fitted: [FittedSection]) -> Bool {
+    fitted.contains { section in
+      section.id == .userFile || section.id == .memoryFile || section.id == .memoryItems
+    }
+  }
+
+  private func latestUserMessage(in history: [StoredMessage]) -> String? {
+    history.last { message in message.role == .user }?.content
+  }
+
+  private func cappedRecallContent(_ content: String) -> String {
+    guard content.count > budget.recallHitCap else {
+      return content
+    }
+    let marker = BudgetFitter.truncationMarker
+    guard budget.recallHitCap > marker.count else {
+      return ""
+    }
+    let prefixCount = budget.recallHitCap - marker.count
+    return String(content.prefix(prefixCount)) + marker
+  }
+
+  private func label(for id: ContextRowID) -> String {
+    switch id {
+    case .userFile:
+      "USER.md"
+    case .memoryFile:
+      "MEMORY.md"
+    case .memoryItems:
+      "memory_items"
+    case .recall:
+      "recall"
+    case .skills:
+      "skills"
+    case .policy, .systemWorkspace, .tools, .metadata, .history:
+      id.rawValue
+    }
+  }
+
+  private func spec(for id: ContextRowID) -> RowSpec {
+    guard let spec = ContextRowPolicy.specs.first(where: { spec in spec.id == id }) else {
+      preconditionFailure("missing context row spec for \(id)")
+    }
+    return spec
+  }
+
+  private static func iso8601(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    return formatter.string(from: date)
   }
 }

--- a/Sources/ClawAgent/Runtime/AgentRuntime.swift
+++ b/Sources/ClawAgent/Runtime/AgentRuntime.swift
@@ -6,6 +6,7 @@ import Foundation
 public enum DegradationKind: String, Sendable, Equatable {
   case providerUnavailable
   case outputTruncated
+  case contextUnavailable
 }
 
 /// The outcome of one orchestrated turn. `runTurn` never throws — every failure becomes one of

--- a/Sources/ClawCore/Persistence/Persistence.swift
+++ b/Sources/ClawCore/Persistence/Persistence.swift
@@ -126,6 +126,25 @@ public struct StoredMessage: Sendable, Equatable {
   }
 }
 
+public struct SessionContextSnapshot: Sendable, Equatable {
+  public let history: [StoredMessage]
+  public let historyMessageIds: [Int64]
+  public let windowStartMessageId: Int64?
+  public let isTainted: Bool
+
+  public init(
+    history: [StoredMessage],
+    historyMessageIds: [Int64],
+    windowStartMessageId: Int64?,
+    isTainted: Bool
+  ) {
+    self.history = history
+    self.historyMessageIds = historyMessageIds
+    self.windowStartMessageId = windowStartMessageId
+    self.isTainted = isTainted
+  }
+}
+
 public struct ProviderUsage: Sendable, Equatable {
   public let runId: Int64
   public let sessionId: Int64

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -101,6 +101,13 @@ public protocol SessionMessageStore: Sendable {
     throughMessageId: Int64,
     limit: Int
   ) throws -> [StoredMessage]
+  /// Context snapshot returned oldest-first and bounded to the message this run is answering.
+  /// Includes the durable session metadata the assembler needs for recall dedup and taint reads.
+  func loadContextSnapshot(
+    sessionId: Int64,
+    throughMessageId: Int64,
+    limit: Int
+  ) throws -> SessionContextSnapshot
   /// Advances the `/new` context boundary to the latest message and clears session taint.
   func resetWindowAndDetaint(sessionId: Int64, now: Date) throws
 }

--- a/Sources/ClawData/Stores/Session/SessionMessageStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Session/SessionMessageStoreGRDB.swift
@@ -93,6 +93,7 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
         sql: "SELECT window_start_message_id, tainted FROM sessions WHERE id = ?",
         arguments: [sessionId]
       )
+
       let windowStartMessageId: Int64?
       let isTainted: Bool
       if let session {
@@ -129,7 +130,9 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
           provenance: Provenance(rawValue: row["provenance"]) ?? .trusted
         )
       }
-      let messageIds = rows.map { row in row["id"] as Int64 }
+      let messageIds = rows.map { row in
+        row["id"] as Int64
+      }
 
       return SessionContextSnapshot(
         history: history,

--- a/Sources/ClawData/Stores/Session/SessionMessageStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Session/SessionMessageStoreGRDB.swift
@@ -75,12 +75,39 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
     throughMessageId: Int64,
     limit: Int
   ) throws -> [StoredMessage] {
+    try loadContextSnapshot(
+      sessionId: sessionId,
+      throughMessageId: throughMessageId,
+      limit: limit
+    ).history
+  }
+
+  public func loadContextSnapshot(
+    sessionId: Int64,
+    throughMessageId: Int64,
+    limit: Int
+  ) throws -> SessionContextSnapshot {
     try writer.readMapping { db in
+      let session = try Row.fetchOne(
+        db,
+        sql: "SELECT window_start_message_id, tainted FROM sessions WHERE id = ?",
+        arguments: [sessionId]
+      )
+      let windowStartMessageId: Int64?
+      let isTainted: Bool
+      if let session {
+        windowStartMessageId = session["window_start_message_id"]
+        isTainted = session["tainted"]
+      } else {
+        windowStartMessageId = nil
+        isTainted = false
+      }
+
       // Limit the newest eligible rows first, then restore chronological order for the model.
       let rows = try Row.fetchAll(
         db,
         sql: """
-          SELECT role, content, provenance FROM (
+          SELECT id, role, content, provenance FROM (
             SELECT m.id, m.role, m.content, m.provenance
             FROM messages m
             JOIN sessions s ON s.id = m.session_id
@@ -95,13 +122,21 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
         arguments: [sessionId, throughMessageId, limit]
       )
 
-      return rows.map { row in
+      let history = rows.map { row in
         StoredMessage(
           role: MessageRole(rawValue: row["role"]) ?? .user,
           content: row["content"],
           provenance: Provenance(rawValue: row["provenance"]) ?? .trusted
         )
       }
+      let messageIds = rows.map { row in row["id"] as Int64 }
+
+      return SessionContextSnapshot(
+        history: history,
+        historyMessageIds: messageIds,
+        windowStartMessageId: windowStartMessageId,
+        isTainted: isTainted
+      )
     }
   }
 

--- a/Sources/ClawGateway/Response/Degradation.swift
+++ b/Sources/ClawGateway/Response/Degradation.swift
@@ -8,6 +8,8 @@ public enum Degradation {
     "I couldn't reach the model. Please try again in a moment."
   public static let outputTruncated =
     "The model hit its output limit before answering. Try a shorter prompt."
+  public static let contextUnavailable =
+    "I couldn't build the context for this turn. Please trim workspace memory or try again."
   /// Used by boot reconciliation (F22) for a run that crashed mid-turn without delivering anything.
   public static let unfinished = "I didn't finish your last request. Please resend it."
   /// Used on the `SQLITE_FULL` path (F23) when the message can't even be persisted.
@@ -31,6 +33,8 @@ public enum Degradation {
       return providerUnavailable
     case .outputTruncated:
       return outputTruncated
+    case .contextUnavailable:
+      return contextUnavailable
     }
   }
 }

--- a/Sources/ClawGateway/Routing/TurnRunner.swift
+++ b/Sources/ClawGateway/Routing/TurnRunner.swift
@@ -22,7 +22,7 @@ public struct TurnRunner: TurnDispatching {
   private let audit: any AuditLog
   private let agent: AgentRuntime
   private let budget: RunBudget
-  private let systemPrompt: String
+  private let contextBuilder: ContextBuilder
   /// Pokes the outbox dispatcher to drain after a commit. A no-op until Task 6 wires the dispatcher.
   private let notifyOutbox: @Sendable () -> Void
   /// Post-commit daily kill-switch + the transport for its owner DM. Both `nil` in tests that don't
@@ -41,7 +41,7 @@ public struct TurnRunner: TurnDispatching {
     audit: any AuditLog,
     agent: AgentRuntime,
     budget: RunBudget,
-    systemPrompt: String,
+    contextBuilder: ContextBuilder,
     notifyOutbox: @escaping @Sendable () -> Void,
     breaker: BudgetBreaker? = nil,
     transport: (any TelegramTransport)? = nil,
@@ -53,7 +53,7 @@ public struct TurnRunner: TurnDispatching {
     self.audit = audit
     self.agent = agent
     self.budget = budget
-    self.systemPrompt = systemPrompt
+    self.contextBuilder = contextBuilder
     self.notifyOutbox = notifyOutbox
     self.breaker = breaker
     self.transport = transport
@@ -80,29 +80,55 @@ public struct TurnRunner: TurnDispatching {
       return
     }
 
-    let history = try sessionMessages.loadContext(
-      sessionId: sessionId,
-      throughMessageId: triggerMessageId,
-      limit: Self.historyLimit
-    )
-    let (todayTokens, todayUSD) = try usageStore.todayTokensAndCost(now: now)
-
-    let context = ContextBuilder.assemble(
-      systemPrompt: systemPrompt,
-      history: history,
-      inputCapGraphemes: TokenEstimator.graphemeBudget(forInputTokens: budget.maxInputTokens)
-    )
+    let buildResult: BuildResult
+    let todayTokens: Int
+    let todayUSD: Double
+    do {
+      let snapshot = try sessionMessages.loadContextSnapshot(
+        sessionId: sessionId,
+        throughMessageId: triggerMessageId,
+        limit: Self.historyLimit
+      )
+      let totals = try usageStore.todayTokensAndCost(now: now)
+      todayTokens = totals.tokens
+      todayUSD = totals.costUSD
+      buildResult = try contextBuilder.assemble(snapshot: snapshot, sessionId: sessionId)
+    } catch StoreError.diskFull {
+      throw StoreError.diskFull
+    } catch {
+      logger.error("context build failed for run \(runId): \(error)")
+      _ = try commitDegradation(
+        runId: runId,
+        sessionId: sessionId,
+        chatId: chatId,
+        usage: nil,
+        message: ownerVisiblePayload(
+          reply: Degradation.contextUnavailable,
+          ownerNotices: []
+        ),
+        action: .turnDegraded,
+        decision: DegradationKind.contextUnavailable.rawValue,
+        at: Date()
+      )
+      return
+    }
 
     let result = await agent.runTurn(
       runId: runId,
       sessionId: sessionId,
       chatId: chatId,
-      context: context,
+      context: buildResult.messages,
       todayTokens: todayTokens,
       todayUSD: todayUSD
     )
 
-    try await commit(result, runId: runId, sessionId: sessionId, chatId: chatId)
+    try await commit(
+      result,
+      runId: runId,
+      sessionId: sessionId,
+      chatId: chatId,
+      ownerNotices: buildResult.ownerNotices
+    )
   }
 
   // MARK: - Load-bearing
@@ -118,7 +144,8 @@ public struct TurnRunner: TurnDispatching {
     _ result: TurnResult,
     runId: Int64,
     sessionId: Int64,
-    chatId: Int64
+    chatId: Int64,
+    ownerNotices: [String]
   ) async throws {
     let committedAt = Date()
 
@@ -130,7 +157,10 @@ public struct TurnRunner: TurnDispatching {
         chatId: chatId,
         content: content,
         usage: usage,
-        chunks: outboxChunks(for: content, chatId: chatId)
+        chunks: outboxChunks(
+          for: ownerVisiblePayload(reply: content, ownerNotices: ownerNotices),
+          chatId: chatId
+        )
       )
 
       let commitResult = try runs.commitAssistantTurn(turn, now: committedAt)
@@ -158,7 +188,10 @@ public struct TurnRunner: TurnDispatching {
         sessionId: sessionId,
         chatId: chatId,
         usage: usage,
-        message: Degradation.message(for: degradationKind),
+        message: ownerVisiblePayload(
+          reply: Degradation.message(for: degradationKind),
+          ownerNotices: ownerNotices
+        ),
         action: .turnDegraded,
         decision: degradationKind.rawValue,
         at: committedAt
@@ -172,7 +205,10 @@ public struct TurnRunner: TurnDispatching {
         sessionId: sessionId,
         chatId: chatId,
         usage: nil,
-        message: Degradation.budget(cap: cap),
+        message: ownerVisiblePayload(
+          reply: Degradation.budget(cap: cap),
+          ownerNotices: ownerNotices
+        ),
         action: .turnBudgetStopped,
         decision: cap,
         at: committedAt
@@ -285,6 +321,13 @@ public struct TurnRunner: TurnDispatching {
       sessionId: sessionId,
       ts: ts
     )
+  }
+
+  private func ownerVisiblePayload(reply: String, ownerNotices: [String]) -> String {
+    guard ownerNotices.isEmpty == false else {
+      return reply
+    }
+    return (ownerNotices + [reply]).joined(separator: "\n\n")
   }
 
   /// Splits an assistant reply into deterministic outbox chunks (grapheme-capped, FNV-1a hashed).

--- a/Sources/ClawGateway/Routing/TurnRunner.swift
+++ b/Sources/ClawGateway/Routing/TurnRunner.swift
@@ -83,15 +83,18 @@ public struct TurnRunner: TurnDispatching {
     let buildResult: BuildResult
     let todayTokens: Int
     let todayUSD: Double
+
     do {
       let snapshot = try sessionMessages.loadContextSnapshot(
         sessionId: sessionId,
         throughMessageId: triggerMessageId,
         limit: Self.historyLimit
       )
+
       let totals = try usageStore.todayTokensAndCost(now: now)
       todayTokens = totals.tokens
       todayUSD = totals.costUSD
+
       buildResult = try contextBuilder.assemble(snapshot: snapshot, sessionId: sessionId)
     } catch StoreError.diskFull {
       throw StoreError.diskFull

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -137,13 +137,28 @@ struct RunCommand: AsyncParsableCommand {
     let outboxSignal = OutboxSignal()
     let breaker = BudgetBreaker(budget: config.budget)
     let lanes = SessionLaneRegistry()
-    let workspaceRoot = config.stateRoot.appendingPathComponent("workspace", isDirectory: true)
+    let workspace = FileSystemWorkspace(
+      root: config.stateRoot.appendingPathComponent("workspace", isDirectory: true)
+    )
+    let contextBudget = ContextBudget(
+      inputCapGraphemes: TokenEstimator.graphemeBudget(
+        forInputTokens: config.budget.maxInputTokens
+      ),
+      userFileCap: ContextBudget.default.userFileCap,
+      memoryFileCap: ContextBudget.default.memoryFileCap,
+      itemsCap: ContextBudget.default.itemsCap,
+      historyCap: ContextBudget.default.historyCap,
+      recallCap: ContextBudget.default.recallCap,
+      skillsCap: ContextBudget.default.skillsCap,
+      recallHitCap: ContextBudget.default.recallHitCap
+    )
     let contextBuilder = ContextBuilder(
       systemPrompt: SystemPrompt.minimal,
-      workspace: FileSystemWorkspace(root: workspaceRoot),
+      workspace: workspace,
       memoryStore: stores.memory,
       retriever: stores.retriever,
-      budget: .default
+      budget: contextBudget,
+      warn: { warning in logger.warning("\(warning)") }
     )
     let turnRunner = TurnRunner(
       sessionMessages: stores.sessionMessages,

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -7,6 +7,7 @@ import ClawGateway
 import ClawLLM
 import ClawSecrets
 import ClawTelegram
+import ClawWorkspace
 import Foundation
 import Logging
 
@@ -136,6 +137,14 @@ struct RunCommand: AsyncParsableCommand {
     let outboxSignal = OutboxSignal()
     let breaker = BudgetBreaker(budget: config.budget)
     let lanes = SessionLaneRegistry()
+    let workspaceRoot = config.stateRoot.appendingPathComponent("workspace", isDirectory: true)
+    let contextBuilder = ContextBuilder(
+      systemPrompt: SystemPrompt.minimal,
+      workspace: FileSystemWorkspace(root: workspaceRoot),
+      memoryStore: stores.memory,
+      retriever: stores.retriever,
+      budget: .default
+    )
     let turnRunner = TurnRunner(
       sessionMessages: stores.sessionMessages,
       runs: stores.runs,
@@ -143,7 +152,7 @@ struct RunCommand: AsyncParsableCommand {
       audit: stores.audit,
       agent: agent,
       budget: config.budget,
-      systemPrompt: SystemPrompt.minimal,
+      contextBuilder: contextBuilder,
       notifyOutbox: { outboxSignal.poke() },
       breaker: breaker,
       transport: transport,

--- a/Tests/ClawAgentTests/Context/BudgetFitterTests.swift
+++ b/Tests/ClawAgentTests/Context/BudgetFitterTests.swift
@@ -236,6 +236,39 @@ import Testing
     #expect(fitted.first?.content == "a…[truncated]")
     #expect(fitted.first?.content.count == 13)
   }
+
+  @Test func historyNewestUnitSurvivesWhenItAloneExceedsBudget() throws {
+    // given
+    let section = FittableSection(
+      id: .history,
+      tier: .mixed,
+      priority: ContextPriority(70),
+      truncatable: true,
+      cap: 4,
+      units: [
+        SectionUnit(id: "history-1", content: "answer this please", canTruncate: false),
+        SectionUnit(id: "history-0", content: "older", canTruncate: false),
+      ]
+    )
+    let budget = ContextBudget(
+      inputCapGraphemes: 5,
+      userFileCap: 1,
+      memoryFileCap: 1,
+      itemsCap: 1,
+      historyCap: 4,
+      recallCap: 1,
+      skillsCap: 1,
+      recallHitCap: 1
+    )
+
+    // when
+    let fitted = try BudgetFitter.fitWithUnits([section], budget: budget)
+
+    // then
+    let history = try #require(fitted.first { row in row.id == .history })
+    #expect(history.units.map(\.id) == ["history-1"])
+    #expect(history.content == "answer this please")
+  }
 }
 
 private func testBudget(inputCap: Int) -> ContextBudget {

--- a/Tests/ClawAgentTests/Context/BudgetFitterTests.swift
+++ b/Tests/ClawAgentTests/Context/BudgetFitterTests.swift
@@ -139,6 +139,82 @@ import Testing
     #expect(fitted.first?.content == "small")
   }
 
+  @Test func historyFitStopsAtFirstNonFittingMessageToPreserveContiguousWindow() throws {
+    // given
+    let section = FittableSection(
+      id: .history,
+      tier: .mixed,
+      priority: ContextPriority(70),
+      truncatable: true,
+      cap: 10,
+      units: [
+        SectionUnit(id: "history-2", content: "newest", canTruncate: false),
+        SectionUnit(id: "history-1", content: "oversized middle", canTruncate: false),
+        SectionUnit(id: "history-0", content: "o", canTruncate: false),
+      ]
+    )
+    let budget = ContextBudget(
+      inputCapGraphemes: 10,
+      userFileCap: 1,
+      memoryFileCap: 1,
+      itemsCap: 1,
+      historyCap: 10,
+      recallCap: 1,
+      skillsCap: 1,
+      recallHitCap: 1
+    )
+
+    // when
+    let fitted = try BudgetFitter.fitWithUnits([section], budget: budget)
+
+    // then
+    let history = try #require(fitted.first { row in row.id == .history })
+    #expect(history.units.map(\.id) == ["history-2"])
+    #expect(history.content == "newest")
+  }
+
+  @Test func existingFitStillReturnsSectionsWithSameContent() throws {
+    // given
+    let section = FittableSection(
+      id: .memoryItems,
+      tier: .untrustedLabeled,
+      priority: ContextPriority(60),
+      truncatable: true,
+      cap: 20,
+      units: [
+        SectionUnit(id: "memory-1", content: "alpha", canTruncate: false),
+        SectionUnit(id: "memory-2", content: "bravo", canTruncate: false),
+      ]
+    )
+    let budget = ContextBudget(
+      inputCapGraphemes: 20,
+      userFileCap: 1,
+      memoryFileCap: 1,
+      itemsCap: 20,
+      historyCap: 1,
+      recallCap: 1,
+      skillsCap: 1,
+      recallHitCap: 1
+    )
+
+    // when
+    let sections = try BudgetFitter.fit([section], budget: budget)
+
+    // then
+    #expect(
+      sections == [
+        Section(
+          id: .memoryItems,
+          tier: .untrustedLabeled,
+          priority: ContextPriority(60),
+          truncatable: true,
+          cap: 20,
+          content: "alpha\nbravo"
+        )
+      ]
+    )
+  }
+
   @Test func truncatesUnitWithMarkerWhenUnitAllowsCharacterTruncation() throws {
     // given
     let sections = [

--- a/Tests/ClawAgentTests/Context/ContextBuilderTests.swift
+++ b/Tests/ClawAgentTests/Context/ContextBuilderTests.swift
@@ -247,6 +247,36 @@ struct ContextBuilderTests {
     #expect(result.messages.suffix(1).map(\.content) == ["newest"])
     #expect(result.messages.contains(where: { message in message.content == "o" }) == false)
   }
+
+  @Test func triggerMessageSurvivesWhenBudgetCannotFitIt() throws {
+    // given
+    let budget = ContextBudget(
+      inputCapGraphemes: 60,
+      userFileCap: 1,
+      memoryFileCap: 1,
+      itemsCap: 1,
+      historyCap: 4,
+      recallCap: 1,
+      skillsCap: 1,
+      recallHitCap: 1
+    )
+    let builder = makeBuilder(budget: budget)
+    let snapshot = SessionContextSnapshot(
+      history: [
+        StoredMessage(role: .user, content: "what is the meaning of this", provenance: .trusted)
+      ],
+      historyMessageIds: [7],
+      windowStartMessageId: 0,
+      isTainted: false
+    )
+
+    // when
+    let result = try builder.assemble(snapshot: snapshot, sessionId: 42)
+
+    // then
+    #expect(result.messages.last?.role == .user)
+    #expect(result.messages.last?.content == "what is the meaning of this")
+  }
 }
 
 private func makeBuilder(

--- a/Tests/ClawAgentTests/Context/ContextBuilderTests.swift
+++ b/Tests/ClawAgentTests/Context/ContextBuilderTests.swift
@@ -81,8 +81,7 @@ struct ContextBuilderTests {
   }
 
   @Test func taintedSnapshotExcludesHighSensitivityMemoryAndSetsPrivateAccessForInjectedItems()
-    throws
-  {
+    throws {
     // given
     let high = memory(id: 1, text: "secret", sensitivity: .high, importance: .high)
     let normal = memory(id: 2, text: "normal fact", sensitivity: .normal, importance: .normal)

--- a/Tests/ClawAgentTests/Context/ContextBuilderTests.swift
+++ b/Tests/ClawAgentTests/Context/ContextBuilderTests.swift
@@ -1,3 +1,5 @@
+import ClawWorkspace
+import Foundation
 import Testing
 
 @testable import ClawAgent
@@ -5,41 +7,373 @@ import Testing
 
 @Suite("ContextBuilder")
 struct ContextBuilderTests {
-  @Test("keeps the system prompt and drops the oldest history to fit the cap")
-  func keepsSystemPromptAndDropsOldestHistoryToFit() throws {
-    // given — cap 11 minus a 3-grapheme prompt leaves 8 graphemes; two 4-grapheme messages fit.
-    let history = [userMessage("aaaa"), userMessage("bbbb"), userMessage("cccc")]
-
-    // when
-    let result = ContextBuilder.assemble(
-      systemPrompt: "Sys",
-      history: history,
-      inputCapGraphemes: 11
+  @Test func assemblesSystemUntrustedAndHistoryInTheRequiredOrder() throws {
+    // given
+    let builder = makeBuilder(
+      workspace: FakeWorkspace(
+        files: [
+          .soul: .present("soul text"),
+          .agents: .present("agent rules"),
+          .tools: .present("tool policy"),
+          .user: .present("owner profile"),
+          .memory: .present("curated memory"),
+        ]
+      )
+    )
+    let snapshot = SessionContextSnapshot(
+      history: [
+        StoredMessage(role: .user, content: "hello", provenance: .trusted),
+        StoredMessage(role: .assistant, content: "hi", provenance: .trusted),
+      ],
+      historyMessageIds: [10, 11],
+      windowStartMessageId: 0,
+      isTainted: false
     )
 
-    // then — oldest "aaaa" dropped; survivors stay chronological; marker on the system prompt.
-    let systemMessage = try #require(result.first)
-    #expect(systemMessage.role == .system)
-    #expect(systemMessage.content.contains("[…earlier conversation truncated]"))
-    #expect(result.dropFirst().map(\.content) == ["bbbb", "cccc"])
+    // when
+    let result = try builder.assemble(snapshot: snapshot, sessionId: 42)
+
+    // then
+    #expect(result.messages.map(\.role) == [.system, .user, .user, .assistant])
+    let system = result.messages[0].content
+    #expect(system.contains("system policy"))
+    #expect(system.contains("soul text"))
+    #expect(system.contains("agent rules"))
+    #expect(system.contains("tool policy"))
+    #expect(system.contains("1970-01-01T00:00:00Z"))
+    #expect(system.contains("owner profile") == false)
+
+    let untrusted = result.messages[1].content
+    #expect(untrusted.contains("label=\"USER.md\""))
+    #expect(untrusted.contains("owner profile"))
+    #expect(untrusted.contains("label=\"MEMORY.md\""))
+    #expect(untrusted.contains("curated memory"))
+    #expect(result.messages.dropFirst(2).map(\.content) == ["hello", "hi"])
+    #expect(result.hasPrivateDataAccess)
+    #expect(result.ownerNotices.isEmpty)
   }
 
-  @Test("the system prompt is never dropped even when it alone exceeds the cap")
-  func systemPromptIsNeverDroppedEvenWhenOverCap() throws {
+  @Test func hardCapOverflowOmitsFileAndProducesOwnerNotice() throws {
     // given
-    let systemPrompt = "A very long system prompt that alone exceeds the cap"
-
-    // when
-    let result = ContextBuilder.assemble(
-      systemPrompt: systemPrompt,
+    let builder = makeBuilder(
+      workspace: FakeWorkspace(files: [.memory: .overCap(count: 2_201)])
+    )
+    let snapshot = SessionContextSnapshot(
       history: [],
-      inputCapGraphemes: 1
+      historyMessageIds: [],
+      windowStartMessageId: 0,
+      isTainted: false
     )
 
-    // then — exactly the system message, unchanged (no history was dropped → no marker).
-    #expect(result.count == 1)
-    let systemMessage = try #require(result.first)
-    #expect(systemMessage.role == .system)
-    #expect(systemMessage.content == systemPrompt)
+    // when
+    let result = try builder.assemble(snapshot: snapshot, sessionId: 42)
+
+    // then
+    #expect(result.messages.count == 1)
+    #expect(result.messages[0].role == .system)
+    #expect(result.messages[0].content.contains("MEMORY.md") == false)
+    #expect(
+      result.ownerNotices == [
+        "⚠ `MEMORY.md` is 2201/2200 — edit it to trim; left out this turn."
+      ]
+    )
+    #expect(result.hasPrivateDataAccess == false)
+  }
+
+  @Test func taintedSnapshotExcludesHighSensitivityMemoryAndSetsPrivateAccessForInjectedItems()
+    throws
+  {
+    // given
+    let high = memory(id: 1, text: "secret", sensitivity: .high, importance: .high)
+    let normal = memory(id: 2, text: "normal fact", sensitivity: .normal, importance: .normal)
+    let memoryStore = FakeMemoryStore(items: [high, normal])
+    let builder = makeBuilder(memoryStore: memoryStore)
+    let snapshot = SessionContextSnapshot(
+      history: [StoredMessage(role: .user, content: "question", provenance: .trusted)],
+      historyMessageIds: [44],
+      windowStartMessageId: 0,
+      isTainted: true
+    )
+
+    // when
+    let result = try builder.assemble(snapshot: snapshot, sessionId: 42)
+
+    // then
+    #expect(memoryStore.fetchRankedCalls == [true])
+    let untrusted = try #require(result.messages.first { message in message.role == .user })
+      .content
+    #expect(untrusted.contains("normal fact"))
+    #expect(untrusted.contains("secret") == false)
+    #expect(result.hasPrivateDataAccess)
+  }
+
+  @Test func recallUsesLatestUserMessageAndExcludesCurrentHistoryIds() throws {
+    // given
+    let retriever = FakeRetriever(
+      hits: [
+        RecallHit(
+          id: 90,
+          sessionId: 2,
+          role: .user,
+          content: String(repeating: "r", count: 450),
+          score: RecallScore(value: 10),
+          createdAt: Date(timeIntervalSince1970: 90)
+        )
+      ]
+    )
+    let builder = makeBuilder(retriever: retriever)
+    let snapshot = SessionContextSnapshot(
+      history: [
+        StoredMessage(role: .user, content: "first", provenance: .trusted),
+        StoredMessage(role: .assistant, content: "answer", provenance: .trusted),
+        StoredMessage(role: .user, content: "latest query", provenance: .trusted),
+      ],
+      historyMessageIds: [10, 11, 12],
+      windowStartMessageId: 7,
+      isTainted: false
+    )
+
+    // when
+    let result = try builder.assemble(snapshot: snapshot, sessionId: 42)
+
+    // then
+    #expect(
+      retriever.calls == [
+        FakeRetriever.Call(
+          query: "latest query",
+          currentSessionId: 42,
+          windowStartMessageId: 7,
+          excludedMessageIds: [10, 11, 12],
+          limit: 20
+        )
+      ]
+    )
+    let untrusted = try #require(result.messages.first { message in message.role == .user })
+      .content
+    #expect(untrusted.contains("label=\"recall\""))
+    #expect(untrusted.contains(BudgetFitter.truncationMarker))
+  }
+
+  @Test func skillsRenderAsUntrustedIndexWithoutSettingPrivateAccess() throws {
+    // given
+    let builder = makeBuilder(
+      workspace: FakeWorkspace(
+        skills: [
+          SkillDescriptor(
+            name: "summarize",
+            description: "Summarize owner-provided text.",
+            directory: URL(fileURLWithPath: "/tmp/skills/summarize")
+          )
+        ]
+      )
+    )
+    let snapshot = SessionContextSnapshot(
+      history: [],
+      historyMessageIds: [],
+      windowStartMessageId: 0,
+      isTainted: false
+    )
+
+    // when
+    let result = try builder.assemble(snapshot: snapshot, sessionId: 42)
+
+    // then
+    let untrusted = try #require(result.messages.first { message in message.role == .user })
+      .content
+    #expect(untrusted.contains("label=\"skills\""))
+    #expect(untrusted.contains("- summarize: Summarize owner-provided text."))
+    #expect(result.hasPrivateDataAccess == false)
+  }
+
+  @Test func fittedHistoryKeepsNewestMessagesButRestoresChronology() throws {
+    // given
+    let budget = ContextBudget(
+      inputCapGraphemes: 80,
+      userFileCap: 1,
+      memoryFileCap: 1,
+      itemsCap: 1,
+      historyCap: 10,
+      recallCap: 1,
+      skillsCap: 1,
+      recallHitCap: 1
+    )
+    let builder = makeBuilder(budget: budget)
+    let snapshot = SessionContextSnapshot(
+      history: [
+        StoredMessage(role: .user, content: "old", provenance: .trusted),
+        StoredMessage(role: .assistant, content: "middle", provenance: .trusted),
+        StoredMessage(role: .user, content: "new", provenance: .trusted),
+      ],
+      historyMessageIds: [1, 2, 3],
+      windowStartMessageId: 0,
+      isTainted: false
+    )
+
+    // when
+    let result = try builder.assemble(snapshot: snapshot, sessionId: 42)
+
+    // then
+    #expect(result.messages.suffix(2).map(\.content) == ["middle", "new"])
+  }
+
+  @Test func fittedHistoryDoesNotReAdmitOlderMessagesAfterOversizedMiddleMessage() throws {
+    // given
+    let budget = ContextBudget(
+      inputCapGraphemes: 80,
+      userFileCap: 1,
+      memoryFileCap: 1,
+      itemsCap: 1,
+      historyCap: 10,
+      recallCap: 1,
+      skillsCap: 1,
+      recallHitCap: 1
+    )
+    let builder = makeBuilder(budget: budget)
+    let snapshot = SessionContextSnapshot(
+      history: [
+        StoredMessage(role: .user, content: "o", provenance: .trusted),
+        StoredMessage(role: .assistant, content: "oversized middle", provenance: .trusted),
+        StoredMessage(role: .user, content: "newest", provenance: .trusted),
+      ],
+      historyMessageIds: [1, 2, 3],
+      windowStartMessageId: 0,
+      isTainted: false
+    )
+
+    // when
+    let result = try builder.assemble(snapshot: snapshot, sessionId: 42)
+
+    // then
+    #expect(result.messages.suffix(1).map(\.content) == ["newest"])
+    #expect(result.messages.contains(where: { message in message.content == "o" }) == false)
+  }
+}
+
+private func makeBuilder(
+  workspace: FakeWorkspace = FakeWorkspace(),
+  memoryStore: FakeMemoryStore = FakeMemoryStore(),
+  retriever: FakeRetriever = FakeRetriever(),
+  budget: ContextBudget = .default
+) -> ContextBuilder {
+  ContextBuilder(
+    systemPrompt: "system policy",
+    workspace: workspace,
+    memoryStore: memoryStore,
+    retriever: retriever,
+    recallCutoff: CandidateCapRecallCutoff(),
+    budget: budget,
+    now: { Date(timeIntervalSince1970: 0) }
+  )
+}
+
+private func memory(
+  id: Int64,
+  text: String,
+  sensitivity: Sensitivity = .normal,
+  importance: Importance
+) -> MemoryItem {
+  MemoryItem(
+    id: id,
+    text: text,
+    kind: .project,
+    sensitivity: sensitivity,
+    importance: importance,
+    source: .owner,
+    sessionId: nil,
+    createdAt: Date(timeIntervalSince1970: Double(id))
+  )
+}
+
+private final class FakeWorkspace: WorkspaceReading, @unchecked Sendable {
+  enum FileState {
+    case present(String)
+    case overCap(count: Int)
+
+    var loadedFile: LoadedFile {
+      switch self {
+      case .present(let text):
+        LoadedFile(outcome: .present, text: text, graphemeCount: text.count)
+      case .overCap(let count):
+        LoadedFile(outcome: .overCap, text: "", graphemeCount: count)
+      }
+    }
+  }
+
+  private let files: [WorkspaceFile: FileState]
+  private let skills: [SkillDescriptor]
+
+  init(files: [WorkspaceFile: FileState] = [:], skills: [SkillDescriptor] = []) {
+    self.files = files
+    self.skills = skills
+  }
+
+  func load(file: WorkspaceFile, maxGraphemes: Int?) -> LoadedFile {
+    files[file]?.loadedFile ?? .missing
+  }
+
+  func loadDailyLog(day: String, maxGraphemes: Int?) -> LoadedFile {
+    .missing
+  }
+
+  func scanSkills() -> SkillScanResult {
+    SkillScanResult(descriptors: skills, warnings: [])
+  }
+}
+
+private final class FakeMemoryStore: MemoryStore, @unchecked Sendable {
+  private let items: [MemoryItem]
+  private(set) var fetchRankedCalls: [Bool] = []
+
+  init(items: [MemoryItem] = []) {
+    self.items = items
+  }
+
+  func append(_ newItem: NewMemoryItem, now: Date) throws -> MemoryItem {
+    throw StoreError.unexpected("not used")
+  }
+
+  func list(kind: MemoryKind?, limit: Int) throws -> [MemoryItem] { [] }
+  func get(id: Int64) throws -> MemoryItem? { nil }
+  func delete(id: Int64) throws -> Bool { false }
+
+  func fetchRanked(excludeSensitive: Bool, limit: Int) throws -> [MemoryItem] {
+    fetchRankedCalls.append(excludeSensitive)
+    return Array(items.prefix(limit))
+  }
+}
+
+private final class FakeRetriever: Retriever, @unchecked Sendable {
+  struct Call: Sendable, Equatable {
+    let query: String
+    let currentSessionId: Int64
+    let windowStartMessageId: Int64?
+    let excludedMessageIds: [Int64]
+    let limit: Int
+  }
+
+  private let hits: [RecallHit]
+  private(set) var calls: [Call] = []
+
+  init(hits: [RecallHit] = []) {
+    self.hits = hits
+  }
+
+  func searchRelevantMessages(
+    query: String,
+    currentSessionId: Int64,
+    windowStartMessageId: Int64?,
+    excludedMessageIds: [Int64],
+    limit: Int
+  ) throws -> [RecallHit] {
+    calls.append(
+      Call(
+        query: query,
+        currentSessionId: currentSessionId,
+        windowStartMessageId: windowStartMessageId,
+        excludedMessageIds: excludedMessageIds,
+        limit: limit
+      )
+    )
+    return Array(hits.prefix(limit))
   }
 }

--- a/Tests/ClawAgentTests/Context/ContextBuilderTests.swift
+++ b/Tests/ClawAgentTests/Context/ContextBuilderTests.swift
@@ -42,6 +42,7 @@ struct ContextBuilderTests {
     #expect(system.contains("tool policy"))
     #expect(system.contains("1970-01-01T00:00:00Z"))
     #expect(system.contains("owner profile") == false)
+    #expect(system.contains("truncated") == false)
 
     let untrusted = result.messages[1].content
     #expect(untrusted.contains("label=\"USER.md\""))
@@ -80,8 +81,8 @@ struct ContextBuilderTests {
     #expect(result.hasPrivateDataAccess == false)
   }
 
-  @Test func taintedSnapshotExcludesHighSensitivityMemoryAndSetsPrivateAccessForInjectedItems()
-    throws {
+  @Test
+  func taintedSnapshotExcludesHighSensitivityMemoryAndSetsPrivateAccessForInjectedItems() throws {
     // given
     let high = memory(id: 1, text: "secret", sensitivity: .high, importance: .high)
     let normal = memory(id: 2, text: "normal fact", sensitivity: .normal, importance: .normal)
@@ -245,6 +246,7 @@ struct ContextBuilderTests {
     // then
     #expect(result.messages.suffix(1).map(\.content) == ["newest"])
     #expect(result.messages.contains(where: { message in message.content == "o" }) == false)
+    #expect(result.messages[0].content.contains("[…earlier conversation truncated]"))
   }
 
   @Test func triggerMessageSurvivesWhenBudgetCannotFitIt() throws {

--- a/Tests/ClawDataTests/Stores/Session/SessionMessageStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Session/SessionMessageStoreTests.swift
@@ -165,6 +165,38 @@ import Testing
     #expect(sessions == 0)
   }
 
+  @Test func loadContextSnapshotIncludesHistoryIdsWindowStartAndTaint() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let store = SessionMessageStoreGRDB(writer: queue)
+    let first = try store.claimAndPersistInbound(inbound(updateId: 1, text: "before"))
+    let second = try store.claimAndPersistInbound(inbound(updateId: 2, text: "after"))
+    let sessionId = try #require(second.sessionId)
+    let firstMessageId = try #require(first.messageId)
+    let secondMessageId = try #require(second.messageId)
+    let triggerMessageId = try #require(second.triggerMessageId)
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE sessions SET window_start_message_id = ?, tainted = 1 WHERE id = ?",
+        arguments: [firstMessageId, sessionId]
+      )
+    }
+
+    // when
+    let snapshot = try store.loadContextSnapshot(
+      sessionId: sessionId,
+      throughMessageId: triggerMessageId,
+      limit: 10
+    )
+
+    // then
+    #expect(snapshot.history.map(\.content) == ["after"])
+    #expect(snapshot.historyMessageIds == [secondMessageId])
+    #expect(snapshot.windowStartMessageId == firstMessageId)
+    #expect(snapshot.isTainted)
+  }
+
   @Test func claimAndPersistRollsBackEntirelyWhenTheRunInsertAborts() throws {
     // given
     let queue = try ClawDatabase.makeInMemoryQueue()

--- a/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
+++ b/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
@@ -3,6 +3,7 @@ import ClawAgent
 import ClawCore
 import ClawData
 import ClawTelegram
+import ClawWorkspace
 import Foundation
 import GRDB
 import Logging
@@ -276,6 +277,30 @@ struct StreamingStack {
   let chatId: Int64
 }
 
+struct AcceptanceWorkspace: WorkspaceReading {
+  func load(file: WorkspaceFile, maxGraphemes: Int?) -> LoadedFile {
+    .missing
+  }
+
+  func loadDailyLog(day: String, maxGraphemes: Int?) -> LoadedFile {
+    .missing
+  }
+
+  func scanSkills() -> SkillScanResult {
+    SkillScanResult(descriptors: [], warnings: [])
+  }
+}
+
+func makeAcceptanceContextBuilder(writer: any DatabaseWriter) -> ContextBuilder {
+  ContextBuilder(
+    systemPrompt: SystemPrompt.minimal,
+    workspace: AcceptanceWorkspace(),
+    memoryStore: MemoryStoreGRDB(writer: writer),
+    retriever: RetrieverGRDB(writer: writer),
+    budget: .default
+  )
+}
+
 /// Assembles the production lane stack over `writer`, seeding `chatId` onto the allowlist and
 /// scripting the provider with `outcome`.
 func makeStack(
@@ -323,7 +348,7 @@ func makeStack(
     audit: audit,
     agent: agent,
     budget: .default,
-    systemPrompt: SystemPrompt.minimal,
+    contextBuilder: makeAcceptanceContextBuilder(writer: writer),
     notifyOutbox: { signal.poke() },
     breaker: BudgetBreaker(budget: .default),
     transport: transport,
@@ -408,7 +433,7 @@ func makeStreamingStack(
     audit: audit,
     agent: agent,
     budget: .default,
-    systemPrompt: SystemPrompt.minimal,
+    contextBuilder: makeAcceptanceContextBuilder(writer: writer),
     notifyOutbox: { signal.poke() },
     breaker: BudgetBreaker(budget: .default),
     transport: transport,
@@ -484,7 +509,7 @@ func makeStopNewStack(
     audit: audit,
     agent: agent,
     budget: .default,
-    systemPrompt: SystemPrompt.minimal,
+    contextBuilder: makeAcceptanceContextBuilder(writer: writer),
     notifyOutbox: { signal.poke() },
     breaker: BudgetBreaker(budget: .default),
     transport: transport,

--- a/Tests/ClawGatewayTests/Routing/MessageRouterTests.swift
+++ b/Tests/ClawGatewayTests/Routing/MessageRouterTests.swift
@@ -23,6 +23,18 @@ struct FullSessions: SessionMessageStore {
   ) throws -> [StoredMessage] {
     []
   }
+  func loadContextSnapshot(
+    sessionId: Int64,
+    throughMessageId: Int64,
+    limit: Int
+  ) throws -> SessionContextSnapshot {
+    SessionContextSnapshot(
+      history: [],
+      historyMessageIds: [],
+      windowStartMessageId: nil,
+      isTainted: false
+    )
+  }
   func resetWindowAndDetaint(sessionId: Int64, now: Date) throws {}
 }
 

--- a/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
+++ b/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
@@ -1,6 +1,7 @@
 import ClawAgent
 import ClawCore
 import ClawData
+import ClawWorkspace
 import Foundation
 import GRDB
 import Logging
@@ -135,6 +136,58 @@ struct DiskFullRuns: RunStore {
   }
 }
 
+struct TurnRunnerWorkspace: WorkspaceReading {
+  let memoryFile: LoadedFile
+
+  init(memoryFile: LoadedFile = .missing) {
+    self.memoryFile = memoryFile
+  }
+
+  func load(file: WorkspaceFile, maxGraphemes: Int?) -> LoadedFile {
+    file == .memory ? memoryFile : .missing
+  }
+
+  func loadDailyLog(day: String, maxGraphemes: Int?) -> LoadedFile {
+    .missing
+  }
+
+  func scanSkills() -> SkillScanResult {
+    SkillScanResult(descriptors: [], warnings: [])
+  }
+}
+
+struct SnapshotFailingSessionMessages: SessionMessageStore {
+  func loadOrCreateSession(sessionKey: String, now: Date) throws -> Int64 { 0 }
+
+  func claimAndPersistInbound(_ inbound: InboundMessage) throws -> ClaimResult {
+    ClaimResult(
+      newlyClaimed: false,
+      sessionId: nil,
+      messageId: nil,
+      runId: nil,
+      triggerMessageId: nil
+    )
+  }
+
+  func loadContext(
+    sessionId: Int64,
+    throughMessageId: Int64,
+    limit: Int
+  ) throws -> [StoredMessage] {
+    []
+  }
+
+  func loadContextSnapshot(
+    sessionId: Int64,
+    throughMessageId: Int64,
+    limit: Int
+  ) throws -> SessionContextSnapshot {
+    throw StoreError.unexpected("snapshot read failed")
+  }
+
+  func resetWindowAndDetaint(sessionId: Int64, now: Date) throws {}
+}
+
 @Suite struct TurnRunnerTests {
   private struct Env {
     let runner: TurnRunner
@@ -148,10 +201,31 @@ struct DiskFullRuns: RunStore {
     let provider: StubLLMProvider
   }
 
+  private func makeContextBuilder(
+    workspace: TurnRunnerWorkspace = TurnRunnerWorkspace(),
+    budget: ContextBudget = .default
+  ) throws -> ContextBuilder {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let memory = MemoryStoreGRDB(writer: queue)
+    let retriever = RetrieverGRDB(writer: queue)
+    return ContextBuilder(
+      systemPrompt: SystemPrompt.minimal,
+      workspace: workspace,
+      memoryStore: memory,
+      retriever: retriever,
+      budget: budget,
+      now: { Date(timeIntervalSince1970: 0) }
+    )
+  }
+
   private func makeEnv(
     agentOutcome: StubLLMProvider.Outcome,
     runs: (any RunStore)? = nil,
-    runsFactory: ((DatabaseQueue, Int64) -> any RunStore)? = nil
+    runsFactory: ((DatabaseQueue, Int64) -> any RunStore)? = nil,
+    contextBuilder: ContextBuilder? = nil,
+    sessionMessagesForRunner: (any SessionMessageStore)? = nil,
+    budget: RunBudget = .default
   ) throws -> Env {
     let queue = try ClawDatabase.makeInMemoryQueue()
     try ClawDatabase.migrate(queue)
@@ -178,6 +252,13 @@ struct DiskFullRuns: RunStore {
     let runId = try #require(claim.runId)
     let triggerMessageId = try #require(claim.triggerMessageId)
 
+    let builder: ContextBuilder
+    if let contextBuilder {
+      builder = contextBuilder
+    } else {
+      builder = try makeContextBuilder()
+    }
+
     let provider = StubLLMProvider(agentOutcome)
     let agent = AgentRuntime(
       provider: provider,
@@ -188,19 +269,19 @@ struct DiskFullRuns: RunStore {
         priceTable: .empty,
         referenceUSDPerToken: RunBudget.default.referenceUSDPerToken
       ),
-      budget: .default,
+      budget: budget,
       model: "gpt-4o",
       sleep: { try await Task.sleep(for: $0) }
     )
 
     let runner = TurnRunner(
-      sessionMessages: sessionMessages,
+      sessionMessages: sessionMessagesForRunner ?? sessionMessages,
       runs: runsFactory?(queue, sessionId) ?? runs ?? RunStoreGRDB(writer: queue),
       usageStore: usage,
       audit: audit,
       agent: agent,
-      budget: .default,
-      systemPrompt: SystemPrompt.minimal,
+      budget: budget,
+      contextBuilder: builder,
       notifyOutbox: {},
       logger: Logger(label: "test")
     )
@@ -395,5 +476,160 @@ struct DiskFullRuns: RunStore {
     // then
     #expect(try latestRunState(raced.queue) == RunState.cancelled.rawValue)
     #expect(try raced.outbox.pendingOutbound().isEmpty)
+  }
+
+  @Test func ownerNoticesArePrefixedToSuccessfulOutboxPayload() async throws {
+    // given
+    let noticeFile = LoadedFile(outcome: .overCap, text: "", graphemeCount: 2_201)
+    let contextBuilder = try makeContextBuilder(
+      workspace: TurnRunnerWorkspace(memoryFile: noticeFile)
+    )
+    let env = try makeEnv(
+      agentOutcome: .respond(okResponse(content: "Hello there")),
+      contextBuilder: contextBuilder
+    )
+
+    // when
+    try await env.runner.run(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: env.chatId,
+      triggerMessageId: env.triggerMessageId
+    )
+
+    // then
+    let pending = try env.outbox.pendingOutbound()
+    let firstPending = try #require(pending.first)
+    #expect(firstPending.payload.contains("`MEMORY.md` is 2201/2200"))
+    #expect(firstPending.payload.contains("Hello there"))
+    let storedAssistant = try #require(
+      try await env.queue.read { db in
+        try String.fetchOne(
+          db,
+          sql: "SELECT content FROM messages WHERE run_id = ? AND role = 'assistant'",
+          arguments: [env.runId]
+        )
+      }
+    )
+    #expect(storedAssistant == "Hello there")
+  }
+
+  @Test func contextBuildFailureFailsRunAndEnqueuesContextDegradation() async throws {
+    // given
+    let tinyBudget = ContextBudget(
+      inputCapGraphemes: 1,
+      userFileCap: 1,
+      memoryFileCap: 1,
+      itemsCap: 1,
+      historyCap: 1,
+      recallCap: 1,
+      skillsCap: 1,
+      recallHitCap: 1
+    )
+    let contextBuilder = try makeContextBuilder(budget: tinyBudget)
+    let env = try makeEnv(
+      agentOutcome: .respond(okResponse(content: "must not call provider")),
+      contextBuilder: contextBuilder
+    )
+
+    // when
+    try await env.runner.run(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: env.chatId,
+      triggerMessageId: env.triggerMessageId
+    )
+
+    // then
+    #expect(await env.provider.callCount == 0)
+    #expect(try latestRunState(env.queue) == RunState.failed.rawValue)
+    let pending = try env.outbox.pendingOutbound()
+    #expect(pending.map(\.payload) == [Degradation.contextUnavailable])
+  }
+
+  @Test func snapshotFailureAfterPickupFailsRunAndEnqueuesContextDegradation() async throws {
+    // given
+    let env = try makeEnv(
+      agentOutcome: .respond(okResponse(content: "must not call provider")),
+      sessionMessagesForRunner: SnapshotFailingSessionMessages()
+    )
+
+    // when
+    try await env.runner.run(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: env.chatId,
+      triggerMessageId: env.triggerMessageId
+    )
+
+    // then
+    #expect(await env.provider.callCount == 0)
+    #expect(try latestRunState(env.queue) == RunState.failed.rawValue)
+    let pending = try env.outbox.pendingOutbound()
+    #expect(pending.map(\.payload) == [Degradation.contextUnavailable])
+  }
+
+  @Test func ownerNoticesArePrefixedToDegradedOutboxPayload() async throws {
+    // given
+    let noticeFile = LoadedFile(outcome: .overCap, text: "", graphemeCount: 2_201)
+    let contextBuilder = try makeContextBuilder(
+      workspace: TurnRunnerWorkspace(memoryFile: noticeFile)
+    )
+    let env = try makeEnv(
+      agentOutcome: .fail(.terminal(status: 400, message: "bad request")),
+      contextBuilder: contextBuilder
+    )
+
+    // when
+    try await env.runner.run(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: env.chatId,
+      triggerMessageId: env.triggerMessageId
+    )
+
+    // then
+    let pending = try env.outbox.pendingOutbound()
+    let firstPending = try #require(pending.first)
+    #expect(firstPending.payload.contains("`MEMORY.md` is 2201/2200"))
+    #expect(firstPending.payload.contains(Degradation.providerUnavailable))
+  }
+
+  @Test func ownerNoticesArePrefixedToBudgetStoppedOutboxPayload() async throws {
+    // given
+    let stoppingBudget = RunBudget(
+      maxInputTokens: RunBudget.default.maxInputTokens,
+      maxOutputTokens: RunBudget.default.maxOutputTokens,
+      wallClockDeadlineSeconds: RunBudget.default.wallClockDeadlineSeconds,
+      retryBudget: RunBudget.default.retryBudget,
+      perRunUSD: RunBudget.default.perRunUSD,
+      perDayUSD: RunBudget.default.perDayUSD,
+      referenceUSDPerToken: RunBudget.default.referenceUSDPerToken,
+      dayTokenCeilingOverride: 1
+    )
+    let noticeFile = LoadedFile(outcome: .overCap, text: "", graphemeCount: 2_201)
+    let contextBuilder = try makeContextBuilder(
+      workspace: TurnRunnerWorkspace(memoryFile: noticeFile)
+    )
+    let env = try makeEnv(
+      agentOutcome: .respond(okResponse(content: "must not call provider")),
+      contextBuilder: contextBuilder,
+      budget: stoppingBudget
+    )
+
+    // when
+    try await env.runner.run(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: env.chatId,
+      triggerMessageId: env.triggerMessageId
+    )
+
+    // then
+    #expect(await env.provider.callCount == 0)
+    let pending = try env.outbox.pendingOutbound()
+    let firstPending = try #require(pending.first)
+    #expect(firstPending.payload.contains("`MEMORY.md` is 2201/2200"))
+    #expect(firstPending.payload.contains(Degradation.budget(cap: "per-day token")))
   }
 }


### PR DESCRIPTION
## What this does

Replaces the Inc 1 history-only context helper with the Increment 3a assembler. `ContextBuilder` now loads workspace files, durable memory items, message recall, and the skills index alongside history, fits them under a budget, and returns a `BuildResult` that `TurnRunner` threads into the turn. Plan 5 of Increment 3a (`docs/superpowers/plans/inc3a/05-context-assembler-wiring.md`).

## Commits

1. `9ec6c25` feat(agent): preserve fitted context units. Adds `SectionUnit.id`, `FittedSection`, and `BudgetFitter.fitWithUnits`. History stops at the first unit that does not fit, so the kept window stays a contiguous newest-first slice instead of skipping a large message to admit older ones.
2. `356eac2` feat(data): expose context snapshot metadata. Adds `SessionContextSnapshot` (history, message ids, `window_start_message_id`, `tainted`) and `loadContextSnapshot` behind the store protocol. `loadContext` becomes a wrapper.
3. `23d8963` feat(agent): assemble increment 3a context. Rewrites `ContextBuilder` into an injected `Sendable` assembler. System rows (1-4) build the system message; USER.md, MEMORY.md, memory items, recall, and skills render in one user-role labeled-context message; history stays role-preserving.
4. `ed37e3b` feat(gateway): run turns with build results. `TurnRunner` takes a `ContextBuilder`, reads the snapshot, and wraps the build in a degradation `do/catch`. `StoreError.diskFull` rethrows; other failures fail the run in-band with `Degradation.contextUnavailable` and never call the provider. Owner notices prefix the completed, degraded, and budget-stopped outbox payloads while the stored assistant row stays raw.
5. `853a1f1` feat(clawd): wire workspace context builder. Builds `FileSystemWorkspace`, derives the `ContextBudget` from the run budget, and passes the builder into the daemon.

## Security

Untrusted content (USER.md, MEMORY.md, memory items, recall, skills) never enters the system role. It renders only in a user-role `LabeledContext` message. `sessions.tainted` gates high-sensitivity memory out of the injection. Durable memory sets `hasPrivateDataAccess` without tainting the session.

## Tests

Full suite 350/350 passing, lint gate clean. New coverage: history contiguity across the fitter and assembler, the snapshot store seam, tier-to-role separation, taint exclusion, recall dedup args, the in-band context-build and snapshot-failure degradations, and owner-notice prefixing on all three outbox branches.

## Follow-ups (non-blocking, from review)

- The memory and recall read catches in `ContextBuilder` degrade on any error, including `diskFull`. The plan sanctions this, and the later assistant-write commit still surfaces a full disk. A throwing-fake test would lock the contract in.
- The `LabeledContext` framing is not charged against the grapheme budget, consistent with the existing token-to-grapheme approximation.
