### PR TITLE
Scheduling substrate: domain types, migration v6, occurrence calculator, and the fused fire-once job store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,21 @@ CLAW_PER_RUN_USD=
 CLAW_PER_DAY_USD=
 CLAW_REFERENCE_USD_PER_TOKEN=
 CLAW_DAY_TOKEN_CEILING=
+
+# Scheduler & proactive (Inc 4)
+# IANA timezone for schedule defaults and the heartbeat day boundary; blank = the host's zone
+CLAW_TIMEZONE=
+# misfires older than this many minutes are skipped, never caught up (>= 1; default 30)
+CLAW_SCHED_CATCHUP_MAX_AGE_MINUTES=
+# floor for every-N-minutes schedules, in minutes (>= 1; default 5)
+CLAW_SCHED_MIN_INTERVAL_MINUTES=
+# nested daily budget for scheduled + heartbeat runs, in USD (> 0; default 2.00)
+CLAW_PROACTIVE_PER_DAY_USD=
+# opt-in heartbeat: true/on/1 or false/off/0 (default off)
+CLAW_HEARTBEAT_ENABLED=
+# minutes between heartbeats (>= 15; default 60)
+CLAW_HEARTBEAT_INTERVAL_MINUTES=
+# HH:MM-HH:MM in CLAW_TIMEZONE; may cross midnight; start must differ from end (default 22:00-09:00)
+CLAW_HEARTBEAT_QUIET_HOURS=
+# max heartbeats per day (>= 1; default 8)
+CLAW_HEARTBEAT_MAX_PER_DAY=

--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ CLAW_PER_DAY_USD=
 CLAW_REFERENCE_USD_PER_TOKEN=
 CLAW_DAY_TOKEN_CEILING=
 
-# Scheduler & proactive (Inc 4)
+# Scheduler & proactive
 # IANA timezone for schedule defaults and the heartbeat day boundary; blank = the host's zone
 CLAW_TIMEZONE=
 # misfires older than this many minutes are skipped, never caught up (>= 1; default 30)

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
   name: "swift-claw",
-  platforms: [.macOS(.v14)],
+  platforms: [.macOS(.v15)],
   products: [
     .executable(name: "clawd", targets: ["clawd"])
   ],

