### PR TITLE
Add tool-calling foundation for the assistant

### DIFF
--- a/Sources/ClawAgent/Runtime/StreamingTurnRuntime.swift
+++ b/Sources/ClawAgent/Runtime/StreamingTurnRuntime.swift
@@ -113,7 +113,7 @@ struct StreamingTurnRuntime: Sendable {
         if !content.isEmpty {
           await snapshot.publish(content)
         }
-      case .finished(let finishReason, let usage, let providerCost):
+      case .finished(let finishReason, let usage, let providerCost, _):
         return ChatResponse(
           content: content,
           finishReason: finishReason,

--- a/Sources/ClawAgent/Runtime/StreamingTurnRuntime.swift
+++ b/Sources/ClawAgent/Runtime/StreamingTurnRuntime.swift
@@ -113,12 +113,13 @@ struct StreamingTurnRuntime: Sendable {
         if !content.isEmpty {
           await snapshot.publish(content)
         }
-      case .finished(let finishReason, let usage, let providerCost, _):
+      case .finished(let finishReason, let usage, let providerCost, let toolCalls):
         return ChatResponse(
           content: content,
           finishReason: finishReason,
           usage: usage,
-          costFromProvider: providerCost
+          costFromProvider: providerCost,
+          toolCalls: toolCalls
         )
       }
     }

--- a/Sources/ClawCore/Config/AppConfig.swift
+++ b/Sources/ClawCore/Config/AppConfig.swift
@@ -14,6 +14,8 @@ public struct AppConfig: Sendable, Equatable {
     static let perDayUSD = "CLAW_PER_DAY_USD"
     static let referenceUSDPerToken = "CLAW_REFERENCE_USD_PER_TOKEN"
     static let dayTokenCeiling = "CLAW_DAY_TOKEN_CEILING"
+    static let maxTurns = "CLAW_MAX_TURNS"
+    static let maxToolCalls = "CLAW_MAX_TOOL_CALLS"
   }
 
   private enum EnvDefaults {
@@ -138,6 +140,8 @@ public struct AppConfig: Sendable, Equatable {
         env[EnvKey.referenceUSDPerToken],
         default: base.referenceUSDPerToken
       ),
+      maxTurns: try positiveBudgetInt(env[EnvKey.maxTurns], default: base.maxTurns),
+      maxToolCalls: try positiveBudgetInt(env[EnvKey.maxToolCalls], default: base.maxToolCalls),
       dayTokenCeilingOverride: try positiveBudgetIntOrNil(env[EnvKey.dayTokenCeiling])
     )
   }
@@ -154,6 +158,21 @@ public struct AppConfig: Sendable, Equatable {
     }
 
     guard let value = Double(trimmed), value > 0 else {
+      throw ConfigError.invalidBudget(trimmed)
+    }
+
+    return value
+  }
+
+  /// A positive `Int` override: `fallback` when absent/blank, else `invalidBudget` on a
+  /// non-numeric or non-positive value.
+  private static func positiveBudgetInt(_ raw: String?, default fallback: Int) throws -> Int {
+    let trimmed = raw?.trimmingCharacters(in: .whitespaces) ?? ""
+    guard !trimmed.isEmpty else {
+      return fallback
+    }
+
+    guard let value = Int(trimmed), value > 0 else {
       throw ConfigError.invalidBudget(trimmed)
     }
 

--- a/Sources/ClawCore/Config/SecretStore.swift
+++ b/Sources/ClawCore/Config/SecretStore.swift
@@ -6,15 +6,18 @@ public protocol SecretStore: Sendable {
   func loadSecrets() throws -> Secrets
 }
 
-/// The loaded secrets. These values feed the **existing** exact-value redactors in `TelegramClient`
-/// (the bot token) and `OpenAICompatibleProvider` (the API key) — no new redaction mechanism.
+/// The loaded secrets. These values feed the exact-value redactors: `TelegramClient` (bot token),
+/// `OpenAICompatibleProvider` (LLM key), and — from 3b — the ClawTools `SecretRedactor` and the
+/// search client (`searchApiKey`).
 public struct Secrets: Sendable, Equatable {
   public let telegramBotToken: String
   public let llmApiKey: String?
+  public let searchApiKey: String?
 
-  public init(telegramBotToken: String, llmApiKey: String?) {
+  public init(telegramBotToken: String, llmApiKey: String?, searchApiKey: String? = nil) {
     self.telegramBotToken = telegramBotToken
     self.llmApiKey = llmApiKey
+    self.searchApiKey = searchApiKey
   }
 }
 

--- a/Sources/ClawCore/Domain/Tools/ExfilApproval.swift
+++ b/Sources/ClawCore/Domain/Tools/ExfilApproval.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// A gate trip awaiting the owner's ephemeral text approval (§9.2). Carries the canonical URL
+/// only; the deterministic prompt text is authored in ClawGateway at the delivery seam (D7).
+public struct ExfilApprovalRequest: Sendable, Equatable {
+  public let canonicalURL: String
+
+  public init(canonicalURL: String) {
+    self.canonicalURL = canonicalURL
+  }
+}
+
+/// The single-use, one-turn grant a `yes` arms: it authorizes exactly one future fetch of the
+/// exact canonical URL if the model re-proposes it (grant semantics, not recorded-args replay).
+public struct OneTurnFetchGrant: Sendable, Equatable {
+  public let canonicalURL: String
+
+  public init(canonicalURL: String) {
+    self.canonicalURL = canonicalURL
+  }
+}

--- a/Sources/ClawCore/Domain/Tools/ToolContracts.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolContracts.swift
@@ -202,6 +202,7 @@ public struct ToolObservation: Sendable, Equatable {
 public protocol Tool: Sendable {
   var definition: ToolDefinition { get }
   var timeout: Duration { get }
+
   func execute(arguments: JSONValue) async -> ToolPayload
 }
 

--- a/Sources/ClawCore/Domain/Tools/ToolContracts.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolContracts.swift
@@ -1,0 +1,236 @@
+import Foundation
+
+/// One proposed call. `argumentsJSON` stays a raw JSON string (the wire form); the dispatcher
+/// decodes it — the LLM layer never interprets arguments. Codable so exchanges persist as one
+/// JSON column (`messages.tool_calls`) with the pinned shape `{"id","name","arguments"}`.
+public struct ToolCall: Sendable, Equatable, Codable {
+  public let id: String
+  public let name: String
+  public let argumentsJSON: String
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case argumentsJSON = "arguments"
+  }
+
+  public init(id: String, name: String, argumentsJSON: String) {
+    self.id = id
+    self.name = name
+    self.argumentsJSON = argumentsJSON
+  }
+}
+
+/// The single encoder/decoder for the `messages.tool_calls` column. Decode is lenient (malformed
+/// history must never crash rendering — the renderer's orphan guard handles the fallout).
+public enum ToolCallCoding {
+  public static func encode(_ calls: [ToolCall]) -> String? {
+    guard let data = try? JSONEncoder().encode(calls) else {
+      return nil
+    }
+    return String(data: data, encoding: .utf8)
+  }
+
+  public static func decode(_ json: String) -> [ToolCall] {
+    (try? JSONDecoder().decode([ToolCall].self, from: Data(json.utf8))) ?? []
+  }
+}
+
+/// A minimal JSON value tree — parameter schemas and decoded arguments. ClawCore has no I/O
+/// deps, so this small enum stands in for any JSON library.
+public indirect enum JSONValue: Sendable, Equatable {
+  case null
+  case bool(Bool)
+  case number(Double)
+  case string(String)
+  case array([JSONValue])
+  case object([String: JSONValue])
+}
+
+extension JSONValue: Codable {
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if container.decodeNil() {
+      self = .null
+    } else if let boolValue = try? container.decode(Bool.self) {
+      self = .bool(boolValue)
+    } else if let numberValue = try? container.decode(Double.self) {
+      self = .number(numberValue)
+    } else if let stringValue = try? container.decode(String.self) {
+      self = .string(stringValue)
+    } else if let arrayValue = try? container.decode([JSONValue].self) {
+      self = .array(arrayValue)
+    } else if let objectValue = try? container.decode([String: JSONValue].self) {
+      self = .object(objectValue)
+    } else {
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "unsupported JSON")
+      )
+    }
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .null:
+      try container.encodeNil()
+    case .bool(let boolValue):
+      try container.encode(boolValue)
+    case .number(let numberValue):
+      try container.encode(numberValue)
+    case .string(let stringValue):
+      try container.encode(stringValue)
+    case .array(let arrayValue):
+      try container.encode(arrayValue)
+    case .object(let objectValue):
+      try container.encode(objectValue)
+    }
+  }
+}
+
+extension JSONValue {
+  /// Parses a raw JSON string (tool `argumentsJSON`); nil on malformed input.
+  public static func parse(_ json: String) -> JSONValue? {
+    try? JSONDecoder().decode(JSONValue.self, from: Data(json.utf8))
+  }
+
+  public var objectValue: [String: JSONValue]? {
+    guard case .object(let objectValue) = self else {
+      return nil
+    }
+    return objectValue
+  }
+
+  public var stringValue: String? {
+    guard case .string(let stringValue) = self else {
+      return nil
+    }
+    return stringValue
+  }
+
+  public var numberValue: Double? {
+    guard case .number(let numberValue) = self else {
+      return nil
+    }
+    return numberValue
+  }
+}
+
+/// What the registry advertises to the provider (wire `tools` entry).
+public struct ToolDefinition: Sendable, Equatable {
+  public let name: String
+  public let description: String
+  public let parameters: JSONValue  // JSON-Schema object
+
+  public init(name: String, description: String, parameters: JSONValue) {
+    self.name = name
+    self.description = description
+    self.parameters = parameters
+  }
+}
+
+public enum ToolObservationStatus: String, Sendable, Equatable {
+  case ok
+  case error  // tool failed; content = plain-language reason
+  case blockedArgs = "blocked_args"  // ExfilArgGuard refusal
+  case blockedSSRF = "blocked_ssrf"
+  case blockedPendingApproval = "blocked_pending_approval"
+}
+
+/// What a tool returns, sans call identity — the dispatcher stamps identity (settles spec §20-6).
+/// `readPrivateData` is true only for a `file_read` whose canonical target is MEMORY.md/USER.md
+/// (rev.1 H1 — the run-local private-data signal).
+public struct ToolPayload: Sendable, Equatable {
+  public let content: String  // already output-capped (§15)
+  public let status: ToolObservationStatus
+  public let ingestedUntrusted: Bool  // true on any successful web/file read
+  public let readPrivateData: Bool
+
+  public init(
+    content: String,
+    status: ToolObservationStatus,
+    ingestedUntrusted: Bool,
+    readPrivateData: Bool = false
+  ) {
+    self.content = content
+    self.status = status
+    self.ingestedUntrusted = ingestedUntrusted
+    self.readPrivateData = readPrivateData
+  }
+}
+
+/// The uniform result of one dispatched call — success and failure are both observations
+/// (failures-as-observations, §19 ARCHITECTURE), never a thrown error crossing the loop.
+public struct ToolObservation: Sendable, Equatable {
+  public let callId: String
+  public let toolName: String
+  public let content: String
+  public let status: ToolObservationStatus
+  public let ingestedUntrusted: Bool
+  public let readPrivateData: Bool
+
+  public init(
+    callId: String,
+    toolName: String,
+    content: String,
+    status: ToolObservationStatus,
+    ingestedUntrusted: Bool,
+    readPrivateData: Bool = false
+  ) {
+    self.callId = callId
+    self.toolName = toolName
+    self.content = content
+    self.status = status
+    self.ingestedUntrusted = ingestedUntrusted
+    self.readPrivateData = readPrivateData
+  }
+
+  public init(call: ToolCall, payload: ToolPayload) {
+    self.init(
+      callId: call.id,
+      toolName: call.name,
+      content: payload.content,
+      status: payload.status,
+      ingestedUntrusted: payload.ingestedUntrusted,
+      readPrivateData: payload.readPrivateData
+    )
+  }
+}
+
+/// The tool seam. Gate checks happen BEFORE dispatch (ToolPolicyGate); an executing tool only
+/// ever sees already-authorized, parsed args.
+public protocol Tool: Sendable {
+  var definition: ToolDefinition { get }
+  var timeout: Duration { get }
+  func execute(arguments: JSONValue) async -> ToolPayload
+}
+
+/// The search seam (D2). One v1 impl: ExaSearchProvider (§7.4, research-settled).
+public protocol SearchProviding: Sendable {
+  func search(query: String, count: Int) async throws -> [SearchResult]
+}
+
+public struct SearchResult: Sendable, Equatable {
+  public let title: String
+  public let url: String
+  public let snippet: String
+
+  public init(title: String, url: String, snippet: String) {
+    self.title = title
+    self.url = url
+    self.snippet = snippet
+  }
+}
+
+/// One persisted round-trip that proposed tool calls: the assistant anchor plus its observations.
+public struct ToolExchange: Sendable, Equatable {
+  public let assistantContent: String  // may be "" (pure tool-call rounds)
+  public let toolCalls: [ToolCall]
+  public let observations: [ToolObservation]
+
+  public init(assistantContent: String, toolCalls: [ToolCall], observations: [ToolObservation]) {
+    self.assistantContent = assistantContent
+    self.toolCalls = toolCalls
+    self.observations = observations
+  }
+}

