### PR TITLE
Developer-facing structured logging across the request lifecycle

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "77e020aad7ce4604fe4e1570755feb3b6e8afe2843e8cd4fad76106740ae8497",
+  "originHash" : "6235d91737d95cb546c72fb08513ebb92fa6af9d47512d856520a0e56e88c8b3",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
-        "version" : "1.13.2"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.11.0"),
     .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.2"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
-    .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+    .package(url: "https://github.com/apple/swift-log.git", from: "1.11.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
     .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.11.0"),
   ],
@@ -50,10 +50,20 @@ let package = Package(
     ),
     .target(
       name: "ClawLLM",
-      dependencies: ["ClawCore"],
+      dependencies: [
+        "ClawCore",
+        .product(name: "Logging", package: "swift-log"),
+      ],
       resources: [.copy("Pricing/Prices.json")]
     ),
-    .target(name: "ClawAgent", dependencies: ["ClawCore", "ClawWorkspace"]),
+    .target(
+      name: "ClawAgent",
+      dependencies: [
+        "ClawCore",
+        "ClawWorkspace",
+        .product(name: "Logging", package: "swift-log"),
+      ]
+    ),
     .target(name: "ClawTools", dependencies: ["ClawCore"]),
     .target(
       name: "ClawGateway",
@@ -96,8 +106,20 @@ let package = Package(
         .product(name: "NIOPosix", package: "swift-nio"),
       ]
     ),