--- a/Sources/ClawCore/Config/AppConfig.swift
+++ b/Sources/ClawCore/Config/AppConfig.swift
@@ -16,6 +16,14 @@ public struct AppConfig: Sendable, Equatable {
     static let dayTokenCeiling = "CLAW_DAY_TOKEN_CEILING"
     static let maxTurns = "CLAW_MAX_TURNS"
     static let maxToolCalls = "CLAW_MAX_TOOL_CALLS"
+    static let timezone = "CLAW_TIMEZONE"
+    static let schedCatchUpMaxAgeMinutes = "CLAW_SCHED_CATCHUP_MAX_AGE_MINUTES"
+    static let schedMinIntervalMinutes = "CLAW_SCHED_MIN_INTERVAL_MINUTES"
+    static let proactivePerDayUSD = "CLAW_PROACTIVE_PER_DAY_USD"
+    static let heartbeatEnabled = "CLAW_HEARTBEAT_ENABLED"
+    static let heartbeatIntervalMinutes = "CLAW_HEARTBEAT_INTERVAL_MINUTES"
+    static let heartbeatQuietHours = "CLAW_HEARTBEAT_QUIET_HOURS"
+    static let heartbeatMaxPerDay = "CLAW_HEARTBEAT_MAX_PER_DAY"
   }
 
   private enum EnvDefaults {
@@ -25,6 +33,12 @@ public struct AppConfig: Sendable, Equatable {
     static let maxOutputTokens = 4096
     static let retryBudget = 3
     static let requestTimeoutSeconds = 180
+    static let schedCatchUpMaxAgeMinutes = 30
+    static let schedMinIntervalMinutes = 5
+    static let proactivePerDayUSD = 2.00
+    static let heartbeatIntervalMinutes = 60
+    static let heartbeatQuietHours = "22:00-09:00"
+    static let heartbeatMaxPerDay = 8
   }
 
   private static let stateRootPermissions = 0o700
@@ -34,19 +48,43 @@ public struct AppConfig: Sendable, Equatable {
   public let pollTimeoutSeconds: Int
   public let llm: LLMConfig
   public let budget: RunBudget
+  public let timezone: TimeZone
+  public let schedCatchUpMaxAgeMinutes: Int
+  public let schedMinIntervalMinutes: Int
+  public let proactivePerDayUSD: Double
+  public let heartbeatEnabled: Bool
+  public let heartbeatIntervalMinutes: Int
+  public let heartbeatQuietHours: QuietHours
+  public let heartbeatMaxPerDay: Int
 
   public init(
     allowlist: Set<Int64>,
     stateRoot: URL,
     pollTimeoutSeconds: Int,
     llm: LLMConfig,
-    budget: RunBudget
+    budget: RunBudget,
+    timezone: TimeZone,
+    schedCatchUpMaxAgeMinutes: Int,
+    schedMinIntervalMinutes: Int,
+    proactivePerDayUSD: Double,
+    heartbeatEnabled: Bool,
+    heartbeatIntervalMinutes: Int,
+    heartbeatQuietHours: QuietHours,
+    heartbeatMaxPerDay: Int
   ) {
     self.allowlist = allowlist
     self.stateRoot = stateRoot
     self.pollTimeoutSeconds = pollTimeoutSeconds
     self.llm = llm
     self.budget = budget
+    self.timezone = timezone
+    self.schedCatchUpMaxAgeMinutes = schedCatchUpMaxAgeMinutes
+    self.schedMinIntervalMinutes = schedMinIntervalMinutes
+    self.proactivePerDayUSD = proactivePerDayUSD
+    self.heartbeatEnabled = heartbeatEnabled
+    self.heartbeatIntervalMinutes = heartbeatIntervalMinutes
+    self.heartbeatQuietHours = heartbeatQuietHours
+    self.heartbeatMaxPerDay = heartbeatMaxPerDay
   }
 
   /// Loads and validates non-secret config from the environment. Secrets (the bot token / LLM key)
@@ -59,13 +97,56 @@ public struct AppConfig: Sendable, Equatable {
       env[EnvKey.pollTimeout].flatMap(Int.init) ?? EnvDefaults.pollTimeoutSeconds
     let llm = try parseLLMConfig(from: env)
     let budget = try parseBudget(from: env, llm: llm)
+    let timezone = try parseTimezone(from: env[EnvKey.timezone])
+    let schedCatchUpMaxAgeMinutes = try boundedInt(
+      env[EnvKey.schedCatchUpMaxAgeMinutes],
+      key: EnvKey.schedCatchUpMaxAgeMinutes,
+      default: EnvDefaults.schedCatchUpMaxAgeMinutes,
+      minimum: 1
+    )
+    let schedMinIntervalMinutes = try boundedInt(
+      env[EnvKey.schedMinIntervalMinutes],
+      key: EnvKey.schedMinIntervalMinutes,
+      default: EnvDefaults.schedMinIntervalMinutes,
+      minimum: 1
+    )
+    let proactivePerDayUSD = try positiveBudgetDouble(
+      env[EnvKey.proactivePerDayUSD],
+      default: EnvDefaults.proactivePerDayUSD
+    )
+    let heartbeatEnabled = try boolValue(
+      env[EnvKey.heartbeatEnabled],
+      key: EnvKey.heartbeatEnabled,
+      default: false
+    )
+    let heartbeatIntervalMinutes = try boundedInt(
+      env[EnvKey.heartbeatIntervalMinutes],
+      key: EnvKey.heartbeatIntervalMinutes,
+      default: EnvDefaults.heartbeatIntervalMinutes,
+      minimum: 15
+    )
+    let heartbeatQuietHours = try parseQuietHours(from: env[EnvKey.heartbeatQuietHours])
+    let heartbeatMaxPerDay = try boundedInt(
+      env[EnvKey.heartbeatMaxPerDay],
+      key: EnvKey.heartbeatMaxPerDay,
+      default: EnvDefaults.heartbeatMaxPerDay,
+      minimum: 1
+    )
 
     return AppConfig(
       allowlist: allowlist,
       stateRoot: stateRoot,
       pollTimeoutSeconds: pollTimeoutSeconds,
       llm: llm,
-      budget: budget
+      budget: budget,
+      timezone: timezone,
+      schedCatchUpMaxAgeMinutes: schedCatchUpMaxAgeMinutes,
+      schedMinIntervalMinutes: schedMinIntervalMinutes,
+      proactivePerDayUSD: proactivePerDayUSD,
+      heartbeatEnabled: heartbeatEnabled,
+      heartbeatIntervalMinutes: heartbeatIntervalMinutes,
+      heartbeatQuietHours: heartbeatQuietHours,
+      heartbeatMaxPerDay: heartbeatMaxPerDay
     )
   }
 
@@ -193,6 +274,57 @@ public struct AppConfig: Sendable, Equatable {
     return value
   }
 
+  /// The scheduling timezone: absent/blank falls back to the host's current zone; a present
+  /// value must resolve via `TimeZone(identifier:)`, else fail-closed.
+  private static func parseTimezone(from raw: String?) throws -> TimeZone {
+    let trimmed = raw?.trimmingCharacters(in: .whitespaces) ?? ""
+    guard !trimmed.isEmpty else {
+      return TimeZone.current
+    }
+
+    guard let zone = TimeZone(identifier: trimmed) else {
+      throw ConfigError.invalidTimezone(trimmed)
+    }
+
+    return zone
+  }
+
+  /// An `Int` override with a lower bound: `fallback` when absent/blank, else
+  /// `invalidScheduling` on a non-numeric or below-minimum value.
+  private static func boundedInt(
+    _ raw: String?,
+    key: String,
+    default fallback: Int,
+    minimum: Int
+  ) throws -> Int {
+    let trimmed = raw?.trimmingCharacters(in: .whitespaces) ?? ""
+    guard !trimmed.isEmpty else {
+      return fallback
+    }
+
+    guard let value = Int(trimmed), value >= minimum else {
+      throw ConfigError.invalidScheduling(key: key, value: trimmed)
+    }
+
+    return value
+  }
+
+  private static func parseQuietHours(from raw: String?) throws -> QuietHours {
+    let trimmed = raw?.trimmingCharacters(in: .whitespaces) ?? ""
+    guard !trimmed.isEmpty else {
+      guard let fallback = QuietHours.parse(EnvDefaults.heartbeatQuietHours) else {
+        throw ConfigError.invalidQuietHours(EnvDefaults.heartbeatQuietHours)
+      }
+      return fallback
+    }
+
+    guard let window = QuietHours.parse(trimmed) else {
+      throw ConfigError.invalidQuietHours(trimmed)
+    }
+
+    return window
+  }
+
   private static func boolValue(
     _ raw: String?,
     key: String,
@@ -258,5 +390,77 @@ public struct AppConfig: Sendable, Equatable {
     }
 
     return stateRootURL
+  }
+}
+
+/// A daily suppression window in minutes-of-day, evaluated in a caller-supplied timezone.
+/// The window is half-open `[start, end)` and may cross midnight (e.g. 22:00-09:00).
+/// `start == end` is rejected at parse: a zero-width window would silently mean "never quiet"
+/// or "always quiet" depending on reading — spec §12 makes it a config error instead.
+public struct QuietHours: Sendable, Equatable {
+  public let startMinuteOfDay: Int
+  public let endMinuteOfDay: Int
+
+  public init(startMinuteOfDay: Int, endMinuteOfDay: Int) {
+    self.startMinuteOfDay = startMinuteOfDay
+    self.endMinuteOfDay = endMinuteOfDay
+  }
+
+  /// Parses `"HH:MM-HH:MM"`; nil on malformed input or a zero-width window.
+  public static func parse(_ raw: String) -> QuietHours? {
+    let parts = raw.split(separator: "-", omittingEmptySubsequences: false)
+    guard
+      parts.count == 2,
+      let start = minuteOfDay(String(parts[0])),
+      let end = minuteOfDay(String(parts[1])),
+      start != end
+    else {
+      return nil
+    }
+
+    return QuietHours(startMinuteOfDay: start, endMinuteOfDay: end)
+  }
+
+  public func contains(_ instant: Date, timezone: TimeZone) -> Bool {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = timezone
+    let components = calendar.dateComponents([.hour, .minute], from: instant)
+    let minute = (components.hour ?? 0) * 60 + (components.minute ?? 0)
+
+    if startMinuteOfDay < endMinuteOfDay {
+      return minute >= startMinuteOfDay && minute < endMinuteOfDay
+    }
+    // Midnight-crossing window: quiet from start until midnight, then until end.
+    return minute >= startMinuteOfDay || minute < endMinuteOfDay
+  }
+
+  public var rendered: String {
+    String(
+      format: "%02d:%02d-%02d:%02d",
+      startMinuteOfDay / 60,
+      startMinuteOfDay % 60,
+      endMinuteOfDay / 60,
+      endMinuteOfDay % 60
+    )
+  }
+
+  private static func minuteOfDay(_ text: String) -> Int? {
+    // Fail-closed HH:MM grammar (spec §13): exactly two ASCII digits per field. "9:00",
+    // "09:0", and "+09:00" are config ERRORS — `Int(_:)` alone would accept all three.
+    let pieces = text.split(separator: ":", omittingEmptySubsequences: false)
+    guard
+      pieces.count == 2,
+      pieces[0].count == 2,
+      pieces[1].count == 2,
+      pieces.allSatisfy({ piece in piece.allSatisfy { char in char.isASCII && char.isNumber } }),
+      let hour = Int(pieces[0]),
+      let minute = Int(pieces[1]),
+      (0...23).contains(hour),
+      (0...59).contains(minute)
+    else {
+      return nil
+    }
+
+    return hour * 60 + minute
   }
 }

--- a/Sources/ClawCore/Config/AppConfig.swift
+++ b/Sources/ClawCore/Config/AppConfig.swift
@@ -5,21 +5,26 @@ public struct AppConfig: Sendable, Equatable {
     static let allowlist = "CLAW_ALLOWLIST"
     static let stateRoot = "CLAW_STATE_ROOT"
     static let pollTimeout = "CLAW_POLL_TIMEOUT"
+
     static let llmBaseURL = "CLAW_LLM_BASE_URL"
     static let llmModel = "CLAW_LLM_MODEL"
     static let llmMaxTokensField = "CLAW_LLM_MAX_TOKENS_FIELD"
     static let llmMaxTokens = "CLAW_LLM_MAX_TOKENS"
     static let llmStreaming = "CLAW_LLM_STREAMING"
+
     static let perRunUSD = "CLAW_PER_RUN_USD"
     static let perDayUSD = "CLAW_PER_DAY_USD"
     static let referenceUSDPerToken = "CLAW_REFERENCE_USD_PER_TOKEN"
     static let dayTokenCeiling = "CLAW_DAY_TOKEN_CEILING"
+
     static let maxTurns = "CLAW_MAX_TURNS"
     static let maxToolCalls = "CLAW_MAX_TOOL_CALLS"
+
     static let timezone = "CLAW_TIMEZONE"
     static let schedCatchUpMaxAgeMinutes = "CLAW_SCHED_CATCHUP_MAX_AGE_MINUTES"
     static let schedMinIntervalMinutes = "CLAW_SCHED_MIN_INTERVAL_MINUTES"
     static let proactivePerDayUSD = "CLAW_PROACTIVE_PER_DAY_USD"
+
     static let heartbeatEnabled = "CLAW_HEARTBEAT_ENABLED"
     static let heartbeatIntervalMinutes = "CLAW_HEARTBEAT_INTERVAL_MINUTES"
     static let heartbeatQuietHours = "CLAW_HEARTBEAT_QUIET_HOURS"
@@ -33,9 +38,11 @@ public struct AppConfig: Sendable, Equatable {
     static let maxOutputTokens = 4096
     static let retryBudget = 3
     static let requestTimeoutSeconds = 180
+
     static let schedCatchUpMaxAgeMinutes = 30
     static let schedMinIntervalMinutes = 5
     static let proactivePerDayUSD = 2.00
+
     static let heartbeatIntervalMinutes = 60
     static let heartbeatQuietHours = "22:00-09:00"
     static let heartbeatMaxPerDay = 8
@@ -48,10 +55,12 @@ public struct AppConfig: Sendable, Equatable {
   public let pollTimeoutSeconds: Int
   public let llm: LLMConfig
   public let budget: RunBudget
+
   public let timezone: TimeZone
   public let schedCatchUpMaxAgeMinutes: Int
   public let schedMinIntervalMinutes: Int
   public let proactivePerDayUSD: Double
+
   public let heartbeatEnabled: Bool
   public let heartbeatIntervalMinutes: Int
   public let heartbeatQuietHours: QuietHours
@@ -97,6 +106,7 @@ public struct AppConfig: Sendable, Equatable {
       env[EnvKey.pollTimeout].flatMap(Int.init) ?? EnvDefaults.pollTimeoutSeconds
     let llm = try parseLLMConfig(from: env)
     let budget = try parseBudget(from: env, llm: llm)
+
     let timezone = try parseTimezone(from: env[EnvKey.timezone])
     let schedCatchUpMaxAgeMinutes = try boundedInt(
       env[EnvKey.schedCatchUpMaxAgeMinutes],
@@ -311,11 +321,12 @@ public struct AppConfig: Sendable, Equatable {
 
   private static func parseQuietHours(from raw: String?) throws -> QuietHours {
     let trimmed = raw?.trimmingCharacters(in: .whitespaces) ?? ""
-    guard !trimmed.isEmpty else {
-      guard let fallback = QuietHours.parse(EnvDefaults.heartbeatQuietHours) else {
-        throw ConfigError.invalidQuietHours(EnvDefaults.heartbeatQuietHours)
+
+    if trimmed.isEmpty {
+      if let fallback = QuietHours.parse(EnvDefaults.heartbeatQuietHours) {
+        return fallback
       }
-      return fallback
+      throw ConfigError.invalidQuietHours(EnvDefaults.heartbeatQuietHours)
     }
 
     guard let window = QuietHours.parse(trimmed) else {
@@ -390,77 +401,5 @@ public struct AppConfig: Sendable, Equatable {
     }
 
     return stateRootURL
-  }
-}
-
-/// A daily suppression window in minutes-of-day, evaluated in a caller-supplied timezone.
-/// The window is half-open `[start, end)` and may cross midnight (e.g. 22:00-09:00).
-/// `start == end` is rejected at parse: a zero-width window would silently mean "never quiet"
-/// or "always quiet" depending on reading — spec §12 makes it a config error instead.
-public struct QuietHours: Sendable, Equatable {
-  public let startMinuteOfDay: Int
-  public let endMinuteOfDay: Int
-
-  public init(startMinuteOfDay: Int, endMinuteOfDay: Int) {
-    self.startMinuteOfDay = startMinuteOfDay
-    self.endMinuteOfDay = endMinuteOfDay
-  }
-
-  /// Parses `"HH:MM-HH:MM"`; nil on malformed input or a zero-width window.
-  public static func parse(_ raw: String) -> QuietHours? {
-    let parts = raw.split(separator: "-", omittingEmptySubsequences: false)
-    guard
-      parts.count == 2,
-      let start = minuteOfDay(String(parts[0])),
-      let end = minuteOfDay(String(parts[1])),
-      start != end
-    else {
-      return nil
-    }
-
-    return QuietHours(startMinuteOfDay: start, endMinuteOfDay: end)
-  }
-
-  public func contains(_ instant: Date, timezone: TimeZone) -> Bool {
-    var calendar = Calendar(identifier: .gregorian)
-    calendar.timeZone = timezone
-    let components = calendar.dateComponents([.hour, .minute], from: instant)
-    let minute = (components.hour ?? 0) * 60 + (components.minute ?? 0)
-
-    if startMinuteOfDay < endMinuteOfDay {
-      return minute >= startMinuteOfDay && minute < endMinuteOfDay
-    }
-    // Midnight-crossing window: quiet from start until midnight, then until end.
-    return minute >= startMinuteOfDay || minute < endMinuteOfDay
-  }
-
-  public var rendered: String {
-    String(
-      format: "%02d:%02d-%02d:%02d",
-      startMinuteOfDay / 60,
-      startMinuteOfDay % 60,
-      endMinuteOfDay / 60,
-      endMinuteOfDay % 60
-    )
-  }
-
-  private static func minuteOfDay(_ text: String) -> Int? {
-    // Fail-closed HH:MM grammar (spec §13): exactly two ASCII digits per field. "9:00",
-    // "09:0", and "+09:00" are config ERRORS — `Int(_:)` alone would accept all three.
-    let pieces = text.split(separator: ":", omittingEmptySubsequences: false)
-    guard
-      pieces.count == 2,
-      pieces[0].count == 2,
-      pieces[1].count == 2,
-      pieces.allSatisfy({ piece in piece.allSatisfy { char in char.isASCII && char.isNumber } }),
-      let hour = Int(pieces[0]),
-      let minute = Int(pieces[1]),
-      (0...23).contains(hour),
-      (0...59).contains(minute)
-    else {
-      return nil
-    }
-
-    return hour * 60 + minute
   }
 }

--- a/Sources/ClawCore/Config/Errors.swift
+++ b/Sources/ClawCore/Config/Errors.swift
@@ -16,6 +16,9 @@ public enum ConfigError: Error, Sendable, Equatable {
   case invalidMaxTokens(String)
   case invalidBudget(String)
   case invalidBool(key: String, value: String)
+  case invalidTimezone(String)
+  case invalidQuietHours(String)
+  case invalidScheduling(key: String, value: String)
 
   public var exitCode: Int32 {
     switch self {
@@ -27,6 +30,9 @@ public enum ConfigError: Error, Sendable, Equatable {
     case .invalidMaxTokens: ClawExitCode.configInvalid.rawValue
     case .invalidBudget: ClawExitCode.configInvalid.rawValue
     case .invalidBool: ClawExitCode.configInvalid.rawValue
+    case .invalidTimezone: ClawExitCode.configInvalid.rawValue
+    case .invalidQuietHours: ClawExitCode.configInvalid.rawValue
+    case .invalidScheduling: ClawExitCode.configInvalid.rawValue
     }
   }
 }

--- a/Sources/ClawCore/Config/QuietHours.swift
+++ b/Sources/ClawCore/Config/QuietHours.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// A daily suppression window in minutes-of-day, evaluated in a caller-supplied timezone.
+/// The window is half-open `[start, end)` and may cross midnight (e.g. 22:00-09:00).
+/// `start == end` is rejected at parse: a zero-width window would silently mean "never quiet"
+/// or "always quiet" depending on reading — spec §12 makes it a config error instead.
+public struct QuietHours: Sendable, Equatable {
+  public let startMinuteOfDay: Int
+  public let endMinuteOfDay: Int
+
+  public init(startMinuteOfDay: Int, endMinuteOfDay: Int) {
+    self.startMinuteOfDay = startMinuteOfDay
+    self.endMinuteOfDay = endMinuteOfDay
+  }
+
+  /// Parses `"HH:MM-HH:MM"`; nil on malformed input or a zero-width window.
+  public static func parse(_ raw: String) -> QuietHours? {
+    let parts = raw.split(separator: "-", omittingEmptySubsequences: false)
+
+    guard
+      parts.count == 2,
+      let start = minuteOfDay(String(parts[0])),
+      let end = minuteOfDay(String(parts[1])),
+      start != end
+    else {
+      return nil
+    }
+
+    return QuietHours(startMinuteOfDay: start, endMinuteOfDay: end)
+  }
+
+  public func contains(_ instant: Date, timezone: TimeZone) -> Bool {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = timezone
+
+    let components = calendar.dateComponents([.hour, .minute], from: instant)
+    let minute = (components.hour ?? 0) * 60 + (components.minute ?? 0)
+
+    if startMinuteOfDay < endMinuteOfDay {
+      return minute >= startMinuteOfDay && minute < endMinuteOfDay
+    }
+    // Midnight-crossing window: quiet from start until midnight, then until end.
+    return minute >= startMinuteOfDay || minute < endMinuteOfDay
+  }
+
+  public var rendered: String {
+    String(
+      format: "%02d:%02d-%02d:%02d",
+      startMinuteOfDay / 60,
+      startMinuteOfDay % 60,
+      endMinuteOfDay / 60,
+      endMinuteOfDay % 60
+    )
+  }
+
+  private static func minuteOfDay(_ text: String) -> Int? {
+    // Fail-closed HH:MM grammar (spec §13): exactly two ASCII digits per field. "9:00",
+    // "09:0", and "+09:00" are config ERRORS — `Int(_:)` alone would accept all three.
+    let pieces = text.split(separator: ":", omittingEmptySubsequences: false)
+
+    guard
+      pieces.count == 2,
+      pieces[0].count == 2,
+      pieces[1].count == 2,
+      pieces.allSatisfy({ piece in piece.allSatisfy { char in char.isASCII && char.isNumber } }),
+      let hour = Int(pieces[0]),
+      let minute = Int(pieces[1]),
+      (0...23).contains(hour),
+      (0...59).contains(minute)
+    else {
+      return nil
+    }
+
+    return hour * 60 + minute
+  }
+}

--- a/Sources/ClawCore/Domain/Scheduling/OccurrenceCalculator.swift
+++ b/Sources/ClawCore/Domain/Scheduling/OccurrenceCalculator.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// The single home of occurrence math over `Calendar.RecurrenceRule` (spec §6): the ticker,
+/// the confirm prompt's next-3 preview, and `/schedule list` all consult this type, so they can
+/// never disagree.
+///
+/// DST policy (pinned, spec §6): a nonexistent local time resolves to the platform's next valid
+/// instant, never dropped; an ambiguous local time yields exactly one resolved UTC instant (the
+/// claim is keyed on it, so it fires once); wall-clock rules stay at local time across
+/// transitions. All three behaviors are pinned by `OccurrenceCalculatorTests`.
+public struct OccurrenceCalculator: Sendable {
+  public init() {}
+
+  /// Occurrences strictly after `after`, ascending. `anchor` seeds `rule.recurrences(of:)` —
+  /// pass the occurrence-chain seed: the occurrence being advanced from (the claimed `due` at
+  /// tick advance; validation `now` at parse/arm; the stale stored next at resume). It pins the
+  /// phase of everyNMinutes rules and is inert for rules that pin hour/minute/weekday (preamble
+  /// deviation 1). `recurrences(of:)` yields the anchor itself when it matches, which the
+  /// strict `after` bound excludes.
+  public func occurrences(
+    rule: Calendar.RecurrenceRule,
+    timezone: TimeZone,
+    anchor: Date,
+    after: Date,
+    limit: Int
+  ) -> [Date] {
+    guard limit > 0 else {
+      return []
+    }
+
+    let localized = Self.installing(timezone, on: rule)
+    var found: [Date] = []
+    // The sequence is ascending, so the loop terminates at `limit` (or at the rule's end).
+    for occurrence in localized.recurrences(of: Self.wholeSecond(anchor)) {
+      guard occurrence > after else {
+        continue
+      }
+      found.append(occurrence)
+      if found.count == limit {
+        break
+      }
+    }
+    return found
+  }
+
+  /// Latest occurrence in `(after, atOrBefore]` — the §5.3 coalesce target. nil when none.
+  public func latestOccurrence(
+    rule: Calendar.RecurrenceRule,
+    timezone: TimeZone,
+    anchor: Date,
+    after: Date,
+    atOrBefore: Date
+  ) -> Date? {
+    guard atOrBefore > after else {
+      return nil
+    }
+
+    let localized = Self.installing(timezone, on: rule)
+    var latest: Date?
+    for occurrence in localized.recurrences(of: Self.wholeSecond(anchor)) {
+      if occurrence > atOrBefore {
+        break  // ascending: nothing later can qualify
+      }
+      if occurrence > after {
+        latest = occurrence
+      }
+    }
+    return latest
+  }
+
+  /// `RecurrenceRule` propagates the seed's fractional seconds into every occurrence
+  /// (verified on this toolchain), and parse/arm-time anchors come from `Date()`. Flooring
+  /// the seed keeps every emitted occurrence a whole second — the store persists integer
+  /// epochs and the fused claim compares exact integers (§5.2).
+  private static func wholeSecond(_ instant: Date) -> Date {
+    Date(timeIntervalSince1970: instant.timeIntervalSince1970.rounded(.down))
+  }
+
+  /// The job's IANA zone lives in its own column (spec D2); installing it on the rule's
+  /// calendar here is what makes the rule's wall-clock components mean "local time in the
+  /// job's zone", wherever the rule was built.
+  private static func installing(
+    _ timezone: TimeZone,
+    on rule: Calendar.RecurrenceRule
+  ) -> Calendar.RecurrenceRule {
+    var localized = rule
+    var calendar = localized.calendar
+    calendar.timeZone = timezone
+    localized.calendar = calendar
+    return localized
+  }
+}

--- a/Sources/ClawCore/Domain/Scheduling/OccurrenceCalculator.swift
+++ b/Sources/ClawCore/Domain/Scheduling/OccurrenceCalculator.swift
@@ -35,11 +35,14 @@ public struct OccurrenceCalculator: Sendable {
       guard occurrence > after else {
         continue
       }
+
       found.append(occurrence)
+
       if found.count == limit {
         break
       }
     }
+
     return found
   }
 
@@ -57,6 +60,7 @@ public struct OccurrenceCalculator: Sendable {
 
     let localized = Self.installing(timezone, on: rule)
     var latest: Date?
+
     for occurrence in localized.recurrences(of: Self.wholeSecond(anchor)) {
       if occurrence > atOrBefore {
         break  // ascending: nothing later can qualify
@@ -65,6 +69,7 @@ public struct OccurrenceCalculator: Sendable {
         latest = occurrence
       }
     }
+
     return latest
   }
 
@@ -85,8 +90,10 @@ public struct OccurrenceCalculator: Sendable {
   ) -> Calendar.RecurrenceRule {
     var localized = rule
     var calendar = localized.calendar
+
     calendar.timeZone = timezone
     localized.calendar = calendar
+
     return localized
   }
 }

--- a/Sources/ClawCore/Domain/Scheduling/ScheduledJob.swift
+++ b/Sources/ClawCore/Domain/Scheduling/ScheduledJob.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+/// Which pathway created a run. The single discriminator driving reduced privilege (spec §10),
+/// the proactive budget (§11), and doctor metrics; persisted via rawValue in `runs.origin`.
+public enum RunOrigin: String, Sendable, Equatable {
+  case interactive
+  case scheduled
+  case heartbeat
+}
+
+/// The scheduled-job status FSM (spec §4.1). `completed`/`cancelled` are terminal; terminal rows
+/// keep `next_occurrence = NULL` so the ticker's partial index never sees them.
+public enum ScheduledJobStatus: String, Sendable, Equatable {
+  case active = "ACTIVE"
+  case paused = "PAUSED"
+  case completed = "COMPLETED"
+  case cancelled = "CANCELLED"
+}
+
+/// The stored recurrence wrapper (spec D2): `{"schema_version":1,"rule":<RecurrenceRule JSON>}`.
+public struct RecurrenceEnvelope: Sendable, Equatable, Codable {
+  public static let currentSchemaVersion = 1
+
+  public let schemaVersion: Int
+  public let rule: Calendar.RecurrenceRule
+
+  enum CodingKeys: String, CodingKey {
+    case schemaVersion = "schema_version"
+    case rule
+  }
+
+  public init(schemaVersion: Int, rule: Calendar.RecurrenceRule) {
+    self.schemaVersion = schemaVersion
+    self.rule = rule
+  }
+
+  /// The pinned storage encoding. `.sortedKeys` makes the stored JSON deterministic, which is
+  /// what gives the byte-for-byte round-trip tripwire (spec §17) its teeth.
+  public func encodedJSON() throws -> String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    return String(decoding: try encoder.encode(self), as: UTF8.self)
+  }
+
+  public static func decode(fromJSON json: String) throws -> RecurrenceEnvelope {
+    try JSONDecoder().decode(RecurrenceEnvelope.self, from: Data(json.utf8))
+  }
+}
+
+/// One row of `scheduled_jobs` (spec §4.1).
+public struct ScheduledJob: Sendable, Equatable {
+  public let id: Int64
+  public let ownerChatId: Int64
+  public let label: String
+  public let prompt: String
+  public let recurrence: RecurrenceEnvelope?  // nil ⇔ one-shot
+  public let timezone: String  // IANA identifier
+  public let nextOccurrence: Date?  // nil once terminal
+  public let lastFiredAt: Date?
+  public let status: ScheduledJobStatus
+  public let sessionId: Int64?  // nil until first fire
+  public let createdTs: Date  // row creation time (house convention)
+  public let updatedTs: Date
+
+  public init(
+    id: Int64,
+    ownerChatId: Int64,
+    label: String,
+    prompt: String,
+    recurrence: RecurrenceEnvelope?,
+    timezone: String,
+    nextOccurrence: Date?,
+    lastFiredAt: Date?,
+    status: ScheduledJobStatus,
+    sessionId: Int64?,
+    createdTs: Date,
+    updatedTs: Date
+  ) {
+    self.id = id
+    self.ownerChatId = ownerChatId
+    self.label = label
+    self.prompt = prompt
+    self.recurrence = recurrence
+    self.timezone = timezone
+    self.nextOccurrence = nextOccurrence
+    self.lastFiredAt = lastFiredAt
+    self.status = status
+    self.sessionId = sessionId
+    self.createdTs = createdTs
+    self.updatedTs = updatedTs
+  }
+}
+
+/// The arm-time insert payload. `ownerChatId` is set in code from the arming chat — never
+/// model- or prompt-controlled (spec §4.1).
+public struct NewScheduledJob: Sendable, Equatable {
+  public let ownerChatId: Int64
+  public let label: String
+  public let prompt: String
+  public let recurrence: RecurrenceEnvelope?
+  public let timezone: String
+  public let nextOccurrence: Date
+
+  public init(
+    ownerChatId: Int64,
+    label: String,
+    prompt: String,
+    recurrence: RecurrenceEnvelope?,
+    timezone: String,
+    nextOccurrence: Date
+  ) {
+    self.ownerChatId = ownerChatId
+    self.label = label
+    self.prompt = prompt
+    self.recurrence = recurrence
+    self.timezone = timezone
+    self.nextOccurrence = nextOccurrence
+  }
+}
+
+/// The single `scheduler_state` row (spec §4.3) — doctor is a separate process, so only
+/// persisted state is visible to it.
+public struct SchedulerState: Sendable, Equatable {
+  public let lastTickAt: Date?
+  public let lastMisfireAt: Date?
+  public let lastMisfireSkippedCount: Int
+  public let lastHeartbeatAt: Date?
+  public let heartbeatCountDay: String?  // "YYYY-MM-DD" in CLAW_TIMEZONE
+  public let heartbeatCount: Int
+
+  public init(
+    lastTickAt: Date?,
+    lastMisfireAt: Date?,
+    lastMisfireSkippedCount: Int,
+    lastHeartbeatAt: Date?,
+    heartbeatCountDay: String?,
+    heartbeatCount: Int
+  ) {
+    self.lastTickAt = lastTickAt
+    self.lastMisfireAt = lastMisfireAt
+    self.lastMisfireSkippedCount = lastMisfireSkippedCount
+    self.lastHeartbeatAt = lastHeartbeatAt
+    self.heartbeatCountDay = heartbeatCountDay
+    self.heartbeatCount = heartbeatCount
+  }
+}

--- a/Sources/ClawCore/Persistence/Persistence.swift
+++ b/Sources/ClawCore/Persistence/Persistence.swift
@@ -54,9 +54,20 @@ public enum CostSource: String, Sendable, Equatable {
 
 public enum SessionKey {
   private static let dmPrefix = "tg:dm:"
+  private static let jobPrefix = "sched:job:"
+
+  /// The heartbeat's dedicated persistent session (spec D3 symmetry). No chat id in the key —
+  /// the delivery target is resolved from config, so `chatId(from:)` stays nil by design.
+  public static let heartbeat = "sched:heartbeat"
 
   public static func telegramDM(chatId: Int64) -> String {
     "\(dmPrefix)\(chatId)"
+  }
+
+  /// A job's dedicated session, created lazily at first fire (spec D3). No chat id in the key —
+  /// the delivery target is `scheduled_jobs.owner_chat_id`, so `chatId(from:)` stays nil by design.
+  public static func scheduledJob(id: Int64) -> String {
+    "\(jobPrefix)\(id)"
   }
 
   public static func chatId(from key: String) -> Int64? {
@@ -320,6 +331,16 @@ public enum AuditAction: String, Sendable, Equatable {
   case budgetTripped = "budget_tripped"
   case turnCancelled = "turn_cancelled"
   case turnSuperseded = "turn_superseded"
+  case jobCreated = "job_created"
+  case jobExecuted = "job_executed"
+  case jobPaused = "job_paused"
+  case jobResumed = "job_resumed"
+  case jobCancelled = "job_cancelled"
+  case jobFailed = "job_failed"
+  case jobMisfire = "job_misfire"
+  case heartbeatFired = "heartbeat_fired"
+  case heartbeatSuppressed = "heartbeat_suppressed"
+  case heartbeatSkipped = "heartbeat_skipped"
 }
 
 public struct AuditEvent: Sendable, Equatable {

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -172,3 +172,75 @@ public protocol OutboxStore: Sendable {
 public protocol AuditLog: Sendable {
   func appendAudit(_ event: AuditEvent) throws
 }
+
+public struct ClaimedFire: Sendable, Equatable {
+  public let runId: Int64
+  public let sessionId: Int64
+  public let triggerMessageId: Int64
+  public let ownerChatId: Int64
+
+  public init(runId: Int64, sessionId: Int64, triggerMessageId: Int64, ownerChatId: Int64) {
+    self.runId = runId
+    self.sessionId = sessionId
+    self.triggerMessageId = triggerMessageId
+    self.ownerChatId = ownerChatId
+  }
+}
+
+public protocol ScheduledJobStore: Sendable {
+  func create(_ job: NewScheduledJob, now: Date) throws -> ScheduledJob
+  func job(id: Int64) throws -> ScheduledJob?
+  func listAll() throws -> [ScheduledJob]
+  func dueJobs(now: Date) throws -> [ScheduledJob]  // status='ACTIVE' AND next_occurrence <= now
+
+  /// Spec §5.2 — the whole fused transaction. `due` is the CAS predicate (the stored
+  /// next_occurrence being claimed); `fireAt` is T_fire (== due on time, the latest missed
+  /// occurrence when coalescing); `nextOccurrence` nil ⇒ one-shot → COMPLETED. Creates the
+  /// job session on first fire (session_key = SessionKey.scheduledJob(id:)), inserts the
+  /// trigger message (role user, provenance trusted, text = job prompt), the PENDING run
+  /// (origin 'scheduled', job_id set), and the jobExecuted audit row — one writeMapping.
+  /// Returns nil when the CAS matches no row (claimed elsewhere / job mutated): no fire.
+  func claimAndFire(
+    jobId: Int64,
+    due: Date,
+    fireAt: Date,
+    nextOccurrence: Date?,
+    now: Date
+  ) throws -> ClaimedFire?
+
+  /// Spec §5.4 run-now: the same fused insert set with NO schedule advance. Requires
+  /// status ACTIVE or PAUSED (nil otherwise). fireAt = now; jobExecuted audited in-txn.
+  func fireNow(jobId: Int64, now: Date) throws -> ClaimedFire?
+
+  /// Spec §5.3 skip: advance next_occurrence past now with no run (nil ⇒ one-shot →
+  /// COMPLETED), update scheduler_state.last_misfire_at / last_misfire_skipped_count, and
+  /// audit jobMisfire — one transaction. Returns false when the job was concurrently mutated.
+  func skipMisfire(
+    jobId: Int64,
+    due: Date,
+    nextOccurrence: Date?,
+    skippedCount: Int,
+    now: Date
+  ) throws -> Bool
+
+  /// ACTIVE→PAUSED, idempotent.
+  func pause(id: Int64, now: Date) throws -> ScheduledJob?
+  /// PAUSED→ACTIVE; the caller recomputes next_occurrence from now.
+  func resume(id: Int64, nextOccurrence: Date?, now: Date) throws -> ScheduledJob?
+  /// ACTIVE|PAUSED→CANCELLED, next NULL, row retained.
+  func cancel(id: Int64, now: Date) throws -> ScheduledJob?
+
+  func schedulerState() throws -> SchedulerState
+  /// Upserts scheduler_state.last_tick_at.
+  func recordTick(at tickTime: Date) throws
+
+  /// Spec §12 (Phase 4): creates/reuses the sched:heartbeat session, inserts the template
+  /// trigger message + PENDING run (origin 'heartbeat', job_id NULL), and updates
+  /// scheduler_state heartbeat fields (last_heartbeat_at, day-counter roll) — one transaction.
+  func fireHeartbeat(
+    prompt: String,
+    ownerChatId: Int64,
+    now: Date,
+    day: String
+  ) throws -> ClaimedFire
+}

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -44,7 +44,6 @@ public struct NewCommandResult: Sendable, Equatable {
 public protocol CommandStore: Sendable {
   /// Atomic `/stop`: claim update + resolve session + RUNNING→CANCELLED + audit in one write.
   func applyStop(updateId: Int64, sessionKey: String, now: Date) throws -> StopCommandResult
-
   /// Atomic `/new`: claim update + resolve session + RUNNING/PENDING→SUPERSEDED +
   /// resetWindowAndDetaint + audit in one write.
   func applyNew(updateId: Int64, sessionKey: String, now: Date) throws -> NewCommandResult
@@ -75,7 +74,6 @@ public protocol MemoryCommandStore: Sendable {
     item: NewMemoryItem,
     now: Date
   ) throws -> MemoryCommandResult
-
   /// Atomic confirmed delete: claim update + hard-delete memory item + audit in one write.
   func applyForget(updateId: Int64, itemId: Int64, now: Date) throws -> MemoryCommandResult
 }

--- a/Sources/ClawData/Database/ClawDatabase.swift
+++ b/Sources/ClawData/Database/ClawDatabase.swift
@@ -160,6 +160,48 @@ public enum ClawDatabase {
         table.add(column: "tool_call_id", .text)
       }
     }
+    migrator.registerMigration("v6") { db in
+      // Spec §4.1. Occurrence/timestamp columns are UTC epoch-second INTEGERs so the fused
+      // claim's compare-and-advance (§5.2) is exact integer equality, never a string compare.
+      try db.create(table: "scheduled_jobs") { table in
+        table.autoIncrementedPrimaryKey("id")
+        table.column("owner_chat_id", .integer).notNull()
+        table.column("label", .text).notNull()
+        table.column("prompt", .text).notNull()
+        // {"schema_version":1,"rule":<RecurrenceRule JSON>}; NULL ⇔ one-shot (D2)
+        table.column("recurrence", .text)
+        table.column("timezone", .text).notNull()
+        table.column("next_occurrence", .integer)
+        table.column("last_fired_at", .integer)
+        table.column("status", .text).notNull()
+        table.column("session_id", .integer).references("sessions", onDelete: .setNull)
+        table.column("created_ts", .integer).notNull()
+        table.column("updated_ts", .integer).notNull()
+      }
+      // Partial: terminal rows keep next_occurrence NULL, so the ticker scan never sees them.
+      try db.create(
+        index: "index_scheduled_jobs_status_next_occurrence",
+        on: "scheduled_jobs",
+        columns: ["status", "next_occurrence"],
+        condition: Column("next_occurrence") != nil
+      )
+      try db.alter(table: "runs") { table in
+        // 'interactive' | 'scheduled' | 'heartbeat' — backfill is the default, no data rewrite.
+        table.add(column: "origin", .text).notNull().defaults(to: "interactive")
+        table.add(column: "job_id", .integer).references("scheduled_jobs")
+      }
+      // Spec §4.3: one row, updated inside tick/claim transactions; doctor reads it from its
+      // separate process. due_count is deliberately NOT stored (computed by query).
+      try db.create(table: "scheduler_state") { table in
+        table.primaryKey("id", .integer).check { id in id == 1 }
+        table.column("last_tick_at", .integer)
+        table.column("last_misfire_at", .integer)
+        table.column("last_misfire_skipped_count", .integer).notNull().defaults(to: 0)
+        table.column("last_heartbeat_at", .integer)
+        table.column("heartbeat_count_day", .text)
+        table.column("heartbeat_count", .integer).notNull().defaults(to: 0)
+      }
+    }
     return migrator
   }
 

--- a/Sources/ClawData/Stores/Scheduling/ScheduledJobStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Scheduling/ScheduledJobStoreGRDB.swift
@@ -1,0 +1,649 @@
+import ClawCore
+import Foundation
+import GRDB
+
+/// GRDB implementation of `ScheduledJobStore`. Occurrence instants persist as UTC epoch-second
+/// INTEGERs (spec §4.1) so the fused claim's compare-and-advance is exact integer equality;
+/// callers pass whole-second `Date`s (`OccurrenceCalculator` emits whole seconds). The protocol
+/// conformance is declared once every method exists (end of this file's build-out); `Sendable`
+/// is declared NOW because Cycle B's task-group race test captures the store in `@Sendable`
+/// child tasks — strict concurrency rejects that until the conformance exists (the only stored
+/// property is the `Sendable` `any DatabaseWriter`). Method groups live in same-type extensions
+/// below purely to keep each extension's body under the project's `type_body_length` gate; the
+/// store is still one type with one stored property.
+public struct ScheduledJobStoreGRDB: Sendable {
+  private let writer: any DatabaseWriter
+
+  public init(writer: any DatabaseWriter) {
+    self.writer = writer
+  }
+}
+
+// MARK: - CRUD
+
+extension ScheduledJobStoreGRDB {
+  public func create(_ job: NewScheduledJob, now: Date) throws -> ScheduledJob {
+    try writer.writeMapping { db in
+      try Self.insertJob(db, job, now: now)
+    }
+  }
+
+  /// In-transaction insert, exposed so the Phase 3 arm commit can fuse update-claim + create +
+  /// jobCreated audit inside the command store's transaction (preamble note on `create`).
+  static func insertJob(_ db: Database, _ job: NewScheduledJob, now: Date) throws -> ScheduledJob {
+    let recurrenceJSON: String?
+    if let envelope = job.recurrence {
+      do {
+        recurrenceJSON = try envelope.encodedJSON()
+      } catch {
+        // Domain-typed at the seam: an EncodingError must not leak past the store either
+        // (mirrors jobFromRow's decode wrap).
+        throw StoreError.unexpected("unencodable recurrence envelope: \(error)")
+      }
+    } else {
+      recurrenceJSON = nil
+    }
+
+    try db.execute(
+      sql: """
+        INSERT INTO scheduled_jobs(owner_chat_id, label, prompt, recurrence, timezone,
+          next_occurrence, status, created_ts, updated_ts)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+      arguments: [
+        job.ownerChatId,
+        job.label,
+        job.prompt,
+        recurrenceJSON,
+        job.timezone,
+        epoch(job.nextOccurrence),
+        ScheduledJobStatus.active.rawValue,
+        epoch(now),
+        epoch(now),
+      ]
+    )
+    guard let created = try fetchJob(db, id: db.lastInsertedRowID) else {
+      throw StoreError.unexpected("scheduled job insert returned no row")
+    }
+    return created
+  }
+
+  public func job(id: Int64) throws -> ScheduledJob? {
+    try writer.readMapping { db in
+      try Self.fetchJob(db, id: id)
+    }
+  }
+
+  public func listAll() throws -> [ScheduledJob] {
+    try writer.readMapping { db in
+      let rows = try Row.fetchAll(db, sql: "SELECT * FROM scheduled_jobs ORDER BY id ASC")
+      return try rows.map { row in try Self.jobFromRow(row) }
+    }
+  }
+
+  public func dueJobs(now: Date) throws -> [ScheduledJob] {
+    try writer.readMapping { db in
+      let rows = try Row.fetchAll(
+        db,
+        sql: """
+          SELECT * FROM scheduled_jobs
+          WHERE status = ? AND next_occurrence IS NOT NULL AND next_occurrence <= ?
+          ORDER BY next_occurrence ASC, id ASC
+          """,
+        arguments: [ScheduledJobStatus.active.rawValue, Self.epoch(now)]
+      )
+      return try rows.map { row in try Self.jobFromRow(row) }
+    }
+  }
+}
+
+// MARK: - Row mapping
+
+extension ScheduledJobStoreGRDB {
+  static func fetchJob(_ db: Database, id: Int64) throws -> ScheduledJob? {
+    guard
+      let row = try Row.fetchOne(
+        db,
+        sql: "SELECT * FROM scheduled_jobs WHERE id = ?",
+        arguments: [id]
+      )
+    else {
+      return nil
+    }
+    return try jobFromRow(row)
+  }
+
+  static func jobFromRow(_ row: Row) throws -> ScheduledJob {
+    let recurrence: RecurrenceEnvelope?
+    if let json = row["recurrence"] as String? {
+      do {
+        recurrence = try RecurrenceEnvelope.decode(fromJSON: json)
+      } catch {
+        // Domain-typed at the seam: a DecodingError must not leak past the store either.
+        throw StoreError.unexpected("undecodable recurrence envelope: \(error)")
+      }
+    } else {
+      recurrence = nil
+    }
+
+    guard let status = ScheduledJobStatus(rawValue: row["status"]) else {
+      throw StoreError.unexpected("unknown scheduled job status")
+    }
+    guard
+      let createdTs = date(fromEpoch: row["created_ts"]),
+      let updatedTs = date(fromEpoch: row["updated_ts"])
+    else {
+      throw StoreError.unexpected("scheduled job row missing timestamps")
+    }
+
+    return ScheduledJob(
+      id: row["id"],
+      ownerChatId: row["owner_chat_id"],
+      label: row["label"],
+      prompt: row["prompt"],
+      recurrence: recurrence,
+      timezone: row["timezone"],
+      nextOccurrence: date(fromEpoch: row["next_occurrence"]),
+      lastFiredAt: date(fromEpoch: row["last_fired_at"]),
+      status: status,
+      sessionId: row["session_id"],
+      createdTs: createdTs,
+      updatedTs: updatedTs
+    )
+  }
+}
+
+// MARK: - The fused claim (spec §5.2)
+
+extension ScheduledJobStoreGRDB {
+  public func claimAndFire(
+    jobId: Int64,
+    due: Date,
+    fireAt: Date,
+    nextOccurrence: Date?,
+    now: Date
+  ) throws -> ClaimedFire? {
+    try writer.writeMapping { db in
+      // Step 1: the compare-and-advance. This IS the atomic claim of ARCHITECTURE §6.3/§14
+      // expressed on the occurrence: the WHERE arms (id, stored due, ACTIVE) make two racers
+      // for the same (job, due) structurally single-winner.
+      if let nextOccurrence {
+        try db.execute(
+          sql: """
+            UPDATE scheduled_jobs
+            SET next_occurrence = ?, last_fired_at = ?, updated_ts = ?
+            WHERE id = ? AND next_occurrence = ? AND status = ?
+            """,
+          arguments: [
+            Self.epoch(nextOccurrence),
+            Self.epoch(fireAt),
+            Self.epoch(now),
+            jobId,
+            Self.epoch(due),
+            ScheduledJobStatus.active.rawValue,
+          ]
+        )
+      } else {
+        // One-shot: fired means done — terminal, NULL next, invisible to the ticker index.
+        try db.execute(
+          sql: """
+            UPDATE scheduled_jobs
+            SET next_occurrence = NULL, last_fired_at = ?, status = ?, updated_ts = ?
+            WHERE id = ? AND next_occurrence = ? AND status = ?
+            """,
+          arguments: [
+            Self.epoch(fireAt),
+            ScheduledJobStatus.completed.rawValue,
+            Self.epoch(now),
+            jobId,
+            Self.epoch(due),
+            ScheduledJobStatus.active.rawValue,
+          ]
+        )
+      }
+      // Step 2: zero changes ⇒ claimed elsewhere or the job mutated — abort silently, no fire.
+      guard db.changesCount > 0 else {
+        return nil
+      }
+      return try Self.insertFireRows(db, jobId: jobId, now: now)
+    }
+  }
+
+  /// Steps 3-6 of the §5.2 transaction: lazy session, trigger message, PENDING run, audit.
+  /// Shared verbatim by `fireNow` (which skips only step 1's advance).
+  static func insertFireRows(_ db: Database, jobId: Int64, now: Date) throws -> ClaimedFire {
+    guard
+      let jobRow = try Row.fetchOne(
+        db,
+        sql: "SELECT owner_chat_id, prompt, session_id FROM scheduled_jobs WHERE id = ?",
+        arguments: [jobId]
+      )
+    else {
+      throw StoreError.unexpected("claimed scheduled job \(jobId) has no row")
+    }
+    let ownerChatId: Int64 = jobRow["owner_chat_id"]
+    let prompt: String = jobRow["prompt"]
+
+    // Step 3: the job's dedicated session, created lazily on first fire (D3). The session row
+    // stores NO chat id — the delivery target stays on the job row (spec §4.1).
+    let sessionId: Int64
+    if let existingSessionId = jobRow["session_id"] as Int64? {
+      sessionId = existingSessionId
+    } else {
+      sessionId = try SessionMessageStoreGRDB.upsertSession(
+        db,
+        sessionKey: SessionKey.scheduledJob(id: jobId),
+        now: now
+      )
+      try db.execute(
+        sql: "UPDATE scheduled_jobs SET session_id = ? WHERE id = ?",
+        arguments: [sessionId, jobId]
+      )
+    }
+
+    // Step 4: the trigger message — the owner's own confirmed text, frozen at arm time, so
+    // trusted-tier deliberately (spec §5.2; anything the RUN ingests stays untrusted).
+    try db.execute(
+      sql: """
+        INSERT INTO messages(session_id, role, content, provenance, ts)
+        VALUES (?, 'user', ?, 'trusted', ?)
+        """,
+      arguments: [sessionId, prompt, now]
+    )
+    let triggerMessageId = db.lastInsertedRowID
+
+    // Step 5: the PENDING run TurnRunner will pick up, stamped with origin + job linkage.
+    try db.execute(
+      sql: """
+        INSERT INTO runs(session_id, state, created_ts, updated_ts, trigger_message_id,
+          origin, job_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+      arguments: [
+        sessionId,
+        RunState.pending.rawValue,
+        now,
+        now,
+        triggerMessageId,
+        RunOrigin.scheduled.rawValue,
+        jobId,
+      ]
+    )
+    let runId = db.lastInsertedRowID
+
+    // Step 6: the audit row rides the same transaction as its side effect (house rule).
+    try AuditLogGRDB.insertAudit(
+      db,
+      AuditEvent(
+        actor: .system,
+        action: .jobExecuted,
+        argsRedacted: "{\"job_id\":\(jobId)}",
+        runId: runId,
+        sessionId: sessionId,
+        ts: now
+      )
+    )
+
+    return ClaimedFire(
+      runId: runId,
+      sessionId: sessionId,
+      triggerMessageId: triggerMessageId,
+      ownerChatId: ownerChatId
+    )
+  }
+}
+
+// MARK: - Run-now (spec §5.4) and misfire skip (spec §5.3)
+
+extension ScheduledJobStoreGRDB {
+  public func fireNow(jobId: Int64, now: Date) throws -> ClaimedFire? {
+    try writer.writeMapping { db in
+      let rawStatus = try String.fetchOne(
+        db,
+        sql: "SELECT status FROM scheduled_jobs WHERE id = ?",
+        arguments: [jobId]
+      )
+      guard
+        let rawStatus,
+        let status = ScheduledJobStatus(rawValue: rawStatus),
+        status == .active || status == .paused
+      else {
+        return nil
+      }
+
+      // A real fire for the bookkeeping (last_fired_at), but NO schedule advance and NO status
+      // change — /runnow on a PAUSED job tests it without unmuting it (spec §5.4).
+      try db.execute(
+        sql: "UPDATE scheduled_jobs SET last_fired_at = ?, updated_ts = ? WHERE id = ?",
+        arguments: [Self.epoch(now), Self.epoch(now), jobId]
+      )
+      return try Self.insertFireRows(db, jobId: jobId, now: now)
+    }
+  }
+
+  public func skipMisfire(
+    jobId: Int64,
+    due: Date,
+    nextOccurrence: Date?,
+    skippedCount: Int,
+    now: Date
+  ) throws -> Bool {
+    try writer.writeMapping { db in
+      // The same CAS predicate as the claim — a concurrently-mutated job means no skip.
+      if let nextOccurrence {
+        try db.execute(
+          sql: """
+            UPDATE scheduled_jobs
+            SET next_occurrence = ?, updated_ts = ?
+            WHERE id = ? AND next_occurrence = ? AND status = ?
+            """,
+          arguments: [
+            Self.epoch(nextOccurrence),
+            Self.epoch(now),
+            jobId,
+            Self.epoch(due),
+            ScheduledJobStatus.active.rawValue,
+          ]
+        )
+      } else {
+        try db.execute(
+          sql: """
+            UPDATE scheduled_jobs
+            SET next_occurrence = NULL, status = ?, updated_ts = ?
+            WHERE id = ? AND next_occurrence = ? AND status = ?
+            """,
+          arguments: [
+            ScheduledJobStatus.completed.rawValue,
+            Self.epoch(now),
+            jobId,
+            Self.epoch(due),
+            ScheduledJobStatus.active.rawValue,
+          ]
+        )
+      }
+      guard db.changesCount > 0 else {
+        return false
+      }
+
+      try db.execute(
+        sql: """
+          INSERT INTO scheduler_state(id, last_misfire_at, last_misfire_skipped_count)
+          VALUES (1, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            last_misfire_at = excluded.last_misfire_at,
+            last_misfire_skipped_count = excluded.last_misfire_skipped_count
+          """,
+        arguments: [Self.epoch(now), skippedCount]
+      )
+      try AuditLogGRDB.insertAudit(
+        db,
+        AuditEvent(
+          actor: .system,
+          action: .jobMisfire,
+          argsRedacted: "{\"job_id\":\(jobId),\"skipped_count\":\(skippedCount)}",
+          ts: now
+        )
+      )
+      return true
+    }
+  }
+}
+
+// MARK: - Scheduler state (spec §4.3)
+
+extension ScheduledJobStoreGRDB {
+  public func schedulerState() throws -> SchedulerState {
+    try writer.readMapping { db in
+      guard
+        let row = try Row.fetchOne(db, sql: "SELECT * FROM scheduler_state WHERE id = 1")
+      else {
+        return SchedulerState(
+          lastTickAt: nil,
+          lastMisfireAt: nil,
+          lastMisfireSkippedCount: 0,
+          lastHeartbeatAt: nil,
+          heartbeatCountDay: nil,
+          heartbeatCount: 0
+        )
+      }
+      return SchedulerState(
+        lastTickAt: Self.date(fromEpoch: row["last_tick_at"]),
+        lastMisfireAt: Self.date(fromEpoch: row["last_misfire_at"]),
+        lastMisfireSkippedCount: row["last_misfire_skipped_count"],
+        lastHeartbeatAt: Self.date(fromEpoch: row["last_heartbeat_at"]),
+        heartbeatCountDay: row["heartbeat_count_day"],
+        heartbeatCount: row["heartbeat_count"]
+      )
+    }
+  }
+
+  public func recordTick(at tickTime: Date) throws {
+    try writer.writeMapping { db in
+      try db.execute(
+        sql: """
+          INSERT INTO scheduler_state(id, last_tick_at) VALUES (1, ?)
+          ON CONFLICT(id) DO UPDATE SET last_tick_at = excluded.last_tick_at
+          """,
+        arguments: [Self.epoch(tickTime)]
+      )
+    }
+  }
+}
+
+// MARK: - Owner verbs (spec §5.4; audits ride the status flip's transaction)
+
+extension ScheduledJobStoreGRDB {
+  public func pause(id: Int64, now: Date) throws -> ScheduledJob? {
+    try writer.writeMapping { db in
+      guard let current = try Self.fetchJob(db, id: id) else {
+        return nil
+      }
+      switch current.status {
+      case .paused:
+        return current  // idempotent re-pause: no write, no duplicate audit
+      case .completed, .cancelled:
+        return nil  // terminal — the FSM has no exit (spec §4.1)
+      case .active:
+        break
+      }
+
+      try db.execute(
+        sql: "UPDATE scheduled_jobs SET status = ?, updated_ts = ? WHERE id = ? AND status = ?",
+        arguments: [
+          ScheduledJobStatus.paused.rawValue,
+          Self.epoch(now),
+          id,
+          ScheduledJobStatus.active.rawValue,
+        ]
+      )
+      try Self.insertVerbAudit(
+        db,
+        action: .jobPaused,
+        jobId: id,
+        sessionId: current.sessionId,
+        now: now
+      )
+      return try Self.fetchJob(db, id: id)
+    }
+  }
+
+  public func resume(id: Int64, nextOccurrence: Date?, now: Date) throws -> ScheduledJob? {
+    try writer.writeMapping { db in
+      guard let current = try Self.fetchJob(db, id: id) else {
+        return nil
+      }
+      switch current.status {
+      case .active:
+        return current  // idempotent: an already-running schedule is never re-aimed
+      case .completed, .cancelled:
+        return nil
+      case .paused:
+        break
+      }
+
+      try db.execute(
+        sql: """
+          UPDATE scheduled_jobs SET status = ?, next_occurrence = ?, updated_ts = ?
+          WHERE id = ? AND status = ?
+          """,
+        arguments: [
+          ScheduledJobStatus.active.rawValue,
+          nextOccurrence.map(Self.epoch),
+          Self.epoch(now),
+          id,
+          ScheduledJobStatus.paused.rawValue,
+        ]
+      )
+      try Self.insertVerbAudit(
+        db,
+        action: .jobResumed,
+        jobId: id,
+        sessionId: current.sessionId,
+        now: now
+      )
+      return try Self.fetchJob(db, id: id)
+    }
+  }
+
+  public func cancel(id: Int64, now: Date) throws -> ScheduledJob? {
+    try writer.writeMapping { db in
+      guard let current = try Self.fetchJob(db, id: id) else {
+        return nil
+      }
+      guard current.status == .active || current.status == .paused else {
+        return nil
+      }
+
+      // Terminal, row retained for audit; NULL next keeps it out of the ticker index forever.
+      try db.execute(
+        sql: """
+          UPDATE scheduled_jobs SET status = ?, next_occurrence = NULL, updated_ts = ?
+          WHERE id = ? AND status IN (?, ?)
+          """,
+        arguments: [
+          ScheduledJobStatus.cancelled.rawValue,
+          Self.epoch(now),
+          id,
+          ScheduledJobStatus.active.rawValue,
+          ScheduledJobStatus.paused.rawValue,
+        ]
+      )
+      try Self.insertVerbAudit(
+        db,
+        action: .jobCancelled,
+        jobId: id,
+        sessionId: current.sessionId,
+        now: now
+      )
+      return try Self.fetchJob(db, id: id)
+    }
+  }
+
+  private static func insertVerbAudit(
+    _ db: Database,
+    action: AuditAction,
+    jobId: Int64,
+    sessionId: Int64?,
+    now: Date
+  ) throws {
+    try AuditLogGRDB.insertAudit(
+      db,
+      AuditEvent(
+        actor: .owner,
+        action: action,
+        argsRedacted: "{\"job_id\":\(jobId)}",
+        sessionId: sessionId,
+        ts: now
+      )
+    )
+  }
+}
+
+// MARK: - Heartbeat fire (spec §12; the gating lives in SchedulerService, Phase 4)
+
+extension ScheduledJobStoreGRDB {
+  public func fireHeartbeat(
+    prompt: String,
+    ownerChatId: Int64,
+    now: Date,
+    day: String
+  ) throws -> ClaimedFire {
+    try writer.writeMapping { db in
+      let sessionId = try SessionMessageStoreGRDB.upsertSession(
+        db,
+        sessionKey: SessionKey.heartbeat,
+        now: now
+      )
+
+      // The gateway-authored template WRAPS HEARTBEAT.md content, so the combined trigger text
+      // carries the untrusted tier — workspace-file data must never enter context as trusted
+      // (spec §12; contrast the scheduled-job trigger, which is pure owner-confirmed text).
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, role, content, provenance, ts)
+          VALUES (?, 'user', ?, 'untrusted', ?)
+          """,
+        arguments: [sessionId, prompt, now]
+      )
+      let triggerMessageId = db.lastInsertedRowID
+
+      try db.execute(
+        sql: """
+          INSERT INTO runs(session_id, state, created_ts, updated_ts, trigger_message_id, origin)
+          VALUES (?, ?, ?, ?, ?, ?)
+          """,
+        arguments: [
+          sessionId,
+          RunState.pending.rawValue,
+          now,
+          now,
+          triggerMessageId,
+          RunOrigin.heartbeat.rawValue,
+        ]
+      )
+      let runId = db.lastInsertedRowID
+
+      // Day-counter roll: same `day` increments; a new `day` resets to 1. `day` is computed by
+      // the caller in CLAW_TIMEZONE so the cap boundary aligns with quiet hours, not UTC.
+      let previous = try Row.fetchOne(
+        db,
+        sql: "SELECT heartbeat_count_day, heartbeat_count FROM scheduler_state WHERE id = 1"
+      )
+      let previousDay = previous?["heartbeat_count_day"] as String?
+      let previousCount = previous?["heartbeat_count"] as Int? ?? 0
+      let newCount = previousDay == day ? previousCount + 1 : 1
+      try db.execute(
+        sql: """
+          INSERT INTO scheduler_state(id, last_heartbeat_at, heartbeat_count_day, heartbeat_count)
+          VALUES (1, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            last_heartbeat_at = excluded.last_heartbeat_at,
+            heartbeat_count_day = excluded.heartbeat_count_day,
+            heartbeat_count = excluded.heartbeat_count
+          """,
+        arguments: [Self.epoch(now), day, newCount]
+      )
+
+      return ClaimedFire(
+        runId: runId,
+        sessionId: sessionId,
+        triggerMessageId: triggerMessageId,
+        ownerChatId: ownerChatId
+      )
+    }
+  }
+}
+
+// MARK: - Epoch-second column codec
+
+extension ScheduledJobStoreGRDB {
+  static func epoch(_ instant: Date) -> Int64 {
+    Int64(instant.timeIntervalSince1970.rounded())
+  }
+
+  static func date(fromEpoch value: Int64?) -> Date? {
+    value.map { seconds in Date(timeIntervalSince1970: TimeInterval(seconds)) }
+  }
+}
+
+extension ScheduledJobStoreGRDB: ScheduledJobStore {}

--- a/Sources/clawd/Subcommands/DoctorCommand.swift
+++ b/Sources/clawd/Subcommands/DoctorCommand.swift
@@ -38,6 +38,22 @@ struct DoctorCommand: AsyncParsableCommand {
     report.add(key: "config.max_tokens", value: "\(config.llm.maxOutputTokens)")
     if checkConfig {
       report.add(key: "llm.streaming", value: config.llm.streamingEnabled ? "on" : "off")
+      report.add(key: "sched.timezone", value: config.timezone.identifier)
+      report.add(key: "sched.catchup_max_age_min", value: "\(config.schedCatchUpMaxAgeMinutes)")
+      report.add(key: "sched.min_interval_min", value: "\(config.schedMinIntervalMinutes)")
+      // Warn-not-fail (spec §13): a proactive cap at/above the global cap is legal but inert —
+      // the household kill-switch dominates.
+      let proactiveNote =
+        config.proactivePerDayUSD >= config.budget.perDayUSD
+        ? " (>= CLAW_PER_DAY_USD; the global cap dominates)" : ""
+      report.add(
+        key: "spend.proactive_per_day_usd",
+        value: String(format: "%.2f", config.proactivePerDayUSD) + proactiveNote
+      )
+      report.add(key: "heartbeat.enabled", value: config.heartbeatEnabled ? "on" : "off")
+      report.add(key: "heartbeat.interval_min", value: "\(config.heartbeatIntervalMinutes)")
+      report.add(key: "heartbeat.quiet_hours", value: config.heartbeatQuietHours.rendered)
+      report.add(key: "heartbeat.max_per_day", value: "\(config.heartbeatMaxPerDay)")
     }
 
     let secretsRow = SecretStoreResolver.doctorRow(

--- a/Tests/ClawCoreTests/Config/AppConfigTests.swift
+++ b/Tests/ClawCoreTests/Config/AppConfigTests.swift
@@ -224,4 +224,99 @@ import Testing
       try AppConfig.load(environment: env)
     }
   }
+
+  @Test func schedulerAndHeartbeatDefaultsArePinned() throws {
+    // given — none of the eight Inc 4 keys set
+    let env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+
+    // when
+    let config = try AppConfig.load(environment: env)
+
+    // then — spec §13 defaults
+    #expect(config.timezone == TimeZone.current)
+    #expect(config.schedCatchUpMaxAgeMinutes == 30)
+    #expect(config.schedMinIntervalMinutes == 5)
+    #expect(config.proactivePerDayUSD == 2.00)
+    #expect(config.heartbeatEnabled == false)
+    #expect(config.heartbeatIntervalMinutes == 60)
+    #expect(config.heartbeatQuietHours == QuietHours.parse("22:00-09:00"))
+    #expect(config.heartbeatMaxPerDay == 8)
+  }
+
+  @Test func schedulerOverridesParse() throws {
+    // given
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[EnvKey.timezone] = "Europe/Berlin"
+    env[EnvKey.schedCatchUpMaxAgeMinutes] = "45"
+    env[EnvKey.schedMinIntervalMinutes] = "10"
+    env[EnvKey.proactivePerDayUSD] = "1.50"
+    env[EnvKey.heartbeatEnabled] = "true"
+    env[EnvKey.heartbeatIntervalMinutes] = "30"
+    env[EnvKey.heartbeatQuietHours] = "23:30-06:15"
+    env[EnvKey.heartbeatMaxPerDay] = "4"
+
+    // when
+    let config = try AppConfig.load(environment: env)
+
+    // then
+    #expect(config.timezone.identifier == "Europe/Berlin")
+    #expect(config.schedCatchUpMaxAgeMinutes == 45)
+    #expect(config.schedMinIntervalMinutes == 10)
+    #expect(config.proactivePerDayUSD == 1.50)
+    #expect(config.heartbeatEnabled)
+    #expect(config.heartbeatIntervalMinutes == 30)
+    #expect(config.heartbeatQuietHours.rendered == "23:30-06:15")
+    #expect(config.heartbeatMaxPerDay == 4)
+  }
+
+  @Test func invalidTimezoneFailsClosed() {
+    // given
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[EnvKey.timezone] = "Mars/Olympus_Mons"
+
+    // when / then
+    #expect(throws: ConfigError.invalidTimezone("Mars/Olympus_Mons")) {
+      try AppConfig.load(environment: env)
+    }
+  }
+
+  @Test func zeroWidthQuietHoursFailClosed() {
+    // given — the OpenClaw always-skipped footgun is a config ERROR here (spec §12)
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[EnvKey.heartbeatQuietHours] = "22:00-22:00"
+
+    // when / then
+    #expect(throws: ConfigError.invalidQuietHours("22:00-22:00")) {
+      try AppConfig.load(environment: env)
+    }
+  }
+
+  @Test(arguments: [
+    (key: AppConfig.EnvKey.schedCatchUpMaxAgeMinutes, value: "0"),
+    (key: AppConfig.EnvKey.schedMinIntervalMinutes, value: "0"),
+    (key: AppConfig.EnvKey.heartbeatIntervalMinutes, value: "14"),  // floor is 15 (spec §13)
+    (key: AppConfig.EnvKey.heartbeatMaxPerDay, value: "0"),
+    (key: AppConfig.EnvKey.schedCatchUpMaxAgeMinutes, value: "soon"),
+  ])
+  func outOfRangeSchedulingValuesFailClosed(_ fixture: (key: String, value: String)) {
+    // given
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[fixture.key] = fixture.value
+
+    // when / then
+    #expect(throws: ConfigError.invalidScheduling(key: fixture.key, value: fixture.value)) {
+      try AppConfig.load(environment: env)
+    }
+  }
+
+  @Test func nonPositiveProactiveBudgetFailsClosed() {
+    // given
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[EnvKey.proactivePerDayUSD] = "0"
+
+    // when / then — reuses the budget-value vocabulary (it IS a budget knob)
+    #expect(throws: ConfigError.invalidBudget("0")) {
+      try AppConfig.load(environment: env)
+    }
+  }
 }

--- a/Tests/ClawCoreTests/Config/QuietHoursTests.swift
+++ b/Tests/ClawCoreTests/Config/QuietHoursTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+
+@testable import ClawCore
+
+@Suite struct QuietHoursTests {
+  private let berlin = TimeZone(identifier: "Europe/Berlin") ?? .gmt
+
+  /// A fixed instant at the given Berlin wall-clock time on 2026-07-06 (no DST edge — QuietHours
+  /// is a pure minute-of-day window; DST behavior belongs to OccurrenceCalculator).
+  private func berlinInstant(hour: Int, minute: Int) -> Date {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = berlin
+    let components = DateComponents(year: 2026, month: 7, day: 6, hour: hour, minute: minute)
+    guard let date = calendar.date(from: components) else {
+      Issue.record("bad fixture: \(components)")
+      return Date(timeIntervalSince1970: 0)
+    }
+    return date
+  }
+
+  @Test func parsesTheDefaultWindow() throws {
+    // given / when
+    let window = try #require(QuietHours.parse("22:00-09:00"))
+
+    // then
+    #expect(window.startMinuteOfDay == 22 * 60)
+    #expect(window.endMinuteOfDay == 9 * 60)
+    #expect(window.rendered == "22:00-09:00")
+  }
+
+  @Test(arguments: [
+    "22:00",  // no end
+    "2200-0900",  // no colons
+    "24:00-09:00",  // hour out of range
+    "22:60-09:00",  // minute out of range
+    "22:00-09:00-10:00",  // extra segment
+    "aa:bb-cc:dd",  // garbage
+    "",  // empty
+    "22:00-22:00",  // zero-width window — a config ERROR, never always-skip (spec §12)
+    "9:00-17:00",  // one-digit hour — HH:MM means exactly two digits (fail-closed, spec §13)
+    "09:0-17:00",  // one-digit minute
+    "+09:00-17:00",  // sign prefix — Int(_:) alone would accept it
+  ])
+  func rejectsMalformedAndZeroWidthWindows(_ raw: String) {
+    // given / when / then
+    #expect(QuietHours.parse(raw) == nil)
+  }
+
+  @Test func midnightCrossingWindowContainsNightAndExcludesDay() throws {
+    // given — the default 22:00-09:00 window crosses midnight
+    let window = try #require(QuietHours.parse("22:00-09:00"))
+
+    // when / then — [start, end): 22:00 is quiet, 09:00 is not
+    #expect(window.contains(berlinInstant(hour: 23, minute: 30), timezone: berlin))
+    #expect(window.contains(berlinInstant(hour: 3, minute: 0), timezone: berlin))
+    #expect(window.contains(berlinInstant(hour: 22, minute: 0), timezone: berlin))
+    #expect(window.contains(berlinInstant(hour: 8, minute: 59), timezone: berlin))
+    #expect(window.contains(berlinInstant(hour: 9, minute: 0), timezone: berlin) == false)
+    #expect(window.contains(berlinInstant(hour: 12, minute: 0), timezone: berlin) == false)
+    #expect(window.contains(berlinInstant(hour: 21, minute: 59), timezone: berlin) == false)
+  }
+
+  @Test func sameDayWindowIsAPlainInterval() throws {
+    // given
+    let window = try #require(QuietHours.parse("09:00-17:00"))
+
+    // when / then
+    #expect(window.contains(berlinInstant(hour: 12, minute: 0), timezone: berlin))
+    #expect(window.contains(berlinInstant(hour: 9, minute: 0), timezone: berlin))
+    #expect(window.contains(berlinInstant(hour: 17, minute: 0), timezone: berlin) == false)
+    #expect(window.contains(berlinInstant(hour: 8, minute: 59), timezone: berlin) == false)
+    #expect(window.contains(berlinInstant(hour: 23, minute: 0), timezone: berlin) == false)
+  }
+
+  @Test func containsEvaluatesInTheGivenTimezone() throws {
+    // given — 23:00 Berlin is 21:00 UTC; the same instant must classify differently per zone
+    let window = try #require(QuietHours.parse("22:00-09:00"))
+    let instant = berlinInstant(hour: 23, minute: 0)
+
+    // when / then
+    #expect(window.contains(instant, timezone: berlin))
+    #expect(window.contains(instant, timezone: TimeZone(identifier: "UTC") ?? .gmt) == false)
+  }
+}

--- a/Tests/ClawCoreTests/Domain/Scheduling/OccurrenceCalculatorTests.swift
+++ b/Tests/ClawCoreTests/Domain/Scheduling/OccurrenceCalculatorTests.swift
@@ -1,0 +1,310 @@
+import Foundation
+import Testing
+
+@testable import ClawCore
+
+@Suite struct OccurrenceCalculatorTests {
+  private let calculator = OccurrenceCalculator()
+  private let berlin = TimeZone(identifier: "Europe/Berlin") ?? .gmt
+  private let utcZone = TimeZone.gmt
+
+  private func utcDate(
+    _ year: Int,
+    _ month: Int,
+    _ day: Int,
+    _ hour: Int,
+    _ minute: Int
+  ) -> Date {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = utcZone
+    let components = DateComponents(
+      year: year,
+      month: month,
+      day: day,
+      hour: hour,
+      minute: minute
+    )
+    guard let date = calendar.date(from: components) else {
+      Issue.record("bad fixture: \(components)")
+      return Date(timeIntervalSince1970: 0)
+    }
+    return date
+  }
+
+  /// Rules are deliberately built on a UTC calendar: the calculator must install the job's
+  /// zone itself (the IANA zone is a separate column rebuilt on load — spec D2).
+  private func utcCalendar() -> Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = utcZone
+    return calendar
+  }
+
+  private func weekdaySevenRule() -> Calendar.RecurrenceRule {
+    Calendar.RecurrenceRule(
+      calendar: utcCalendar(),
+      frequency: .weekly,
+      weekdays: [
+        .every(.monday), .every(.tuesday), .every(.wednesday), .every(.thursday), .every(.friday),
+      ],
+      hours: [7],
+      minutes: [0]
+    )
+  }
+
+  private func dailyTwoThirtyRule() -> Calendar.RecurrenceRule {
+    Calendar.RecurrenceRule(
+      calendar: utcCalendar(),
+      frequency: .daily,
+      hours: [2],
+      minutes: [30]
+    )
+  }
+
+  private func everyThirtyMinutesRule() -> Calendar.RecurrenceRule {
+    Calendar.RecurrenceRule(calendar: utcCalendar(), frequency: .minutely, interval: 30)
+  }
+
+  private func berlinHourMinute(of date: Date) -> DateComponents {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = berlin
+    return calendar.dateComponents([.hour, .minute], from: date)
+  }
+
+  @Test func weekdaySevenStaysAtLocalSevenAcrossSpringForward() {
+    // given — anchored Thu 2026-03-26 12:00Z; Europe/Berlin springs forward Sun 2026-03-29
+    let anchor = utcDate(2026, 3, 26, 12, 0)
+
+    // when
+    let occurrences = calculator.occurrences(
+      rule: weekdaySevenRule(),
+      timezone: berlin,
+      anchor: anchor,
+      after: anchor,
+      limit: 3
+    )
+
+    // then — the UTC instant shifts 06:00Z → 05:00Z; the Berlin wall clock does not move (SC7)
+    #expect(
+      occurrences == [
+        utcDate(2026, 3, 27, 6, 0),
+        utcDate(2026, 3, 30, 5, 0),
+        utcDate(2026, 3, 31, 5, 0),
+      ]
+    )
+    for occurrence in occurrences {
+      let local = berlinHourMinute(of: occurrence)
+      #expect(local.hour == 7)
+      #expect(local.minute == 0)
+    }
+  }
+
+  @Test func weekdaySevenStaysAtLocalSevenAcrossFallBack() {
+    // given — anchored Thu 2026-10-22 12:00Z; Europe/Berlin falls back Sun 2026-10-25
+    let anchor = utcDate(2026, 10, 22, 12, 0)
+
+    // when
+    let occurrences = calculator.occurrences(
+      rule: weekdaySevenRule(),
+      timezone: berlin,
+      anchor: anchor,
+      after: anchor,
+      limit: 3
+    )
+
+    // then — the UTC instant shifts 05:00Z → 06:00Z; local 07:00 on both sides
+    #expect(
+      occurrences == [
+        utcDate(2026, 10, 23, 5, 0),
+        utcDate(2026, 10, 26, 6, 0),
+        utcDate(2026, 10, 27, 6, 0),
+      ]
+    )
+    for occurrence in occurrences {
+      let local = berlinHourMinute(of: occurrence)
+      #expect(local.hour == 7)
+      #expect(local.minute == 0)
+    }
+  }
+
+  @Test func nonexistentLocalTimeResolvesForwardAndRecoversNextDay() {
+    // given — 02:30 does not exist on 2026-03-29 in Berlin (02:00 jumps to 03:00)
+    let anchor = utcDate(2026, 3, 27, 12, 0)
+
+    // when
+    let occurrences = calculator.occurrences(
+      rule: dailyTwoThirtyRule(),
+      timezone: berlin,
+      anchor: anchor,
+      after: utcDate(2026, 3, 28, 12, 0),
+      limit: 2
+    )
+
+    // then — resolved to the platform's next valid instant (03:30 local), never dropped
+    // (spec §6); the following day is back at the nominal local 02:30
+    #expect(occurrences == [utcDate(2026, 3, 29, 1, 30), utcDate(2026, 3, 30, 0, 30)])
+    let transitionDayLocal = berlinHourMinute(of: occurrences[0])
+    #expect(transitionDayLocal.hour == 3)
+    #expect(transitionDayLocal.minute == 30)
+    let nextDayLocal = berlinHourMinute(of: occurrences[1])
+    #expect(nextDayLocal.hour == 2)
+    #expect(nextDayLocal.minute == 30)
+  }
+
+  @Test func ambiguousLocalTimeYieldsExactlyOneInstant() {
+    // given — 02:30 occurs twice on 2026-10-25 in Berlin (03:00 CEST falls back to 02:00 CET)
+    let anchor = utcDate(2026, 10, 23, 12, 0)
+
+    // when
+    let occurrences = calculator.occurrences(
+      rule: dailyTwoThirtyRule(),
+      timezone: berlin,
+      anchor: anchor,
+      after: utcDate(2026, 10, 24, 12, 0),
+      limit: 2
+    )
+
+    // then — one resolved UTC instant per local day; the claim keys on it, so one fire (§6)
+    #expect(occurrences == [utcDate(2026, 10, 25, 0, 30), utcDate(2026, 10, 26, 1, 30)])
+    let berlinDayStart = utcDate(2026, 10, 24, 22, 0)  // local 2026-10-25 00:00 (CEST)
+    let berlinDayEnd = utcDate(2026, 10, 25, 23, 0)  // local 2026-10-26 00:00 (CET)
+    let onTransitionDay = occurrences.filter { instant in
+      instant >= berlinDayStart && instant < berlinDayEnd
+    }
+    #expect(onTransitionDay.count == 1)
+  }
+
+  @Test func everyThirtyMinutesKeepsTheAnchorPhase() {
+    // given — anchored at 10:07Z: the phase is :07/:37 forever, whatever the query time
+    let anchor = utcDate(2026, 7, 6, 10, 7)
+
+    // when
+    let nearQuery = calculator.occurrences(
+      rule: everyThirtyMinutesRule(),
+      timezone: berlin,
+      anchor: anchor,
+      after: utcDate(2026, 7, 6, 11, 0),
+      limit: 2
+    )
+    let laterQuery = calculator.occurrences(
+      rule: everyThirtyMinutesRule(),
+      timezone: berlin,
+      anchor: anchor,
+      after: utcDate(2026, 7, 6, 12, 0),
+      limit: 2
+    )
+
+    // then — a stable anchor means the phase can never drift with the query date
+    #expect(nearQuery == [utcDate(2026, 7, 6, 11, 7), utcDate(2026, 7, 6, 11, 37)])
+    #expect(laterQuery == [utcDate(2026, 7, 6, 12, 7), utcDate(2026, 7, 6, 12, 37)])
+  }
+
+  @Test func fractionalSecondAnchorsAreFlooredToWholeSeconds() {
+    // given — a parse/arm-time anchor seeded from Date() carries fractional seconds;
+    // RecurrenceRule would propagate them into every occurrence, breaking the store's
+    // exact integer-epoch CAS (§5.2). The calculator floors the seed.
+    let fractional = Date(
+      timeIntervalSince1970: utcDate(2026, 7, 6, 10, 7).timeIntervalSince1970 + 0.75
+    )
+
+    // when
+    let occurrences = calculator.occurrences(
+      rule: everyThirtyMinutesRule(),
+      timezone: berlin,
+      anchor: fractional,
+      after: fractional,
+      limit: 2
+    )
+
+    // then — whole seconds, identical to the whole-second anchor's chain
+    #expect(occurrences == [utcDate(2026, 7, 6, 10, 37), utcDate(2026, 7, 6, 11, 7)])
+    for occurrence in occurrences {
+      #expect(
+        occurrence.timeIntervalSince1970 == occurrence.timeIntervalSince1970.rounded(.down)
+      )
+    }
+  }
+
+  @Test func occurrencesAreStrictlyAfterTheQueryInstant() {
+    // given — recurrences(of:) includes the anchor itself; `after` must exclude it
+    let anchor = utcDate(2026, 7, 6, 10, 7)
+
+    // when
+    let occurrences = calculator.occurrences(
+      rule: everyThirtyMinutesRule(),
+      timezone: berlin,
+      anchor: anchor,
+      after: anchor,
+      limit: 1
+    )
+
+    // then
+    #expect(occurrences == [utcDate(2026, 7, 6, 10, 37)])
+  }
+
+  @Test func latestOccurrenceCoalescesToTheNewestMissedInstant() {
+    // given — five missed 30-minute occurrences: the §5.3 coalesce target is the LATEST one
+    let anchor = utcDate(2026, 7, 6, 10, 7)
+
+    // when
+    let latest = calculator.latestOccurrence(
+      rule: everyThirtyMinutesRule(),
+      timezone: berlin,
+      anchor: anchor,
+      after: utcDate(2026, 7, 6, 10, 10),
+      atOrBefore: utcDate(2026, 7, 6, 12, 40)
+    )
+
+    // then
+    #expect(latest == utcDate(2026, 7, 6, 12, 37))
+  }
+
+  @Test func latestOccurrenceIncludesTheBoundaryAndCanBeNil() {
+    // given
+    let anchor = utcDate(2026, 7, 6, 10, 7)
+
+    // when — the window is (after, atOrBefore]
+    let boundary = calculator.latestOccurrence(
+      rule: everyThirtyMinutesRule(),
+      timezone: berlin,
+      anchor: anchor,
+      after: utcDate(2026, 7, 6, 10, 10),
+      atOrBefore: utcDate(2026, 7, 6, 10, 37)
+    )
+    let none = calculator.latestOccurrence(
+      rule: everyThirtyMinutesRule(),
+      timezone: berlin,
+      anchor: anchor,
+      after: utcDate(2026, 7, 6, 10, 10),
+      atOrBefore: utcDate(2026, 7, 6, 10, 30)
+    )
+
+    // then
+    #expect(boundary == utcDate(2026, 7, 6, 10, 37))
+    #expect(none == nil)
+  }
+
+  @Test func degenerateInputsAreEmpty() {
+    // given
+    let anchor = utcDate(2026, 7, 6, 10, 7)
+
+    // when / then — zero limit and an inverted/empty window produce nothing, never hang
+    #expect(
+      calculator.occurrences(
+        rule: everyThirtyMinutesRule(),
+        timezone: berlin,
+        anchor: anchor,
+        after: anchor,
+        limit: 0
+      ).isEmpty
+    )
+    #expect(
+      calculator.latestOccurrence(
+        rule: everyThirtyMinutesRule(),
+        timezone: berlin,
+        anchor: anchor,
+        after: anchor,
+        atOrBefore: anchor
+      ) == nil
+    )
+  }
+}

--- a/Tests/ClawCoreTests/Domain/Scheduling/ScheduledJobTests.swift
+++ b/Tests/ClawCoreTests/Domain/Scheduling/ScheduledJobTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@testable import ClawCore
+
+@Suite struct RecurrenceEnvelopeTests {
+  private func weekdaySevenBerlinRule() throws -> Calendar.RecurrenceRule {
+    var calendar = Calendar(identifier: .gregorian)
+    // force_unwrapping is `error` project-wide with no Tests exclusion (.swiftlint.yml); #require
+    // is the house pattern for a lookup that is statically known to succeed.
+    calendar.timeZone = try #require(TimeZone(identifier: "Europe/Berlin"))
+    return Calendar.RecurrenceRule(
+      calendar: calendar,
+      frequency: .weekly,
+      weekdays: [
+        .every(.monday), .every(.tuesday), .every(.wednesday), .every(.thursday), .every(.friday),
+      ],
+      hours: [7],
+      minutes: [0]
+    )
+  }
+
+  @Test func roundTripIsByteForByteStable() throws {
+    // given — the toolchain-drift tripwire (spec §17, preamble Verification Notes): if a future
+    // Foundation changes the rule's encoding, this breaks BEFORE any stored row does.
+    let envelope = RecurrenceEnvelope(
+      schemaVersion: RecurrenceEnvelope.currentSchemaVersion,
+      rule: try weekdaySevenBerlinRule()
+    )
+
+    // when
+    let firstJSON = try envelope.encodedJSON()
+    let decoded = try RecurrenceEnvelope.decode(fromJSON: firstJSON)
+    let secondJSON = try decoded.encodedJSON()
+
+    // then — byte-for-byte re-decodability, not merely value equality
+    #expect(secondJSON == firstJSON)
+    #expect(decoded == envelope)
+    #expect(decoded.rule == envelope.rule)
+  }
+
+  @Test func envelopeUsesThePinnedStorageKeys() throws {
+    // given
+    let envelope = RecurrenceEnvelope(schemaVersion: 1, rule: try weekdaySevenBerlinRule())
+
+    // when
+    let json = try envelope.encodedJSON()
+    let object = try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+
+    // then — the stored wrapper is exactly {"schema_version":1,"rule":{…}} (spec D2)
+    #expect(object?.keys.sorted() == ["rule", "schema_version"])
+    #expect(object?["schema_version"] as? Int == 1)
+  }
+}
+
+@Suite struct SchedulingDomainTests {
+  @Test func statusRawValuesMatchTheDBVocabulary() {
+    // given / when / then — the closed FSM vocabulary of spec §4.1
+    #expect(ScheduledJobStatus.active.rawValue == "ACTIVE")
+    #expect(ScheduledJobStatus.paused.rawValue == "PAUSED")
+    #expect(ScheduledJobStatus.completed.rawValue == "COMPLETED")
+    #expect(ScheduledJobStatus.cancelled.rawValue == "CANCELLED")
+  }
+
+  @Test func originRawValuesMatchTheRunsColumnVocabulary() {
+    // given / when / then — the runs.origin discriminator of spec §4.2
+    #expect(RunOrigin.interactive.rawValue == "interactive")
+    #expect(RunOrigin.scheduled.rawValue == "scheduled")
+    #expect(RunOrigin.heartbeat.rawValue == "heartbeat")
+  }
+}

--- a/Tests/ClawCoreTests/Persistence/AuditActionTests.swift
+++ b/Tests/ClawCoreTests/Persistence/AuditActionTests.swift
@@ -25,4 +25,23 @@ import Testing
     #expect(event.action.rawValue == "memory_write")
     #expect(event.sessionId == 42)
   }
+
+  private static let schedulerActions: [(action: AuditAction, rawValue: String)] = [
+    (.jobCreated, "job_created"),
+    (.jobExecuted, "job_executed"),
+    (.jobPaused, "job_paused"),
+    (.jobResumed, "job_resumed"),
+    (.jobCancelled, "job_cancelled"),
+    (.jobFailed, "job_failed"),
+    (.jobMisfire, "job_misfire"),
+    (.heartbeatFired, "heartbeat_fired"),
+    (.heartbeatSuppressed, "heartbeat_suppressed"),
+    (.heartbeatSkipped, "heartbeat_skipped"),
+  ]
+
+  @Test(arguments: schedulerActions)
+  func schedulerActionsHaveStableRawValues(_ fixture: (action: AuditAction, rawValue: String)) {
+    // given / when / then — rawValues are the durable audit vocabulary (preamble)
+    #expect(fixture.action.rawValue == fixture.rawValue)
+  }
 }

--- a/Tests/ClawCoreTests/Persistence/SessionKeyTests.swift
+++ b/Tests/ClawCoreTests/Persistence/SessionKeyTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Testing
+
+@testable import ClawCore
+
+@Suite struct SessionKeyTests {
+  @Test func syntheticFormsRenderAndNeverResolveAChatId() {
+    // given / when / then — delivery targets live on the job row / in config, never in the key
+    // (preamble Global Constraints); chatId(from:) must stay nil for both synthetic forms.
+    #expect(SessionKey.scheduledJob(id: 7) == "sched:job:7")
+    #expect(SessionKey.heartbeat == "sched:heartbeat")
+    #expect(SessionKey.chatId(from: SessionKey.scheduledJob(id: 7)) == nil)
+    #expect(SessionKey.chatId(from: SessionKey.heartbeat) == nil)
+  }
+
+  @Test func telegramDMKeysStillRoundTrip() {
+    // given / when / then — the existing form is untouched
+    #expect(SessionKey.telegramDM(chatId: 42) == "tg:dm:42")
+    #expect(SessionKey.chatId(from: SessionKey.telegramDM(chatId: 42)) == 42)
+  }
+}

--- a/Tests/ClawDataTests/Database/V6MigrationTests.swift
+++ b/Tests/ClawDataTests/Database/V6MigrationTests.swift
@@ -1,0 +1,141 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct V6MigrationTests {
+  private func columnNames(_ queue: DatabaseQueue, table: String) throws -> [String] {
+    try queue.read { db in
+      try Row.fetchAll(db, sql: "PRAGMA table_info(\(table))").map { row in
+        row["name"] as String
+      }
+    }
+  }
+
+  @Test func vSixCreatesTheSchedulingTablesAndRunColumns() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+
+    // when
+    try ClawDatabase.migrate(queue)
+
+    // then — the exact §4.1 column set, in declaration order
+    #expect(
+      try columnNames(queue, table: "scheduled_jobs") == [
+        "id", "owner_chat_id", "label", "prompt", "recurrence", "timezone",
+        "next_occurrence", "last_fired_at", "status", "session_id", "created_ts", "updated_ts",
+      ]
+    )
+
+    let runColumns = try columnNames(queue, table: "runs")
+    #expect(runColumns.contains("origin"))
+    #expect(runColumns.contains("job_id"))
+
+    #expect(
+      try columnNames(queue, table: "scheduler_state") == [
+        "id", "last_tick_at", "last_misfire_at", "last_misfire_skipped_count",
+        "last_heartbeat_at", "heartbeat_count_day", "heartbeat_count",
+      ]
+    )
+  }
+
+  @Test func tickerIndexIsPartialOnStatusAndNextOccurrence() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+
+    // when
+    try ClawDatabase.migrate(queue)
+
+    // then — a PARTIAL index (WHERE clause) so terminal NULL-next rows never bloat the scan
+    let indexSQL = try queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: """
+          SELECT sql FROM sqlite_master
+          WHERE type = 'index' AND name = 'index_scheduled_jobs_status_next_occurrence'
+          """
+      )
+    }
+    #expect(indexSQL?.contains("status") == true)
+    #expect(indexSQL?.contains("next_occurrence") == true)
+    #expect(indexSQL?.localizedCaseInsensitiveContains("where") == true)
+  }
+
+  @Test func schedulerStateAcceptsOnlyTheSingletonRow() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+
+    // when — the singleton row inserts; any other id violates the CHECK
+    try queue.write { db in
+      try db.execute(sql: "INSERT INTO scheduler_state(id) VALUES (1)")
+    }
+
+    // then
+    #expect(throws: (any Error).self) {
+      try queue.write { db in
+        try db.execute(sql: "INSERT INTO scheduler_state(id) VALUES (2)")
+      }
+    }
+    let skipped = try queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT last_misfire_skipped_count FROM scheduler_state WHERE id = 1"
+      )
+    }
+    #expect(skipped == 0)  // NOT NULL defaults let partial upserts work
+  }
+
+  @Test func vSixUpgradesAPopulatedVFiveDatabase() throws {
+    // given — a v5 database that already holds a session, a message, and a run
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrator.migrate(queue, upTo: "v5")
+    try queue.write { db in
+      try db.execute(
+        sql:
+          "INSERT INTO sessions(session_key, created_ts, updated_ts, tainted) VALUES ('tg:dm:1', ?, ?, 0)",
+        arguments: [Date(), Date()]
+      )
+      try db.execute(
+        sql:
+          "INSERT INTO messages(session_id, role, content, provenance, ts) VALUES (1, 'user', 'old row', 'trusted', ?)",
+        arguments: [Date()]
+      )
+      try db.execute(
+        sql: """
+          INSERT INTO runs(session_id, state, created_ts, updated_ts, trigger_message_id)
+          VALUES (1, 'DONE', ?, ?, 1)
+          """,
+        arguments: [Date(), Date()]
+      )
+    }
+
+    // when
+    try ClawDatabase.migrate(queue)
+
+    // then — the old run is backfilled by the column default, with no job linkage
+    let runRow = try queue.read { db in
+      try Row.fetchOne(db, sql: "SELECT origin, job_id FROM runs WHERE id = 1")
+    }
+    #expect(runRow?["origin"] == "interactive")
+    #expect((runRow?["job_id"] as Int64?) == nil)
+
+    // and a scheduled_jobs insert works against the upgraded schema
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO scheduled_jobs(owner_chat_id, label, prompt, recurrence, timezone,
+            next_occurrence, status, created_ts, updated_ts)
+          VALUES (7, 'digest', 'Summarize my unread items', NULL, 'Europe/Berlin',
+            1782000000, 'ACTIVE', 1781990000, 1781990000)
+          """
+      )
+    }
+    let status = try queue.read { db in
+      try String.fetchOne(db, sql: "SELECT status FROM scheduled_jobs WHERE id = 1")
+    }
+    #expect(status == "ACTIVE")
+  }
+}

--- a/Tests/ClawDataTests/Stores/Scheduling/ScheduledJobStoreGRDBTests.swift
+++ b/Tests/ClawDataTests/Stores/Scheduling/ScheduledJobStoreGRDBTests.swift
@@ -1,0 +1,652 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+// Cycle A-E `@Test` methods live in same-type extensions below purely to keep each extension's
+// body under the project's `type_body_length` gate; this is still one `@Suite` with one set of
+// shared fixtures/helpers declared here.
+@Suite struct ScheduledJobStoreGRDBTests {
+  // Whole-second fixtures: the store persists occurrence instants as epoch-second INTEGERs.
+  private let baseNow = Date(timeIntervalSince1970: 1_782_000_000)
+  private let dueFirst = Date(timeIntervalSince1970: 1_782_000_600)
+  private let dueNext = Date(timeIntervalSince1970: 1_782_087_000)
+  private let dueThird = Date(timeIntervalSince1970: 1_782_173_400)
+
+  private func makeStore() throws -> (store: ScheduledJobStoreGRDB, queue: DatabaseQueue) {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    return (ScheduledJobStoreGRDB(writer: queue), queue)
+  }
+
+  private func weekdayEnvelope() -> RecurrenceEnvelope {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(identifier: "Europe/Berlin") ?? .gmt
+    let rule = Calendar.RecurrenceRule(
+      calendar: calendar,
+      frequency: .weekly,
+      weekdays: [
+        .every(.monday), .every(.tuesday), .every(.wednesday), .every(.thursday), .every(.friday),
+      ],
+      hours: [7],
+      minutes: [0]
+    )
+    return RecurrenceEnvelope(schemaVersion: RecurrenceEnvelope.currentSchemaVersion, rule: rule)
+  }
+
+  @discardableResult
+  private func makeJob(
+    _ store: ScheduledJobStoreGRDB,
+    recurrence: RecurrenceEnvelope?,
+    next: Date,
+    now: Date,
+    label: String = "digest"
+  ) throws -> ScheduledJob {
+    try store.create(
+      NewScheduledJob(
+        ownerChatId: 777,
+        label: label,
+        prompt: "Summarize my unread items",
+        recurrence: recurrence,
+        timezone: "Europe/Berlin",
+        nextOccurrence: next
+      ),
+      now: now
+    )
+  }
+
+  private func count(
+    _ queue: DatabaseQueue,
+    sql: String,
+    arguments: StatementArguments = StatementArguments()
+  ) throws -> Int {
+    try queue.read { db in
+      try Int.fetchOne(db, sql: sql, arguments: arguments) ?? -1
+    }
+  }
+
+  private func auditCount(_ queue: DatabaseQueue, action: AuditAction) throws -> Int {
+    try count(
+      queue,
+      sql: "SELECT COUNT(*) FROM audit_events WHERE action = ?",
+      arguments: [action.rawValue]
+    )
+  }
+}
+
+// MARK: - Cycle A: CRUD
+
+extension ScheduledJobStoreGRDBTests {
+  @Test func createRoundTripsTheJobRow() throws {
+    // given
+    let (store, _) = try makeStore()
+    let envelope = weekdayEnvelope()
+
+    // when
+    let created = try makeJob(store, recurrence: envelope, next: dueFirst, now: baseNow)
+    let fetched = try store.job(id: created.id)
+
+    // then — the envelope survives the JSON column byte-for-byte enough to compare equal
+    #expect(fetched == created)
+    #expect(created.status == .active)
+    #expect(created.recurrence == envelope)
+    #expect(created.nextOccurrence == dueFirst)
+    #expect(created.sessionId == nil)
+    #expect(created.lastFiredAt == nil)
+    #expect(created.createdTs == baseNow)
+    #expect(created.updatedTs == baseNow)
+    #expect(try store.job(id: created.id + 99) == nil)
+  }
+
+  @Test func oneShotRoundTripsWithNilRecurrence() throws {
+    // given
+    let (store, _) = try makeStore()
+
+    // when
+    let created = try makeJob(store, recurrence: nil, next: dueFirst, now: baseNow)
+
+    // then
+    #expect(try store.job(id: created.id)?.recurrence == nil)
+  }
+
+  @Test func listAllReturnsEveryRowInIdOrder() throws {
+    // given
+    let (store, _) = try makeStore()
+    let first = try makeJob(store, recurrence: nil, next: dueFirst, now: baseNow, label: "a")
+    let second = try makeJob(store, recurrence: nil, next: dueNext, now: baseNow, label: "b")
+
+    // when / then
+    #expect(try store.listAll().map(\.id) == [first.id, second.id])
+  }
+
+  @Test func dueJobsReturnsOnlyActiveDueRowsInDueOrder() throws {
+    // given — two due (out of insert order), one future
+    let (store, queue) = try makeStore()
+    let later = try makeJob(
+      store,
+      recurrence: nil,
+      next: Date(timeIntervalSince1970: 1_781_999_500),
+      now: baseNow,
+      label: "later-due"
+    )
+    let earlier = try makeJob(
+      store,
+      recurrence: nil,
+      next: Date(timeIntervalSince1970: 1_781_999_000),
+      now: baseNow,
+      label: "earlier-due"
+    )
+    let future = try makeJob(
+      store,
+      recurrence: nil,
+      next: Date(timeIntervalSince1970: 1_782_000_600),
+      now: baseNow,
+      label: "future"
+    )
+
+    // when / then — due-time order, not id order
+    #expect(try store.dueJobs(now: baseNow).map(\.id) == [earlier.id, later.id])
+
+    // and a non-ACTIVE row disappears from the scan even while due
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE scheduled_jobs SET status = ? WHERE id = ?",
+        arguments: [ScheduledJobStatus.paused.rawValue, later.id]
+      )
+    }
+    #expect(try store.dueJobs(now: baseNow).map(\.id) == [earlier.id])
+
+    // and a NULL next_occurrence row does too
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE scheduled_jobs SET next_occurrence = NULL WHERE id = ?",
+        arguments: [earlier.id]
+      )
+    }
+    #expect(try store.dueJobs(now: baseNow).isEmpty)
+    _ = future  // silences the unused-binding warning; the row proves the <= now bound
+  }
+}
+
+// MARK: - Cycle B: the fused claim (KEYSTONE)
+
+extension ScheduledJobStoreGRDBTests {
+  @Test func staleDueClaimLosesAfterTheFirstAdvance() throws {
+    // given — two claims for the same (job, due): the second models a racing ticker that read
+    // the row before the first advanced it
+    let (store, queue) = try makeStore()
+    let job = try makeJob(store, recurrence: weekdayEnvelope(), next: dueFirst, now: baseNow)
+    let fireTime = dueFirst.addingTimeInterval(30)
+
+    // when
+    let winner = try store.claimAndFire(
+      jobId: job.id,
+      due: dueFirst,
+      fireAt: dueFirst,
+      nextOccurrence: dueNext,
+      now: fireTime
+    )
+    let loser = try store.claimAndFire(
+      jobId: job.id,
+      due: dueFirst,
+      fireAt: dueFirst,
+      nextOccurrence: dueNext,
+      now: fireTime
+    )
+
+    // then — exactly one fire: one run row, next_occurrence advanced exactly once
+    #expect(winner != nil)
+    #expect(loser == nil)
+    #expect(try count(queue, sql: "SELECT COUNT(*) FROM runs") == 1)
+    let after = try store.job(id: job.id)
+    #expect(after?.nextOccurrence == dueNext)
+    #expect(after?.lastFiredAt == dueFirst)
+    #expect(after?.status == .active)
+    #expect(try auditCount(queue, action: .jobExecuted) == 1)
+  }
+
+  @Test func concurrentClaimsAllowExactlyOneWinner() async throws {
+    // given — a real writer race on a file-backed WAL pool, not the serialized test queue
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("claw-sched-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let pool = try ClawDatabase.makePool(
+      path: directory.appendingPathComponent("claw.sqlite").path
+    )
+    try ClawDatabase.migrate(pool)
+    let store = ScheduledJobStoreGRDB(writer: pool)
+    let job = try makeJob(store, recurrence: weekdayEnvelope(), next: dueFirst, now: baseNow)
+    let fireTime = dueFirst.addingTimeInterval(30)
+    let claimDue = dueFirst
+    let claimNext = dueNext
+
+    // when — two tasks race the same (job, due)
+    let claims = await withTaskGroup(of: ClaimedFire?.self) { group in
+      for _ in 0..<2 {
+        group.addTask {
+          try? store.claimAndFire(
+            jobId: job.id,
+            due: claimDue,
+            fireAt: claimDue,
+            nextOccurrence: claimNext,
+            now: fireTime
+          )
+        }
+      }
+      var collected: [ClaimedFire?] = []
+      for await claim in group {
+        collected.append(claim)
+      }
+      return collected
+    }
+
+    // then — exactly one winner AND exactly one run row (a swallowed error cannot fake this:
+    // zero fires would leave zero runs and zero winners; two would leave two)
+    #expect(claims.compactMap { claim in claim }.count == 1)
+    let runCount = try await pool.read { db in
+      try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM runs") ?? -1
+    }
+    #expect(runCount == 1)
+    #expect(try store.job(id: job.id)?.nextOccurrence == dueNext)
+  }
+
+  @Test func oneShotClaimCompletesTheJob() throws {
+    // given
+    let (store, queue) = try makeStore()
+    let job = try makeJob(store, recurrence: nil, next: dueFirst, now: baseNow)
+
+    // when — nextOccurrence nil ⇒ one-shot terminal transition
+    let claimed = try store.claimAndFire(
+      jobId: job.id,
+      due: dueFirst,
+      fireAt: dueFirst,
+      nextOccurrence: nil,
+      now: dueFirst
+    )
+    let replay = try store.claimAndFire(
+      jobId: job.id,
+      due: dueFirst,
+      fireAt: dueFirst,
+      nextOccurrence: nil,
+      now: dueFirst
+    )
+
+    // then — COMPLETED, NULL next, invisible to the ticker, unrepeatable
+    #expect(claimed != nil)
+    #expect(replay == nil)
+    let after = try store.job(id: job.id)
+    #expect(after?.status == .completed)
+    #expect(after?.nextOccurrence == nil)
+    #expect(try store.dueJobs(now: dueNext).isEmpty)
+    #expect(try count(queue, sql: "SELECT COUNT(*) FROM runs") == 1)
+  }
+
+  @Test func firstClaimLazilyCreatesTheJobSessionThenReusesIt() throws {
+    // given
+    let (store, queue) = try makeStore()
+    let job = try makeJob(store, recurrence: weekdayEnvelope(), next: dueFirst, now: baseNow)
+
+    // when — two consecutive fires
+    let first = try store.claimAndFire(
+      jobId: job.id,
+      due: dueFirst,
+      fireAt: dueFirst,
+      nextOccurrence: dueNext,
+      now: dueFirst
+    )
+    let second = try store.claimAndFire(
+      jobId: job.id,
+      due: dueNext,
+      fireAt: dueNext,
+      nextOccurrence: dueThird,
+      now: dueNext
+    )
+
+    // then — one dedicated session, reused; runs carry origin + job linkage; the trigger
+    // message is the owner's own confirmed prompt at the trusted tier (spec §5.2)
+    let firstFire = try #require(first)
+    let secondFire = try #require(second)
+    #expect(firstFire.sessionId == secondFire.sessionId)
+    #expect(firstFire.triggerMessageId != secondFire.triggerMessageId)
+    #expect(firstFire.ownerChatId == 777)
+    #expect(
+      try count(
+        queue,
+        sql: "SELECT COUNT(*) FROM sessions WHERE session_key = ?",
+        arguments: [SessionKey.scheduledJob(id: job.id)]
+      ) == 1
+    )
+    #expect(try store.job(id: job.id)?.sessionId == firstFire.sessionId)
+    #expect(
+      try count(
+        queue,
+        sql: "SELECT COUNT(*) FROM runs WHERE origin = ? AND job_id = ? AND state = ?",
+        arguments: [RunOrigin.scheduled.rawValue, job.id, "PENDING"]
+      ) == 2
+    )
+    #expect(
+      try count(
+        queue,
+        sql: """
+          SELECT COUNT(*) FROM messages
+          WHERE role = 'user' AND provenance = 'trusted' AND content = 'Summarize my unread items'
+          """
+      ) == 2
+    )
+  }
+}
+
+// MARK: - Cycle C: scheduler_state, run-now, misfire
+
+extension ScheduledJobStoreGRDBTests {
+  @Test func schedulerStateStartsEmptyAndRecordTickUpserts() throws {
+    // given
+    let (store, _) = try makeStore()
+
+    // when / then — no row yet reads as the zero state
+    #expect(
+      try store.schedulerState()
+        == SchedulerState(
+          lastTickAt: nil,
+          lastMisfireAt: nil,
+          lastMisfireSkippedCount: 0,
+          lastHeartbeatAt: nil,
+          heartbeatCountDay: nil,
+          heartbeatCount: 0
+        )
+    )
+
+    // when — two ticks upsert the same singleton row
+    try store.recordTick(at: baseNow)
+    let laterTick = baseNow.addingTimeInterval(60)
+    try store.recordTick(at: laterTick)
+
+    // then
+    let state = try store.schedulerState()
+    #expect(state.lastTickAt == laterTick)
+    #expect(state.lastMisfireAt == nil)
+    #expect(state.heartbeatCount == 0)
+  }
+
+  @Test func fireNowFiresWithoutTouchingTheSchedule() throws {
+    // given
+    let (store, queue) = try makeStore()
+    let job = try makeJob(store, recurrence: weekdayEnvelope(), next: dueFirst, now: baseNow)
+
+    // when
+    let claimed = try store.fireNow(jobId: job.id, now: baseNow)
+
+    // then — a real fire (run + audit + last_fired_at) with the schedule untouched (spec §5.4)
+    #expect(claimed != nil)
+    let after = try store.job(id: job.id)
+    #expect(after?.nextOccurrence == dueFirst)
+    #expect(after?.status == .active)
+    #expect(after?.lastFiredAt == baseNow)
+    #expect(
+      try count(
+        queue,
+        sql: "SELECT COUNT(*) FROM runs WHERE origin = ? AND job_id = ?",
+        arguments: [RunOrigin.scheduled.rawValue, job.id]
+      ) == 1
+    )
+    #expect(try auditCount(queue, action: .jobExecuted) == 1)
+  }
+
+  @Test func fireNowRequiresActiveOrPaused() throws {
+    // given — PAUSED is allowed (test a job without unmuting it, spec §5.4); terminal is not
+    let (store, queue) = try makeStore()
+    let job = try makeJob(store, recurrence: weekdayEnvelope(), next: dueFirst, now: baseNow)
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE scheduled_jobs SET status = ? WHERE id = ?",
+        arguments: [ScheduledJobStatus.paused.rawValue, job.id]
+      )
+    }
+
+    // when / then — fires on PAUSED without changing the status
+    #expect(try store.fireNow(jobId: job.id, now: baseNow) != nil)
+    #expect(try store.job(id: job.id)?.status == .paused)
+
+    // and refuses terminal states and absent ids
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE scheduled_jobs SET status = ?, next_occurrence = NULL WHERE id = ?",
+        arguments: [ScheduledJobStatus.cancelled.rawValue, job.id]
+      )
+    }
+    #expect(try store.fireNow(jobId: job.id, now: baseNow) == nil)
+    #expect(try store.fireNow(jobId: job.id + 99, now: baseNow) == nil)
+  }
+
+  @Test func skipMisfireAdvancesWithNoRunAndAuditsTheSkip() throws {
+    // given
+    let (store, queue) = try makeStore()
+    let job = try makeJob(store, recurrence: weekdayEnvelope(), next: dueFirst, now: baseNow)
+    let skipTime = dueFirst.addingTimeInterval(3_600)
+
+    // when — five occurrences fell out of the catch-up window
+    let applied = try store.skipMisfire(
+      jobId: job.id,
+      due: dueFirst,
+      nextOccurrence: dueNext,
+      skippedCount: 5,
+      now: skipTime
+    )
+    let stale = try store.skipMisfire(
+      jobId: job.id,
+      due: dueFirst,
+      nextOccurrence: dueNext,
+      skippedCount: 5,
+      now: skipTime
+    )
+
+    // then — advanced, no run, nothing "fired", misfire state + audit written
+    #expect(applied)
+    #expect(stale == false)
+    #expect(try count(queue, sql: "SELECT COUNT(*) FROM runs") == 0)
+    let after = try store.job(id: job.id)
+    #expect(after?.nextOccurrence == dueNext)
+    #expect(after?.lastFiredAt == nil)
+    let state = try store.schedulerState()
+    #expect(state.lastMisfireAt == skipTime)
+    #expect(state.lastMisfireSkippedCount == 5)
+    #expect(try auditCount(queue, action: .jobMisfire) == 1)
+  }
+
+  @Test func skipMisfireCompletesAOneShot() throws {
+    // given — a one-shot whose single occurrence aged out entirely
+    let (store, queue) = try makeStore()
+    let job = try makeJob(store, recurrence: nil, next: dueFirst, now: baseNow)
+
+    // when
+    let applied = try store.skipMisfire(
+      jobId: job.id,
+      due: dueFirst,
+      nextOccurrence: nil,
+      skippedCount: 1,
+      now: dueNext
+    )
+
+    // then
+    #expect(applied)
+    let after = try store.job(id: job.id)
+    #expect(after?.status == .completed)
+    #expect(after?.nextOccurrence == nil)
+    #expect(try count(queue, sql: "SELECT COUNT(*) FROM runs") == 0)
+  }
+}
+
+// MARK: - Cycle D: verb semantics (spec §5.4, §4.1 FSM)
+
+extension ScheduledJobStoreGRDBTests {
+  @Test func pauseIsIdempotentAndHidesTheJobFromTheTicker() throws {
+    // given
+    let (store, queue) = try makeStore()
+    let job = try makeJob(store, recurrence: weekdayEnvelope(), next: dueFirst, now: baseNow)
+
+    // when
+    let paused = try store.pause(id: job.id, now: baseNow)
+    let pausedAgain = try store.pause(id: job.id, now: baseNow)
+
+    // then — PAUSED, invisible to the scan, idempotent with a single audit row
+    #expect(paused?.status == .paused)
+    #expect(pausedAgain?.status == .paused)
+    #expect(try store.dueJobs(now: dueNext).isEmpty)
+    #expect(try auditCount(queue, action: .jobPaused) == 1)
+    #expect(try store.pause(id: job.id + 99, now: baseNow) == nil)
+  }
+
+  @Test func resumeAppliesTheCallerRecomputedNextOccurrence() throws {
+    // given — pause = "be quiet", not "queue up": the caller recomputes from now, so
+    // occurrences inside the paused window are skipped, never caught up (spec §5.4)
+    let (store, queue) = try makeStore()
+    let job = try makeJob(store, recurrence: weekdayEnvelope(), next: dueFirst, now: baseNow)
+    _ = try store.pause(id: job.id, now: baseNow)
+
+    // when
+    let resumed = try store.resume(id: job.id, nextOccurrence: dueThird, now: dueNext)
+    let resumedAgain = try store.resume(id: job.id, nextOccurrence: dueFirst, now: dueNext)
+
+    // then — ACTIVE at the recomputed occurrence; a second resume is a no-op (no re-aim)
+    #expect(resumed?.status == .active)
+    #expect(resumed?.nextOccurrence == dueThird)
+    #expect(resumedAgain?.status == .active)
+    #expect(resumedAgain?.nextOccurrence == dueThird)
+    #expect(try auditCount(queue, action: .jobResumed) == 1)
+  }
+
+  @Test func cancelIsTerminalAndRetainsTheRow() throws {
+    // given
+    let (store, queue) = try makeStore()
+    let job = try makeJob(store, recurrence: weekdayEnvelope(), next: dueFirst, now: baseNow)
+
+    // when
+    let cancelled = try store.cancel(id: job.id, now: baseNow)
+    let cancelledAgain = try store.cancel(id: job.id, now: baseNow)
+
+    // then — CANCELLED with NULL next, row retained for audit, no exit from terminal
+    #expect(cancelled?.status == .cancelled)
+    #expect(cancelled?.nextOccurrence == nil)
+    #expect(cancelledAgain == nil)
+    #expect(try store.job(id: job.id) != nil)
+    #expect(try store.dueJobs(now: dueNext).isEmpty)
+    #expect(try auditCount(queue, action: .jobCancelled) == 1)
+    // terminal states refuse every verb and every fire path
+    #expect(try store.pause(id: job.id, now: baseNow) == nil)
+    #expect(try store.resume(id: job.id, nextOccurrence: dueNext, now: baseNow) == nil)
+    #expect(try store.fireNow(jobId: job.id, now: baseNow) == nil)
+    #expect(
+      try store.claimAndFire(
+        jobId: job.id,
+        due: dueFirst,
+        fireAt: dueFirst,
+        nextOccurrence: dueNext,
+        now: baseNow
+      ) == nil
+    )
+  }
+
+  @Test func cancelAppliesFromPausedToo() throws {
+    // given
+    let (store, _) = try makeStore()
+    let job = try makeJob(store, recurrence: weekdayEnvelope(), next: dueFirst, now: baseNow)
+    _ = try store.pause(id: job.id, now: baseNow)
+
+    // when / then
+    #expect(try store.cancel(id: job.id, now: baseNow)?.status == .cancelled)
+  }
+}
+
+// MARK: - Cycle E: heartbeat fire + conformance
+
+extension ScheduledJobStoreGRDBTests {
+  @Test func fireHeartbeatCreatesTheHeartbeatRunOnItsOwnSession() throws {
+    // given
+    let (store, queue) = try makeStore()
+
+    // when
+    let fired = try store.fireHeartbeat(
+      prompt: "Review the checklist below…",
+      ownerChatId: 777,
+      now: baseNow,
+      day: "2026-07-06"
+    )
+
+    // then — dedicated persistent session; origin heartbeat; NO job linkage; the template
+    // wraps HEARTBEAT.md content, so the trigger rides the UNTRUSTED tier (spec §12)
+    #expect(fired.ownerChatId == 777)
+    #expect(
+      try count(
+        queue,
+        sql: "SELECT COUNT(*) FROM sessions WHERE session_key = ?",
+        arguments: [SessionKey.heartbeat]
+      ) == 1
+    )
+    #expect(
+      try count(
+        queue,
+        sql: "SELECT COUNT(*) FROM runs WHERE origin = ? AND job_id IS NULL AND state = ?",
+        arguments: [RunOrigin.heartbeat.rawValue, "PENDING"]
+      ) == 1
+    )
+    #expect(
+      try count(
+        queue,
+        sql: "SELECT COUNT(*) FROM messages WHERE role = 'user' AND provenance = 'untrusted'"
+      ) == 1
+    )
+    let state = try store.schedulerState()
+    #expect(state.lastHeartbeatAt == baseNow)
+    #expect(state.heartbeatCountDay == "2026-07-06")
+    #expect(state.heartbeatCount == 1)
+  }
+
+  @Test func heartbeatDayCounterRollsAtTheDayBoundary() throws {
+    // given
+    let (store, queue) = try makeStore()
+    let secondFire = baseNow.addingTimeInterval(3_600)
+    let nextDayFire = baseNow.addingTimeInterval(86_400)
+
+    // when
+    _ = try store.fireHeartbeat(prompt: "check", ownerChatId: 777, now: baseNow, day: "2026-07-06")
+    _ = try store.fireHeartbeat(
+      prompt: "check",
+      ownerChatId: 777,
+      now: secondFire,
+      day: "2026-07-06"
+    )
+    let sameDayState = try store.schedulerState()
+    _ = try store.fireHeartbeat(
+      prompt: "check",
+      ownerChatId: 777,
+      now: nextDayFire,
+      day: "2026-07-07"
+    )
+    let nextDayState = try store.schedulerState()
+
+    // then — the cap's day boundary is the caller's CLAW_TIMEZONE day string, not UTC (spec §4.3)
+    #expect(sameDayState.heartbeatCount == 2)
+    #expect(nextDayState.heartbeatCountDay == "2026-07-07")
+    #expect(nextDayState.heartbeatCount == 1)
+    #expect(nextDayState.lastHeartbeatAt == nextDayFire)
+    // and the session is reused, never duplicated
+    #expect(
+      try count(
+        queue,
+        sql: "SELECT COUNT(*) FROM sessions WHERE session_key = ?",
+        arguments: [SessionKey.heartbeat]
+      ) == 1
+    )
+  }
+
+  @Test func storeConformsToTheScheduledJobStoreProtocol() throws {
+    // given / when — compile-time proof the whole preamble contract is implemented
+    let (store, _) = try makeStore()
+    let conforming: any ScheduledJobStore = store
+
+    // then
+    #expect(try conforming.listAll().isEmpty)
+  }
+}