--- a/Sources/ClawCore/Domain/Tools/ToolDispatching.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolDispatching.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// The per-call policy inputs the gate reads. Taint and private-data are each the OR of the
+/// persisted/assembly flag and the run-local flag (§9.1: `(session ∪ run)` / `(assembly ∪ run)`).
+public struct ToolDispatchContext: Sendable, Equatable {
+  public let sessionTainted: Bool
+  public let runIngestedUntrusted: Bool
+  public let assemblyPrivateData: Bool
+  public let runPrivateData: Bool
+  public let grant: OneTurnFetchGrant?
+  public let approvalAlreadyPending: Bool
+
+  public init(
+    sessionTainted: Bool,
+    runIngestedUntrusted: Bool,
+    assemblyPrivateData: Bool,
+    runPrivateData: Bool,
+    grant: OneTurnFetchGrant?,
+    approvalAlreadyPending: Bool
+  ) {
+    self.sessionTainted = sessionTainted
+    self.runIngestedUntrusted = runIngestedUntrusted
+    self.assemblyPrivateData = assemblyPrivateData
+    self.runPrivateData = runPrivateData
+    self.grant = grant
+    self.approvalAlreadyPending = approvalAlreadyPending
+  }
+}
+
+/// One dispatched call's full result: the observation, the audit-safe args rendering (§9.1 —
+/// matched spans replaced, never the secret), the first-trip approval request, and whether the
+/// grant was consumed.
+public struct ToolDispatchOutcome: Sendable, Equatable {
+  public let observation: ToolObservation
+  public let argsRedacted: String
+  public let pendingApproval: ExfilApprovalRequest?
+  public let consumedGrant: Bool
+
+  public init(
+    observation: ToolObservation,
+    argsRedacted: String,
+    pendingApproval: ExfilApprovalRequest? = nil,
+    consumedGrant: Bool = false
+  ) {
+    self.observation = observation
+    self.argsRedacted = argsRedacted
+    self.pendingApproval = pendingApproval
+    self.consumedGrant = consumedGrant
+  }
+}
+
+/// The loop's one seam onto tools: registry lookup, arg parse, policy gate, timeout, and
+/// execution all live behind it (`ClawTools.GatedToolDispatcher` in production; a scripted fake
+/// in loop tests). Keeps the module DAG intact — ClawAgent never imports ClawTools.
+public protocol ToolDispatching: Sendable {
+  var definitions: [ToolDefinition] { get }
+  func dispatch(call: ToolCall, context: ToolDispatchContext) async -> ToolDispatchOutcome
+}