-    .testTarget(name: "ClawLLMTests", dependencies: ["ClawLLM", "ClawCore"]),
-    .testTarget(name: "ClawAgentTests", dependencies: ["ClawAgent", "ClawCore", "ClawWorkspace"]),
+    .testTarget(
+      name: "ClawLLMTests",
+      dependencies: [
+        "ClawLLM", "ClawCore",
+        .product(name: "Logging", package: "swift-log"),
+      ]
+    ),
+    .testTarget(
+      name: "ClawAgentTests",
+      dependencies: [
+        "ClawAgent", "ClawCore", "ClawWorkspace",
+        .product(name: "Logging", package: "swift-log"),
+      ]
+    ),
     .testTarget(name: "ClawToolsTests", dependencies: ["ClawTools", "ClawCore"]),
     .testTarget(
       name: "ClawGatewayTests",

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.11.0"),
     .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.2"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
-    .package(url: "https://github.com/apple/swift-log.git", from: "1.11.0"),
+    .package(url: "https://github.com/apple/swift-log.git", from: "1.14.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
     .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.11.0"),
   ],

--- a/Sources/ClawAgent/Runtime/AgentRuntime.swift
+++ b/Sources/ClawAgent/Runtime/AgentRuntime.swift
@@ -1,5 +1,6 @@
 import ClawCore
 import Foundation
+import Logging
 
 /// Why a turn produced no usable answer. Maps to a plain-language degradation reply (§7); the
 /// stable `rawValue` is what the audit log records, so it survives case renames.
@@ -61,7 +62,9 @@ public struct AgentRuntime: Sendable {
   private let toolDispatcher: (any ToolDispatching)?
   private let usageStore: any UsageStore
   private let auditLog: any AuditLog
-  private let warn: @Sendable (String) -> Void
+  /// Developer-facing diagnostics (swift-log). Distinct from `auditLog`, which is the durable
+  /// business/security trail. Defaults to a no-op so tests stay silent unless they inject one.
+  private let logger: Logger
   /// Injected so tests can make the deadline fire instantly with a no-op sleep.
   private let sleep: @Sendable (Duration) async throws -> Void
 
@@ -77,7 +80,7 @@ public struct AgentRuntime: Sendable {
     toolDispatcher: (any ToolDispatching)? = nil,
     usageStore: any UsageStore,
     auditLog: any AuditLog,
-    warn: @escaping @Sendable (String) -> Void = { _ in },
+    logger: Logger = Logger(label: "clawd.agent", factory: { _ in SwiftLogNoOpLogHandler() }),
     sleep: @escaping @Sendable (Duration) async throws -> Void
   ) {
     self.provider = provider
@@ -91,7 +94,7 @@ public struct AgentRuntime: Sendable {
     self.toolDispatcher = toolDispatcher
     self.usageStore = usageStore
     self.auditLog = auditLog
-    self.warn = warn
+    self.logger = logger
     self.sleep = sleep
   }
 
@@ -117,6 +120,17 @@ public struct AgentRuntime: Sendable {
     let definitions = toolDispatcher?.definitions ?? []
     let gate = BudgetGate(budget: budget)
 
+    // Turn-scoped logger: every line below inherits run/session metadata, so one `grep run=<id>`
+    // ties the round-trips, tool calls, and outcome of a single turn together.
+    var turnLog = logger
+    for (key, value) in Self.turnMetadata(runId: runId, sessionId: sessionId) {
+      turnLog[metadataKey: key] = value
+    }
+    let turnStart = ContinuousClock.now
+    turnLog.info(
+      "turn started model=\(model) origin=\(origin) contextMessages=\(buildResult.messages.count) streaming=\(streamingEnabled) tools=\(definitions.count)"
+    )
+
     var wire = buildResult.messages
     var exchanges: [ToolExchange] = []
 
@@ -130,8 +144,12 @@ public struct AgentRuntime: Sendable {
     var recordedRunTokens = 0
     var recordedRunUSD = 0.0
 
+    // Terminal choke-point for the RESULT paths: every `return outcome(...)` flows through here, so a
+    // turn that produces a `TurnOutcome` emits exactly one finished line (see `logFinish`). The
+    // `StoreError.diskFull` fast-path throws to the gateway instead, which logs that terminal.
     func outcome(_ result: TurnResult) -> TurnOutcome {
-      TurnOutcome(
+      Self.logFinish(result, on: turnLog, elapsed: ContinuousClock.now - turnStart)
+      return TurnOutcome(
         result: result,
         exchanges: exchanges,
         ingestedUntrusted: ingestedUntrusted,
@@ -139,7 +157,7 @@ public struct AgentRuntime: Sendable {
       )
     }
 
-    for _ in 0..<max(1, budget.maxTurns) {
+    for roundTripIndex in 1...max(1, budget.maxTurns) {
       // Per-round-trip preflight (§6.2): day totals at run start + everything this run recorded.
       let inputTokens = TokenEstimator.estimateInputTokens(wire)
       let estimate = inputTokens + budget.maxOutputTokens
@@ -173,6 +191,7 @@ public struct AgentRuntime: Sendable {
 
       let remaining = deadline - ContinuousClock.now
       guard remaining > .zero else {
+        turnLog.notice("round-trip \(roundTripIndex) wall-clock exhausted before send; degrading")
         return outcome(
           .degraded(
             .providerUnavailable,
@@ -181,6 +200,9 @@ public struct AgentRuntime: Sendable {
         )
       }
 
+      turnLog.debug(
+        "round-trip \(roundTripIndex) inputTokens~=\(inputTokens) estCostUSD=\(USD.precise(estimatedCost))"
+      )
       let request = ChatRequest(
         model: model,
         messages: wire,
@@ -197,6 +219,7 @@ public struct AgentRuntime: Sendable {
           deadlineSeconds: max(1, Int(remaining.components.seconds))
         )
       } catch is DeadlineExceeded {
+        turnLog.notice("round-trip \(roundTripIndex) exceeded the wall-clock deadline; degrading")
         return outcome(
           .degraded(
             .providerUnavailable,
@@ -208,6 +231,7 @@ public struct AgentRuntime: Sendable {
         // an ESTIMATED row (`degradedForStreamingError`); the typing path debits nil for a terminal
         // (`degradedForCaughtError`). §15 estimated-debit rule; keeps
         // `terminalStreamFailureDegradesAndDebitsTheEstimate` green and both helpers live.
+        turnLog.warning("round-trip \(roundTripIndex) provider error (degrading): \(error)")
         let degradation =
           streamingEnabled
           ? degradedForStreamingError(error, context: wire, runId: runId, sessionId: sessionId)
@@ -230,7 +254,7 @@ public struct AgentRuntime: Sendable {
       } catch StoreError.diskFull {
         throw StoreError.diskFull
       } catch {
-        warn("mid-run usage write failed; halting provider calls: \(error)")
+        turnLog.warning("mid-run usage write failed; halting provider calls: \(error)")
         return outcome(.degraded(.accountingFailed, usage: nil))
       }
       recordedRunTokens += intermediate.promptTokens + intermediate.completionTokens
@@ -280,7 +304,12 @@ public struct AgentRuntime: Sendable {
           continue
         }
 
+        turnLog.debug("tool \(call.name) invoked")
+        let toolStart = ContinuousClock.now
         let dispatched = await toolDispatcher.dispatch(call: call, context: context)
+        turnLog.debug(
+          "tool \(call.name) done decision=\(dispatched.observation.status.rawValue) bytes=\(dispatched.observation.content.utf8.count) ms=\(Self.millis(ContinuousClock.now - toolStart))"
+        )
         try recordToolAudit(for: call, outcome: dispatched, runId: runId, sessionId: sessionId)
 
         observations.append(dispatched.observation)
@@ -326,12 +355,46 @@ public struct AgentRuntime: Sendable {
 
     return outcome(.budgetStopped(cap: "per-run turn"))
   }
+}
 
-  // MARK: - Load-bearing
+// MARK: - Load-bearing
 
+extension AgentRuntime {
   /// Marker error thrown by turn-runtime deadline children when the wall-clock window elapses; the
   /// `runTurn` shell maps it to the estimated-debit degradation path.
   struct DeadlineExceeded: Error {}
+
+  /// The correlation fields stamped on every developer log line for one turn, so a single
+  /// `grep run=<id>` ties the turn's round-trips, tool calls, and outcome together.
+  private static func turnMetadata(runId: Int64, sessionId: Int64) -> Logger.Metadata {
+    ["run": "\(runId)", "session": "\(sessionId)"]
+  }
+
+  /// Emits the one finished line for a turn; its level reflects severity — completed → info,
+  /// budget-stopped → notice (an expected guard), degraded → warning (something went wrong). Only
+  /// safe fields (counts, tokens, cost, elapsed) are logged, never the reply text.
+  private static func logFinish(_ result: TurnResult, on log: Logger, elapsed: Duration) {
+    let elapsedMillis = millis(elapsed)
+    switch result {
+    case .completed(let content, let usage):
+      log.info(
+        "turn finished completed chars=\(content.count) tokens=\(usage.promptTokens + usage.completionTokens) usd=\(USD.precise(usage.costUSD)) ms=\(elapsedMillis)"
+      )
+    case .degraded(let kind, let usage):
+      let tokens = usage.map { "\($0.promptTokens + $0.completionTokens)" } ?? "n/a"
+      log.warning(
+        "turn finished degraded kind=\(kind.rawValue) tokens=\(tokens) ms=\(elapsedMillis)"
+      )
+    case .budgetStopped(let cap):
+      log.notice("turn finished budget-stopped cap=\(cap) ms=\(elapsedMillis)")
+    }
+  }
+
+  /// Whole milliseconds of a `Duration`, for compact latency fields in developer logs.
+  private static func millis(_ duration: Duration) -> Int64 {
+    let parts = duration.components
+    return parts.seconds * 1000 + parts.attoseconds / 1_000_000_000_000_000
+  }
 
   /// One audit row per dispatch, written immediately, blocked calls included (FR-T1/§6). Audit is
   /// observability, not a gate: a non-diskFull failure logs and the run continues.
@@ -358,7 +421,10 @@ public struct AgentRuntime: Sendable {
     } catch StoreError.diskFull {
       throw StoreError.diskFull
     } catch {
-      warn("tool audit write failed (continuing): \(error)")
+      logger.warning(
+        "tool audit write failed (continuing): \(error)",
+        metadata: Self.turnMetadata(runId: runId, sessionId: sessionId)
+      )
     }
   }
 

--- a/Sources/ClawCore/Config/SecretStore.swift
+++ b/Sources/ClawCore/Config/SecretStore.swift
@@ -19,6 +19,13 @@ public struct Secrets: Sendable, Equatable {
     self.llmApiKey = llmApiKey
     self.searchApiKey = searchApiKey
   }
+
+  /// The concrete secret strings an exact-value redactor should scrub — from tool output
+  /// (`SecretRedactor`) and from developer logs (the log-handler redactor). One source of truth so
+  /// the two call sites can never drift on what counts as a secret.
+  public var redactionValues: [String] {
+    [telegramBotToken, llmApiKey, searchApiKey].compactMap { value in value }
+  }
 }
 
 /// State-root-relative filenames the encrypted backend owns. Shared so the resolver's existence

--- a/Sources/ClawCore/Domain/Support/USD.swift
+++ b/Sources/ClawCore/Domain/Support/USD.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Canonical formatting for USD amounts. Keeps the `%.Nf` precision in one place instead of as a
+/// magic format string scattered across turn-cost logs, the doctor report, and scheduler health.
+public enum USD {
+  /// Sub-cent precision (4 dp) — spend detail: per-turn cost logs and the doctor `spend.today_usd`.
+  public static func precise(_ amount: Double) -> String {
+    String(format: "%.4f", amount)
+  }
+
+  /// Cent precision (2 dp) — owner-facing caps, remaining budget, and proactive-spend display.
+  public static func display(_ amount: Double) -> String {
+    String(format: "%.2f", amount)
+  }
+}

--- a/Sources/ClawGateway/Infrastructure/Daemon.swift
+++ b/Sources/ClawGateway/Infrastructure/Daemon.swift
@@ -32,10 +32,15 @@ public struct Daemon: Sendable {
     // runs (F22), so Telegram's state and the run table match this process before any update lands.
     await boot()
 
+    // ServiceLifecycle logs the whole service graph at debug/trace. Floor its logger at .info so a
+    // developer who sets CLAW_LOG_LEVEL=debug sees the app's request-lifecycle logs, not a large
+    // framework graph dump. The app's own loggers keep the configured level (separate copies).
+    var lifecycleLogger = logger
+    lifecycleLogger.logLevel = max(logger.logLevel, .info)
     var configuration = ServiceGroupConfiguration(
       services: services,
       gracefulShutdownSignals: gracefulShutdownSignals,
-      logger: logger
+      logger: lifecycleLogger
     )
     configuration.maximumGracefulShutdownDuration = .seconds(gracefulShutdownSeconds)
 

--- a/Sources/ClawGateway/Infrastructure/DeveloperLogging.swift
+++ b/Sources/ClawGateway/Infrastructure/DeveloperLogging.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Logging
+
+/// Developer-facing logging setup for the daemon. This is the runtime diagnostic stream
+/// (`stdout` via swift-log), deliberately separate from the durable `audit_events` trail: audit is
+/// the business/security record, these logs are for watching the request lifecycle in local dev.
+///
+/// Verbosity is controlled by the `CLAW_LOG_LEVEL` environment variable (swift-log level raw
+/// values); absent or unrecognized falls back to `.info`. Every line is passed through a secret
+/// redactor before it is written, so an accidental `\(error)` that embeds the bot token or an API
+/// key can never leak.
+public enum DeveloperLogging {
+  /// Overrides the developer-log verbosity. Values are swift-log `Logger.Level` raw values:
+  /// `trace | debug | info | notice | warning | error | critical`. Absent/unrecognized ⇒ `.info`.
+  public static let levelEnvKey = "CLAW_LOG_LEVEL"
+
+  /// Parses a `CLAW_LOG_LEVEL` value into a level, defaulting to `.info` for absent, blank, or
+  /// unrecognized input (a typo must never silence logging).
+  public static func level(from raw: String?) -> Logger.Level {
+    let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+    guard !trimmed.isEmpty else {
+      return .info
+    }
+    return Logger.Level(rawValue: trimmed) ?? .info
+  }
+
+  /// Installs the process-wide swift-log backend: a ``RedactingLogHandler`` over `stdout` at
+  /// `level`. Call exactly once, before the first `Logger` is constructed. `redact` is applied to
+  /// every message and string metadata value — wire `SecretRedactor.redact` here.
+  public static func bootstrap(
+    level: Logger.Level,
+    redact: @escaping @Sendable (String) -> String
+  ) {
+    LoggingSystem.bootstrap { label in
+      var handler = RedactingLogHandler(
+        base: StreamLogHandler.standardOutput(label: label),
+        redact: redact
+      )
+      handler.logLevel = level
+      return handler
+    }
+  }
+}
+
+/// A `LogHandler` decorator that scrubs known secret values from EVERY channel the wrapped handler
+/// can render — the message, per-call and persistent metadata values, a `metadataProvider`'s output,
+/// and a structured `error` — before delegating. It is the single choke-point that keeps the bot
+/// token / API keys out of developer logs, including any accidental `\(error)` interpolation at
+/// existing call sites. The durable audit trail does not flow through swift-log and is unaffected.
+struct RedactingLogHandler: LogHandler {
+  private var base: any LogHandler
+  private let redact: @Sendable (String) -> String
+
+  init(base: any LogHandler, redact: @escaping @Sendable (String) -> String) {
+    self.base = base
+    self.redact = redact
+  }
+
+  func log(event: LogEvent) {
+    var metadata = event.metadata.map { Self.redacted($0, using: redact) } ?? [:]
+    if let error = event.error {
+      // `StreamLogHandler` renders `event.error` into these two keys. Do it here (redacted) and pass
+      // `error: nil` downstream, so the detail survives without a second, unredacted render.
+      metadata["error.message"] = .string(redact("\(error)"))
+      metadata["error.type"] = .string("\(String(reflecting: type(of: error)))")
+    }
+    base.log(
+      event: LogEvent(
+        level: event.level,
+        message: Logger.Message(stringLiteral: redact(event.message.description)),
+        metadata: metadata.isEmpty ? nil : metadata,
+        source: event.source,
+        file: event.file,
+        function: event.function,
+        line: event.line
+      )
+    )
+  }
+
+  var logLevel: Logger.Level {
+    get { base.logLevel }
+    set { base.logLevel = newValue }
+  }
+
+  // Persistent metadata and the provider are merged by the base handler AFTER `log(event:)` runs, so
+  // they are redacted here at ingress instead — otherwise a secret stamped via `logger[metadataKey:]`
+  // or surfaced by a `metadataProvider` would reach stdout unscrubbed.
+  var metadata: Logger.Metadata {
+    get { base.metadata }
+    set { base.metadata = Self.redacted(newValue, using: redact) }
+  }
+
+  var metadataProvider: Logger.MetadataProvider? {
+    get { base.metadataProvider }
+    set {
+      let redact = self.redact
+      base.metadataProvider = newValue.map { provider in
+        Logger.MetadataProvider { Self.redacted(provider.get(), using: redact) }
+      }
+    }
+  }
+
+  subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+    get { base[metadataKey: key] }
+    set { base[metadataKey: key] = newValue.map { Self.redacted($0, using: redact) } }
+  }
+
+  private static func redacted(
+    _ metadata: Logger.Metadata,
+    using redact: (String) -> String
+  ) -> Logger.Metadata {
+    metadata.mapValues { redacted($0, using: redact) }
+  }
+
+  private static func redacted(
+    _ value: Logger.MetadataValue,
+    using redact: (String) -> String
+  ) -> Logger.MetadataValue {
+    switch value {
+    case .string(let text):
+      return .string(redact(text))
+    case .stringConvertible(let convertible):
+      return .string(redact("\(convertible)"))
+    case .array(let values):
+      return .array(values.map { redacted($0, using: redact) })
+    case .dictionary(let nested):
+      return .dictionary(redacted(nested, using: redact))
+    }
+  }
+}

--- a/Sources/ClawGateway/Infrastructure/DeveloperLogging.swift
+++ b/Sources/ClawGateway/Infrastructure/DeveloperLogging.swift
@@ -18,9 +18,11 @@ public enum DeveloperLogging {
   /// unrecognized input (a typo must never silence logging).
   public static func level(from raw: String?) -> Logger.Level {
     let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+
     guard !trimmed.isEmpty else {
       return .info
     }
+
     return Logger.Level(rawValue: trimmed) ?? .info
   }
 
@@ -58,12 +60,14 @@ struct RedactingLogHandler: LogHandler {
 
   func log(event: LogEvent) {
     var metadata = event.metadata.map { Self.redacted($0, using: redact) } ?? [:]
+
     if let error = event.error {
       // `StreamLogHandler` renders `event.error` into these two keys. Do it here (redacted) and pass
       // `error: nil` downstream, so the detail survives without a second, unredacted render.
       metadata["error.message"] = .string(redact("\(error)"))
       metadata["error.type"] = .string("\(String(reflecting: type(of: error)))")
     }
+
     base.log(
       event: LogEvent(
         level: event.level,
@@ -118,13 +122,13 @@ struct RedactingLogHandler: LogHandler {
   ) -> Logger.MetadataValue {
     switch value {
     case .string(let text):
-      return .string(redact(text))
+      .string(redact(text))
     case .stringConvertible(let convertible):
-      return .string(redact("\(convertible)"))
+      .string(redact("\(convertible)"))
     case .array(let values):
-      return .array(values.map { redacted($0, using: redact) })
+      .array(values.map { redacted($0, using: redact) })
     case .dictionary(let nested):
-      return .dictionary(redacted(nested, using: redact))
+      .dictionary(redacted(nested, using: redact))
     }
   }
 }

--- a/Sources/ClawGateway/Response/SchedulerHealth.swift
+++ b/Sources/ClawGateway/Response/SchedulerHealth.swift
@@ -34,7 +34,7 @@ public enum SchedulerHealth {
     let todayCount = heartbeatCountToday(state: state, timezone: timezone, now: now)
     // Spec §11: a proactive-cap trip is visible here even while global spend is under its cap.
     let proactiveSpend =
-      proactiveTodayUSD.map { spent in String(format: "%.2f", spent) } ?? "unknown"
+      proactiveTodayUSD.map { spent in USD.display(spent) } ?? "unknown"
 
     return [
       Row(
@@ -45,7 +45,7 @@ public enum SchedulerHealth {
       Row(key: "scheduler.last_misfire", value: misfire),
       Row(
         key: "spend.proactive_today_usd",
-        value: "\(proactiveSpend)/\(String(format: "%.2f", proactivePerDayUSD))"
+        value: "\(proactiveSpend)/\(USD.display(proactivePerDayUSD))"
       ),
       Row(key: "heartbeat.enabled", value: heartbeatEnabled ? "on" : "off"),
       Row(

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -597,8 +597,19 @@ extension MessageRouter {
       return .skipped
     }
 
+    // The inbound → run bridge: the one INFO line that shows a real message was accepted and which
+    // run it became. run/session/update ride as metadata so the whole lifecycle greps by `run=<id>`;
+    // only the message SIZE is logged, never its text.
+    var runLog = logger
+    runLog[metadataKey: "run"] = "\(runId)"
+    runLog[metadataKey: "session"] = "\(sessionId)"
+    runLog[metadataKey: "update"] = "\(rawUpdate.updateId)"
+    runLog.info(
+      "message accepted; dispatching run (chars=\(text.count) edited=\(message.isEdited))"
+    )
+
     let lane = await lanes.actor(for: sessionId)
-    await lane.enqueue(runId: runId) { [turnRunner, logger] in
+    await lane.enqueue(runId: runId) { [turnRunner, runLog] in
       do {
         try await turnRunner.run(
           runId: runId,
@@ -608,9 +619,9 @@ extension MessageRouter {
           grant: grant
         )
       } catch StoreError.diskFull {
-        logger.error("turn \(runId) stopped by storage full after enqueue")
+        runLog.error("turn stopped by storage full after enqueue")
       } catch {
-        logger.error("turn run error (handled in-band) for update \(rawUpdate.updateId): \(error)")
+        runLog.error("turn run error (handled in-band): \(error)")
       }
     }
 

--- a/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
+++ b/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
@@ -1,5 +1,6 @@
 import ClawCore
 import Foundation
+import Logging
 
 /// OpenAI-compatible Chat Completions client over the `HTTPExecuting` seam: request shaping
 /// (output-cap field switch, no sampling params), defensive response parse, status→`ProviderError`
@@ -15,23 +16,33 @@ public struct OpenAICompatibleProvider: LLMProvider {
   private let http: any HTTPExecuting & HTTPStreaming
   private let sleep: @Sendable (Double) async throws -> Void
   private let jitter: @Sendable (Double) -> Double
+  /// Developer-facing diagnostics (swift-log). Lines self-tag `[ClawLLM]` via the source module; a
+  /// no-op default keeps tests silent unless they inject one. Carries no run id by design — the
+  /// per-turn correlation lives in `AgentRuntime`, so the `LLMProvider` contract stays unchanged.
+  private let logger: Logger
 
   public init(
     config: LLMConfig,
     http: any HTTPExecuting & HTTPStreaming,
     sleep: @escaping @Sendable (Double) async throws -> Void,
-    jitter: @escaping @Sendable (Double) -> Double
+    jitter: @escaping @Sendable (Double) -> Double,
+    logger: Logger = Logger(label: "clawd.llm", factory: { _ in SwiftLogNoOpLogHandler() })
   ) {
     self.config = config
     self.http = http
     self.sleep = sleep
     self.jitter = jitter
+    self.logger = logger
   }
 
   public func complete(request: ChatRequest) async throws -> ChatResponse {
     let body = try encode(request: request)
     let url = chatCompletionsURL()
     let headers = requestHeaders()
+
+    logger.debug(
+      "chat request model=\(request.model) messages=\(request.messages.count) tools=\(request.tools.count)"
+    )
 
     var attempt = 0
     while true {
@@ -51,6 +62,9 @@ public struct OpenAICompatibleProvider: LLMProvider {
         guard attempt < config.retryBudget else {
           throw ProviderError.retryable(status: nil, message: message)
         }
+        logger.notice(
+          "chat transport error (attempt \(attempt)/\(config.retryBudget)); retrying: \(message)"
+        )
         try await backoff(attempt: attempt, retryAfterSeconds: nil)
         continue
       }
@@ -67,6 +81,9 @@ public struct OpenAICompatibleProvider: LLMProvider {
         throw ProviderError.retryable(status: result.statusCode, message: message)
       }
 
+      logger.notice(
+        "chat retryable status \(result.statusCode) (attempt \(attempt)/\(config.retryBudget)); retrying"
+      )
       try await backoff(attempt: attempt, retryAfterSeconds: retryAfterSeconds(from: result))
     }
   }
@@ -76,6 +93,9 @@ public struct OpenAICompatibleProvider: LLMProvider {
       let task = Task {
         do {
           let body = try encode(request: request, streaming: true)
+          logger.debug(
+            "chat stream request model=\(request.model) messages=\(request.messages.count) tools=\(request.tools.count)"
+          )
           let response = try await http.postStream(
             url: chatCompletionsURL(),
             headers: requestHeaders(),
@@ -86,6 +106,7 @@ public struct OpenAICompatibleProvider: LLMProvider {
           guard (200..<300).contains(response.head.statusCode) else {
             let errorBody = try await collectStreamingErrorBody(response.body)
             let message = sanitize(message: errorMessage(from: errorBody))
+            logger.notice("chat stream status \(response.head.statusCode)")
 
             if Self.isRetryableStatus(response.head.statusCode) {
               throw ProviderError.retryable(status: response.head.statusCode, message: message)

--- a/Sources/clawd/Subcommands/DoctorCommand.swift
+++ b/Sources/clawd/Subcommands/DoctorCommand.swift
@@ -48,7 +48,7 @@ struct DoctorCommand: AsyncParsableCommand {
         ? " (>= CLAW_PER_DAY_USD; the global cap dominates)" : ""
       report.add(
         key: "spend.proactive_per_day_usd",
-        value: String(format: "%.2f", config.proactivePerDayUSD) + proactiveNote
+        value: USD.display(config.proactivePerDayUSD) + proactiveNote
       )
       report.add(key: "heartbeat.enabled", value: config.heartbeatEnabled ? "on" : "off")
       report.add(key: "heartbeat.interval_min", value: "\(config.heartbeatIntervalMinutes)")
@@ -168,13 +168,13 @@ struct DoctorCommand: AsyncParsableCommand {
 
     let (todayTokens, todayUSD) = (try? stores.usage.todayTokensAndCost(now: now)) ?? (0, 0)
     let mix = (try? stores.usage.costSourceMix(now: now)) ?? [:]
-    report.add(key: "spend.today_usd", value: String(format: "%.4f", todayUSD))
+    report.add(key: "spend.today_usd", value: USD.precise(todayUSD))
     report.add(key: "spend.today_tokens", value: "\(todayTokens)")
     report.add(
       key: "spend.remaining_day_usd",
-      value: String(format: "%.2f", max(0, config.budget.perDayUSD - todayUSD))
+      value: USD.display(max(0, config.budget.perDayUSD - todayUSD))
     )
-    report.add(key: "spend.per_run_cap_usd", value: String(format: "%.2f", config.budget.perRunUSD))
+    report.add(key: "spend.per_run_cap_usd", value: USD.display(config.budget.perRunUSD))
     let mixText = mix.map { "\($0.key.rawValue)=\($0.value)" }.sorted().joined(separator: " ")
     report.add(key: "spend.cost_source_mix", value: mixText.isEmpty ? "none" : mixText)
 

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -19,9 +19,9 @@ struct RunCommand: AsyncParsableCommand {
   )
 
   func run() async throws {
-    let logger = Logger(label: "clawd")
     let config = try Self.loadConfigOrExit()
     let secrets = try Self.loadSecretsOrExit(config: config)
+    let logger = Self.bootstrapLogger(secrets: secrets)
 
     // Single-instance guard — held until the process exits (defer covers the graceful path).
     let lockPath = config.stateRoot.appendingPathComponent(StateFile.lock).path
@@ -103,6 +103,20 @@ struct RunCommand: AsyncParsableCommand {
       throw runFailure
     }
     logger.info("clawd stopped")
+  }
+
+  /// Installs the redacting swift-log backend (level from `CLAW_LOG_LEVEL`, default `.info`) over
+  /// stdout, then returns the root logger. Bootstrapping here — after secrets load, before the first
+  /// `Logger` — hands the redactor the real secret values so no downstream log line can leak them.
+  /// The earlier config/secret-load failures stay on stderr and cannot contain these secrets.
+  private static func bootstrapLogger(secrets: Secrets) -> Logger {
+    let environment = ProcessInfo.processInfo.environment
+    let redactor = SecretRedactor(secretValues: secrets.redactionValues)
+    DeveloperLogging.bootstrap(
+      level: DeveloperLogging.level(from: environment[DeveloperLogging.levelEnvKey]),
+      redact: { message in redactor.redact(message) }
+    )
+    return Logger(label: "clawd")
   }
 
   /// Loads config from the process environment, printing a diagnostic and exiting with the
@@ -270,8 +284,7 @@ struct RunCommand: AsyncParsableCommand {
     workspace: FileSystemWorkspace,
     toolExecutor: AsyncHTTPExecutor
   ) -> GatedToolDispatcher {
-    let secretValues = [secrets.telegramBotToken, secrets.llmApiKey, secrets.searchApiKey]
-      .compactMap { value in value }
+    let secretValues = secrets.redactionValues
     let redactor = SecretRedactor(secretValues: secretValues)
 
     var tools: [any Tool] = [
@@ -319,7 +332,8 @@ struct RunCommand: AsyncParsableCommand {
       config: config.llm.withAPIKey(secrets.llmApiKey ?? ""),
       http: executor,
       sleep: { try await Task.sleep(for: .seconds($0)) },
-      jitter: { Double.random(in: 0...$0) }
+      jitter: { Double.random(in: 0...$0) },
+      logger: logger
     )
 
     let costResolver = CostResolver(
@@ -338,7 +352,7 @@ struct RunCommand: AsyncParsableCommand {
       toolDispatcher: toolDispatcher,
       usageStore: stores.usage,
       auditLog: stores.audit,
-      warn: { warning in logger.warning("\(warning)") },
+      logger: logger,
       sleep: { try await Task.sleep(for: $0) }
     )
   }

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -112,10 +112,12 @@ struct RunCommand: AsyncParsableCommand {
   private static func bootstrapLogger(secrets: Secrets) -> Logger {
     let environment = ProcessInfo.processInfo.environment
     let redactor = SecretRedactor(secretValues: secrets.redactionValues)
+
     DeveloperLogging.bootstrap(
       level: DeveloperLogging.level(from: environment[DeveloperLogging.levelEnvKey]),
-      redact: { message in redactor.redact(message) }
+      redact: { redactor.redact($0) }
     )
+
     return Logger(label: "clawd")
   }
 

--- a/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
+++ b/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
@@ -201,7 +201,7 @@ func makeSC3Harness(
 
   // 7. TurnRunner sharing the router's registry instance.
   let transport = RecordingTransport()
-  let logger = Logger(label: "sc3")
+  let logger = TestLog.silent
   let runner = TurnRunner(
     sessionMessages: stores.sessionMessages,
     runs: stores.runs,

--- a/Tests/ClawGatewayTests/BootReconcileTests.swift
+++ b/Tests/ClawGatewayTests/BootReconcileTests.swift
@@ -19,7 +19,7 @@ import Testing
       outbox: fixture.outbox,
       transport: transport,
       signal: signal,
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     // when — boot reconcile sweeps the orphan to FAILED and enqueues the degradation, then the

--- a/Tests/ClawGatewayTests/Infrastructure/DeveloperLoggingTests.swift
+++ b/Tests/ClawGatewayTests/Infrastructure/DeveloperLoggingTests.swift
@@ -1,0 +1,171 @@
+import ClawTools
+import Foundation
+import Logging
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct DeveloperLoggingTests {
+  @Test func levelDefaultsToInfoWhenAbsentBlankOrUnrecognized() {
+    // given / when / then
+    #expect(DeveloperLogging.level(from: nil) == .info)
+    #expect(DeveloperLogging.level(from: "") == .info)
+    #expect(DeveloperLogging.level(from: "   ") == .info)
+    #expect(DeveloperLogging.level(from: "verbose") == .info)
+  }
+
+  @Test func levelParsesSwiftLogRawValuesCaseInsensitively() {
+    // given / when / then
+    #expect(DeveloperLogging.level(from: "debug") == .debug)
+    #expect(DeveloperLogging.level(from: "DEBUG") == .debug)
+    #expect(DeveloperLogging.level(from: " Trace ") == .trace)
+    #expect(DeveloperLogging.level(from: "warning") == .warning)
+    #expect(DeveloperLogging.level(from: "critical") == .critical)
+  }
+
+  @Test func redactsSecretInterpolatedIntoMessage() {
+    // given
+    let secret = "1234567:AA-super-secret-bot-token"
+    let capture = CaptureBox()
+    let logger = Self.redactingLogger(secret: secret, into: capture)
+
+    // when
+    logger.error("telegram send failed: transport(\(secret))")
+
+    // then
+    let line = capture.messages.last ?? ""
+    #expect(!line.contains(secret))
+    #expect(line.contains(SecretRedactor.replacement))
+  }
+
+  @Test func redactsSecretInStringMetadataValue() {
+    // given
+    let secret = "sk-live-abcdef-api-key"
+    let capture = CaptureBox()
+    let logger = Self.redactingLogger(secret: secret, into: capture)
+
+    // when
+    logger.info("fetch done", metadata: ["url": .string("https://api.example/\(secret)/v1")])
+
+    // then
+    let rendered = capture.metadatas.last.map { "\($0)" } ?? ""
+    #expect(!rendered.contains(secret))
+    #expect(rendered.contains(SecretRedactor.replacement))
+  }
+
+  @Test func passesThroughNonSecretContentUnchanged() {
+    // given
+    let capture = CaptureBox()
+    let logger = Self.redactingLogger(secret: "unused-secret", into: capture)
+
+    // when
+    logger.info("turn finished outcome=completed tokens=1200 usd=0.004")
+
+    // then
+    #expect(capture.messages.last == "turn finished outcome=completed tokens=1200 usd=0.004")
+  }
+
+  @Test func redactsSecretSetAsPersistentMetadata() {
+    // given — a secret stamped via the persistent-metadata subscript (merged by the base handler,
+    // so it must be scrubbed at ingress, not in log(event:)).
+    let secret = "1234:AA-persistent-token"
+    let redactor = SecretRedactor(secretValues: [secret])
+    var handler = RedactingLogHandler(
+      base: CapturingLogHandler(box: CaptureBox()),
+      redact: { redactor.redact($0) }
+    )
+
+    // when
+    handler[metadataKey: "authorization"] = .string("Bearer \(secret)")
+
+    // then — reading it back reflects what was stored on the base handler.
+    let stored = handler[metadataKey: "authorization"].map { "\($0)" } ?? ""
+    #expect(!stored.contains(secret))
+    #expect(stored.contains(SecretRedactor.replacement))
+  }
+
+  @Test func redactsSecretCarriedByStructuredError() {
+    // given
+    let secret = "sk-live-error-embedded-key"
+    let redactor = SecretRedactor(secretValues: [secret])
+    let capture = CaptureBox()
+    let handler = RedactingLogHandler(
+      base: CapturingLogHandler(box: capture),
+      redact: { redactor.redact($0) }
+    )
+
+    // when — a structured error whose description embeds a secret.
+    handler.log(
+      event: LogEvent(
+        level: .error,
+        message: "store write failed",
+        error: FakeSecretError(detail: secret),
+        metadata: nil,
+        source: "test",
+        file: #fileID,
+        function: #function,
+        line: #line
+      )
+    )
+
+    // then — the base handler receives the error only as redacted metadata.
+    let rendered = capture.metadatas.last.map { "\($0)" } ?? ""
+    #expect(!rendered.contains(secret))
+    #expect(rendered.contains(SecretRedactor.replacement))
+  }
+
+  private static func redactingLogger(secret: String, into capture: CaptureBox) -> Logger {
+    let redactor = SecretRedactor(secretValues: [secret])
+    var logger = Logger(label: "test") { _ in
+      RedactingLogHandler(base: CapturingLogHandler(box: capture), redact: { redactor.redact($0) })
+    }
+    logger.logLevel = .trace
+    return logger
+  }
+}
+
+private struct FakeSecretError: Error, CustomStringConvertible {
+  let detail: String
+  var description: String { "write failed: \(detail)" }
+}
+
+/// Thread-safe sink so the test can read back what the wrapped handler received post-redaction.
+private final class CaptureBox: @unchecked Sendable {
+  private let lock = NSLock()
+  private var messageLog: [String] = []
+  private var metadataLog: [Logger.Metadata] = []
+
+  var messages: [String] {
+    lock.lock()
+    defer { lock.unlock() }
+    return messageLog
+  }
+
+  var metadatas: [Logger.Metadata] {
+    lock.lock()
+    defer { lock.unlock() }
+    return metadataLog
+  }
+
+  func record(message: String, metadata: Logger.Metadata?) {
+    lock.lock()
+    defer { lock.unlock() }
+    messageLog.append(message)
+    metadataLog.append(metadata ?? [:])
+  }
+}
+
+private struct CapturingLogHandler: LogHandler {
+  let box: CaptureBox
+  var logLevel: Logger.Level = .trace
+  var metadata: Logger.Metadata = [:]
+
+  subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+    get { metadata[key] }
+    set { metadata[key] = newValue }
+  }
+
+  func log(event: LogEvent) {
+    box.record(message: event.message.description, metadata: event.metadata)
+  }
+}

--- a/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
+++ b/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
@@ -330,7 +330,7 @@ func makeStack(
   let transport = RecordingTransport()
   let signal = OutboxSignal()
   let lanes = SessionLaneRegistry()
-  let logger = Logger(label: "inc1-acceptance")
+  let logger = TestLog.silent
 
   let agent = AgentRuntime(
     provider: provider,
@@ -419,7 +419,7 @@ func makeStreamingStack(
   let transport = RecordingTransport()
   let signal = OutboxSignal()
   let lanes = SessionLaneRegistry()
-  let logger = Logger(label: "streaming-acceptance")
+  let logger = TestLog.silent
   let draftStreamer = TelegramRichDraftStreamer(transport: transport)
   let agent = AgentRuntime(
     provider: provider,
@@ -500,7 +500,7 @@ func makeStopNewStack(
   let transport = RecordingTransport()
   let signal = OutboxSignal()
   let lanes = SessionLaneRegistry()
-  let logger = Logger(label: "stop-new-acceptance")
+  let logger = TestLog.silent
 
   let agent = AgentRuntime(
     provider: provider,

--- a/Tests/ClawGatewayTests/Routing/MessageRouterTests.swift
+++ b/Tests/ClawGatewayTests/Routing/MessageRouterTests.swift
@@ -82,7 +82,7 @@ struct FullSessions: SessionMessageStore {
       transport: transport,
       turnRunner: dispatcher,
       lanes: SessionLaneRegistry(),
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     return Harness(
@@ -288,7 +288,7 @@ struct FullSessions: SessionMessageStore {
       transport: transport,
       turnRunner: dispatcher,
       lanes: SessionLaneRegistry(),
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     // when
@@ -348,7 +348,7 @@ struct FullSessions: SessionMessageStore {
       transport: transport,
       turnRunner: dispatcher,
       lanes: SessionLaneRegistry(),
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     // when
@@ -409,7 +409,7 @@ struct FullSessions: SessionMessageStore {
       transport: transport,
       turnRunner: FakeTurnRunner(),
       lanes: SessionLaneRegistry(),
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     // when

--- a/Tests/ClawGatewayTests/Routing/ToolApprovalRoutingTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ToolApprovalRoutingTests.swift
@@ -38,7 +38,7 @@ import Testing
       transport: transport,
       turnRunner: runner,
       lanes: SessionLaneRegistry(),
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
     return Fixture(
       router: router,

--- a/Tests/ClawGatewayTests/Routing/TurnRunnerOutcomeTests.swift
+++ b/Tests/ClawGatewayTests/Routing/TurnRunnerOutcomeTests.swift
@@ -62,7 +62,7 @@ import Testing
       contextBuilder: makeEmptyContextBuilder(),
       pendingConfirmations: registry,
       notifyOutbox: {},
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
     return Fixture(
       runner: runner,

--- a/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
+++ b/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
@@ -299,7 +299,7 @@ private func makeEnv(
     notifyOutbox: {},
     breaker: breaker,
     transport: transport,
-    logger: Logger(label: "test")
+    logger: TestLog.silent
   )
 
   return Env(

--- a/Tests/ClawGatewayTests/Services/OutboxDispatcherTests.swift
+++ b/Tests/ClawGatewayTests/Services/OutboxDispatcherTests.swift
@@ -82,7 +82,7 @@ private struct MarkSentFailingOutbox: OutboxStore {
       outbox: fixture.outbox,
       transport: transport,
       signal: OutboxSignal(),
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     // when
@@ -105,7 +105,7 @@ private struct MarkSentFailingOutbox: OutboxStore {
       outbox: fixture.outbox,
       transport: transport,
       signal: OutboxSignal(),
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     // when
@@ -126,7 +126,7 @@ private struct MarkSentFailingOutbox: OutboxStore {
       outbox: fixture.outbox,
       transport: transport,
       signal: signal,
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     // when — run the service; its boot drain delivers the pre-committed row, then we stop it
@@ -150,7 +150,7 @@ private struct MarkSentFailingOutbox: OutboxStore {
       outbox: fixture.outbox,
       transport: transport,
       signal: OutboxSignal(),
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     // when
@@ -173,7 +173,7 @@ private struct MarkSentFailingOutbox: OutboxStore {
       outbox: MarkSentFailingOutbox(base: fixture.outbox),
       transport: transport,
       signal: OutboxSignal(),
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     // when

--- a/Tests/ClawGatewayTests/Services/OutboxFallbackTests.swift
+++ b/Tests/ClawGatewayTests/Services/OutboxFallbackTests.swift
@@ -37,7 +37,7 @@ import Testing
       outbox: fixture.outbox,
       transport: transport,
       signal: OutboxSignal(),
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
   }
 

--- a/Tests/ClawGatewayTests/Services/SchedulerServiceTests.swift
+++ b/Tests/ClawGatewayTests/Services/SchedulerServiceTests.swift
@@ -221,7 +221,7 @@ private final class SleepRecorder: @unchecked Sendable {
       catchUpMaxAge: .seconds(1800),
       now: { now },
       sleep: { _ in },
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
     return Fixture(service: service, store: store, runner: runner)
   }
@@ -393,7 +393,7 @@ private final class SleepRecorder: @unchecked Sendable {
         recorder.append(duration)
         throw CancellationError()
       },
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     // when — restart recovery: the first tick happens BEFORE the first sleep

--- a/Tests/ClawGatewayTests/Services/TelegramPollerServiceTests.swift
+++ b/Tests/ClawGatewayTests/Services/TelegramPollerServiceTests.swift
@@ -78,7 +78,7 @@ private actor BlockingTurnRunner: TurnDispatching {
       transport: transport,
       turnRunner: dispatcher,
       lanes: SessionLaneRegistry(),
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
     let cursor = UpdateCursorStoreGRDB(writer: queue)
 
@@ -87,7 +87,7 @@ private actor BlockingTurnRunner: TurnDispatching {
       router: router,
       cursor: cursor,
       pollTimeout: 0,
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     return Stack(poller: poller, transport: transport, cursor: cursor, dispatcher: dispatcher)
@@ -144,7 +144,7 @@ private actor BlockingTurnRunner: TurnDispatching {
       transport: transport,
       turnRunner: runner,
       lanes: SessionLaneRegistry(),
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
     let cursor = UpdateCursorStoreGRDB(writer: queue)
     let poller = TelegramPollerService(
@@ -152,7 +152,7 @@ private actor BlockingTurnRunner: TurnDispatching {
       router: router,
       cursor: cursor,
       pollTimeout: 0,
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     // when

--- a/Tests/ClawGatewayTests/Support/MemoryRoutingHarness.swift
+++ b/Tests/ClawGatewayTests/Support/MemoryRoutingHarness.swift
@@ -46,7 +46,7 @@ struct MemoryRoutingHarness {
       transport: transport,
       turnRunner: dispatcher,
       lanes: SessionLaneRegistry(),
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
 
     return MemoryRoutingHarness(

--- a/Tests/ClawGatewayTests/Support/TestLog.swift
+++ b/Tests/ClawGatewayTests/Support/TestLog.swift
@@ -1,0 +1,8 @@
+import Logging
+
+/// A silent logger for the gateway test suite. Components under test emit developer logs by design;
+/// tests inject this no-op sink so the suite output stays quiet and deterministic. Use it wherever a
+/// component under test requires a `Logger` and the test does not assert on log output.
+enum TestLog {
+  static let silent = Logger(label: "test.silent", factory: { _ in SwiftLogNoOpLogHandler() })
+}


### PR DESCRIPTION
Closes #23.

## Problem

When the daemon processes a Telegram message, there was almost no developer-facing output between the major stages. swift-log was already a dependency, but no `LoggingSystem.bootstrap` ran (so `.info` was fixed with no way to enable debug), and only `ClawGateway`/`clawd` depended on `Logging` — everything from `agent.runTurn(...)` inward was dark.

## Approach

Reuse swift-log rather than invent a new seam.

- **Bootstrap** a `RedactingLogHandler` over stdout at a level from **`CLAW_LOG_LEVEL`** (default `.info`), installed after secrets load so the redactor holds the real secret values.
- Add `Logging` to `ClawAgent` and `ClawLLM` only; their lines self-tag `[ClawAgent]`/`[ClawLLM]` via swift-log's module `source`.
- Thread a turn-scoped `Logger` (with `run`/`session` metadata) through `AgentRuntime`, so a single `grep run=<id>` ties a whole request together.

## What you get

- **`.info` (default):** the lifecycle spine — `message accepted -> dispatching run N`, `turn started`, `turn finished` (outcome, tokens, cost, ms).
- **`CLAW_LOG_LEVEL=debug`:** per-hop trace — round-trip start, tool invoked/done + duration, provider request + retry/backoff/status.

Level policy: `info` for the load-bearing lifecycle lines, `debug` for the per-hop trace, `notice`/`warning` for budget denials / degradations / retries / 429, `error` for real faults.

## Security

New log sites emit only ids, counts, enum raw values, byte/token sizes, USD, and durations — never message text, tool args, observations, or raw request/response bodies. `RedactingLogHandler` is a sink-level backstop that scrubs known secrets from every channel it can render (message, per-call + persistent metadata, `metadataProvider`, structured `error`). Verified against a real run: the bot token that ServiceLifecycle would otherwise dump was redacted 62x, 0 leaks.

## Notable details

- `Daemon` floors ServiceLifecycle's logger at `.info` so debug shows the app's lifecycle, not the framework's ~1 MB service-graph dump.
- Canonical `USD` formatter (`ClawCore`) replaces scattered `%.Nf` cost-format strings in `AgentRuntime`, `DoctorCommand`, and `SchedulerHealth` (output-identical).
- Gateway tests inject a no-op `TestLog.silent` so the suite stays quiet.

## Testing

- `swift build`, `scripts/lint.sh`, and the full `swift test` (671 tests) all pass.
- New `DeveloperLoggingTests` cover level parsing and redaction across all four channels (message, per-call metadata, persistent metadata, structured error).
- Ran the real binary with `CLAW_LOG_LEVEL=debug` end to end: clean lifecycle output, `[module]` tags, `run=<id>` correlation, and no secret leakage.

A pre-merge review pass drove three hardening fixes folded into this branch: bumping the `swift-log` floor to `1.11.0` (where `LogEvent`/`log(event:)` was introduced), completing the redactor across the persistent-metadata / `metadataProvider` / structured-error channels, and correcting an over-stated invariant comment.