### PR DESCRIPTION
Lays the groundwork for owner-scheduled jobs. Everything here is intentionally **dormant** — no runtime code constructs any of it yet, so daemon behavior is unchanged apart from the platform floor. This slice is independently shippable and the foundation the scheduler service and owner commands will build on next.

## What's in it
- **Platform floor → macOS 15** so we can use `Calendar.RecurrenceRule` with no availability guards.
- **Scheduling domain types** in ClawCore: `RunOrigin`, `ScheduledJobStatus`, `RecurrenceEnvelope` (with a pinned, deterministic JSON storage codec), `ScheduledJob`/`NewScheduledJob`/`SchedulerState`, the synthetic `sched:job:<id>` / `sched:heartbeat` session keys, and ten new audit actions.
- **Eight config keys** with a `QuietHours` value type (half-open window, may cross midnight; zero-width and malformed inputs fail closed), documented in `.env.example` and surfaced by `doctor --check-config`.
- **Migration v6**: `scheduled_jobs`, a partial ticker index, `runs.origin`/`runs.job_id` (additive, backfilled by default), and a singleton `scheduler_state` row. Occurrence/timestamp columns are UTC epoch-second integers so the claim compares exact integers.
- **`OccurrenceCalculator`**: the single home of occurrence math with a pinned DST policy — nonexistent local times resolve forward, ambiguous times fire once, and wall-clock rules (e.g. weekday 07:00 Europe/Berlin) stay at local time across both 2026 transitions.
- **`ScheduledJobStoreGRDB`**: CRUD plus the fused fire-once claim, run-now, misfire skip, pause/resume/cancel, and the heartbeat fire — each an atomic transaction with its audit row.

## Correctness
- The fused claim is **structurally** single-winner: the first claim advances `next_occurrence`, which makes a racing claim's compare-and-advance match zero rows. Proven by two CAS tests — a serialized stale-due case and a real file-backed WAL task-group race — asserting exactly one winner, one run row, and one advance. Verified repeatedly with no flakiness.
- The `RecurrenceEnvelope` round-trip is a byte-for-byte tripwire, and the four DST expectations are pinned against verified instants — both guard against future toolchain drift.
- `swift build` clean, full suite **630 tests / 117 suites** green, `scripts/lint.sh` clean.

## Follow-ups (non-blocking)
- The epoch codec rounds-to-nearest while the calculator floors; they agree today because every value that reaches the claim is already whole-second. Worth single-sourcing (floor in both) whenever the codec is next touched — no behavior change today.