--- a/Sources/ClawCore/Domain/Tools/ToolDispatching.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolDispatching.swift
@@ -54,5 +54,6 @@ public struct ToolDispatchOutcome: Sendable, Equatable {
 /// in loop tests). Keeps the module DAG intact — ClawAgent never imports ClawTools.
 public protocol ToolDispatching: Sendable {
   var definitions: [ToolDefinition] { get }
+
   func dispatch(call: ToolCall, context: ToolDispatchContext) async -> ToolDispatchOutcome
 }

--- a/Sources/ClawCore/LLM/LLM.swift
+++ b/Sources/ClawCore/LLM/LLM.swift
@@ -2,15 +2,25 @@ import Foundation
 
 // MARK: - Chat contract
 
-/// One message in an OpenAI-compatible chat exchange. Reuses `MessageRole`
-/// (system/user/assistant) so the persisted role and the wire role share one vocabulary.
+/// One message in an OpenAI-compatible chat exchange. `toolCalls` carries assistant proposals
+/// ([] otherwise); `toolCallId` is set iff `role == .tool`. Both default so every pre-3b call
+/// site compiles unchanged.
 public struct ChatMessage: Sendable, Equatable {
   public let role: MessageRole
   public let content: String
+  public let toolCalls: [ToolCall]
+  public let toolCallId: String?
 
-  public init(role: MessageRole, content: String) {
+  public init(
+    role: MessageRole,
+    content: String,
+    toolCalls: [ToolCall] = [],
+    toolCallId: String? = nil
+  ) {
     self.role = role
     self.content = content
+    self.toolCalls = toolCalls
+    self.toolCallId = toolCallId
   }
 }
 
@@ -21,18 +31,21 @@ public struct ChatRequest: Sendable, Equatable {
   public let maxOutputTokens: Int
   // swiftlint:disable:next discouraged_optional_collection
   public let stop: [String]?
+  public let tools: [ToolDefinition]
 
   public init(
     model: String,
     messages: [ChatMessage],
     maxOutputTokens: Int,
     // swiftlint:disable:next discouraged_optional_collection
-    stop: [String]? = nil
+    stop: [String]? = nil,
+    tools: [ToolDefinition] = []
   ) {
     self.model = model
     self.messages = messages
     self.maxOutputTokens = maxOutputTokens
     self.stop = stop
+    self.tools = tools
   }
 }
 
@@ -60,23 +73,31 @@ public struct ChatResponse: Sendable, Equatable {
   public let finishReason: String?
   public let usage: ChatUsage?
   public let costFromProvider: Double?
+  public let toolCalls: [ToolCall]
 
   public init(
     content: String,
     finishReason: String?,
     usage: ChatUsage?,
-    costFromProvider: Double?
+    costFromProvider: Double?,
+    toolCalls: [ToolCall] = []
   ) {
     self.content = content
     self.finishReason = finishReason
     self.usage = usage
     self.costFromProvider = costFromProvider
+    self.toolCalls = toolCalls
   }
 }
 
 public enum StreamEvent: Sendable, Equatable {
   case delta(String)
-  case finished(finishReason: String?, usage: ChatUsage?, providerCost: Double?)
+  case finished(
+    finishReason: String?,
+    usage: ChatUsage?,
+    providerCost: Double?,
+    toolCalls: [ToolCall]
+  )
 }
 
 public enum LLMStreamLimits {
@@ -204,9 +225,16 @@ public struct PriceTable: Sendable, Equatable {
 /// up at each step; `graphemeBudget` is its inverse (rounds down) for the §9 assembly cap.
 public enum TokenEstimator {
   /// Estimated input tokens, summed per message so each message's rounding adds headroom.
+  /// Re-sent assistant `tool_calls` (name + arguments JSON) are counted too (rev.1 L3).
   public static func estimateInputTokens(_ messages: [ChatMessage]) -> Int {
     messages.reduce(0) { running, message in
-      running + estimateTokens(forText: message.content)
+      running + estimateTokens(forText: message.content) + toolCallTokens(for: message)
+    }
+  }
+
+  private static func toolCallTokens(for message: ChatMessage) -> Int {
+    message.toolCalls.reduce(0) { running, call in
+      running + estimateTokens(forText: call.name) + estimateTokens(forText: call.argumentsJSON)
     }
   }
 

--- a/Sources/ClawCore/LLM/RunBudget.swift
+++ b/Sources/ClawCore/LLM/RunBudget.swift
@@ -11,6 +11,8 @@ public struct RunBudget: Sendable, Equatable {
   public let perRunUSD: Double
   public let perDayUSD: Double
   public let referenceUSDPerToken: Double
+  public let maxTurns: Int
+  public let maxToolCalls: Int
   public let dayTokenCeilingOverride: Int?
 
   public init(
@@ -21,6 +23,8 @@ public struct RunBudget: Sendable, Equatable {
     perRunUSD: Double,
     perDayUSD: Double,
     referenceUSDPerToken: Double,
+    maxTurns: Int = 12,
+    maxToolCalls: Int = 20,
     dayTokenCeilingOverride: Int? = nil
   ) {
     self.maxInputTokens = maxInputTokens
@@ -30,6 +34,8 @@ public struct RunBudget: Sendable, Equatable {
     self.perRunUSD = perRunUSD
     self.perDayUSD = perDayUSD
     self.referenceUSDPerToken = referenceUSDPerToken
+    self.maxTurns = maxTurns
+    self.maxToolCalls = maxToolCalls
     self.dayTokenCeilingOverride = dayTokenCeilingOverride
   }
 
@@ -49,7 +55,9 @@ public struct RunBudget: Sendable, Equatable {
     retryBudget: 3,
     perRunUSD: 0.50,
     perDayUSD: 10.00,
-    referenceUSDPerToken: 0.000_015
+    referenceUSDPerToken: 0.000_015,
+    maxTurns: 12,
+    maxToolCalls: 20
   )
 }
 

--- a/Sources/ClawCore/Persistence/Persistence.swift
+++ b/Sources/ClawCore/Persistence/Persistence.swift
@@ -119,11 +119,21 @@ public struct StoredMessage: Sendable, Equatable {
   public let role: MessageRole
   public let content: String
   public let provenance: Provenance
+  public let toolCallsJSON: String?
+  public let toolCallId: String?
 
-  public init(role: MessageRole, content: String, provenance: Provenance) {
+  public init(
+    role: MessageRole,
+    content: String,
+    provenance: Provenance,
+    toolCallsJSON: String? = nil,
+    toolCallId: String? = nil
+  ) {
     self.role = role
     self.content = content
     self.provenance = provenance
+    self.toolCallsJSON = toolCallsJSON
+    self.toolCallId = toolCallId
   }
 }
 

--- a/Sources/ClawCore/Persistence/Persistence.swift
+++ b/Sources/ClawCore/Persistence/Persistence.swift
@@ -43,6 +43,7 @@ public enum MessageRole: String, Sendable, Equatable {
   case system
   case user
   case assistant
+  case tool
 }
 
 public enum CostSource: String, Sendable, Equatable {

--- a/Sources/ClawCore/Persistence/Persistence.swift
+++ b/Sources/ClawCore/Persistence/Persistence.swift
@@ -249,6 +249,8 @@ public struct AssistantTurn: Sendable, Equatable {
   public let content: String
   public let usage: ProviderUsage
   public let chunks: [OutboxChunk]
+  public let exchanges: [ToolExchange]
+  public let setTainted: Bool
 
   public init(
     runId: Int64,
@@ -256,7 +258,9 @@ public struct AssistantTurn: Sendable, Equatable {
     chatId: Int64,
     content: String,
     usage: ProviderUsage,
-    chunks: [OutboxChunk]
+    chunks: [OutboxChunk],
+    exchanges: [ToolExchange] = [],
+    setTainted: Bool = false
   ) {
     self.runId = runId
     self.sessionId = sessionId
@@ -264,6 +268,8 @@ public struct AssistantTurn: Sendable, Equatable {
     self.content = content
     self.usage = usage
     self.chunks = chunks
+    self.exchanges = exchanges
+    self.setTainted = setTainted
   }
 }
 
@@ -273,19 +279,22 @@ public struct DegradedTurn: Sendable, Equatable {
   public let chatId: Int64
   public let usage: ProviderUsage?
   public let chunk: OutboxChunk
+  public let setTainted: Bool
 
   public init(
     runId: Int64,
     sessionId: Int64,
     chatId: Int64,
     usage: ProviderUsage?,
-    chunk: OutboxChunk
+    chunk: OutboxChunk,
+    setTainted: Bool = false
   ) {
     self.runId = runId
     self.sessionId = sessionId
     self.chatId = chatId
     self.usage = usage
     self.chunk = chunk
+    self.setTainted = setTainted
   }
 }
 

--- a/Sources/ClawCore/Transport/HTTPExecuting.swift
+++ b/Sources/ClawCore/Transport/HTTPExecuting.swift
@@ -39,6 +39,16 @@ public protocol HTTPExecuting: Sendable {
     jsonBody: Data,
     timeoutSeconds: Int
   ) async throws -> HTTPResult
+
+  /// Plain GET for tool fetches. The production client is configured with
+  /// `RedirectConfiguration.disallow`, so a 3xx comes back as an ordinary `HTTPResult`; the body
+  /// is collected up to `maxBodyBytes` and an over-cap response throws.
+  func get(
+    url: String,
+    headers: [String: String],
+    timeoutSeconds: Int,
+    maxBodyBytes: Int
+  ) async throws -> HTTPResult
 }
 
 public protocol HTTPStreaming: Sendable {

--- a/Sources/ClawData/Database/ClawDatabase.swift
+++ b/Sources/ClawData/Database/ClawDatabase.swift
@@ -156,8 +156,8 @@ public enum ClawDatabase {
     }
     migrator.registerMigration("v5") { db in
       try db.alter(table: "messages") { table in
-        table.add(column: "tool_calls", .text)  // JSON [ToolCall]; NULL for non-proposing rows
-        table.add(column: "tool_call_id", .text)  // set iff role='tool'
+        table.add(column: "tool_calls", .text)
+        table.add(column: "tool_call_id", .text)
       }
     }
     return migrator

--- a/Sources/ClawData/Database/ClawDatabase.swift
+++ b/Sources/ClawData/Database/ClawDatabase.swift
@@ -154,6 +154,12 @@ public enum ClawDatabase {
         table.column("content")
       }
     }
+    migrator.registerMigration("v5") { db in
+      try db.alter(table: "messages") { table in
+        table.add(column: "tool_calls", .text)  // JSON [ToolCall]; NULL for non-proposing rows
+        table.add(column: "tool_call_id", .text)  // set iff role='tool'
+      }
+    }
     return migrator
   }
 

--- a/Sources/ClawData/Stores/Memory/RetrieverGRDB.swift
+++ b/Sources/ClawData/Stores/Memory/RetrieverGRDB.swift
@@ -29,6 +29,7 @@ public struct RetrieverGRDB: Retriever {
         FROM messages m
         JOIN messages_fts ON messages_fts.rowid = m.id
         WHERE messages_fts MATCH ?
+          AND m.role IN ('user', 'assistant')
         """
       var arguments: StatementArguments = [pattern]
 

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -51,6 +51,9 @@ public struct RunStoreGRDB: RunStore {
       }
 
       guard currentState == .running else {
+        if turn.setTainted, currentState == .cancelled {
+          try Self.setSessionTainted(db, sessionId: turn.sessionId, now: now)
+        }
         return try Self.recordTerminalUsageIfNeeded(
           db,
           usage: turn.usage,
@@ -67,6 +70,16 @@ public struct RunStoreGRDB: RunStore {
       )
       guard let nextState else {
         return .ignored
+      }
+
+      for exchange in turn.exchanges {
+        try Self.insertExchangeRows(
+          db,
+          sessionId: turn.sessionId,
+          runId: turn.runId,
+          exchange: exchange,
+          now: now
+        )
       }
 
       let usage = turn.usage
@@ -102,6 +115,10 @@ public struct RunStoreGRDB: RunStore {
         _ = try Self.insertOutbox(db, runId: turn.runId, chunk: chunk, now: now)
       }
 
+      if turn.setTainted {
+        try Self.setSessionTainted(db, sessionId: turn.sessionId, now: now)
+      }
+
       return .committed
     }
   }
@@ -113,6 +130,9 @@ public struct RunStoreGRDB: RunStore {
       }
 
       guard currentState == .running else {
+        if turn.setTainted, currentState == .cancelled {
+          try Self.setSessionTainted(db, sessionId: turn.sessionId, now: now)
+        }
         if let usage = turn.usage {
           return try Self.recordTerminalUsageIfNeeded(
             db,
@@ -134,6 +154,10 @@ public struct RunStoreGRDB: RunStore {
       }
 
       _ = try Self.insertOutbox(db, runId: turn.runId, chunk: turn.chunk, now: now)
+
+      if turn.setTainted {
+        try Self.setSessionTainted(db, sessionId: turn.sessionId, now: now)
+      }
 
       return .committed
     }
@@ -380,6 +404,42 @@ public struct RunStoreGRDB: RunStore {
         usage.runId,
       ]
     )
+  }
+
+  private static func setSessionTainted(_ db: Database, sessionId: Int64, now: Date) throws {
+    try db.execute(
+      sql: "UPDATE sessions SET tainted = 1, updated_ts = ? WHERE id = ?",
+      arguments: [now, sessionId]
+    )
+  }
+
+  /// Writes one exchange as rows: the assistant anchor (tool_calls JSON, trusted) then each
+  /// observation (raw content, untrusted, tool_call_id) — spec §11 row shapes.
+  private static func insertExchangeRows(
+    _ db: Database,
+    sessionId: Int64,
+    runId: Int64,
+    exchange: ToolExchange,
+    now: Date
+  ) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_calls)
+        VALUES (?, ?, 'assistant', ?, 'trusted', ?, ?)
+        """,
+      arguments: [
+        sessionId, runId, exchange.assistantContent, now, ToolCallCoding.encode(exchange.toolCalls),
+      ]
+    )
+    for observation in exchange.observations {
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_call_id)
+          VALUES (?, ?, 'tool', ?, 'untrusted', ?, ?)
+          """,
+        arguments: [sessionId, runId, observation.content, now, observation.callId]
+      )
+    }
   }
 
   static func insertOutbox(

--- a/Sources/ClawData/Stores/Session/SessionMessageStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Session/SessionMessageStoreGRDB.swift
@@ -135,32 +135,45 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
         isTainted = false
       }
 
-      // Limit the newest eligible rows first, then restore chronological order for the model.
+      // The window is bounded by CONVERSATIONAL rows (rev.1 H2): find the id of the `limit`-th
+      // newest user/assistant row, then load ALL rows from it through the trigger. Tool rows ride
+      // along; the boundary is a conversational row by construction, so an exchange is always
+      // included or excluded whole, and tool-row inflation can never evict conversation.
+      let windowStart = windowStartMessageId ?? 0
+      let boundaryId =
+        try Int64.fetchOne(
+          db,
+          sql: """
+            SELECT id FROM messages
+            WHERE session_id = ? AND id > ? AND id <= ? AND role IN ('user', 'assistant')
+            ORDER BY id DESC
+            LIMIT 1 OFFSET ?
+            """,
+          arguments: [sessionId, windowStart, throughMessageId, max(0, limit - 1)]
+        ) ?? 0
+
       let rows = try Row.fetchAll(
         db,
         sql: """
-          SELECT id, role, content, provenance FROM (
-            SELECT m.id, m.role, m.content, m.provenance
-            FROM messages m
-            JOIN sessions s ON s.id = m.session_id
-            WHERE m.session_id = ?
-              AND m.id > s.window_start_message_id
-              AND m.id <= ?
-            ORDER BY m.id DESC
-            LIMIT ?
-          )
+          SELECT id, role, content, provenance, tool_calls, tool_call_id
+          FROM messages
+          WHERE session_id = ? AND id > ? AND id <= ? AND id >= ?
           ORDER BY id ASC
           """,
-        arguments: [sessionId, throughMessageId, limit]
+        arguments: [sessionId, windowStart, throughMessageId, boundaryId]
       )
 
       let history = rows.map { row in
         StoredMessage(
           role: MessageRole(rawValue: row["role"]) ?? .user,
           content: row["content"],
-          provenance: Provenance(rawValue: row["provenance"]) ?? .trusted
+          provenance: Provenance(rawValue: row["provenance"]) ?? .trusted,
+          toolCallsJSON: row["tool_calls"],
+          toolCallId: row["tool_call_id"]
         )
       }
+
+      // The new SELECT already returns `id`, so the id remap stays valid.
       let messageIds = rows.map { row in
         row["id"] as Int64
       }

--- a/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
+++ b/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
@@ -142,22 +142,50 @@ public struct OpenAICompatibleProvider: LLMProvider {
     return headers
   }
 
-  private func encode(request: ChatRequest, streaming: Bool = false) throws -> Data {
+  func encode(request: ChatRequest, streaming: Bool = false) throws -> Data {
+    let wireMessages = request.messages.map { message -> WireMessage in
+      let wireCalls = message.toolCalls.map { call in
+        WireToolCall(
+          id: call.id,
+          type: "function",
+          function: WireToolCallFunction(name: call.name, arguments: call.argumentsJSON)
+        )
+      }
+      // An empty-content assistant proposal omits `content` (some providers reject "" + tool_calls).
+      let omitContent = message.role == .assistant && message.content.isEmpty && !wireCalls.isEmpty
+      return WireMessage(
+        role: message.role.rawValue,
+        content: omitContent ? nil : message.content,
+        toolCalls: wireCalls.isEmpty ? nil : wireCalls,
+        toolCallId: message.toolCallId
+      )
+    }
+    let wireTools = request.tools.map { definition in
+      WireToolDefinition(
+        type: "function",
+        function: WireToolDefinition.Function(
+          name: definition.name,
+          description: definition.description,
+          parameters: definition.parameters
+        )
+      )
+    }
     let payload = RequestBody(
       model: request.model,
-      messages: request.messages.map { WireMessage(role: $0.role.rawValue, content: $0.content) },
+      messages: wireMessages,
       maxTokensKey: config.maxTokensField.rawValue,
       maxOutputTokens: request.maxOutputTokens,
       stop: request.stop,
       stream: streaming,
-      streamOptions: streaming ? StreamOptions(includeUsage: true) : nil
+      streamOptions: streaming ? StreamOptions(includeUsage: true) : nil,
+      tools: wireTools.isEmpty ? nil : wireTools
     )
     return try JSONEncoder().encode(payload)
   }
 
   // MARK: - Response
 
-  private func parse(result: HTTPResult) throws -> ChatResponse {
+  func parse(result: HTTPResult) throws -> ChatResponse {
     let decoded: ResponseBody
     do {
       decoded = try JSONDecoder().decode(ResponseBody.self, from: result.body)
@@ -180,11 +208,19 @@ public struct OpenAICompatibleProvider: LLMProvider {
     // OpenRouter reports cost in usage.cost; LiteLLM in a response header.
     let providerCost = decoded.usage?.cost ?? providerCost(from: result)
 
+    let toolCalls = (choice?.message.toolCalls ?? []).compactMap { decoded -> ToolCall? in
+      guard let callId = decoded.id, let name = decoded.function?.name else {
+        return nil
+      }
+      return ToolCall(id: callId, name: name, argumentsJSON: decoded.function?.arguments ?? "{}")
+    }
+
     return ChatResponse(
       content: choice?.message.content ?? "",
       finishReason: choice?.finishReason,
       usage: usage,
-      costFromProvider: providerCost
+      costFromProvider: providerCost,
+      toolCalls: toolCalls
     )
   }
 
@@ -279,9 +315,41 @@ private struct DynamicKey: CodingKey {
   }
 }
 
+private struct WireToolCallFunction: Codable {
+  let name: String
+  let arguments: String
+}
+
+private struct WireToolCall: Codable {
+  let id: String
+  let type: String
+  let function: WireToolCallFunction
+}
+
+private struct WireToolDefinition: Encodable {
+  struct Function: Encodable {
+    let name: String
+    let description: String
+    let parameters: JSONValue
+  }
+
+  let type: String
+  let function: Function
+}
+
 private struct WireMessage: Encodable {
   let role: String
-  let content: String
+  let content: String?
+  // swiftlint:disable:next discouraged_optional_collection
+  let toolCalls: [WireToolCall]?
+  let toolCallId: String?
+
+  enum CodingKeys: String, CodingKey {
+    case role
+    case content
+    case toolCalls = "tool_calls"
+    case toolCallId = "tool_call_id"
+  }
 }
 
 private struct RequestBody: Encodable {
@@ -293,6 +361,8 @@ private struct RequestBody: Encodable {
   let stop: [String]?
   let stream: Bool
   let streamOptions: StreamOptions?
+  // swiftlint:disable:next discouraged_optional_collection
+  let tools: [WireToolDefinition]?
 
   func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: DynamicKey.self)
@@ -302,6 +372,7 @@ private struct RequestBody: Encodable {
     try container.encode(stream, forKey: DynamicKey("stream"))
     try container.encodeIfPresent(streamOptions, forKey: DynamicKey("stream_options"))
     try container.encodeIfPresent(stop, forKey: DynamicKey("stop"))
+    try container.encodeIfPresent(tools, forKey: DynamicKey("tools"))
   }
 }
 
@@ -313,10 +384,27 @@ private struct StreamOptions: Encodable {
   }
 }
 
+private struct DecodedToolCall: Decodable {
+  struct Function: Decodable {
+    let name: String?
+    let arguments: String?
+  }
+
+  let id: String?
+  let function: Function?
+}
+
 private struct ResponseBody: Decodable {
   struct Choice: Decodable {
     struct Message: Decodable {
       let content: String?
+      // swiftlint:disable:next discouraged_optional_collection
+      let toolCalls: [DecodedToolCall]?
+
+      enum CodingKeys: String, CodingKey {
+        case content
+        case toolCalls = "tool_calls"
+      }
     }
 
     let message: Message

--- a/Sources/ClawLLM/Provider/SSEParser.swift
+++ b/Sources/ClawLLM/Provider/SSEParser.swift
@@ -173,14 +173,19 @@ public struct SSEParser: Sendable {
     return events
   }
 
-  /// Fragments assembled in index order — emitted only on `.finished` (D5).
+  /// Fragments assembled in index order — emitted only on `.finished` (D5). Drops any
+  /// accumulator that never received an id/name (malformed stream) and defaults empty
+  /// arguments to `"{}"`, mirroring the blocking path's `parse(result:)` (same rule, two seams).
   private var assembledToolCalls: [ToolCall] {
-    toolCallAccumulators.keys.sorted().map { index in
+    toolCallAccumulators.keys.sorted().compactMap { index in
       let accumulator = toolCallAccumulators[index] ?? ToolCallAccumulator()
+      guard !accumulator.id.isEmpty, !accumulator.name.isEmpty else {
+        return nil
+      }
       return ToolCall(
         id: accumulator.id,
         name: accumulator.name,
-        argumentsJSON: accumulator.arguments
+        argumentsJSON: accumulator.arguments.isEmpty ? "{}" : accumulator.arguments
       )
     }
   }

--- a/Sources/ClawLLM/Provider/SSEParser.swift
+++ b/Sources/ClawLLM/Provider/SSEParser.swift
@@ -24,6 +24,8 @@ public struct SSEParser: Sendable {
   private var usage: ChatUsage?
   private var providerCost: Double?
 
+  private var toolCallAccumulators: [Int: ToolCallAccumulator] = [:]
+
   public init(
     maxEventBytes: Int = LLMStreamLimits.maxEventBytes,
     maxBufferedBytes: Int = LLMStreamLimits.maxBufferedBytes,
@@ -85,7 +87,7 @@ public struct SSEParser: Sendable {
       finishReason: finishReason,
       usage: usage,
       providerCost: providerCost,
-      toolCalls: []
+      toolCalls: assembledToolCalls
     )
   }
 
@@ -131,7 +133,7 @@ public struct SSEParser: Sendable {
           finishReason: finishReason,
           usage: usage,
           providerCost: providerCost,
-          toolCalls: []
+          toolCalls: assembledToolCalls
         )
       ]
     }
@@ -158,12 +160,47 @@ public struct SSEParser: Sendable {
       finishReason = reason
     }
 
+    if let fragments = choice.delta?.toolCalls {
+      try accumulate(fragments)
+      sawEvent = true
+    }
+
     if let content = choice.delta?.content {
       try appendContentBytes(content.utf8.count)
       events.append(.delta(content))
     }
 
     return events
+  }
+
+  /// Fragments assembled in index order — emitted only on `.finished` (D5).
+  private var assembledToolCalls: [ToolCall] {
+    toolCallAccumulators.keys.sorted().map { index in
+      let accumulator = toolCallAccumulators[index] ?? ToolCallAccumulator()
+      return ToolCall(
+        id: accumulator.id,
+        name: accumulator.name,
+        argumentsJSON: accumulator.arguments
+      )
+    }
+  }
+
+  private mutating func accumulate(_ fragments: [DeltaToolCall]) throws {
+    for fragment in fragments {
+      let index = fragment.index ?? 0
+      var accumulator = toolCallAccumulators[index] ?? ToolCallAccumulator()
+      if let fragmentId = fragment.id, !fragmentId.isEmpty {
+        accumulator.id = fragmentId
+      }
+      if let name = fragment.function?.name, !name.isEmpty {
+        accumulator.name = name
+      }
+      if let arguments = fragment.function?.arguments {
+        try appendContentBytes(arguments.utf8.count)
+        accumulator.arguments += arguments
+      }
+      toolCallAccumulators[index] = accumulator
+    }
   }
 
   private mutating func appendContentBytes(_ byteCount: Int) throws {
@@ -217,6 +254,30 @@ private struct Choice: Decodable {
 
 private struct Delta: Decodable {
   let content: String?
+  // swiftlint:disable:next discouraged_optional_collection
+  let toolCalls: [DeltaToolCall]?
+
+  enum CodingKeys: String, CodingKey {
+    case content
+    case toolCalls = "tool_calls"
+  }
+}
+
+private struct DeltaToolCall: Decodable {
+  struct Function: Decodable {
+    let name: String?
+    let arguments: String?
+  }
+
+  let index: Int?
+  let id: String?
+  let function: Function?
+}
+
+private struct ToolCallAccumulator {
+  var id = ""
+  var name = ""
+  var arguments = ""
 }
 
 private struct Usage: Decodable {

--- a/Sources/ClawLLM/Provider/SSEParser.swift
+++ b/Sources/ClawLLM/Provider/SSEParser.swift
@@ -81,7 +81,12 @@ public struct SSEParser: Sendable {
     }
 
     finished = true
-    return .finished(finishReason: finishReason, usage: usage, providerCost: providerCost)
+    return .finished(
+      finishReason: finishReason,
+      usage: usage,
+      providerCost: providerCost,
+      toolCalls: []
+    )
   }
 
   private mutating func parseEvent(_ data: Data) throws -> [StreamEvent] {
@@ -121,7 +126,14 @@ public struct SSEParser: Sendable {
     let payload = payloadLines.joined(separator: "\n")
     if payload == "[DONE]" {
       finished = true
-      return [.finished(finishReason: finishReason, usage: usage, providerCost: providerCost)]
+      return [
+        .finished(
+          finishReason: finishReason,
+          usage: usage,
+          providerCost: providerCost,
+          toolCalls: []
+        )
+      ]
     }
 
     let chunk = try decodeChunk(payload)

--- a/Sources/ClawSecrets/EncryptedFileSecretStore.swift
+++ b/Sources/ClawSecrets/EncryptedFileSecretStore.swift
@@ -92,17 +92,20 @@ public struct EncryptedFileSecretStore: SecretStore {
   private struct Payload: Codable {
     let telegramBotToken: String
     let llmApiKey: String?
+    let searchApiKey: String?
 
     enum CodingKeys: String, CodingKey {
       case telegramBotToken = "telegram_bot_token"
       case llmApiKey = "llm_api_key"
+      case searchApiKey = "search_api_key"
     }
   }
 
   static func encode(_ secrets: Secrets) throws -> Data {
     let payload = Payload(
       telegramBotToken: secrets.telegramBotToken,
-      llmApiKey: secrets.llmApiKey
+      llmApiKey: secrets.llmApiKey,
+      searchApiKey: secrets.searchApiKey
     )
     return try JSONEncoder().encode(payload)
   }
@@ -116,10 +119,12 @@ public struct EncryptedFileSecretStore: SecretStore {
       throw SecretStoreError.missingTelegramToken
     }
     let apiKey = payload.llmApiKey.flatMap { $0.isEmpty ? nil : $0 }
+    let searchKey = payload.searchApiKey.flatMap { $0.isEmpty ? nil : $0 }
 
     return Secrets(
       telegramBotToken: payload.telegramBotToken,
-      llmApiKey: apiKey
+      llmApiKey: apiKey,
+      searchApiKey: searchKey
     )
   }
 

--- a/Sources/ClawSecrets/EnvSecretStore.swift
+++ b/Sources/ClawSecrets/EnvSecretStore.swift
@@ -7,6 +7,7 @@ public struct EnvSecretStore: SecretStore {
   public enum EnvKey {
     public static let botToken = "CLAW_TELEGRAM_BOT_TOKEN"
     public static let llmApiKey = "CLAW_LLM_API_KEY"
+    public static let searchApiKey = "CLAW_SEARCH_API_KEY"
   }
 
   private let environment: [String: String]
@@ -30,10 +31,12 @@ public struct EnvSecretStore: SecretStore {
     )
 
     let apiKey = environment[EnvKey.llmApiKey].flatMap { $0.isEmpty ? nil : $0 }
+    let searchKey = environment[EnvKey.searchApiKey].flatMap { $0.isEmpty ? nil : $0 }
 
     return Secrets(
       telegramBotToken: botToken,
-      llmApiKey: apiKey
+      llmApiKey: apiKey,
+      searchApiKey: searchKey
     )
   }
 

--- a/Sources/ClawTelegram/Wire/HTTPExecuting.swift
+++ b/Sources/ClawTelegram/Wire/HTTPExecuting.swift
@@ -39,6 +39,29 @@ public struct AsyncHTTPExecutor: HTTPExecuting, HTTPStreaming {
     )
   }
 
+  public func get(
+    url: String,
+    headers: [String: String],
+    timeoutSeconds: Int,
+    maxBodyBytes: Int
+  ) async throws -> HTTPResult {
+    var request = HTTPClientRequest(url: url)
+    request.method = .GET
+    request.headers.add(name: "accept-encoding", value: "gzip")
+    for (name, value) in headers {
+      request.headers.add(name: name, value: value)
+    }
+
+    let response = try await client.execute(request, timeout: .seconds(Int64(timeoutSeconds)))
+    let buffer = try await response.body.collect(upTo: maxBodyBytes)
+
+    return HTTPResult(
+      statusCode: Int(response.status.code),
+      headers: responseHeaders(response),
+      body: Data(buffer: buffer)
+    )
+  }
+
   public func postStream(
     url: String,
     headers: [String: String],

--- a/Sources/clawd/Subcommands/SecretsCommand.swift
+++ b/Sources/clawd/Subcommands/SecretsCommand.swift
@@ -54,7 +54,8 @@ struct SecretsCommand: AsyncParsableCommand {
         """
         Sealed secrets → \(envelopePath)
         Key → \(keyPath) (mode 0600 — keep this OUTSIDE your state-root backup boundary)
-        You may now remove the plaintext CLAW_TELEGRAM_BOT_TOKEN / CLAW_LLM_API_KEY from the env.
+        You may now remove the plaintext CLAW_TELEGRAM_BOT_TOKEN / CLAW_LLM_API_KEY /
+        CLAW_SEARCH_API_KEY from the env.
         """
       )
     }

--- a/Tests/ClawAgentTests/Runtime/AgentRuntimeStreamingTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentRuntimeStreamingTests.swift
@@ -350,7 +350,8 @@ func waitForTurnResult(
         .finished(
           finishReason: "stop",
           usage: ChatUsage(promptTokens: 3, completionTokens: 2, totalTokens: 5),
-          providerCost: 0.001
+          providerCost: 0.001,
+          toolCalls: []
         ),
       ])
     )
@@ -390,7 +391,7 @@ func waitForTurnResult(
         gate,
         [
           .delta("hi"),
-          .finished(finishReason: "stop", usage: nil, providerCost: nil),
+          .finished(finishReason: "stop", usage: nil, providerCost: nil, toolCalls: []),
         ]
       )
     )
@@ -428,7 +429,7 @@ func waitForTurnResult(
         TimedStreamEvent(pauseBefore: .milliseconds(80), event: .delta("hello")),
         TimedStreamEvent(
           pauseBefore: .zero,
-          event: .finished(finishReason: "stop", usage: nil, providerCost: nil)
+          event: .finished(finishReason: "stop", usage: nil, providerCost: nil, toolCalls: [])
         ),
       ])
     )
@@ -459,7 +460,7 @@ func waitForTurnResult(
       streamScript: .events([
         .delta("hel"),
         .delta("lo"),
-        .finished(finishReason: "stop", usage: nil, providerCost: nil),
+        .finished(finishReason: "stop", usage: nil, providerCost: nil, toolCalls: []),
       ])
     )
     let drafts = BlockingFinalDrafts(finalMarkdown: "hello")
@@ -610,7 +611,8 @@ func waitForTurnResult(
         .finished(
           finishReason: "stop",
           usage: ChatUsage(promptTokens: 3, completionTokens: 2, totalTokens: 5),
-          providerCost: 0.001
+          providerCost: 0.001,
+          toolCalls: []
         ),
       ])
     )

--- a/Tests/ClawCoreTests/Config/RunBudgetToolPinsTests.swift
+++ b/Tests/ClawCoreTests/Config/RunBudgetToolPinsTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import ClawCore
+
+@Suite struct RunBudgetToolPinsTests {
+  private func baseEnvironment() -> [String: String] {
+    [
+      "CLAW_LLM_BASE_URL": "http://localhost:1234/v1",
+      "CLAW_LLM_MODEL": "test-model",
+      "CLAW_STATE_ROOT": FileManager.default.temporaryDirectory
+        .appendingPathComponent("claw-test-\(UUID().uuidString)").path,
+    ]
+  }
+
+  @Test func defaultsArePinnedToSpecValues() {
+    // given / when / then — §5.3 pins
+    #expect(RunBudget.default.maxTurns == 12)
+    #expect(RunBudget.default.maxToolCalls == 20)
+  }
+
+  @Test func envOverridesParsePositiveIntegers() throws {
+    // given
+    var environment = baseEnvironment()
+    environment["CLAW_MAX_TURNS"] = "3"
+    environment["CLAW_MAX_TOOL_CALLS"] = "7"
+
+    // when
+    let config = try AppConfig.load(environment: environment)
+
+    // then
+    #expect(config.budget.maxTurns == 3)
+    #expect(config.budget.maxToolCalls == 7)
+  }
+
+  @Test func invalidOverrideFailsClosed() {
+    // given
+    var environment = baseEnvironment()
+    environment["CLAW_MAX_TURNS"] = "zero"
+
+    // when / then
+    #expect(throws: ConfigError.self) {
+      _ = try AppConfig.load(environment: environment)
+    }
+  }
+}

--- a/Tests/ClawCoreTests/Domain/Tools/ChatContractToolTests.swift
+++ b/Tests/ClawCoreTests/Domain/Tools/ChatContractToolTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+
+@testable import ClawCore
+
+@Suite struct ChatContractToolTests {
+  @Test func existingCallSiteShapesStillCompileAndDefaultEmpty() {
+    // given / when
+    let message = ChatMessage(role: .user, content: "hi")
+    let request = ChatRequest(model: "m", messages: [message], maxOutputTokens: 100)
+    let response = ChatResponse(
+      content: "ok",
+      finishReason: "stop",
+      usage: nil,
+      costFromProvider: nil
+    )
+
+    // then
+    #expect(message.toolCalls.isEmpty)
+    #expect(message.toolCallId == nil)
+    #expect(request.tools.isEmpty)
+    #expect(response.toolCalls.isEmpty)
+  }
+
+  @Test func toolRoleAndToolMessageShape() {
+    // given
+    let observationMessage = ChatMessage(role: .tool, content: "fetched text", toolCallId: "call_1")
+
+    // then
+    #expect(MessageRole.tool.rawValue == "tool")
+    #expect(observationMessage.toolCallId == "call_1")
+  }
+
+  @Test func estimatorCountsToolCallArgumentsText() {
+    // given — identical content; one message re-sends a large tool-call arguments blob
+    let argumentsBlob = String(repeating: "x", count: 4_000)
+    let plain = ChatMessage(role: .assistant, content: "same")
+    let proposing = ChatMessage(
+      role: .assistant,
+      content: "same",
+      toolCalls: [ToolCall(id: "call_1", name: "web_fetch", argumentsJSON: argumentsBlob)]
+    )
+
+    // when
+    let plainEstimate = TokenEstimator.estimateInputTokens([plain])
+    let proposingEstimate = TokenEstimator.estimateInputTokens([proposing])
+
+    // then — the arguments blob must ride inside the estimate (rev.1 L3)
+    #expect(proposingEstimate > plainEstimate + 1_000)
+  }
+}

--- a/Tests/ClawCoreTests/Domain/Tools/ToolContractsTests.swift
+++ b/Tests/ClawCoreTests/Domain/Tools/ToolContractsTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+
+@testable import ClawCore
+
+@Suite struct ToolContractsTests {
+  @Test func jsonValueParsesObjectsAndAccessors() throws {
+    // given
+    let raw = #"{"url": "https://example.com/a?q=1", "count": 5, "deep": {"flag": true}}"#
+
+    // when
+    let parsed = try #require(JSONValue.parse(raw))
+
+    // then
+    let object = try #require(parsed.objectValue)
+    #expect(object["url"]?.stringValue == "https://example.com/a?q=1")
+    #expect(object["count"]?.numberValue == 5)
+    #expect(object["deep"]?.objectValue?["flag"] == .bool(true))
+  }
+
+  @Test func jsonValueParseRejectsMalformedJSON() {
+    // given / when / then
+    #expect(JSONValue.parse(#"{"url": "#) == nil)
+    #expect(JSONValue.parse("") == nil)
+  }
+
+  @Test func jsonValueEncodesBackToJSON() throws {
+    // given
+    let value = JSONValue.object([
+      "type": .string("object"),
+      "required": .array([.string("url")]),
+    ])
+
+    // when
+    let data = try JSONEncoder().encode(value)
+    let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
+
+    // then
+    #expect(decoded == value)
+  }
+
+  @Test func toolCallCodingRoundTripsThePersistedShape() throws {
+    // given
+    let calls = [
+      ToolCall(
+        id: "call_1",
+        name: "web_fetch",
+        argumentsJSON: #"{"url":"https://a.example/x?q=1"}"#
+      ),
+      ToolCall(id: "call_2", name: "file_read", argumentsJSON: #"{"path":"notes/a.md"}"#),
+    ]
+
+    // when
+    let encoded = try #require(ToolCallCoding.encode(calls))
+    let decoded = ToolCallCoding.decode(encoded)
+
+    // then
+    #expect(decoded == calls)
+    #expect(encoded.contains(#""arguments""#))  // the pinned column shape
+  }
+
+  @Test func toolCallCodingDecodeReturnsEmptyOnMalformedJSON() {
+    // given / when / then
+    #expect(ToolCallCoding.decode("not json") == [])
+    #expect(ToolCallCoding.decode("") == [])
+  }
+
+  @Test func observationStampsCallIdentityOntoPayload() {
+    // given
+    let call = ToolCall(id: "call_9", name: "web_search", argumentsJSON: #"{"query":"swift"}"#)
+    let payload = ToolPayload(
+      content: "- Swift.org — https://swift.org\n  The Swift language",
+      status: .ok,
+      ingestedUntrusted: true
+    )
+
+    // when
+    let observation = ToolObservation(call: call, payload: payload)
+
+    // then
+    #expect(observation.callId == "call_9")
+    #expect(observation.toolName == "web_search")
+    #expect(observation.status == .ok)
+    #expect(observation.ingestedUntrusted)
+    #expect(observation.readPrivateData == false)
+  }
+
+  @Test func observationStatusRawValuesArePinned() {
+    // given / when / then — audit rows persist these raw values
+    #expect(ToolObservationStatus.ok.rawValue == "ok")
+    #expect(ToolObservationStatus.error.rawValue == "error")
+    #expect(ToolObservationStatus.blockedArgs.rawValue == "blocked_args")
+    #expect(ToolObservationStatus.blockedSSRF.rawValue == "blocked_ssrf")
+    #expect(ToolObservationStatus.blockedPendingApproval.rawValue == "blocked_pending_approval")
+  }
+
+  @Test func dispatchContextAndGrantAreValueTypes() {
+    // given
+    let grant = OneTurnFetchGrant(canonicalURL: "https://example.com/a?q=1")
+
+    // when
+    let context = ToolDispatchContext(
+      sessionTainted: true,
+      runIngestedUntrusted: false,
+      assemblyPrivateData: true,
+      runPrivateData: false,
+      grant: grant,
+      approvalAlreadyPending: false
+    )
+
+    // then
+    #expect(context.grant == grant)
+    #expect(
+      ExfilApprovalRequest(canonicalURL: "https://x.example/").canonicalURL == "https://x.example/"
+    )
+  }
+}

--- a/Tests/ClawDataTests/Database/V5MigrationTests.swift
+++ b/Tests/ClawDataTests/Database/V5MigrationTests.swift
@@ -1,0 +1,105 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct V5MigrationTests {
+  @Test func vFiveAddsNullableToolColumns() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+
+    // when
+    try ClawDatabase.migrate(queue)
+
+    // then
+    let columns = try queue.read { db in
+      try Row.fetchAll(db, sql: "PRAGMA table_info(messages)").map { row in row["name"] as String }
+    }
+    #expect(columns.contains("tool_calls"))
+    #expect(columns.contains("tool_call_id"))
+  }
+
+  @Test func vFiveUpgradesAPopulatedVFourDatabase() throws {
+    // given — a v4 database that already holds a message row
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrator.migrate(queue, upTo: "v4")
+    try queue.write { db in
+      try db.execute(
+        sql:
+          "INSERT INTO sessions(session_key, created_ts, updated_ts, tainted) VALUES ('tg:dm:1', ?, ?, 0)",
+        arguments: [Date(), Date()]
+      )
+      try db.execute(
+        sql:
+          "INSERT INTO messages(session_id, role, content, provenance, ts) VALUES (1, 'user', 'old row', 'trusted', ?)",
+        arguments: [Date()]
+      )
+    }
+
+    // when
+    try ClawDatabase.migrate(queue)
+
+    // then — the old row survives with NULL tool columns
+    let row = try queue.read { db in
+      try Row.fetchOne(
+        db,
+        sql: "SELECT content, tool_calls, tool_call_id FROM messages WHERE id = 1"
+      )
+    }
+    #expect(row?["content"] == "old row")
+    #expect((row?["tool_calls"] as String?) == nil)
+    #expect((row?["tool_call_id"] as String?) == nil)
+  }
+
+  /// §20 item 5 — BLOCKING verification: GRDB's generated external-content sync triggers must
+  /// stay consistent when a non-indexed column is updated, and delete must still de-index.
+  @Test func ftsSurvivesToolColumnWritesAndDeletes() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    try queue.write { db in
+      try db.execute(
+        sql:
+          "INSERT INTO sessions(session_key, created_ts, updated_ts, tainted) VALUES ('tg:dm:1', ?, ?, 0)",
+        arguments: [Date(), Date()]
+      )
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, role, content, provenance, ts, tool_calls)
+          VALUES (1, 'assistant', 'fetch the zebra page', 'trusted', ?, '[]')
+          """,
+        arguments: [Date()]
+      )
+    }
+    func zebraMatches() throws -> Int {
+      try queue.read { db in
+        try Int.fetchOne(
+          db,
+          sql: "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'zebra'"
+        ) ?? -1
+      }
+    }
+    #expect(try zebraMatches() == 1)
+
+    // when — update ONLY the non-indexed column
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE messages SET tool_calls = ? WHERE id = 1",
+        arguments: ["[{\"id\":\"c\",\"name\":\"n\",\"arguments\":\"{}\"}]"]
+      )
+    }
+
+    // then — still exactly one match (no duplicate, no loss)
+    #expect(try zebraMatches() == 1)
+
+    // when — delete the row
+    try queue.write { db in
+      try db.execute(sql: "DELETE FROM messages WHERE id = 1")
+    }
+
+    // then — de-indexed
+    #expect(try zebraMatches() == 0)
+  }
+}

--- a/Tests/ClawDataTests/Stores/Run/ExchangeCommitTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/ExchangeCommitTests.swift
@@ -1,0 +1,249 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct ExchangeCommitTests {
+  private struct Fixture {
+    let queue: DatabaseQueue
+    let runs: RunStoreGRDB
+    let sessionId: Int64
+    let runId: Int64
+  }
+
+  /// One RUNNING run with its inbound user message, ready to commit against.
+  private func makeRunningFixture() throws -> Fixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: "tg:dm:7",
+        chatId: 7,
+        userId: 7,
+        text: "read a page",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let runs = RunStoreGRDB(writer: queue)
+    let runId = claim.runId ?? 0
+    #expect(try runs.pickUp(runId: runId, now: Date()))
+    return Fixture(queue: queue, runs: runs, sessionId: claim.sessionId ?? 0, runId: runId)
+  }
+
+  private func makeUsage(_ fixture: Fixture) -> ProviderUsage {
+    ProviderUsage(
+      runId: fixture.runId,
+      sessionId: fixture.sessionId,
+      model: "m",
+      promptTokens: 10,
+      completionTokens: 5,
+      costUSD: 0.001,
+      costSource: .heuristic,
+      isEstimated: false,
+      ts: Date()
+    )
+  }
+
+  private func makeExchange() -> ToolExchange {
+    ToolExchange(
+      assistantContent: "let me fetch that",
+      toolCalls: [
+        ToolCall(id: "c1", name: "web_fetch", argumentsJSON: #"{"url":"https://e.example/"}"#)
+      ],
+      observations: [
+        ToolObservation(
+          callId: "c1",
+          toolName: "web_fetch",
+          content: "raw page text",
+          status: .ok,
+          ingestedUntrusted: true
+        )
+      ]
+    )
+  }
+
+  private func isTainted(_ fixture: Fixture) throws -> Bool {
+    try fixture.queue.read { db in
+      try Bool.fetchOne(
+        db,
+        sql: "SELECT tainted FROM sessions WHERE id = ?",
+        arguments: [fixture.sessionId]
+      ) ?? false
+    }
+  }
+
+  @Test func commitWritesExchangeRowsInOrderThenReplyThenTaint() throws {
+    // given
+    let fixture = try makeRunningFixture()
+    let turn = AssistantTurn(
+      runId: fixture.runId,
+      sessionId: fixture.sessionId,
+      chatId: 7,
+      content: "summary of the page",
+      usage: makeUsage(fixture),
+      chunks: [
+        OutboxChunk(stepIndex: 0, chatId: 7, payload: "summary of the page", payloadHash: "h")
+      ],
+      exchanges: [makeExchange()],
+      setTainted: true
+    )
+
+    // when
+    let result = try fixture.runs.commitAssistantTurn(turn, now: Date())
+
+    // then
+    #expect(result == .committed)
+    let rows = try fixture.queue.read { db in
+      try Row.fetchAll(
+        db,
+        sql:
+          "SELECT role, content, provenance, tool_calls, tool_call_id, run_id FROM messages ORDER BY id ASC"
+      )
+    }
+    // user inbound, exchange anchor, tool observation, final reply
+    #expect(rows.count == 4)
+    #expect(rows[1]["role"] == "assistant")
+    #expect((rows[1]["tool_calls"] as String?)?.contains("web_fetch") == true)
+    #expect(rows[1]["provenance"] == "trusted")
+    #expect(rows[2]["role"] == "tool")
+    #expect(rows[2]["content"] == "raw page text")  // raw, un-wrapped (§11)
+    #expect(rows[2]["provenance"] == "untrusted")
+    #expect(rows[2]["tool_call_id"] == "c1")
+    #expect(rows[2]["run_id"] == fixture.runId)
+    #expect(rows[3]["content"] == "summary of the page")
+    #expect(try isTainted(fixture))
+  }
+
+  @Test func committedTurnWithoutIngestionDoesNotTaint() throws {
+    // given
+    let fixture = try makeRunningFixture()
+    let turn = AssistantTurn(
+      runId: fixture.runId,
+      sessionId: fixture.sessionId,
+      chatId: 7,
+      content: "plain",
+      usage: makeUsage(fixture),
+      chunks: [OutboxChunk(stepIndex: 0, chatId: 7, payload: "plain", payloadHash: "h")]
+    )
+
+    // when
+    _ = try fixture.runs.commitAssistantTurn(turn, now: Date())
+
+    // then
+    #expect(try isTainted(fixture) == false)
+  }
+
+  @Test func degradedCommitStillTaints() throws {
+    // given — spec §10: a degraded turn that ingested content persists the taint (amendment F)
+    let fixture = try makeRunningFixture()
+    let turn = DegradedTurn(
+      runId: fixture.runId,
+      sessionId: fixture.sessionId,
+      chatId: 7,
+      usage: makeUsage(fixture),
+      chunk: OutboxChunk(stepIndex: 0, chatId: 7, payload: "degraded", payloadHash: "h"),
+      setTainted: true
+    )
+
+    // when
+    let result = try fixture.runs.commitDegradedTurn(turn, now: Date())
+
+    // then — degraded path writes NO exchange rows, but the taint persists
+    #expect(result == .committed)
+    #expect(try isTainted(fixture))
+    let toolRows = try fixture.queue.read { db in
+      try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM messages WHERE role = 'tool'") ?? -1
+    }
+    #expect(toolRows == 0)
+  }
+
+  @Test func cancelledArbitrationArmStillTaints() throws {
+    // given — /stop won the race (rev.1 M1: CANCELLED taints)
+    let fixture = try makeRunningFixture()
+    _ = try fixture.runs.cancelActiveRun(
+      sessionId: fixture.sessionId,
+      reason: .cancelled,
+      now: Date()
+    )
+    let turn = AssistantTurn(
+      runId: fixture.runId,
+      sessionId: fixture.sessionId,
+      chatId: 7,
+      content: "late",
+      usage: makeUsage(fixture),
+      chunks: [OutboxChunk(stepIndex: 0, chatId: 7, payload: "late", payloadHash: "h")],
+      exchanges: [makeExchange()],
+      setTainted: true
+    )
+
+    // when
+    let result = try fixture.runs.commitAssistantTurn(turn, now: Date())
+
+    // then — usage recorded, no reply/exchange rows, taint SET
+    #expect(result == .usageRecordedAfterTerminal)
+    #expect(try isTainted(fixture))
+    let messageCount = try fixture.queue.read { db in
+      try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM messages") ?? -1
+    }
+    #expect(messageCount == 1)  // only the inbound user message
+  }
+
+  @Test func supersededArbitrationArmNeverRetaints() throws {
+    // given — /new won the race; detaint already ran (rev.1 M1: SUPERSEDED skips)
+    let fixture = try makeRunningFixture()
+    _ = try fixture.runs.cancelActiveRun(
+      sessionId: fixture.sessionId,
+      reason: .superseded,
+      now: Date()
+    )
+    let sessions = SessionMessageStoreGRDB(writer: fixture.queue)
+    try sessions.resetWindowAndDetaint(sessionId: fixture.sessionId, now: Date())
+    let turn = AssistantTurn(
+      runId: fixture.runId,
+      sessionId: fixture.sessionId,
+      chatId: 7,
+      content: "late",
+      usage: makeUsage(fixture),
+      chunks: [OutboxChunk(stepIndex: 0, chatId: 7, payload: "late", payloadHash: "h")],
+      setTainted: true
+    )
+
+    // when
+    let result = try fixture.runs.commitAssistantTurn(turn, now: Date())
+
+    // then — the fresh window stays untainted
+    #expect(result == .usageRecordedAfterTerminal)
+    #expect(try isTainted(fixture) == false)
+  }
+
+  @Test func cancelledNilUsageDegradedCommitStillTaints() throws {
+    // given — cancellation raced a degraded turn that has no usage row to record
+    let fixture = try makeRunningFixture()
+    _ = try fixture.runs.cancelActiveRun(
+      sessionId: fixture.sessionId,
+      reason: .cancelled,
+      now: Date()
+    )
+    let turn = DegradedTurn(
+      runId: fixture.runId,
+      sessionId: fixture.sessionId,
+      chatId: 7,
+      usage: nil,
+      chunk: OutboxChunk(stepIndex: 0, chatId: 7, payload: "late", payloadHash: "h"),
+      setTainted: true
+    )
+
+    // when
+    let result = try fixture.runs.commitDegradedTurn(turn, now: Date())
+
+    // then — nothing to record, but the ingestion happened: taint is a side effect of the
+    // arbitration arm, not of usage recording
+    #expect(result == .ignored)
+    #expect(try isTainted(fixture))
+  }
+}

--- a/Tests/ClawDataTests/Stores/Session/ConversationalWindowTests.swift
+++ b/Tests/ClawDataTests/Stores/Session/ConversationalWindowTests.swift
@@ -1,0 +1,207 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct ConversationalWindowTests {
+  /// Seeds one session and returns (store, sessionId, writer). Rows are inserted raw so tests
+  /// control ids/roles exactly.
+  private func makeFixture() throws -> (
+    store: SessionMessageStoreGRDB, sessionId: Int64, queue: DatabaseQueue
+  ) {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let store = SessionMessageStoreGRDB(writer: queue)
+    let sessionId = try store.loadOrCreateSession(sessionKey: "tg:dm:1", now: Date())
+    return (store, sessionId, queue)
+  }
+
+  private func insert(
+    _ queue: DatabaseQueue,
+    sessionId: Int64,
+    role: String,
+    content: String,
+    toolCalls: String? = nil,
+    toolCallId: String? = nil
+  ) throws -> Int64 {
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, role, content, provenance, ts, tool_calls, tool_call_id)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+          """,
+        arguments: [
+          sessionId, role, content, role == "tool" ? "untrusted" : "trusted", Date(), toolCalls,
+          toolCallId,
+        ]
+      )
+      return db.lastInsertedRowID
+    }
+  }
+
+  @Test func limitCountsOnlyConversationalRowsAndToolRowsRideAlong() throws {
+    // given — u1, a1(anchor)+2 tool rows, u2, a2; a window of 3 conversational rows
+    let fixture = try makeFixture()
+    _ = try insert(fixture.queue, sessionId: fixture.sessionId, role: "user", content: "u1")
+    _ = try insert(
+      fixture.queue,
+      sessionId: fixture.sessionId,
+      role: "assistant",
+      content: "",
+      toolCalls: #"[{"id":"c1","name":"web_fetch","arguments":"{}"}]"#
+    )
+    _ = try insert(
+      fixture.queue,
+      sessionId: fixture.sessionId,
+      role: "tool",
+      content: "page text",
+      toolCallId: "c1"
+    )
+    _ = try insert(
+      fixture.queue,
+      sessionId: fixture.sessionId,
+      role: "tool",
+      content: "more text",
+      toolCallId: "c1b"
+    )
+    _ = try insert(fixture.queue, sessionId: fixture.sessionId, role: "user", content: "u2")
+    let lastId = try insert(
+      fixture.queue,
+      sessionId: fixture.sessionId,
+      role: "assistant",
+      content: "a2"
+    )
+
+    // when
+    let snapshot = try fixture.store.loadContextSnapshot(
+      sessionId: fixture.sessionId,
+      throughMessageId: lastId,
+      limit: 3
+    )
+
+    // then — 3 conversational rows (anchor, u2, a2) plus 2 riding tool rows = 5; u1 evicted
+    #expect(snapshot.history.count == 5)
+    #expect(snapshot.history.first?.role == .assistant)
+    #expect(snapshot.history.first?.toolCallsJSON != nil)
+    #expect(snapshot.history.filter { stored in stored.role == .tool }.count == 2)
+    #expect(snapshot.history.contains { stored in stored.content == "u1" } == false)
+  }
+
+  @Test func toolRowInflationCannotEvictConversationalHistory() throws {
+    // given — u1, then an anchor with 30 tool rows, then a2; limit 3 conversational rows
+    let fixture = try makeFixture()
+    _ = try insert(fixture.queue, sessionId: fixture.sessionId, role: "user", content: "u1")
+    _ = try insert(
+      fixture.queue,
+      sessionId: fixture.sessionId,
+      role: "assistant",
+      content: "",
+      toolCalls: #"[{"id":"c1","name":"web_search","arguments":"{}"}]"#
+    )
+    for index in 1...30 {
+      _ = try insert(
+        fixture.queue,
+        sessionId: fixture.sessionId,
+        role: "tool",
+        content: "obs \(index)",
+        toolCallId: "c\(index)"
+      )
+    }
+    let lastId = try insert(
+      fixture.queue,
+      sessionId: fixture.sessionId,
+      role: "assistant",
+      content: "a2"
+    )
+
+    // when
+    let snapshot = try fixture.store.loadContextSnapshot(
+      sessionId: fixture.sessionId,
+      throughMessageId: lastId,
+      limit: 3
+    )
+
+    // then — u1 still present: 3 conversational + 30 tool rows
+    #expect(snapshot.history.contains { stored in stored.content == "u1" })
+    #expect(snapshot.history.count == 33)
+  }
+
+  @Test func windowNeverStartsOnAToolRow() throws {
+    // given — an exchange straddling the boundary: limit lands mid-exchange under the OLD cut
+    let fixture = try makeFixture()
+    for index in 1...5 {
+      _ = try insert(
+        fixture.queue,
+        sessionId: fixture.sessionId,
+        role: "user",
+        content: "u\(index)"
+      )
+    }
+    _ = try insert(
+      fixture.queue,
+      sessionId: fixture.sessionId,
+      role: "assistant",
+      content: "",
+      toolCalls: #"[{"id":"c1","name":"web_fetch","arguments":"{}"}]"#
+    )
+    _ = try insert(
+      fixture.queue,
+      sessionId: fixture.sessionId,
+      role: "tool",
+      content: "obs",
+      toolCallId: "c1"
+    )
+    let lastId = try insert(
+      fixture.queue,
+      sessionId: fixture.sessionId,
+      role: "user",
+      content: "tail"
+    )
+
+    // when — a window that would have cut between anchor and tool row by raw row count
+    let snapshot = try fixture.store.loadContextSnapshot(
+      sessionId: fixture.sessionId,
+      throughMessageId: lastId,
+      limit: 2
+    )
+
+    // then — the anchor is in-window with its tool row (boundary is conversational)
+    #expect(snapshot.history.first?.role == .assistant)
+    #expect(snapshot.history.count == 3)  // anchor + tool + tail
+  }
+
+  @Test func recallExcludesToolRows() throws {
+    // given — a tool row and an assistant row both matching the query, in another session
+    let fixture = try makeFixture()
+    let otherSession = try fixture.store.loadOrCreateSession(sessionKey: "tg:dm:2", now: Date())
+    _ = try insert(
+      fixture.queue,
+      sessionId: otherSession,
+      role: "tool",
+      content: "quokka page body",
+      toolCallId: "c1"
+    )
+    _ = try insert(
+      fixture.queue,
+      sessionId: otherSession,
+      role: "assistant",
+      content: "the quokka answer"
+    )
+    let retriever = RetrieverGRDB(writer: fixture.queue)
+
+    // when
+    let hits = try retriever.searchRelevantMessages(
+      query: "quokka",
+      currentSessionId: fixture.sessionId,
+      windowStartMessageId: nil,
+      excludedMessageIds: [],
+      limit: 10
+    )
+
+    // then — only the conversational row is recallable (§18-D)
+    #expect(hits.count == 1)
+    #expect(hits.first?.role == .assistant)
+  }
+}

--- a/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
+++ b/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
@@ -117,7 +117,8 @@ actor StreamingAcceptanceProvider: LLMProvider {
             .finished(
               finishReason: "stop",
               usage: ChatUsage(promptTokens: 10, completionTokens: 5, totalTokens: 15),
-              providerCost: 0.0021
+              providerCost: 0.0021,
+              toolCalls: []
             )
           )
           continuation.finish()

--- a/Tests/ClawLLMTests/Provider/OpenAICompatibleProviderTests.swift
+++ b/Tests/ClawLLMTests/Provider/OpenAICompatibleProviderTests.swift
@@ -213,7 +213,8 @@ import Testing
         .finished(
           finishReason: "stop",
           usage: ChatUsage(promptTokens: 4, completionTokens: 2, totalTokens: 6),
-          providerCost: nil
+          providerCost: nil,
+          toolCalls: []
         ),
       ]
     )
@@ -251,7 +252,8 @@ import Testing
         == .finished(
           finishReason: "stop",
           usage: ChatUsage(promptTokens: 4, completionTokens: 2, totalTokens: 6),
-          providerCost: 0.0034
+          providerCost: 0.0034,
+          toolCalls: []
         )
     )
   }

--- a/Tests/ClawLLMTests/Provider/SSEParserTests.swift
+++ b/Tests/ClawLLMTests/Provider/SSEParserTests.swift
@@ -24,7 +24,9 @@ import Testing
     // then
     #expect(first.isEmpty)
     #expect(second == [.delta("he"), .delta("llo")])
-    #expect(third == [.finished(finishReason: "stop", usage: nil, providerCost: nil)])
+    #expect(
+      third == [.finished(finishReason: "stop", usage: nil, providerCost: nil, toolCalls: [])]
+    )
     #expect(try parser.finish() == nil)
   }
 
@@ -44,7 +46,7 @@ import Testing
     )
 
     // then
-    #expect(events == [.finished(finishReason: nil, usage: nil, providerCost: nil)])
+    #expect(events == [.finished(finishReason: nil, usage: nil, providerCost: nil, toolCalls: [])])
     #expect(later.isEmpty)
     #expect(try parser.finish() == nil)
   }
@@ -89,7 +91,8 @@ import Testing
         .finished(
           finishReason: "stop",
           usage: ChatUsage(promptTokens: 7, completionTokens: 3, totalTokens: 10),
-          providerCost: 0.0042
+          providerCost: 0.0042,
+          toolCalls: []
         )
       ]
     )
@@ -114,7 +117,8 @@ import Testing
         .finished(
           finishReason: "stop",
           usage: ChatUsage(promptTokens: 7, completionTokens: 3, totalTokens: 10),
-          providerCost: 0.0034
+          providerCost: 0.0034,
+          toolCalls: []
         )
       ]
     )
@@ -139,7 +143,8 @@ import Testing
         .finished(
           finishReason: "stop",
           usage: ChatUsage(promptTokens: 7, completionTokens: 3, totalTokens: 10),
-          providerCost: 0.0042
+          providerCost: 0.0042,
+          toolCalls: []
         )
       ]
     )
@@ -170,7 +175,8 @@ import Testing
         .finished(
           finishReason: "stop",
           usage: ChatUsage(promptTokens: 8, completionTokens: 4, totalTokens: 12),
-          providerCost: 0.0042
+          providerCost: 0.0042,
+          toolCalls: []
         )
       ]
     )
@@ -190,7 +196,9 @@ import Testing
 
     // then
     #expect(events == [.delta("hi")])
-    #expect(finished == .finished(finishReason: "stop", usage: nil, providerCost: nil))
+    #expect(
+      finished == .finished(finishReason: "stop", usage: nil, providerCost: nil, toolCalls: [])
+    )
   }
 
   @Test func eofMidEventThrowsTruncated() throws {
@@ -215,7 +223,9 @@ import Testing
     let finished = try parser.push(Data("data: [DONE]\n\n".utf8))
 
     // then
-    #expect(finished == [.finished(finishReason: "stop", usage: nil, providerCost: nil)])
+    #expect(
+      finished == [.finished(finishReason: "stop", usage: nil, providerCost: nil, toolCalls: [])]
+    )
   }
 
   @Test func boundsSingleEventAndBufferedStream() throws {

--- a/Tests/ClawLLMTests/Provider/SSEParserToolCallTests.swift
+++ b/Tests/ClawLLMTests/Provider/SSEParserToolCallTests.swift
@@ -1,0 +1,113 @@
+import ClawCore
+import Foundation
+import Testing
+
+@testable import ClawLLM
+
+@Suite struct SSEParserToolCallTests {
+  private func pushAll(_ parser: inout SSEParser, _ events: [String]) throws -> [StreamEvent] {
+    var collected: [StreamEvent] = []
+    for event in events {
+      collected.append(contentsOf: try parser.push(Data(("data: " + event + "\n\n").utf8)))
+    }
+    return collected
+  }
+
+  private func finishedToolCalls(_ events: [StreamEvent]) -> [ToolCall]? {
+    for event in events {
+      if case .finished(_, _, _, let toolCalls) = event {
+        return toolCalls
+      }
+    }
+    return nil
+  }
+
+  @Test func assemblesSplitIdAndArgumentFragments() throws {
+    // given — id/name arrive first; arguments arrive as concatenatable pieces
+    var parser = SSEParser()
+    let events = try pushAll(
+      &parser,
+      [
+        #"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"web_fetch","arguments":""}}]}}]}"#,
+        #"{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"url\":"}}]}}]}"#,
+        #"{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"https://e.example/\"}"}}]}}],"usage":null}"#,
+        #"{"choices":[{"delta":{},"finish_reason":"tool_calls"}]}"#,
+        "[DONE]",
+      ]
+    )
+
+    // then — nothing emitted per-fragment; one assembled call on .finished
+    let toolCalls = finishedToolCalls(events)
+    #expect(
+      toolCalls == [
+        ToolCall(id: "call_1", name: "web_fetch", argumentsJSON: #"{"url":"https://e.example/"}"#)
+      ]
+    )
+    #expect(events.filter { if case .delta = $0 { true } else { false } }.isEmpty)
+  }
+
+  @Test func assemblesMultipleIndicesInOrder() throws {
+    // given
+    var parser = SSEParser()
+    let events = try pushAll(
+      &parser,
+      [
+        #"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"a","function":{"name":"web_search","arguments":"{}"}},{"index":1,"id":"b","function":{"name":"file_read","arguments":"{}"}}]}}]}"#,
+        "[DONE]",
+      ]
+    )
+
+    // then
+    #expect(finishedToolCalls(events)?.map(\.id) == ["a", "b"])
+  }
+
+  @Test func accumulatedArgumentBytesRespectTheStreamLimit() throws {
+    // given — a parser with a tiny accumulation limit
+    var parser = SSEParser(maxAccumulatedContentBytes: 64)
+    let hugeArguments = String(repeating: "x", count: 128)
+
+    // when / then
+    #expect(throws: SSEParserError.accumulatedContentTooLarge) {
+      _ = try parser.push(
+        Data(
+          ("data: "
+            + #"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"a","function":{"name":"n","arguments":"\#(hugeArguments)"}}]}}]}"#
+            + "\n\n").utf8
+        )
+      )
+    }
+  }
+
+  @Test func textDeltasStillStreamAlongsideToolFragments() throws {
+    // given
+    var parser = SSEParser()
+    let events = try pushAll(
+      &parser,
+      [
+        #"{"choices":[{"delta":{"content":"Let me check."}}]}"#,
+        #"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"a","function":{"name":"web_fetch","arguments":"{}"}}]}}]}"#,
+        "[DONE]",
+      ]
+    )
+
+    // then
+    #expect(events.contains(.delta("Let me check.")))
+    #expect(finishedToolCalls(events)?.count == 1)
+  }
+
+  @Test func eofWithoutFinishedYieldsNoToolCalls() throws {
+    // given — deltas then EOF (no [DONE]): the runtime treats this as a complete text reply
+    var parser = SSEParser()
+    _ = try parser.push(Data("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n".utf8))
+
+    // when
+    let finished = try parser.finish()
+
+    // then
+    if case .finished(_, _, _, let toolCalls)? = finished {
+      #expect(toolCalls.isEmpty)
+    } else {
+      Issue.record("expected a finished event")
+    }
+  }
+}

--- a/Tests/ClawLLMTests/Provider/SSEParserToolCallTests.swift
+++ b/Tests/ClawLLMTests/Provider/SSEParserToolCallTests.swift
@@ -110,4 +110,37 @@ import Testing
       Issue.record("expected a finished event")
     }
   }
+
+  @Test func fragmentMissingIdAndNameIsDropped() throws {
+    // given — an arguments fragment arrives but the header carrying id/name never does
+    // (a malformed stream) — this must drop the same way the blocking path does
+    var parser = SSEParser()
+    let events = try pushAll(
+      &parser,
+      [
+        #"{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"url\":\"x\"}"}}]}}]}"#,
+        "[DONE]",
+      ]
+    )
+
+    // then — the accumulator never got an id/name, so it is dropped, not emitted empty
+    let toolCalls = finishedToolCalls(events)
+    #expect(toolCalls == [])
+  }
+
+  @Test func missingArgumentsFragmentAssemblesToEmptyObject() throws {
+    // given — id/name arrive but no arguments fragment is ever sent
+    var parser = SSEParser()
+    let events = try pushAll(
+      &parser,
+      [
+        #"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_2","function":{"name":"web_fetch"}}]}}]}"#,
+        "[DONE]",
+      ]
+    )
+
+    // then — empty accumulated arguments normalize to "{}", matching the blocking path's default
+    let toolCalls = finishedToolCalls(events)
+    #expect(toolCalls == [ToolCall(id: "call_2", name: "web_fetch", argumentsJSON: "{}")])
+  }
 }

--- a/Tests/ClawLLMTests/Provider/ToolWireCodingTests.swift
+++ b/Tests/ClawLLMTests/Provider/ToolWireCodingTests.swift
@@ -181,4 +181,88 @@ import Testing
     #expect(response.content == "hi")
     #expect(response.toolCalls.isEmpty)
   }
+
+  @Test func toolCallMissingIdIsDropped() throws {
+    // given — a tool_calls entry that omits id (malformed provider response)
+    let fixture = #"""
+      {
+        "choices": [{
+          "message": {
+            "content": null,
+            "tool_calls": [{
+              "type": "function",
+              "function": {"name": "web_search", "arguments": "{}"}
+            }]
+          },
+          "finish_reason": "tool_calls"
+        }]
+      }
+      """#
+
+    // when
+    let response = try makeProvider().parse(
+      result: HTTPResult(statusCode: 200, headers: [:], body: Data(fixture.utf8))
+    )
+
+    // then — dropped, not crashed
+    #expect(response.toolCalls.isEmpty)
+  }
+
+  @Test func toolCallMissingFunctionNameIsDropped() throws {
+    // given — a tool_calls entry that omits function.name
+    let fixture = #"""
+      {
+        "choices": [{
+          "message": {
+            "content": null,
+            "tool_calls": [{
+              "id": "call_1",
+              "type": "function",
+              "function": {"arguments": "{}"}
+            }]
+          },
+          "finish_reason": "tool_calls"
+        }]
+      }
+      """#
+
+    // when
+    let response = try makeProvider().parse(
+      result: HTTPResult(statusCode: 200, headers: [:], body: Data(fixture.utf8))
+    )
+
+    // then
+    #expect(response.toolCalls.isEmpty)
+  }
+
+  @Test func toolCallMissingArgumentsDefaultsToEmptyObject() throws {
+    // given — id and name present but the arguments field is absent
+    let fixture = #"""
+      {
+        "choices": [{
+          "message": {
+            "content": null,
+            "tool_calls": [{
+              "id": "call_9",
+              "type": "function",
+              "function": {"name": "web_search"}
+            }]
+          },
+          "finish_reason": "tool_calls"
+        }]
+      }
+      """#
+
+    // when
+    let response = try makeProvider().parse(
+      result: HTTPResult(statusCode: 200, headers: [:], body: Data(fixture.utf8))
+    )
+
+    // then
+    #expect(
+      response.toolCalls == [
+        ToolCall(id: "call_9", name: "web_search", argumentsJSON: "{}")
+      ]
+    )
+  }
 }

--- a/Tests/ClawLLMTests/Provider/ToolWireCodingTests.swift
+++ b/Tests/ClawLLMTests/Provider/ToolWireCodingTests.swift
@@ -1,0 +1,184 @@
+import ClawCore
+import Foundation
+import Testing
+
+@testable import ClawLLM
+
+@Suite struct ToolWireCodingTests {
+  private func makeProvider() -> OpenAICompatibleProvider {
+    OpenAICompatibleProvider(
+      config: LLMConfig(
+        baseURL: "http://localhost/v1",
+        model: "m",
+        apiKey: "",
+        maxTokensField: .maxTokens,
+        maxOutputTokens: 100,
+        retryBudget: 1,
+        requestTimeoutSeconds: 5
+      ),
+      http: UnusedHTTP(),
+      sleep: { _ in },
+      jitter: { $0 }
+    )
+  }
+
+  private struct UnusedHTTP: HTTPExecuting, HTTPStreaming {
+    func post(url: String, headers: [String: String], jsonBody: Data, timeoutSeconds: Int)
+      async throws -> HTTPResult
+    {
+      HTTPResult(statusCode: 500, headers: [:], body: Data())
+    }
+    func get(url: String, headers: [String: String], timeoutSeconds: Int, maxBodyBytes: Int)
+      async throws -> HTTPResult
+    {
+      HTTPResult(statusCode: 500, headers: [:], body: Data())
+    }
+    func postStream(url: String, headers: [String: String], jsonBody: Data, timeoutSeconds: Int)
+      async throws -> (head: HTTPStreamHead, body: AsyncThrowingStream<Data, Error>)
+    {
+      (HTTPStreamHead(statusCode: 500, headers: [:]), AsyncThrowingStream { $0.finish() })
+    }
+  }
+
+  private func encodeToDictionary(_ request: ChatRequest) throws -> [String: Any] {
+    let data = try makeProvider().encode(request: request)
+    let object = try JSONSerialization.jsonObject(with: data)
+    return object as? [String: Any] ?? [:]
+  }
+
+  @Test func requestEncodesToolsArray() throws {
+    // given
+    let definition = ToolDefinition(
+      name: "web_fetch",
+      description: "Fetch a public URL.",
+      parameters: .object([
+        "type": .string("object"),
+        "properties": .object(["url": .object(["type": .string("string")])]),
+        "required": .array([.string("url")]),
+      ])
+    )
+    let request = ChatRequest(
+      model: "m",
+      messages: [ChatMessage(role: .user, content: "go")],
+      maxOutputTokens: 100,
+      tools: [definition]
+    )
+
+    // when
+    let payload = try encodeToDictionary(request)
+
+    // then
+    let tools = try #require(payload["tools"] as? [[String: Any]])
+    #expect(tools.count == 1)
+    #expect(tools[0]["type"] as? String == "function")
+    let function = try #require(tools[0]["function"] as? [String: Any])
+    #expect(function["name"] as? String == "web_fetch")
+    let parameters = try #require(function["parameters"] as? [String: Any])
+    #expect(parameters["type"] as? String == "object")
+  }
+
+  @Test func toollessRequestOmitsToolsKey() throws {
+    // given
+    let request = ChatRequest(
+      model: "m",
+      messages: [ChatMessage(role: .user, content: "hi")],
+      maxOutputTokens: 10
+    )
+
+    // when
+    let payload = try encodeToDictionary(request)
+
+    // then
+    #expect(payload["tools"] == nil)
+  }
+
+  @Test func assistantProposalAndToolResultEncodeTheExchangeShape() throws {
+    // given — an assistant anchor (empty content) and its tool result message
+    let request = ChatRequest(
+      model: "m",
+      messages: [
+        ChatMessage(role: .user, content: "read it"),
+        ChatMessage(
+          role: .assistant,
+          content: "",
+          toolCalls: [
+            ToolCall(
+              id: "call_1",
+              name: "web_fetch",
+              argumentsJSON: #"{"url":"https://e.example/"}"#
+            )
+          ]
+        ),
+        ChatMessage(role: .tool, content: "page text", toolCallId: "call_1"),
+      ],
+      maxOutputTokens: 100
+    )
+
+    // when
+    let payload = try encodeToDictionary(request)
+
+    // then
+    let messages = try #require(payload["messages"] as? [[String: Any]])
+    let anchor = messages[1]
+    #expect(anchor["role"] as? String == "assistant")
+    #expect(anchor["content"] == nil)  // empty content + tool_calls → omitted
+    let calls = try #require(anchor["tool_calls"] as? [[String: Any]])
+    #expect(calls[0]["id"] as? String == "call_1")
+    #expect(calls[0]["type"] as? String == "function")
+    let function = try #require(calls[0]["function"] as? [String: Any])
+    #expect(function["name"] as? String == "web_fetch")
+    #expect(function["arguments"] as? String == #"{"url":"https://e.example/"}"#)
+    let toolMessage = messages[2]
+    #expect(toolMessage["role"] as? String == "tool")
+    #expect(toolMessage["tool_call_id"] as? String == "call_1")
+    #expect(toolMessage["content"] as? String == "page text")
+  }
+
+  @Test func responseDecodesToolCallsAndFinishReason() throws {
+    // given — a captured-shape tool-call response body
+    let fixture = #"""
+      {
+        "choices": [{
+          "message": {
+            "content": null,
+            "tool_calls": [{
+              "id": "call_9",
+              "type": "function",
+              "function": {"name": "web_search", "arguments": "{\"query\":\"swift\"}"}
+            }]
+          },
+          "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 12, "completion_tokens": 7, "total_tokens": 19}
+      }
+      """#
+
+    // when
+    let response = try makeProvider().parse(
+      result: HTTPResult(statusCode: 200, headers: [:], body: Data(fixture.utf8))
+    )
+
+    // then
+    #expect(response.finishReason == "tool_calls")
+    #expect(response.content == "")
+    #expect(
+      response.toolCalls == [
+        ToolCall(id: "call_9", name: "web_search", argumentsJSON: #"{"query":"swift"}"#)
+      ]
+    )
+  }
+
+  @Test func plainResponseStillDecodesWithEmptyToolCalls() throws {
+    // given
+    let fixture = #"{"choices":[{"message":{"content":"hi"},"finish_reason":"stop"}]}"#
+
+    // when
+    let response = try makeProvider().parse(
+      result: HTTPResult(statusCode: 200, headers: [:], body: Data(fixture.utf8))
+    )
+
+    // then
+    #expect(response.content == "hi")
+    #expect(response.toolCalls.isEmpty)
+  }
+}

--- a/Tests/ClawLLMTests/Support/LLMTestSupport.swift
+++ b/Tests/ClawLLMTests/Support/LLMTestSupport.swift
@@ -60,6 +60,16 @@ actor ScriptedHTTPExecutor: HTTPExecuting, HTTPStreaming {
     }
   }
 
+  func get(
+    url: String,
+    headers: [String: String],
+    timeoutSeconds: Int,
+    maxBodyBytes: Int
+  ) async throws -> HTTPResult {
+    struct GetUnsupported: Error {}
+    throw GetUnsupported()
+  }
+
   func postStream(
     url: String,
     headers: [String: String],

--- a/Tests/ClawSecretsTests/SearchApiKeySecretTests.swift
+++ b/Tests/ClawSecretsTests/SearchApiKeySecretTests.swift
@@ -1,0 +1,54 @@
+import ClawCore
+import Crypto
+import Foundation
+import Testing
+
+@testable import ClawSecrets
+
+@Suite struct SearchApiKeySecretTests {
+  @Test func envStoreReadsSearchKeyAndTreatsEmptyAsAbsent() throws {
+    // given
+    let populated = EnvSecretStore(
+      environment: [
+        "CLAW_TELEGRAM_BOT_TOKEN": "123:abc",
+        "CLAW_SEARCH_API_KEY": "exa-key-1",
+      ],
+      warn: { _ in }
+    )
+    let empty = EnvSecretStore(
+      environment: [
+        "CLAW_TELEGRAM_BOT_TOKEN": "123:abc",
+        "CLAW_SEARCH_API_KEY": "",
+      ],
+      warn: { _ in }
+    )
+
+    // when / then
+    #expect(try populated.loadSecrets().searchApiKey == "exa-key-1")
+    #expect(try empty.loadSecrets().searchApiKey == nil)
+  }
+
+  @Test func encryptedPayloadRoundTripsSearchKey() throws {
+    // given
+    let secrets = Secrets(telegramBotToken: "123:abc", llmApiKey: "sk-x", searchApiKey: "exa-key-1")
+
+    // when
+    let decoded = try EncryptedFileSecretStore.decode(EncryptedFileSecretStore.encode(secrets))
+
+    // then
+    #expect(decoded == secrets)
+  }
+
+  @Test func preThreeBEnvelopePayloadStillDecodes() throws {
+    // given — the exact payload shape sealed before 3b (no search_api_key)
+    let legacyPayload = Data(#"{"telegram_bot_token":"123:abc","llm_api_key":"sk-x"}"#.utf8)
+
+    // when
+    let decoded = try EncryptedFileSecretStore.decode(legacyPayload)
+
+    // then
+    #expect(decoded.telegramBotToken == "123:abc")
+    #expect(decoded.llmApiKey == "sk-x")
+    #expect(decoded.searchApiKey == nil)
+  }
+}

--- a/Tests/ClawTelegramTests/Client/RichMessageTests.swift
+++ b/Tests/ClawTelegramTests/Client/RichMessageTests.swift
@@ -21,6 +21,16 @@ private actor CapturingExecutor: HTTPExecuting {
     capturedBody = jsonBody
     return result
   }
+
+  func get(
+    url: String,
+    headers: [String: String],
+    timeoutSeconds: Int,
+    maxBodyBytes: Int
+  ) async throws -> HTTPResult {
+    struct GetUnsupported: Error {}
+    throw GetUnsupported()
+  }
 }
 
 @Suite struct RichMessageTests {

--- a/Tests/ClawTelegramTests/Client/TelegramClientTests.swift
+++ b/Tests/ClawTelegramTests/Client/TelegramClientTests.swift
@@ -13,6 +13,16 @@ struct MockHTTPExecutor: HTTPExecuting {
     jsonBody: Data,
     timeoutSeconds: Int
   ) async throws -> HTTPResult { result }
+
+  func get(
+    url: String,
+    headers: [String: String],
+    timeoutSeconds: Int,
+    maxBodyBytes: Int
+  ) async throws -> HTTPResult {
+    struct GetUnsupported: Error {}
+    throw GetUnsupported()
+  }
 }
 
 struct RecordingHTTPExecutor: HTTPExecuting {
@@ -42,6 +52,16 @@ struct RecordingHTTPExecutor: HTTPExecuting {
     await recorder.append(url: url, body: jsonBody, timeout: timeoutSeconds)
     return result
   }
+
+  func get(
+    url: String,
+    headers: [String: String],
+    timeoutSeconds: Int,
+    maxBodyBytes: Int
+  ) async throws -> HTTPResult {
+    struct GetUnsupported: Error {}
+    throw GetUnsupported()
+  }
 }
 
 /// Simulates a transport error whose description echoes the request URL (which carries the token).
@@ -58,6 +78,16 @@ struct URLEchoingExecutor: HTTPExecuting {
     timeoutSeconds: Int
   ) async throws -> HTTPResult {
     throw URLEchoError(url: url)
+  }
+
+  func get(
+    url: String,
+    headers: [String: String],
+    timeoutSeconds: Int,
+    maxBodyBytes: Int
+  ) async throws -> HTTPResult {
+    struct GetUnsupported: Error {}
+    throw GetUnsupported()
   }
 }
 

--- a/Tests/ClawTelegramTests/Wire/AsyncHTTPExecutorGetTests.swift
+++ b/Tests/ClawTelegramTests/Wire/AsyncHTTPExecutorGetTests.swift
@@ -1,0 +1,176 @@
+import AsyncHTTPClient
+import ClawCore
+import Foundation
+import NIOCore
+import NIOHTTP1
+import NIOPosix
+import Testing
+
+@testable import ClawTelegram
+
+/// A scripted response for one request path.
+struct ScriptedResponse: Sendable {
+  let status: HTTPResponseStatus
+  let headers: [(String, String)]
+  let body: String
+}
+
+/// A minimal one-shot HTTP/1.1 server: responds to any request with the scripted response for
+/// its URI (or 404). Bound to 127.0.0.1 on an ephemeral port.
+final class ScriptedHTTPServer: @unchecked Sendable {
+  private let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+  private var channel: Channel?
+  private(set) var port = 0
+
+  init(routes: [String: ScriptedResponse]) throws {
+    let bootstrap = ServerBootstrap(group: group)
+      .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+      .childChannelInitializer { channel in
+        channel.pipeline.configureHTTPServerPipeline().flatMap {
+          channel.pipeline.addHandler(ScriptedHandler(routes: routes))
+        }
+      }
+    channel = try bootstrap.bind(host: "127.0.0.1", port: 0).wait()
+    port = channel?.localAddress?.port ?? 0
+  }
+
+  func shutdown() {
+    try? channel?.close().wait()
+    try? group.syncShutdownGracefully()
+  }
+}
+
+private final class ScriptedHandler: ChannelInboundHandler, @unchecked Sendable {
+  typealias InboundIn = HTTPServerRequestPart
+  typealias OutboundOut = HTTPServerResponsePart
+
+  private let routes: [String: ScriptedResponse]
+
+  init(routes: [String: ScriptedResponse]) {
+    self.routes = routes
+  }
+
+  func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+    guard case .head(let head) = unwrapInboundIn(data) else {
+      return
+    }
+    let scripted =
+      routes[head.uri]
+      ?? ScriptedResponse(status: .notFound, headers: [], body: "missing")
+
+    var responseHeaders = HTTPHeaders()
+    responseHeaders.add(name: "content-length", value: "\(scripted.body.utf8.count)")
+    for (name, value) in scripted.headers {
+      responseHeaders.add(name: name, value: value)
+    }
+    context.write(
+      wrapOutboundOut(
+        .head(
+          HTTPResponseHead(version: .http1_1, status: scripted.status, headers: responseHeaders)
+        )
+      ),
+      promise: nil
+    )
+    context.write(
+      wrapOutboundOut(.body(.byteBuffer(context.channel.allocator.buffer(string: scripted.body)))),
+      promise: nil
+    )
+    context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+  }
+}
+
+@Suite(.serialized) struct AsyncHTTPExecutorGetTests {
+  /// `HTTPClient.syncShutdown()` is unavailable from async contexts on this toolchain, and defer
+  /// bodies cannot `await`; this helper guarantees `shutdown()` runs on every exit path (the AHC
+  /// `HTTPClient` deinit precondition-fails in debug builds if a client is dropped un-shut-down).
+  private func withNoRedirectExecutor<Result>(
+    _ operation: (AsyncHTTPExecutor) async throws -> Result
+  ) async throws -> Result {
+    var configuration = HTTPClient.Configuration()
+    configuration.redirectConfiguration = .disallow
+    let client = HTTPClient(eventLoopGroupProvider: .singleton, configuration: configuration)
+    do {
+      let result = try await operation(AsyncHTTPExecutor(client: client))
+      try await client.shutdown()
+      return result
+    } catch {
+      try? await client.shutdown()
+      throw error
+    }
+  }
+
+  @Test func getReturnsStatusHeadersAndBody() async throws {
+    // given
+    let server = try ScriptedHTTPServer(routes: [
+      "/page": ScriptedResponse(
+        status: .ok,
+        headers: [("content-type", "text/html")],
+        body: "<html><body>hello</body></html>"
+      )
+    ])
+    defer { server.shutdown() }
+
+    // when
+    let result = try await withNoRedirectExecutor { executor in
+      try await executor.get(
+        url: "http://127.0.0.1:\(server.port)/page",
+        headers: [:],
+        timeoutSeconds: 5,
+        maxBodyBytes: 1024 * 1024
+      )
+    }
+
+    // then
+    #expect(result.statusCode == 200)
+    #expect(result.getHeader(for: "Content-Type") == "text/html")
+    #expect(String(data: result.body, encoding: .utf8)?.contains("hello") == true)
+  }
+
+  /// §20 item 3 — BLOCKING verification. The SSRF design requires that a redirect is NOT followed
+  /// automatically: the 3xx must surface as the result so the tool can re-check the next hop.
+  @Test func disallowConfiguredClientSurfacesRedirectInsteadOfFollowing() async throws {
+    // given
+    let server = try ScriptedHTTPServer(routes: [
+      "/hop": ScriptedResponse(
+        status: .movedPermanently,
+        headers: [("location", "http://127.0.0.1:1/private")],
+        body: ""
+      )
+    ])
+    defer { server.shutdown() }
+
+    // when
+    let result = try await withNoRedirectExecutor { executor in
+      try await executor.get(
+        url: "http://127.0.0.1:\(server.port)/hop",
+        headers: [:],
+        timeoutSeconds: 5,
+        maxBodyBytes: 1024
+      )
+    }
+
+    // then — the redirect came back to us; nothing fetched the Location target
+    #expect(result.statusCode == 301)
+    #expect(result.getHeader(for: "Location") == "http://127.0.0.1:1/private")
+  }
+
+  @Test func bodyBeyondMaxBodyBytesThrows() async throws {
+    // given
+    let server = try ScriptedHTTPServer(routes: [
+      "/big": ScriptedResponse(status: .ok, headers: [], body: String(repeating: "a", count: 4096))
+    ])
+    defer { server.shutdown() }
+
+    // when / then
+    await #expect(throws: (any Error).self) {
+      try await withNoRedirectExecutor { executor in
+        _ = try await executor.get(
+          url: "http://127.0.0.1:\(server.port)/big",
+          headers: [:],
+          timeoutSeconds: 5,
+          maxBodyBytes: 128
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the groundwork the assistant needs to call read-only tools (web search, web fetch, and workspace file reads) in a later change. Nothing here turns a tool on: the model is offered no tools, the agent still makes exactly one model round-trip per turn, and the two new database columns stay empty for every row written. Because none of it is active, this can merge and ship on its own without changing current behavior.

## What's included

- **Tool data model:** value types for a tool call, its result, and a full request/result exchange, the tool and search definitions the assistant would advertise, and the protocols that dispatch a call and run a search.
- **Chat request/response format:** the tool-calling fields on chat messages, requests, and responses, a new message role for tool results, and token counting for re-sent tool calls. Existing call sites are untouched, and a request with no tools serializes exactly as before (the tools field is omitted, not empty).
- **Per-run limits and config:** caps on turns (12) and tool calls (20) per run, overridable by environment variables and rejecting invalid values.
- **Secrets:** an optional search-provider API key carried through both secret backends, still reading older secret files that predate it.
- **HTTP fetching:** a GET that does not follow redirects and caps the response body size, the basis for later fetch safety.
- **Persistence:** a schema migration adding two nullable columns for tool data; a history window that counts conversation turns rather than raw rows, so tool-result rows ride along and can never push real conversation out of context; recall restricted to user and assistant messages so tool output is never resurfaced; and a single-transaction commit that records a tool exchange and marks the session as having ingested untrusted content, with the right behavior when a run is cancelled or superseded.
- **Streaming and non-streaming wire:** encoding and decoding of tool calls on both the blocking request path and the streamed-response path, assembling split streamed fragments into whole tool calls.

## Safety checks

Two behaviors that later features depend on are proven here against real infrastructure:

- **Redirect handling:** a client configured to reject redirects returns the redirect response itself instead of following it, verified against a local server whose redirect points at an unreachable address. This underpins the later protection against requests to internal addresses.
- **Search-index consistency:** the full-text search index stays correct when the new non-indexed columns are written or updated, and a deleted message is removed from the index.