### PR TITLE
Split MessageRouter into family handlers and domain occurrence policy

### DIFF
--- a/Sources/ClawCore/Domain/Scheduling/OccurrencePolicy.swift
+++ b/Sources/ClawCore/Domain/Scheduling/OccurrencePolicy.swift
@@ -48,9 +48,11 @@ public struct OccurrencePolicy: Sendable {
     guard let envelope = validated.recurrence else {
       return validated.firstOccurrence > nowDate ? validated.firstOccurrence : nil
     }
+
     guard let timezone = TimeZone(identifier: validated.timezone) else {
       return validated.firstOccurrence > nowDate ? validated.firstOccurrence : nil
     }
+
     return calculator.occurrences(
       rule: envelope.rule,
       timezone: timezone,

--- a/Sources/ClawCore/Domain/Scheduling/OccurrencePolicy.swift
+++ b/Sources/ClawCore/Domain/Scheduling/OccurrencePolicy.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+/// Use-case anchoring policy over `OccurrenceCalculator` (spec §5.3/§5.4/§8): each method names
+/// one moment the system asks "what fires next / what fires now" and pins that moment's anchor
+/// and cutoff, so the confirm preview, arm, resume, tick advance, and misfire coalesce can never
+/// drift apart. The calculator answers "which instants match the rule"; this type answers "which
+/// of them this use case wants".
+public struct OccurrencePolicy: Sendable {
+  private let calculator: OccurrenceCalculator
+
+  public init(calculator: OccurrenceCalculator = OccurrenceCalculator()) {
+    self.calculator = calculator
+  }
+
+  /// The confirm preview's fire times. The SAME `nowDate` that validation used seeds the
+  /// calculator, so the preview's first entry IS the parked `firstOccurrence`.
+  public func confirmPreview(
+    for validated: ValidatedSchedule,
+    from nowDate: Date,
+    limit: Int
+  ) -> [Date] {
+    guard
+      let envelope = validated.recurrence,
+      let timezone = TimeZone(identifier: validated.timezone)
+    else {
+      return [validated.firstOccurrence]
+    }
+    return calculator.occurrences(
+      rule: envelope.rule,
+      timezone: timezone,
+      anchor: nowDate,
+      after: nowDate,
+      limit: limit
+    )
+  }
+
+  /// The fire time to arm with. Anchoring on the parked `firstOccurrence` (not arm-time `now`)
+  /// keeps the previewed everyNMinutes phase intact (preamble deviation #1: phase-continuous
+  /// from preview through every fire) — mirroring `resumeOccurrence`, which anchors on the
+  /// stored occurrence rather than `now` for the same reason. `after: nowDate` still does the
+  /// M1 job: it skips any occurrence already past by confirm time, so a draft confirmed long
+  /// after its preview can't arm an already-past occurrence (a one-shot would silently misfire
+  /// to COMPLETED; a recurring one would fire immediately). This re-runs the SAME parked rule —
+  /// not a re-parse (§8): label/prompt/rule/timezone are still the parked draft's. Returns nil
+  /// when nothing valid remains to arm: a one-shot whose instant has passed, or (pathological)
+  /// a rule with no upcoming occurrence.
+  public func armOccurrence(for validated: ValidatedSchedule, at nowDate: Date) -> Date? {
+    guard let envelope = validated.recurrence else {
+      return validated.firstOccurrence > nowDate ? validated.firstOccurrence : nil
+    }
+    guard let timezone = TimeZone(identifier: validated.timezone) else {
+      return validated.firstOccurrence > nowDate ? validated.firstOccurrence : nil
+    }
+    return calculator.occurrences(
+      rule: envelope.rule,
+      timezone: timezone,
+      anchor: validated.firstOccurrence,
+      after: nowDate,
+      limit: 1
+    ).first
+  }
+
+  /// Resume's next fire: recurring ⇒ the calculator's next occurrence after now; one-shot ⇒ its
+  /// stored instant if still ahead, else nothing left to fire. Anchor = the stale stored next
+  /// (pause leaves next_occurrence untouched): the recompute stays on the armed chain —
+  /// everyNMinutes keeps its phase — while `after: nowDate` skips everything inside the paused
+  /// window (§5.4: pause = "be quiet", never catch up).
+  public func resumeOccurrence(for job: ScheduledJob, from nowDate: Date) -> Date? {
+    guard
+      let envelope = job.recurrence,
+      let timezone = TimeZone(identifier: job.timezone)
+    else {
+      guard let instant = job.nextOccurrence, instant > nowDate else {
+        return nil
+      }
+      return instant
+    }
+    return calculator.occurrences(
+      rule: envelope.rule,
+      timezone: timezone,
+      anchor: job.nextOccurrence ?? job.createdTs,
+      after: nowDate,
+      limit: 1
+    ).first
+  }
+
+  /// The advanced next_occurrence after a fire or skip: strictly after `after`; nil for a
+  /// one-shot (→ COMPLETED). `anchor` is the occurrence being advanced from (the claimed or
+  /// skipped due) — advances stay on the armed chain, so /schedule's confirm preview can never
+  /// disagree with actual fires.
+  public func advance(
+    for job: ScheduledJob,
+    timezone: TimeZone,
+    anchor: Date,
+    after: Date
+  ) -> Date? {
+    job.recurrence.flatMap { envelope in
+      calculator.occurrences(
+        rule: envelope.rule,
+        timezone: timezone,
+        anchor: anchor,
+        after: after,
+        limit: 1
+      ).first
+    }
+  }
+
+  /// Coalesce (§5.3): N missed occurrences inside the catch-up window fire ONCE, at the latest
+  /// missed occurrence ≤ `atOrBefore`; the claim's CAS still matches the stored due. Anchor =
+  /// the stored due: every advance stays on the chain the confirm preview showed (for
+  /// everyNMinutes the phase is due + k·N; time-of-day rules are anchor-inert). A one-shot has
+  /// exactly one occurrence — the stored one.
+  public func coalescedFireTime(
+    for job: ScheduledJob,
+    timezone: TimeZone,
+    due: Date,
+    atOrBefore: Date
+  ) -> Date {
+    guard let envelope = job.recurrence else {
+      return due
+    }
+    return calculator.latestOccurrence(
+      rule: envelope.rule,
+      timezone: timezone,
+      anchor: due,
+      after: due.addingTimeInterval(-1),
+      atOrBefore: atOrBefore
+    ) ?? due
+  }
+
+  /// How many occurrences a skip-misfire jumped over (observability only — the count feeds the
+  /// `jobMisfire` audit details, never control flow). `limit` caps the scan so a months-old due
+  /// date cannot enumerate unbounded dates.
+  public func missedOccurrenceCount(
+    for job: ScheduledJob,
+    timezone: TimeZone,
+    due: Date,
+    atOrBefore: Date,
+    limit: Int
+  ) -> Int {
+    job.recurrence.map { envelope in
+      calculator.occurrences(
+        rule: envelope.rule,
+        timezone: timezone,
+        anchor: due,
+        after: due.addingTimeInterval(-1),
+        limit: limit
+      ).filter { occurrence in
+        occurrence <= atOrBefore
+      }.count
+    } ?? 1
+  }
+}

--- a/Sources/ClawGateway/Routing/CommandHandlers.swift
+++ b/Sources/ClawGateway/Routing/CommandHandlers.swift
@@ -140,15 +140,15 @@ struct CommandHandlers: Sendable {
   ) async throws(RoutingHalt) -> HandleOutcome {
     switch command {
     case .review:
-      return try await memoryReview(rawUpdate: rawUpdate, chatId: message.chatId, kind: nil)
+      try await memoryReview(rawUpdate: rawUpdate, chatId: message.chatId, kind: nil)
     case .filter(let kind):
-      return try await memoryReview(rawUpdate: rawUpdate, chatId: message.chatId, kind: kind)
+      try await memoryReview(rawUpdate: rawUpdate, chatId: message.chatId, kind: kind)
     case .show(let id):
-      return try await memoryShow(rawUpdate: rawUpdate, chatId: message.chatId, id: id)
+      try await memoryShow(rawUpdate: rawUpdate, chatId: message.chatId, id: id)
     case .delete(let id):
-      return try await memoryDelete(rawUpdate: rawUpdate, chatId: message.chatId, id: id)
+      try await memoryDelete(rawUpdate: rawUpdate, chatId: message.chatId, id: id)
     case .invalid:
-      return await replies.sendCanned(
+      await replies.sendCanned(
         updateId: rawUpdate.updateId,
         chatId: message.chatId,
         text: MemoryReplies.memoryUsage
@@ -174,7 +174,10 @@ private extension CommandHandlers {
     }
 
     let text =
-      items.isEmpty ? MemoryReplies.emptyReview(kind: kind) : MemoryReplies.reviewList(items: items)
+      items.isEmpty
+      ? MemoryReplies.emptyReview(kind: kind)
+      : MemoryReplies.reviewList(items: items)
+
     return await replies.sendCanned(updateId: rawUpdate.updateId, chatId: chatId, text: text)
   }
 

--- a/Sources/ClawGateway/Routing/CommandHandlers.swift
+++ b/Sources/ClawGateway/Routing/CommandHandlers.swift
@@ -1,0 +1,243 @@
+import ClawAgent
+import ClawCore
+import Foundation
+import Logging
+
+/// The session and memory command family: /stop, /new, /remember, /memory. Every effect claims
+/// its update through a fused store seam or parks a confirmation; nothing here dispatches turns.
+struct CommandHandlers: Sendable {
+  let commands: any CommandStore
+  let sessionMessages: any SessionMessageStore
+  let memory: any MemoryStore
+  let pendingConfirmations: PendingConfirmationRegistry
+  let lanes: SessionLaneRegistry
+  let replies: ReplySender
+  let now: @Sendable () -> Date
+  let logger: Logger
+
+  func stop(
+    rawUpdate: RawUpdate,
+    message: IncomingMessage
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    let result = try await replies.perform(
+      "stop command",
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId
+    ) {
+      try commands.applyStop(
+        updateId: rawUpdate.updateId,
+        sessionKey: SessionKey.telegramDM(chatId: message.chatId),
+        now: now()
+      )
+    }
+
+    guard result.newlyClaimed else {
+      return replies.skipDuplicate(updateId: rawUpdate.updateId)
+    }
+
+    if let sessionId = result.sessionId, let runId = result.cancelledRunId {
+      let lane = await lanes.actor(for: sessionId)
+      await lane.cancel(runId: runId)
+    }
+
+    let reply = result.cancelledRunId == nil ? CommandReplies.nothingToStop : CommandReplies.stopped
+    return await replies.sendCommandAck(
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      text: reply
+    )
+  }
+
+  func new(
+    rawUpdate: RawUpdate,
+    message: IncomingMessage
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    let result = try await replies.perform(
+      "new command",
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId
+    ) {
+      try commands.applyNew(
+        updateId: rawUpdate.updateId,
+        sessionKey: SessionKey.telegramDM(chatId: message.chatId),
+        now: now()
+      )
+    }
+
+    guard result.newlyClaimed else {
+      return replies.skipDuplicate(updateId: rawUpdate.updateId)
+    }
+
+    if let sessionId = result.sessionId {
+      let lane = await lanes.actor(for: sessionId)
+      await lane.cancelAll()
+      await pendingConfirmations.clear(sessionId: sessionId)
+    }
+
+    return await replies.sendCommandAck(
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      text: CommandReplies.freshConversation
+    )
+  }
+
+  /// `/remember` is handled directly: claim the update, resolve the session, build the pure write
+  /// request, park it, and send the confirm prompt. No durable memory row is written until the
+  /// owner confirms.
+  func remember(
+    rawUpdate: RawUpdate,
+    message: IncomingMessage,
+    command: RememberCommand
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    guard case .save(let kind, let text) = command else {
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: MemoryReplies.rememberUsage
+      )
+    }
+
+    let claim = try await replies.perform(
+      "remember claim",
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId
+    ) {
+      try sessionMessages.claimCommandUpdate(
+        updateId: rawUpdate.updateId,
+        sessionKey: SessionKey.telegramDM(chatId: message.chatId),
+        now: now()
+      )
+    }
+
+    guard case .claimed(let sessionId) = claim else {
+      return replies.skipDuplicate(updateId: rawUpdate.updateId)
+    }
+
+    let request: MemoryWriteRequest
+    do {
+      request = try MemoryWriteBuilder.build(rawText: text, kind: kind, sessionId: sessionId)
+    } catch {
+      return await replies.sendCommandAck(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: MemoryReplies.nothingToSave
+      )
+    }
+
+    await pendingConfirmations.park(.command(.rememberWrite(request)), sessionId: sessionId)
+
+    return await replies.sendCommandAck(
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      text: request.confirmationText
+    )
+  }
+
+  func memory(
+    rawUpdate: RawUpdate,
+    message: IncomingMessage,
+    command: MemoryCommand
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    switch command {
+    case .review:
+      return try await memoryReview(rawUpdate: rawUpdate, chatId: message.chatId, kind: nil)
+    case .filter(let kind):
+      return try await memoryReview(rawUpdate: rawUpdate, chatId: message.chatId, kind: kind)
+    case .show(let id):
+      return try await memoryShow(rawUpdate: rawUpdate, chatId: message.chatId, id: id)
+    case .delete(let id):
+      return try await memoryDelete(rawUpdate: rawUpdate, chatId: message.chatId, id: id)
+    case .invalid:
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: MemoryReplies.memoryUsage
+      )
+    }
+  }
+}
+
+// MARK: - Memory Commands
+
+private extension CommandHandlers {
+  func memoryReview(
+    rawUpdate: RawUpdate,
+    chatId: Int64,
+    kind: MemoryKind?
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    let items = try await replies.perform(
+      "memory review",
+      updateId: rawUpdate.updateId,
+      chatId: chatId
+    ) {
+      try memory.list(kind: kind, limit: MemoryReplies.reviewListLimit)
+    }
+
+    let text =
+      items.isEmpty ? MemoryReplies.emptyReview(kind: kind) : MemoryReplies.reviewList(items: items)
+    return await replies.sendCanned(updateId: rawUpdate.updateId, chatId: chatId, text: text)
+  }
+
+  func memoryShow(
+    rawUpdate: RawUpdate,
+    chatId: Int64,
+    id: Int64
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    let item = try await replies.perform(
+      "memory show",
+      updateId: rawUpdate.updateId,
+      chatId: chatId
+    ) {
+      try memory.get(id: id)
+    }
+
+    let text = item.map(MemoryReplies.showItem) ?? MemoryReplies.notFound(id: id)
+    return await replies.sendCanned(updateId: rawUpdate.updateId, chatId: chatId, text: text)
+  }
+
+  func memoryDelete(
+    rawUpdate: RawUpdate,
+    chatId: Int64,
+    id: Int64
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    let existing = try await replies.perform(
+      "memory delete lookup",
+      updateId: rawUpdate.updateId,
+      chatId: chatId
+    ) {
+      try memory.get(id: id)
+    }
+
+    guard let item = existing else {
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
+        chatId: chatId,
+        text: MemoryReplies.notFound(id: id)
+      )
+    }
+
+    let claim = try await replies.perform(
+      "memory delete claim",
+      updateId: rawUpdate.updateId,
+      chatId: chatId
+    ) {
+      try sessionMessages.claimCommandUpdate(
+        updateId: rawUpdate.updateId,
+        sessionKey: SessionKey.telegramDM(chatId: chatId),
+        now: now()
+      )
+    }
+
+    guard case .claimed(let sessionId) = claim else {
+      return replies.skipDuplicate(updateId: rawUpdate.updateId)
+    }
+
+    await pendingConfirmations.park(.command(.deleteItem(id: id)), sessionId: sessionId)
+
+    return await replies.sendCommandAck(
+      updateId: rawUpdate.updateId,
+      chatId: chatId,
+      text: MemoryReplies.deleteConfirmPrompt(item: item)
+    )
+  }
+}

--- a/Sources/ClawGateway/Routing/ConfirmationResolver.swift
+++ b/Sources/ClawGateway/Routing/ConfirmationResolver.swift
@@ -199,15 +199,15 @@ private extension ConfirmationResolver {
 
     await pendingConfirmations.clear(sessionId: sessionId)
 
-    let errorText: String
-    switch confirmation {
-    case .rememberWrite:
-      errorText = MemoryReplies.saveFailed
-    case .deleteItem:
-      errorText = MemoryReplies.deleteFailed
-    case .scheduleArm:
-      errorText = ScheduleReplies.armFailed
-    }
+    let errorText: String =
+      switch confirmation {
+      case .rememberWrite:
+        MemoryReplies.saveFailed
+      case .deleteItem:
+        MemoryReplies.deleteFailed
+      case .scheduleArm:
+        ScheduleReplies.armFailed
+      }
 
     return await replies.sendCommandAck(
       updateId: rawUpdate.updateId,

--- a/Sources/ClawGateway/Routing/ConfirmationResolver.swift
+++ b/Sources/ClawGateway/Routing/ConfirmationResolver.swift
@@ -1,0 +1,235 @@
+import ClawCore
+import Foundation
+import Logging
+
+/// Intercepts plain text while a confirmation is parked for the session (§9/§14). The session
+/// lookup is read-only and fails closed: with the lookup down we cannot prove whether a parked
+/// "yes" should be intercepted, so nothing is claimed and the update is retried instead.
+struct ConfirmationResolver: Sendable {
+  let sessionMessages: any SessionMessageStore
+  let pendingConfirmations: PendingConfirmationRegistry
+  let memoryCommands: any MemoryCommandStore
+  let schedule: ScheduleSurface
+  let turnDispatch: TurnDispatch
+  let replies: ReplySender
+  let now: @Sendable () -> Date
+  let logger: Logger
+
+  /// nil ⇒ nothing to resolve; the caller falls through to normal turn dispatch.
+  func resolve(
+    rawUpdate: RawUpdate,
+    message: IncomingMessage,
+    text: String
+  ) async throws(RoutingHalt) -> HandleOutcome? {
+    let existing = try await replies.perform(
+      "pending lookup",
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId
+    ) {
+      try sessionMessages.findSession(sessionKey: SessionKey.telegramDM(chatId: message.chatId))
+    }
+    guard let sessionId = existing else {
+      return nil
+    }
+
+    guard let entry = await pendingConfirmations.pending(sessionId: sessionId) else {
+      return nil
+    }
+
+    // A tool approval differs from the memory-confirm flow: BOTH a confirm and a non-confirm
+    // reply become an ordinary persisted turn (never a command ack, §14).
+    if case .toolApproval(let request) = entry {
+      await pendingConfirmations.clear(sessionId: sessionId)
+      let grant: OneTurnGrant? =
+        ConfirmationReply.parse(text) == .confirm
+        ? OneTurnGrant(action: request.action)
+        : nil
+      return try await turnDispatch.dispatch(
+        rawUpdate: rawUpdate,
+        message: message,
+        text: text,
+        grant: grant
+      )
+    }
+
+    guard case .command(let confirmation) = entry else {
+      return nil
+    }
+
+    switch ConfirmationReply.parse(text) {
+    case .confirm:
+      return try await commitPending(
+        confirmation,
+        sessionId: sessionId,
+        rawUpdate: rawUpdate,
+        message: message
+      )
+    case .cancel:
+      return try await cancelPending(
+        sessionId: sessionId,
+        rawUpdate: rawUpdate,
+        message: message
+      )
+    case .other:
+      await pendingConfirmations.clear(sessionId: sessionId)
+      return nil
+    }
+  }
+}
+
+// MARK: - Commit & Cancel
+
+private extension ConfirmationResolver {
+  /// Confirms a parked effect through its atomic claim+effect+audit store seam.
+  func commitPending(
+    _ confirmation: CommandConfirmation,
+    sessionId: Int64,
+    rawUpdate: RawUpdate,
+    message: IncomingMessage
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    // A parked schedule can be confirmed long after its preview; recompute the fire time from
+    // the parked rule against the arm-time clock (details in OccurrencePolicy.armOccurrence).
+    // A one-shot whose instant has passed cannot be salvaged — reject it so the owner
+    // reschedules rather than arming a job that silently never fires.
+    var scheduleArmNext: Date?
+    if case .scheduleArm(let validated) = confirmation {
+      guard let recomputed = schedule.policy.armOccurrence(for: validated, at: now()) else {
+        return try await rejectStaleArm(
+          sessionId: sessionId,
+          rawUpdate: rawUpdate,
+          message: message
+        )
+      }
+      scheduleArmNext = recomputed
+    }
+
+    let newlyClaimed: Bool
+    let ackText: String
+    do {
+      switch confirmation {
+      case .rememberWrite(let request):
+        let result = try memoryCommands.applyRemember(
+          updateId: rawUpdate.updateId,
+          item: request.item,
+          now: now()
+        )
+        newlyClaimed = result.newlyClaimed
+        ackText = MemoryReplies.saved(id: result.item?.id)
+      case .deleteItem(let itemId):
+        let result = try memoryCommands.applyForget(
+          updateId: rawUpdate.updateId,
+          itemId: itemId,
+          now: now()
+        )
+        newlyClaimed = result.newlyClaimed
+        ackText = MemoryReplies.deleted(id: itemId)
+      case .scheduleArm(let validated):
+        // owner_chat_id is set HERE, in code, from the arming chat — never model- or
+        // prompt-controlled (spec §4.1). The insert is the exact parked draft (§8, no re-parse).
+        let newJob = NewScheduledJob(
+          ownerChatId: message.chatId,
+          label: validated.label,
+          prompt: validated.prompt,
+          recurrence: validated.recurrence,
+          timezone: validated.timezone,
+          nextOccurrence: scheduleArmNext ?? validated.firstOccurrence
+        )
+        let result = try schedule.commands.applyArm(
+          updateId: rawUpdate.updateId,
+          job: newJob,
+          now: now()
+        )
+        newlyClaimed = result.newlyClaimed
+        ackText = ScheduleReplies.armed(job: result.job)
+      }
+    } catch StoreError.diskFull {
+      throw RoutingHalt(outcome: await replies.storageFull(chatId: message.chatId))
+    } catch {
+      // A non-disk commit failure is terminal for the parked entry — recovery is claim + clear
+      // + per-entry ack, which `perform`'s retry/ack options don't express.
+      logger.error("confirmation commit failed for update \(rawUpdate.updateId): \(error)")
+      return try await failPendingCommit(
+        confirmation,
+        sessionId: sessionId,
+        rawUpdate: rawUpdate,
+        message: message
+      )
+    }
+
+    guard newlyClaimed else {
+      return replies.skipDuplicate(updateId: rawUpdate.updateId)
+    }
+
+    await pendingConfirmations.clear(sessionId: sessionId)
+
+    return await replies.sendCommandAck(
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      text: ackText
+    )
+  }
+
+  /// A parked schedule confirmed after its only fire time has passed: nothing valid remains to
+  /// arm. Claim the update (dedup), clear the slot, and tell the owner to reschedule.
+  func rejectStaleArm(
+    sessionId: Int64,
+    rawUpdate: RawUpdate,
+    message: IncomingMessage
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    try await replies.claimUpdate(updateId: rawUpdate.updateId, chatId: message.chatId)
+
+    await pendingConfirmations.clear(sessionId: sessionId)
+
+    return await replies.sendCommandAck(
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      text: ScheduleReplies.armExpired
+    )
+  }
+
+  /// A non-disk commit failure is terminal for the parked entry: claim the update, clear the
+  /// ephemeral pending state, and tell the owner nothing changed so they can re-issue.
+  func failPendingCommit(
+    _ confirmation: CommandConfirmation,
+    sessionId: Int64,
+    rawUpdate: RawUpdate,
+    message: IncomingMessage
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    try await replies.claimUpdate(updateId: rawUpdate.updateId, chatId: message.chatId)
+
+    await pendingConfirmations.clear(sessionId: sessionId)
+
+    let errorText: String
+    switch confirmation {
+    case .rememberWrite:
+      errorText = MemoryReplies.saveFailed
+    case .deleteItem:
+      errorText = MemoryReplies.deleteFailed
+    case .scheduleArm:
+      errorText = ScheduleReplies.armFailed
+    }
+
+    return await replies.sendCommandAck(
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      text: errorText
+    )
+  }
+
+  /// A negative confirmation claims the update, clears the parked entry, and sends a cancel ack.
+  func cancelPending(
+    sessionId: Int64,
+    rawUpdate: RawUpdate,
+    message: IncomingMessage
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    try await replies.claimUpdate(updateId: rawUpdate.updateId, chatId: message.chatId)
+
+    await pendingConfirmations.clear(sessionId: sessionId)
+
+    return await replies.sendCommandAck(
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      text: MemoryReplies.cancelled
+    )
+  }
+}

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -289,7 +289,7 @@ private extension MessageRouter {
       )
     }
 
-    await pendingConfirmations.park(.rememberWrite(request), sessionId: sessionId)
+    await pendingConfirmations.park(.command(.rememberWrite(request)), sessionId: sessionId)
 
     return await sendCommandAck(
       rawUpdate: rawUpdate,
@@ -401,7 +401,7 @@ private extension MessageRouter {
       return .skipped
     }
 
-    await pendingConfirmations.park(.deleteItem(id: id), sessionId: sessionId)
+    await pendingConfirmations.park(.command(.deleteItem(id: id)), sessionId: sessionId)
 
     return await sendCommandAck(
       rawUpdate: rawUpdate,
@@ -499,7 +499,7 @@ private extension MessageRouter {
         )
       case .success(let validated):
         // Single slot per session: a second /schedule visibly displaces the older draft (§9).
-        await pendingConfirmations.park(.scheduleArm(validated), sessionId: sessionId)
+        await pendingConfirmations.park(.command(.scheduleArm(validated)), sessionId: sessionId)
         return await sendCommandAck(
           rawUpdate: rawUpdate,
           chatId: message.chatId,
@@ -788,10 +788,16 @@ private extension MessageRouter {
       )
     }
 
+    guard case .command(let confirmation) = entry else {
+      // .toolApproval returned above; the guard keeps the destructuring exhaustive without a
+      // fatal arm.
+      return nil
+    }
+
     switch ConfirmationReply.parse(text) {
     case .confirm:
       return await commitPending(
-        entry,
+        confirmation,
         sessionId: sessionId,
         rawUpdate: rawUpdate,
         message: message
@@ -810,7 +816,7 @@ private extension MessageRouter {
 
   /// Confirms a parked effect through its atomic claim+effect+audit store seam.
   func commitPending(
-    _ entry: PendingConfirmation,
+    _ entry: CommandConfirmation,
     sessionId: Int64,
     rawUpdate: RawUpdate,
     message: IncomingMessage
@@ -865,8 +871,6 @@ private extension MessageRouter {
         )
         newlyClaimed = result.newlyClaimed
         ackText = ScheduleReplies.armed(job: result.job)
-      case .toolApproval:
-        preconditionFailure("approvals resolve in resolvePendingConfirmation before commitPending")
       }
     } catch StoreError.diskFull {
       return await storageFull(chatId: message.chatId)
@@ -924,7 +928,7 @@ private extension MessageRouter {
   /// A non-disk commit failure is terminal for the parked entry: claim the update, clear the
   /// ephemeral pending state, and tell the owner nothing changed so they can re-issue the command.
   func failPendingCommit(
-    _ entry: PendingConfirmation,
+    _ entry: CommandConfirmation,
     sessionId: Int64,
     rawUpdate: RawUpdate,
     message: IncomingMessage
@@ -954,8 +958,6 @@ private extension MessageRouter {
       errorText = MemoryReplies.deleteFailed
     case .scheduleArm:
       errorText = ScheduleReplies.armFailed
-    case .toolApproval:
-      preconditionFailure("approvals resolve in resolvePendingConfirmation before commitPending")
     }
 
     return await sendCommandAck(rawUpdate: rawUpdate, chatId: message.chatId, text: errorText)

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -21,8 +21,6 @@ public enum HandleOutcome: Sendable, Equatable {
 public struct MessageRouter: Sendable {
   private let processed: any ProcessedUpdateStore
   private let sessionMessages: any SessionMessageStore
-  private let commands: any CommandStore
-  private let memory: any MemoryStore
   private let pendingConfirmations: PendingConfirmationRegistry
   private let botUsername: String?
   private let accessControl: AccessControl
@@ -36,6 +34,7 @@ public struct MessageRouter: Sendable {
   private let enqueuer: TurnEnqueuer
   private let turnDispatch: TurnDispatch
   private let confirmations: ConfirmationResolver
+  private let commandHandlers: CommandHandlers
 
   public init(
     processed: any ProcessedUpdateStore,
@@ -55,8 +54,6 @@ public struct MessageRouter: Sendable {
   ) {
     self.processed = processed
     self.sessionMessages = sessionMessages
-    self.commands = commands
-    self.memory = memory
     self.pendingConfirmations = pendingConfirmations
     self.botUsername = botUsername
     self.accessControl = accessControl
@@ -67,6 +64,16 @@ public struct MessageRouter: Sendable {
     self.now = now
     self.logger = logger
     self.replies = ReplySender(processed: processed, transport: transport, logger: logger)
+    self.commandHandlers = CommandHandlers(
+      commands: commands,
+      sessionMessages: sessionMessages,
+      memory: memory,
+      pendingConfirmations: pendingConfirmations,
+      lanes: lanes,
+      replies: self.replies,
+      now: now,
+      logger: logger
+    )
     self.enqueuer = TurnEnqueuer(lanes: lanes, turns: turnRunner, logger: logger)
     let turnDispatch = TurnDispatch(
       sessionMessages: sessionMessages,
@@ -130,17 +137,17 @@ public struct MessageRouter: Sendable {
         guard isAllowed else {
           return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
         }
-        return await handleStop(rawUpdate: rawUpdate, message: message)
+        return try await commandHandlers.stop(rawUpdate: rawUpdate, message: message)
       case .new:
         guard isAllowed else {
           return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
         }
-        return await handleNew(rawUpdate: rawUpdate, message: message)
+        return try await commandHandlers.new(rawUpdate: rawUpdate, message: message)
       case .remember(let rememberCommand):
         guard isAllowed else {
           return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
         }
-        return await handleRemember(
+        return try await commandHandlers.remember(
           rawUpdate: rawUpdate,
           message: message,
           command: rememberCommand
@@ -149,7 +156,7 @@ public struct MessageRouter: Sendable {
         guard isAllowed else {
           return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
         }
-        return await handleMemory(
+        return try await commandHandlers.memory(
           rawUpdate: rawUpdate,
           message: message,
           command: memoryCommand
@@ -194,242 +201,9 @@ public struct MessageRouter: Sendable {
   }
 }
 
-// MARK: - Session Commands
+// MARK: - Schedule Creation & Listing
 
 private extension MessageRouter {
-  func handleStop(rawUpdate: RawUpdate, message: IncomingMessage) async -> HandleOutcome {
-    let result: StopCommandResult
-    do {
-      result = try commands.applyStop(
-        updateId: rawUpdate.updateId,
-        sessionKey: SessionKey.telegramDM(chatId: message.chatId),
-        now: Date()
-      )
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("stop command failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    guard result.newlyClaimed else {
-      logger.debug("duplicate update \(rawUpdate.updateId), skipping")
-      return .skipped
-    }
-
-    if let sessionId = result.sessionId, let runId = result.cancelledRunId {
-      let lane = await lanes.actor(for: sessionId)
-      await lane.cancel(runId: runId)
-    }
-
-    let reply = result.cancelledRunId == nil ? CommandReplies.nothingToStop : CommandReplies.stopped
-    return await sendCommandAck(rawUpdate: rawUpdate, chatId: message.chatId, text: reply)
-  }
-
-  func handleNew(rawUpdate: RawUpdate, message: IncomingMessage) async -> HandleOutcome {
-    let result: NewCommandResult
-    do {
-      result = try commands.applyNew(
-        updateId: rawUpdate.updateId,
-        sessionKey: SessionKey.telegramDM(chatId: message.chatId),
-        now: Date()
-      )
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("new command failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    guard result.newlyClaimed else {
-      logger.debug("duplicate update \(rawUpdate.updateId), skipping")
-      return .skipped
-    }
-
-    if let sessionId = result.sessionId {
-      let lane = await lanes.actor(for: sessionId)
-      await lane.cancelAll()
-      await pendingConfirmations.clear(sessionId: sessionId)
-    }
-
-    return await sendCommandAck(
-      rawUpdate: rawUpdate,
-      chatId: message.chatId,
-      text: CommandReplies.freshConversation
-    )
-  }
-
-  // MARK: - Memory Commands
-
-  /// `/remember` is handled directly: claim the update, resolve the session, build the pure write
-  /// request, park it, and send the confirm prompt. No durable memory row is written until the
-  /// owner confirms.
-  func handleRemember(
-    rawUpdate: RawUpdate,
-    message: IncomingMessage,
-    command: RememberCommand
-  ) async -> HandleOutcome {
-    guard case .save(let kind, let text) = command else {
-      return await sendCanned(
-        rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: MemoryReplies.rememberUsage
-      )
-    }
-
-    let claim: CommandClaim
-    do {
-      claim = try sessionMessages.claimCommandUpdate(
-        updateId: rawUpdate.updateId,
-        sessionKey: SessionKey.telegramDM(chatId: message.chatId),
-        now: Date()
-      )
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("remember claim failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    guard case .claimed(let sessionId) = claim else {
-      logger.debug("duplicate update \(rawUpdate.updateId), skipping")
-      return .skipped
-    }
-
-    let request: MemoryWriteRequest
-    do {
-      request = try MemoryWriteBuilder.build(rawText: text, kind: kind, sessionId: sessionId)
-    } catch {
-      return await sendCommandAck(
-        rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: MemoryReplies.nothingToSave
-      )
-    }
-
-    await pendingConfirmations.park(.command(.rememberWrite(request)), sessionId: sessionId)
-
-    return await sendCommandAck(
-      rawUpdate: rawUpdate,
-      chatId: message.chatId,
-      text: request.confirmationText
-    )
-  }
-
-  func handleMemory(
-    rawUpdate: RawUpdate,
-    message: IncomingMessage,
-    command: MemoryCommand
-  ) async -> HandleOutcome {
-    switch command {
-    case .review:
-      return await handleMemoryReview(rawUpdate: rawUpdate, chatId: message.chatId, kind: nil)
-    case .filter(let kind):
-      return await handleMemoryReview(rawUpdate: rawUpdate, chatId: message.chatId, kind: kind)
-    case .show(let id):
-      return await handleMemoryShow(rawUpdate: rawUpdate, chatId: message.chatId, id: id)
-    case .delete(let id):
-      return await handleMemoryDelete(rawUpdate: rawUpdate, chatId: message.chatId, id: id)
-    case .invalid:
-      return await sendCanned(
-        rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: MemoryReplies.memoryUsage
-      )
-    }
-  }
-
-  func handleMemoryReview(
-    rawUpdate: RawUpdate,
-    chatId: Int64,
-    kind: MemoryKind?
-  ) async -> HandleOutcome {
-    let items: [MemoryItem]
-    do {
-      items = try memory.list(kind: kind, limit: MemoryReplies.reviewListLimit)
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: chatId)
-    } catch {
-      logger.error("memory review failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    let text =
-      items.isEmpty ? MemoryReplies.emptyReview(kind: kind) : MemoryReplies.reviewList(items: items)
-    return await sendCanned(rawUpdate: rawUpdate, chatId: chatId, text: text)
-  }
-
-  func handleMemoryShow(
-    rawUpdate: RawUpdate,
-    chatId: Int64,
-    id: Int64
-  ) async -> HandleOutcome {
-    let item: MemoryItem?
-    do {
-      item = try memory.get(id: id)
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: chatId)
-    } catch {
-      logger.error("memory show failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    let text = item.map(MemoryReplies.showItem) ?? MemoryReplies.notFound(id: id)
-    return await sendCanned(rawUpdate: rawUpdate, chatId: chatId, text: text)
-  }
-
-  func handleMemoryDelete(
-    rawUpdate: RawUpdate,
-    chatId: Int64,
-    id: Int64
-  ) async -> HandleOutcome {
-    let item: MemoryItem
-    do {
-      guard let existing = try memory.get(id: id) else {
-        return await sendCanned(
-          rawUpdate: rawUpdate,
-          chatId: chatId,
-          text: MemoryReplies.notFound(id: id)
-        )
-      }
-      item = existing
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: chatId)
-    } catch {
-      logger.error("memory delete lookup failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    let claim: CommandClaim
-    do {
-      claim = try sessionMessages.claimCommandUpdate(
-        updateId: rawUpdate.updateId,
-        sessionKey: SessionKey.telegramDM(chatId: chatId),
-        now: Date()
-      )
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: chatId)
-    } catch {
-      logger.error("memory delete claim failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    guard case .claimed(let sessionId) = claim else {
-      logger.debug("duplicate update \(rawUpdate.updateId), skipping")
-      return .skipped
-    }
-
-    await pendingConfirmations.park(.command(.deleteItem(id: id)), sessionId: sessionId)
-
-    return await sendCommandAck(
-      rawUpdate: rawUpdate,
-      chatId: chatId,
-      text: MemoryReplies.deleteConfirmPrompt(item: item)
-    )
-  }
-
-  // MARK: - Schedule Creation & Listing
-
   /// Fans the allowlisted scheduling family — plus `/help`, which shares the identical
   /// owner-only `isAllowed` gate and has no state of its own to warrant a standalone arm in
   /// `handle` — out to its per-verb handler. The `isAllowed` gate is applied once by the caller
@@ -535,7 +309,7 @@ private extension MessageRouter {
   }
 
   /// `/schedule list` (spec §9): read-only, deduped via the canned-reply claim like
-  /// `handleMemoryReview`.
+  /// `CommandHandlers.memoryReview`.
   func handleScheduleList(rawUpdate: RawUpdate, chatId: Int64) async -> HandleOutcome {
     let jobs: [ScheduledJob]
     do {

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -129,10 +129,10 @@ private extension MessageRouter {
       )
     case .text(let text):
       let command = Command.parse(text, botUsername: botUsername)
-      guard isAllowed else {
-        return await denyAccess(command, rawUpdate: rawUpdate, message: message)
+      if isAllowed {
+        return try await routeAllowed(command, rawUpdate: rawUpdate, message: message)
       }
-      return try await routeAllowed(command, rawUpdate: rawUpdate, message: message)
+      return await denyAccess(command, rawUpdate: rawUpdate, message: message)
     }
   }
 
@@ -143,14 +143,14 @@ private extension MessageRouter {
     rawUpdate: RawUpdate,
     message: IncomingMessage
   ) async -> HandleOutcome {
-    guard case .start = command else {
-      return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
+    if case .start = command {
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: Self.unauthorizedStartText(userId: message.userId)
+      )
     }
-    return await replies.sendCanned(
-      updateId: rawUpdate.updateId,
-      chatId: message.chatId,
-      text: Self.unauthorizedStartText(userId: message.userId)
-    )
+    return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
   }
 
   func routeAllowed(

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -11,30 +11,22 @@ public enum HandleOutcome: Sendable, Equatable {
   case storageFull  // disk full while persisting — notice sent; back off, do NOT advance
 }
 
-/// Routes one inbound update. Allowlisted plain text becomes a real LLM turn (persisted via the
-/// fused `claimAndPersistInbound`, then dispatched to the `TurnRunner`); everything else —
-/// `/start`, `/remember`, unauthorized senders, unsupported media — gets a direct canned reply or
-/// command ack. Memory commands (`/remember`, `/memory`) are handled directly too, and while a
-/// confirmation is parked for a session, the next plain text resolves it here before any turn is
-/// dispatched. The two dedup paths share the `processed_updates` key space, and each update takes
-/// exactly one path, so an update is claimed once.
+/// Routes one inbound update: normalize, apply default-deny access control, parse the command,
+/// and delegate to the family handler — `CommandHandlers` (/stop, /new, /remember, /memory),
+/// `ScheduleHandlers` (the /schedule family), `ConfirmationResolver` (parked yes/no interception,
+/// which runs before any turn is dispatched), or `TurnDispatch` (plain text → durable run).
+/// The dedup paths share the `processed_updates` key space and each update takes exactly one
+/// path, so an update is claimed once. Handlers unwind mapped failures via `RoutingHalt`;
+/// `handle` is the single place the outcome returns to the poller.
 public struct MessageRouter: Sendable {
-  private let processed: any ProcessedUpdateStore
-  private let sessionMessages: any SessionMessageStore
-  private let pendingConfirmations: PendingConfirmationRegistry
   private let botUsername: String?
   private let accessControl: AccessControl
-  private let transport: any TelegramTransport
-  private let turnRunner: any TurnDispatching
-  private let lanes: SessionLaneRegistry
-  private let schedule: ScheduleSurface
-  private let now: @Sendable () -> Date
-  private let logger: Logger
   private let replies: ReplySender
-  private let enqueuer: TurnEnqueuer
-  private let turnDispatch: TurnDispatch
-  private let confirmations: ConfirmationResolver
   private let commandHandlers: CommandHandlers
+  private let scheduleHandlers: ScheduleHandlers
+  private let confirmations: ConfirmationResolver
+  private let turnDispatch: TurnDispatch
+  private let logger: Logger
 
   public init(
     processed: any ProcessedUpdateStore,
@@ -52,44 +44,47 @@ public struct MessageRouter: Sendable {
     now: @escaping @Sendable () -> Date = { Date() },
     logger: Logger
   ) {
-    self.processed = processed
-    self.sessionMessages = sessionMessages
-    self.pendingConfirmations = pendingConfirmations
     self.botUsername = botUsername
     self.accessControl = accessControl
-    self.transport = transport
-    self.turnRunner = turnRunner
-    self.lanes = lanes
-    self.schedule = schedule
-    self.now = now
     self.logger = logger
-    self.replies = ReplySender(processed: processed, transport: transport, logger: logger)
+
+    let replies = ReplySender(processed: processed, transport: transport, logger: logger)
+    let enqueuer = TurnEnqueuer(lanes: lanes, turns: turnRunner, logger: logger)
+    let turnDispatch = TurnDispatch(
+      sessionMessages: sessionMessages,
+      enqueuer: enqueuer,
+      replies: replies,
+      now: now,
+      logger: logger
+    )
+    self.replies = replies
+    self.turnDispatch = turnDispatch
     self.commandHandlers = CommandHandlers(
       commands: commands,
       sessionMessages: sessionMessages,
       memory: memory,
       pendingConfirmations: pendingConfirmations,
       lanes: lanes,
-      replies: self.replies,
+      replies: replies,
       now: now,
       logger: logger
     )
-    self.enqueuer = TurnEnqueuer(lanes: lanes, turns: turnRunner, logger: logger)
-    let turnDispatch = TurnDispatch(
+    self.scheduleHandlers = ScheduleHandlers(
+      schedule: schedule,
       sessionMessages: sessionMessages,
-      enqueuer: self.enqueuer,
-      replies: self.replies,
+      pendingConfirmations: pendingConfirmations,
+      replies: replies,
+      enqueuer: enqueuer,
       now: now,
       logger: logger
     )
-    self.turnDispatch = turnDispatch
     self.confirmations = ConfirmationResolver(
       sessionMessages: sessionMessages,
       pendingConfirmations: pendingConfirmations,
       memoryCommands: memoryCommands,
       schedule: schedule,
       turnDispatch: turnDispatch,
-      replies: self.replies,
+      replies: replies,
       now: now,
       logger: logger
     )
@@ -110,8 +105,12 @@ public struct MessageRouter: Sendable {
       return error.outcome
     }
   }
+}
 
-  private func route(rawUpdate: RawUpdate) async throws(RoutingHalt) -> HandleOutcome {
+// MARK: - Routing
+
+private extension MessageRouter {
+  func route(rawUpdate: RawUpdate) async throws(RoutingHalt) -> HandleOutcome {
     guard let message = IncomingMessage.normalize(from: rawUpdate) else {
       logger.debug("update \(rawUpdate.updateId) has nothing actionable, skipping")
       return .skipped
@@ -120,69 +119,6 @@ public struct MessageRouter: Sendable {
     let isAllowed = accessControl.isAllowed(userId: message.userId)
 
     switch message.content {
-    case .text(let text):
-      let command = Command.parse(text, botUsername: botUsername)
-      switch command {
-      case .start:
-        // Onboarding stays a direct reply for both tiers: the owner gets the welcome; a stranger
-        // gets THEIR own id to request access (never the allowlist, never a turn).
-        let reply =
-          isAllowed ? Self.welcomeText : Self.unauthorizedStartText(userId: message.userId)
-        return await replies.sendCanned(
-          updateId: rawUpdate.updateId,
-          chatId: message.chatId,
-          text: reply
-        )
-      case .stop:
-        guard isAllowed else {
-          return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
-        }
-        return try await commandHandlers.stop(rawUpdate: rawUpdate, message: message)
-      case .new:
-        guard isAllowed else {
-          return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
-        }
-        return try await commandHandlers.new(rawUpdate: rawUpdate, message: message)
-      case .remember(let rememberCommand):
-        guard isAllowed else {
-          return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
-        }
-        return try await commandHandlers.remember(
-          rawUpdate: rawUpdate,
-          message: message,
-          command: rememberCommand
-        )
-      case .memory(let memoryCommand):
-        guard isAllowed else {
-          return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
-        }
-        return try await commandHandlers.memory(
-          rawUpdate: rawUpdate,
-          message: message,
-          command: memoryCommand
-        )
-      case .schedule, .pause, .resume, .runNow, .cancelJob, .help:
-        guard isAllowed else {
-          return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
-        }
-        return await handleScheduleCommand(command, rawUpdate: rawUpdate, message: message)
-      case .plain(let plainText):
-        guard isAllowed else {
-          return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
-        }
-        if let resolved = try await confirmations.resolve(
-          rawUpdate: rawUpdate,
-          message: message,
-          text: plainText
-        ) {
-          return resolved
-        }
-        return try await turnDispatch.dispatch(
-          rawUpdate: rawUpdate,
-          message: message,
-          text: plainText
-        )
-      }
     case .unsupported(let kind):
       // Never reveal capabilities to a stranger; the owner gets a specific "can't read X yet".
       let reply = isAllowed ? Self.unsupportedMediaText(kind: kind) : Self.privateBotText
@@ -191,357 +127,109 @@ public struct MessageRouter: Sendable {
         chatId: message.chatId,
         text: reply
       )
+    case .text(let text):
+      let command = Command.parse(text, botUsername: botUsername)
+      guard isAllowed else {
+        return await denyAccess(command, rawUpdate: rawUpdate, message: message)
+      }
+      return try await routeAllowed(command, rawUpdate: rawUpdate, message: message)
     }
   }
 
-  private static func unauthorizedStartText(userId: Int64) -> String {
-    """
-    This is a private bot. Your Telegram user ID is \(userId). Ask the owner to add it to the allowlist.
-    """
-  }
-}
-
-// MARK: - Schedule Creation & Listing
-
-private extension MessageRouter {
-  /// Fans the allowlisted scheduling family — plus `/help`, which shares the identical
-  /// owner-only `isAllowed` gate and has no state of its own to warrant a standalone arm in
-  /// `handle` — out to its per-verb handler. The `isAllowed` gate is applied once by the caller
-  /// for the whole family; `default` is unreachable — only the schedule create/list command,
-  /// the four management verbs, and `/help` route here.
-  func handleScheduleCommand(
+  /// Default-deny, applied ONCE for every command: a stranger's /start gets THEIR own id to
+  /// request access (never the allowlist, never a turn); everything else is the private-bot line.
+  func denyAccess(
     _ command: Command,
     rawUpdate: RawUpdate,
     message: IncomingMessage
   ) async -> HandleOutcome {
+    guard case .start = command else {
+      return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
+    }
+    return await replies.sendCanned(
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      text: Self.unauthorizedStartText(userId: message.userId)
+    )
+  }
+
+  func routeAllowed(
+    _ command: Command,
+    rawUpdate: RawUpdate,
+    message: IncomingMessage
+  ) async throws(RoutingHalt) -> HandleOutcome {
     switch command {
-    case .schedule(.create(let text)):
-      return await handleScheduleCreate(rawUpdate: rawUpdate, message: message, text: text)
-    case .schedule(.list):
-      return await handleScheduleList(rawUpdate: rawUpdate, chatId: message.chatId)
-    case .pause(let jobId):
-      return await handlePause(rawUpdate: rawUpdate, message: message, jobId: jobId)
-    case .resume(let jobId):
-      return await handleResume(rawUpdate: rawUpdate, message: message, jobId: jobId)
-    case .runNow(let jobId):
-      return await handleRunNow(rawUpdate: rawUpdate, message: message, jobId: jobId)
-    case .cancelJob(let jobId):
-      return await handleCancelJob(rawUpdate: rawUpdate, message: message, jobId: jobId)
+    case .start:
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: Self.welcomeText
+      )
     case .help:
       return await replies.sendCanned(
         updateId: rawUpdate.updateId,
         chatId: message.chatId,
         text: CommandReplies.help
       )
-    default:
-      logger.error("non-schedule command \(command) reached handleScheduleCommand")
-      return .skipped
-    }
-  }
-
-  /// `/schedule <text>` (spec §7/§8): claim the update, run the ONE parse call, validate
-  /// deterministically, park the validated draft, and send the gateway-authored confirm prompt.
-  /// Nothing is armed here; every failure is a plain-language reply and parks nothing.
-  func handleScheduleCreate(
-    rawUpdate: RawUpdate,
-    message: IncomingMessage,
-    text: String
-  ) async -> HandleOutcome {
-    let claim: CommandClaim
-    do {
-      claim = try sessionMessages.claimCommandUpdate(
-        updateId: rawUpdate.updateId,
-        sessionKey: SessionKey.telegramDM(chatId: message.chatId),
-        now: now()
-      )
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("schedule claim failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    guard case .claimed(let sessionId) = claim else {
-      logger.debug("duplicate update \(rawUpdate.updateId), skipping")
-      return .skipped
-    }
-
-    switch await schedule.parser.parse(ownerText: text) {
-    case .providerUnavailable:
-      // DEG-01: an LLM/API failure degrades exactly like any turn; nothing armed.
-      return await sendCommandAck(
+    case .stop:
+      return try await commandHandlers.stop(rawUpdate: rawUpdate, message: message)
+    case .new:
+      return try await commandHandlers.new(rawUpdate: rawUpdate, message: message)
+    case .remember(let rememberCommand):
+      return try await commandHandlers.remember(
         rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: Degradation.providerUnavailable
+        message: message,
+        command: rememberCommand
       )
-    case .unparseable:
-      return await sendCommandAck(
+    case .memory(let memoryCommand):
+      return try await commandHandlers.memory(
         rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: ScheduleReplies.parseFailed
+        message: message,
+        command: memoryCommand
       )
-    case .draft(let draft):
-      let nowDate = now()
-      switch schedule.validator.validate(draft, now: nowDate) {
-      case .failure(let problem):
-        return await sendCommandAck(
-          rawUpdate: rawUpdate,
-          chatId: message.chatId,
-          text: problem.ownerReply
-        )
-      case .success(let validated):
-        // Single slot per session: a second /schedule visibly displaces the older draft (§9).
-        await pendingConfirmations.park(.command(.scheduleArm(validated)), sessionId: sessionId)
-        return await sendCommandAck(
-          rawUpdate: rawUpdate,
-          chatId: message.chatId,
-          text: ScheduleReplies.confirmPrompt(
-            schedule: validated,
-            nextFires: schedule.policy.confirmPreview(
-              for: validated,
-              from: nowDate,
-              limit: ScheduleReplies.confirmPreviewCount
-            )
-          )
-        )
+    case .schedule(.create(let text)):
+      return try await scheduleHandlers.create(rawUpdate: rawUpdate, message: message, text: text)
+    case .schedule(.list):
+      return try await scheduleHandlers.list(rawUpdate: rawUpdate, chatId: message.chatId)
+    case .pause(let jobId):
+      return try await scheduleHandlers.pause(rawUpdate: rawUpdate, message: message, jobId: jobId)
+    case .resume(let jobId):
+      return try await scheduleHandlers.resume(
+        rawUpdate: rawUpdate,
+        message: message,
+        jobId: jobId
+      )
+    case .runNow(let jobId):
+      return try await scheduleHandlers.runNow(
+        rawUpdate: rawUpdate,
+        message: message,
+        jobId: jobId
+      )
+    case .cancelJob(let jobId):
+      return try await scheduleHandlers.cancelJob(
+        rawUpdate: rawUpdate,
+        message: message,
+        jobId: jobId
+      )
+    case .plain(let plainText):
+      if let resolved = try await confirmations.resolve(
+        rawUpdate: rawUpdate,
+        message: message,
+        text: plainText
+      ) {
+        return resolved
       }
-    }
-  }
-
-  /// `/schedule list` (spec §9): read-only, deduped via the canned-reply claim like
-  /// `CommandHandlers.memoryReview`.
-  func handleScheduleList(rawUpdate: RawUpdate, chatId: Int64) async -> HandleOutcome {
-    let jobs: [ScheduledJob]
-    do {
-      jobs = try schedule.jobs.listAll()
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: chatId)
-    } catch {
-      logger.error("schedule list failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    guard jobs.isEmpty == false else {
-      return await sendCanned(rawUpdate: rawUpdate, chatId: chatId, text: ScheduleReplies.emptyList)
-    }
-
-    let rows = jobs.map { job in
-      (job: job, nextFire: displayNextFire(job))
-    }
-    return await sendCanned(
-      rawUpdate: rawUpdate,
-      chatId: chatId,
-      text: ScheduleReplies.listLines(rows)
-    )
-  }
-
-  /// The list's next-fire column: the stored `next_occurrence`, which is itself
-  /// calculator-produced — materialized at arm time and advanced only inside the claim (§4.1) —
-  /// so the list can never disagree with what actually fires (spec §9's single-source rule),
-  /// including everyNMinutes phase. Non-ACTIVE rows show none.
-  func displayNextFire(_ job: ScheduledJob) -> Date? {
-    guard job.status == .active else {
-      return nil
-    }
-    return job.nextOccurrence
-  }
-
-  // MARK: - Schedule Management Verbs
-
-  /// Claims a verb command's update BEFORE its effect, so a redelivered command applies once
-  /// (spec §5.4: /runnow idempotency rides the update_id claim; pause/resume/cancel get the
-  /// same discipline for uniformity). nil ⇒ claimed, proceed; non-nil ⇒ the outcome to return.
-  func claimVerbUpdate(rawUpdate: RawUpdate, chatId: Int64) async -> HandleOutcome? {
-    do {
-      guard try processed.claimUpdate(updateId: rawUpdate.updateId) else {
-        logger.debug("duplicate update \(rawUpdate.updateId), skipping")
-        return .skipped
-      }
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: chatId)
-    } catch {
-      logger.error("verb claim failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-    return nil
-  }
-
-  func handlePause(
-    rawUpdate: RawUpdate,
-    message: IncomingMessage,
-    jobId: Int64?
-  ) async -> HandleOutcome {
-    guard let jobId else {
-      return await sendCanned(
+      return try await turnDispatch.dispatch(
         rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: ScheduleReplies.pauseUsage
+        message: message,
+        text: plainText
       )
     }
-    if let handled = await claimVerbUpdate(rawUpdate: rawUpdate, chatId: message.chatId) {
-      return handled
-    }
-
-    let paused: ScheduledJob?
-    do {
-      paused = try schedule.jobs.pause(id: jobId, now: now())
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("pause failed for update \(rawUpdate.updateId): \(error)")
-      return await sendCommandAck(
-        rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: ScheduleReplies.verbFailed
-      )
-    }
-
-    let reply = paused.map(ScheduleReplies.paused) ?? ScheduleReplies.notFound(id: jobId)
-    return await sendCommandAck(rawUpdate: rawUpdate, chatId: message.chatId, text: reply)
   }
 
-  func handleResume(
-    rawUpdate: RawUpdate,
-    message: IncomingMessage,
-    jobId: Int64?
-  ) async -> HandleOutcome {
-    guard let jobId else {
-      return await sendCanned(
-        rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: ScheduleReplies.resumeUsage
-      )
-    }
-    if let handled = await claimVerbUpdate(rawUpdate: rawUpdate, chatId: message.chatId) {
-      return handled
-    }
-
-    let resumed: ScheduledJob?
-    do {
-      // The CALLER recomputes next-from-now (preamble contract): occurrences inside the paused
-      // window are skipped, never caught up (§5.4). No race with the ticker: the row is PAUSED
-      // until `resume` commits, and the ticker's scan predicate excludes PAUSED.
-      guard let job = try schedule.jobs.job(id: jobId) else {
-        return await sendCommandAck(
-          rawUpdate: rawUpdate,
-          chatId: message.chatId,
-          text: ScheduleReplies.notFound(id: jobId)
-        )
-      }
-      resumed = try schedule.jobs.resume(
-        id: jobId,
-        nextOccurrence: schedule.policy.resumeOccurrence(for: job, from: now()),
-        now: now()
-      )
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("resume failed for update \(rawUpdate.updateId): \(error)")
-      return await sendCommandAck(
-        rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: ScheduleReplies.verbFailed
-      )
-    }
-
-    let reply = resumed.map(ScheduleReplies.resumed) ?? ScheduleReplies.notFound(id: jobId)
-    return await sendCommandAck(rawUpdate: rawUpdate, chatId: message.chatId, text: reply)
-  }
-
-  func handleRunNow(
-    rawUpdate: RawUpdate,
-    message: IncomingMessage,
-    jobId: Int64?
-  ) async -> HandleOutcome {
-    guard let jobId else {
-      return await sendCanned(
-        rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: ScheduleReplies.runNowUsage
-      )
-    }
-    if let handled = await claimVerbUpdate(rawUpdate: rawUpdate, chatId: message.chatId) {
-      return handled
-    }
-
-    let fire: ClaimedFire?
-    do {
-      fire = try schedule.jobs.fireNow(jobId: jobId, now: now())
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("run-now failed for update \(rawUpdate.updateId): \(error)")
-      return await sendCommandAck(
-        rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: ScheduleReplies.verbFailed
-      )
-    }
-
-    guard let fire else {
-      return await sendCommandAck(
-        rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: ScheduleReplies.notFound(id: jobId)
-      )
-    }
-
-    // The fused fireNow already created the session, trigger message, PENDING run, and
-    // jobExecuted audit; TurnEnqueuer gives the run ordering and cancellability (D1).
-    await enqueuer.enqueue(fire: fire)
-
-    return await sendCommandAck(
-      rawUpdate: rawUpdate,
-      chatId: message.chatId,
-      text: ScheduleReplies.runningNow(id: jobId)
-    )
-  }
-
-  func handleCancelJob(
-    rawUpdate: RawUpdate,
-    message: IncomingMessage,
-    jobId: Int64?
-  ) async -> HandleOutcome {
-    guard let jobId else {
-      return await sendCanned(
-        rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: ScheduleReplies.cancelUsage
-      )
-    }
-    if let handled = await claimVerbUpdate(rawUpdate: rawUpdate, chatId: message.chatId) {
-      return handled
-    }
-
-    let cancelled: ScheduledJob?
-    do {
-      cancelled = try schedule.jobs.cancel(id: jobId, now: now())
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("cancel failed for update \(rawUpdate.updateId): \(error)")
-      return await sendCommandAck(
-        rawUpdate: rawUpdate,
-        chatId: message.chatId,
-        text: ScheduleReplies.verbFailed
-      )
-    }
-
-    let reply = cancelled.map(ScheduleReplies.cancelled) ?? ScheduleReplies.notFound(id: jobId)
-    return await sendCommandAck(rawUpdate: rawUpdate, chatId: message.chatId, text: reply)
-  }
-
-  // MARK: - Outbound Replies
-
-  func sendCommandAck(rawUpdate: RawUpdate, chatId: Int64, text: String) async -> HandleOutcome {
-    await replies.sendCommandAck(updateId: rawUpdate.updateId, chatId: chatId, text: text)
-  }
-
-  func sendCanned(rawUpdate: RawUpdate, chatId: Int64, text: String) async -> HandleOutcome {
-    await replies.sendCanned(updateId: rawUpdate.updateId, chatId: chatId, text: text)
-  }
-
-  func storageFull(chatId: Int64) async -> HandleOutcome {
-    await replies.storageFull(chatId: chatId)
+  static func unauthorizedStartText(userId: Int64) -> String {
+    """
+    This is a private bot. Your Telegram user ID is \(userId). Ask the owner to add it to the allowlist.
+    """
   }
 }

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -23,7 +23,6 @@ public struct MessageRouter: Sendable {
   private let sessionMessages: any SessionMessageStore
   private let commands: any CommandStore
   private let memory: any MemoryStore
-  private let memoryCommands: any MemoryCommandStore
   private let pendingConfirmations: PendingConfirmationRegistry
   private let botUsername: String?
   private let accessControl: AccessControl
@@ -35,6 +34,8 @@ public struct MessageRouter: Sendable {
   private let logger: Logger
   private let replies: ReplySender
   private let enqueuer: TurnEnqueuer
+  private let turnDispatch: TurnDispatch
+  private let confirmations: ConfirmationResolver
 
   public init(
     processed: any ProcessedUpdateStore,
@@ -56,7 +57,6 @@ public struct MessageRouter: Sendable {
     self.sessionMessages = sessionMessages
     self.commands = commands
     self.memory = memory
-    self.memoryCommands = memoryCommands
     self.pendingConfirmations = pendingConfirmations
     self.botUsername = botUsername
     self.accessControl = accessControl
@@ -68,6 +68,24 @@ public struct MessageRouter: Sendable {
     self.logger = logger
     self.replies = ReplySender(processed: processed, transport: transport, logger: logger)
     self.enqueuer = TurnEnqueuer(lanes: lanes, turns: turnRunner, logger: logger)
+    let turnDispatch = TurnDispatch(
+      sessionMessages: sessionMessages,
+      enqueuer: self.enqueuer,
+      replies: self.replies,
+      now: now,
+      logger: logger
+    )
+    self.turnDispatch = turnDispatch
+    self.confirmations = ConfirmationResolver(
+      sessionMessages: sessionMessages,
+      pendingConfirmations: pendingConfirmations,
+      memoryCommands: memoryCommands,
+      schedule: schedule,
+      turnDispatch: turnDispatch,
+      replies: self.replies,
+      now: now,
+      logger: logger
+    )
   }
 
   static let welcomeText = "Hi! I'm online. Send me a message and I'll do my best to help."
@@ -145,14 +163,14 @@ public struct MessageRouter: Sendable {
         guard isAllowed else {
           return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
         }
-        if let resolved = await resolvePendingConfirmation(
+        if let resolved = try await confirmations.resolve(
           rawUpdate: rawUpdate,
           message: message,
           text: plainText
         ) {
           return resolved
         }
-        return await dispatchTurn(
+        return try await turnDispatch.dispatch(
           rawUpdate: rawUpdate,
           message: message,
           text: plainText
@@ -737,323 +755,6 @@ private extension MessageRouter {
 
     let reply = cancelled.map(ScheduleReplies.cancelled) ?? ScheduleReplies.notFound(id: jobId)
     return await sendCommandAck(rawUpdate: rawUpdate, chatId: message.chatId, text: reply)
-  }
-
-  // MARK: - Pending Confirmation Resolution
-
-  /// Intercepts plain text while a confirmation is parked for the session. Returns nil when there
-  /// is nothing to resolve, so the caller falls through to normal turn dispatch. The session lookup
-  /// is read-only and fails closed: with the lookup down we cannot prove whether a parked "yes"
-  /// should be intercepted, so nothing is claimed and the update is retried instead.
-  func resolvePendingConfirmation(
-    rawUpdate: RawUpdate,
-    message: IncomingMessage,
-    text: String
-  ) async -> HandleOutcome? {
-    let sessionId: Int64
-    do {
-      guard
-        let existing = try sessionMessages.findSession(
-          sessionKey: SessionKey.telegramDM(chatId: message.chatId)
-        )
-      else {
-        return nil
-      }
-      sessionId = existing
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("pending lookup failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    guard let entry = await pendingConfirmations.pending(sessionId: sessionId) else {
-      return nil
-    }
-
-    // A tool approval differs from the memory-confirm flow: BOTH a confirm and a non-confirm
-    // reply become an ordinary persisted turn (never a command ack, §14), so it resolves here,
-    // before the memory-only commit/cancel switch below ever sees the entry.
-    if case .toolApproval(let request) = entry {
-      await pendingConfirmations.clear(sessionId: sessionId)
-      let grant: OneTurnGrant? =
-        ConfirmationReply.parse(text) == .confirm
-        ? OneTurnGrant(action: request.action)
-        : nil
-      return await dispatchTurn(
-        rawUpdate: rawUpdate,
-        message: message,
-        text: text,
-        grant: grant
-      )
-    }
-
-    guard case .command(let confirmation) = entry else {
-      // .toolApproval returned above; the guard keeps the destructuring exhaustive without a
-      // fatal arm.
-      return nil
-    }
-
-    switch ConfirmationReply.parse(text) {
-    case .confirm:
-      return await commitPending(
-        confirmation,
-        sessionId: sessionId,
-        rawUpdate: rawUpdate,
-        message: message
-      )
-    case .cancel:
-      return await cancelPending(
-        sessionId: sessionId,
-        rawUpdate: rawUpdate,
-        message: message
-      )
-    case .other:
-      await pendingConfirmations.clear(sessionId: sessionId)
-      return nil
-    }
-  }
-
-  /// Confirms a parked effect through its atomic claim+effect+audit store seam.
-  func commitPending(
-    _ entry: CommandConfirmation,
-    sessionId: Int64,
-    rawUpdate: RawUpdate,
-    message: IncomingMessage
-  ) async -> HandleOutcome {
-    // A parked schedule can be confirmed long after its preview; recompute the fire time from the
-    // parked rule against the arm-time clock (details in OccurrencePolicy.armOccurrence). A
-    // one-shot whose instant has passed cannot be salvaged — reject it so the owner reschedules
-    // rather than arming a job that silently never fires.
-    var scheduleArmNext: Date?
-    if case .scheduleArm(let validated) = entry {
-      guard let recomputed = schedule.policy.armOccurrence(for: validated, at: now()) else {
-        return await rejectStaleArm(sessionId: sessionId, rawUpdate: rawUpdate, message: message)
-      }
-      scheduleArmNext = recomputed
-    }
-
-    let newlyClaimed: Bool
-    let ackText: String
-    do {
-      switch entry {
-      case .rememberWrite(let request):
-        let result = try memoryCommands.applyRemember(
-          updateId: rawUpdate.updateId,
-          item: request.item,
-          now: Date()
-        )
-        newlyClaimed = result.newlyClaimed
-        ackText = MemoryReplies.saved(id: result.item?.id)
-      case .deleteItem(let itemId):
-        let result = try memoryCommands.applyForget(
-          updateId: rawUpdate.updateId,
-          itemId: itemId,
-          now: Date()
-        )
-        newlyClaimed = result.newlyClaimed
-        ackText = MemoryReplies.deleted(id: itemId)
-      case .scheduleArm(let validated):
-        // owner_chat_id is set HERE, in code, from the arming chat — never model- or
-        // prompt-controlled (spec §4.1). The insert is the exact parked draft (§8, no re-parse).
-        let newJob = NewScheduledJob(
-          ownerChatId: message.chatId,
-          label: validated.label,
-          prompt: validated.prompt,
-          recurrence: validated.recurrence,
-          timezone: validated.timezone,
-          nextOccurrence: scheduleArmNext ?? validated.firstOccurrence
-        )
-        let result = try schedule.commands.applyArm(
-          updateId: rawUpdate.updateId,
-          job: newJob,
-          now: now()
-        )
-        newlyClaimed = result.newlyClaimed
-        ackText = ScheduleReplies.armed(job: result.job)
-      }
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("confirmation commit failed for update \(rawUpdate.updateId): \(error)")
-      return await failPendingCommit(
-        entry,
-        sessionId: sessionId,
-        rawUpdate: rawUpdate,
-        message: message
-      )
-    }
-
-    guard newlyClaimed else {
-      logger.debug("duplicate update \(rawUpdate.updateId), skipping")
-      return .skipped
-    }
-
-    await pendingConfirmations.clear(sessionId: sessionId)
-
-    return await sendCommandAck(rawUpdate: rawUpdate, chatId: message.chatId, text: ackText)
-  }
-
-  /// A parked schedule confirmed after its only fire time has passed: nothing valid remains to
-  /// arm. Claim the update (dedup), clear the slot, and tell the owner to reschedule.
-  func rejectStaleArm(
-    sessionId: Int64,
-    rawUpdate: RawUpdate,
-    message: IncomingMessage
-  ) async -> HandleOutcome {
-    let claimed: Bool
-    do {
-      claimed = try processed.claimUpdate(updateId: rawUpdate.updateId)
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("stale-arm claim failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    guard claimed else {
-      logger.debug("duplicate update \(rawUpdate.updateId), skipping")
-      return .skipped
-    }
-
-    await pendingConfirmations.clear(sessionId: sessionId)
-
-    return await sendCommandAck(
-      rawUpdate: rawUpdate,
-      chatId: message.chatId,
-      text: ScheduleReplies.armExpired
-    )
-  }
-
-  /// A non-disk commit failure is terminal for the parked entry: claim the update, clear the
-  /// ephemeral pending state, and tell the owner nothing changed so they can re-issue the command.
-  func failPendingCommit(
-    _ entry: CommandConfirmation,
-    sessionId: Int64,
-    rawUpdate: RawUpdate,
-    message: IncomingMessage
-  ) async -> HandleOutcome {
-    let claimed: Bool
-    do {
-      claimed = try processed.claimUpdate(updateId: rawUpdate.updateId)
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("failure-claim failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    guard claimed else {
-      logger.debug("duplicate update \(rawUpdate.updateId), skipping")
-      return .skipped
-    }
-
-    await pendingConfirmations.clear(sessionId: sessionId)
-
-    let errorText: String
-    switch entry {
-    case .rememberWrite:
-      errorText = MemoryReplies.saveFailed
-    case .deleteItem:
-      errorText = MemoryReplies.deleteFailed
-    case .scheduleArm:
-      errorText = ScheduleReplies.armFailed
-    }
-
-    return await sendCommandAck(rawUpdate: rawUpdate, chatId: message.chatId, text: errorText)
-  }
-
-  /// A negative confirmation claims the update, clears the parked entry, and sends a cancel ack.
-  func cancelPending(
-    sessionId: Int64,
-    rawUpdate: RawUpdate,
-    message: IncomingMessage
-  ) async -> HandleOutcome {
-    let claimed: Bool
-    do {
-      claimed = try processed.claimUpdate(updateId: rawUpdate.updateId)
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("cancel claim failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    guard claimed else {
-      logger.debug("duplicate update \(rawUpdate.updateId), skipping")
-      return .skipped
-    }
-
-    await pendingConfirmations.clear(sessionId: sessionId)
-
-    return await sendCommandAck(
-      rawUpdate: rawUpdate,
-      chatId: message.chatId,
-      text: MemoryReplies.cancelled
-    )
-  }
-
-  // MARK: - Turn Dispatch
-
-  /// Fuses claim + persistence, then enqueues the durable run and returns without awaiting it.
-  /// Persistence failure prevents cursor advancement; background turn failures are logged in-band.
-  func dispatchTurn(
-    rawUpdate: RawUpdate,
-    message: IncomingMessage,
-    text: String,
-    grant: OneTurnGrant? = nil
-  ) async -> HandleOutcome {
-    let inbound = InboundMessage(
-      updateId: rawUpdate.updateId,
-      sessionKey: SessionKey.telegramDM(chatId: message.chatId),
-      chatId: message.chatId,
-      userId: message.userId,
-      text: text,
-      isEdited: message.isEdited,
-      ts: Date()
-    )
-
-    let claim: ClaimResult
-    do {
-      claim = try sessionMessages.claimAndPersistInbound(inbound)
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: message.chatId)
-    } catch {
-      logger.error("persist failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    guard
-      claim.newlyClaimed,
-      let sessionId = claim.sessionId,
-      let runId = claim.runId,
-      let triggerMessageId = claim.triggerMessageId
-    else {
-      logger.debug("duplicate update \(rawUpdate.updateId), skipping")
-      return .skipped
-    }
-
-    // The inbound → run bridge: the one INFO line that shows a real message was accepted and which
-    // run it became. run/session/update ride as metadata so the whole lifecycle greps by `run=<id>`;
-    // only the message SIZE is logged, never its text.
-    var runLog = logger
-    runLog[metadataKey: "run"] = "\(runId)"
-    runLog[metadataKey: "session"] = "\(sessionId)"
-    runLog[metadataKey: "update"] = "\(rawUpdate.updateId)"
-    runLog.info(
-      "message accepted; dispatching run (chars=\(text.count) edited=\(message.isEdited))"
-    )
-
-    await enqueuer.enqueue(
-      runId: runId,
-      sessionId: sessionId,
-      chatId: message.chatId,
-      triggerMessageId: triggerMessageId,
-      grant: grant,
-      log: runLog
-    )
-
-    return .processed
   }
 
   // MARK: - Outbound Replies

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -33,6 +33,8 @@ public struct MessageRouter: Sendable {
   private let schedule: ScheduleSurface
   private let now: @Sendable () -> Date
   private let logger: Logger
+  private let replies: ReplySender
+  private let enqueuer: TurnEnqueuer
 
   public init(
     processed: any ProcessedUpdateStore,
@@ -64,6 +66,8 @@ public struct MessageRouter: Sendable {
     self.schedule = schedule
     self.now = now
     self.logger = logger
+    self.replies = ReplySender(processed: processed, transport: transport, logger: logger)
+    self.enqueuer = TurnEnqueuer(lanes: lanes, turns: turnRunner, logger: logger)
   }
 
   static let welcomeText = "Hi! I'm online. Send me a message and I'll do my best to help."
@@ -75,6 +79,14 @@ public struct MessageRouter: Sendable {
 
   @discardableResult
   public func handle(rawUpdate: RawUpdate) async -> HandleOutcome {
+    do throws(RoutingHalt) {
+      return try await route(rawUpdate: rawUpdate)
+    } catch {
+      return error.outcome
+    }
+  }
+
+  private func route(rawUpdate: RawUpdate) async throws(RoutingHalt) -> HandleOutcome {
     guard let message = IncomingMessage.normalize(from: rawUpdate) else {
       logger.debug("update \(rawUpdate.updateId) has nothing actionable, skipping")
       return .skipped
@@ -91,24 +103,24 @@ public struct MessageRouter: Sendable {
         // gets THEIR own id to request access (never the allowlist, never a turn).
         let reply =
           isAllowed ? Self.welcomeText : Self.unauthorizedStartText(userId: message.userId)
-        return await sendCanned(
-          rawUpdate: rawUpdate,
+        return await replies.sendCanned(
+          updateId: rawUpdate.updateId,
           chatId: message.chatId,
           text: reply
         )
       case .stop:
         guard isAllowed else {
-          return await sendPrivateBotReply(rawUpdate: rawUpdate, chatId: message.chatId)
+          return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
         }
         return await handleStop(rawUpdate: rawUpdate, message: message)
       case .new:
         guard isAllowed else {
-          return await sendPrivateBotReply(rawUpdate: rawUpdate, chatId: message.chatId)
+          return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
         }
         return await handleNew(rawUpdate: rawUpdate, message: message)
       case .remember(let rememberCommand):
         guard isAllowed else {
-          return await sendPrivateBotReply(rawUpdate: rawUpdate, chatId: message.chatId)
+          return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
         }
         return await handleRemember(
           rawUpdate: rawUpdate,
@@ -117,7 +129,7 @@ public struct MessageRouter: Sendable {
         )
       case .memory(let memoryCommand):
         guard isAllowed else {
-          return await sendPrivateBotReply(rawUpdate: rawUpdate, chatId: message.chatId)
+          return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
         }
         return await handleMemory(
           rawUpdate: rawUpdate,
@@ -126,12 +138,12 @@ public struct MessageRouter: Sendable {
         )
       case .schedule, .pause, .resume, .runNow, .cancelJob, .help:
         guard isAllowed else {
-          return await sendPrivateBotReply(rawUpdate: rawUpdate, chatId: message.chatId)
+          return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
         }
         return await handleScheduleCommand(command, rawUpdate: rawUpdate, message: message)
       case .plain(let plainText):
         guard isAllowed else {
-          return await sendPrivateBotReply(rawUpdate: rawUpdate, chatId: message.chatId)
+          return await replies.sendPrivateBot(updateId: rawUpdate.updateId, chatId: message.chatId)
         }
         if let resolved = await resolvePendingConfirmation(
           rawUpdate: rawUpdate,
@@ -149,7 +161,11 @@ public struct MessageRouter: Sendable {
     case .unsupported(let kind):
       // Never reveal capabilities to a stranger; the owner gets a specific "can't read X yet".
       let reply = isAllowed ? Self.unsupportedMediaText(kind: kind) : Self.privateBotText
-      return await sendCanned(rawUpdate: rawUpdate, chatId: message.chatId, text: reply)
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: reply
+      )
     }
   }
 
@@ -420,8 +436,8 @@ private extension MessageRouter {
     case .cancelJob(let jobId):
       return await handleCancelJob(rawUpdate: rawUpdate, message: message, jobId: jobId)
     case .help:
-      return await sendCanned(
-        rawUpdate: rawUpdate,
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
         chatId: message.chatId,
         text: CommandReplies.help
       )
@@ -743,25 +759,9 @@ private extension MessageRouter {
       )
     }
 
-    // Exactly the SchedulerService post-claim enqueue: the fused fireNow already created the
-    // session, trigger message, PENDING run, and jobExecuted audit; the lane gives the run
-    // ordering and cancellability, and `run` may throw only StoreError.diskFull (D1).
-    let lane = await lanes.actor(for: fire.sessionId)
-    await lane.enqueue(runId: fire.runId) { [turnRunner, logger] in
-      do {
-        try await turnRunner.run(
-          runId: fire.runId,
-          sessionId: fire.sessionId,
-          chatId: fire.ownerChatId,
-          triggerMessageId: fire.triggerMessageId,
-          grant: nil
-        )
-      } catch StoreError.diskFull {
-        logger.error("run-now turn \(fire.runId) stopped by storage full after enqueue")
-      } catch {
-        logger.error("run-now turn error (handled in-band) for job \(jobId): \(error)")
-      }
-    }
+    // The fused fireNow already created the session, trigger message, PENDING run, and
+    // jobExecuted audit; TurnEnqueuer gives the run ordering and cancellability (D1).
+    await enqueuer.enqueue(fire: fire)
 
     return await sendCommandAck(
       rawUpdate: rawUpdate,
@@ -1107,84 +1107,29 @@ private extension MessageRouter {
       "message accepted; dispatching run (chars=\(text.count) edited=\(message.isEdited))"
     )
 
-    let lane = await lanes.actor(for: sessionId)
-    await lane.enqueue(runId: runId) { [turnRunner, runLog] in
-      do {
-        try await turnRunner.run(
-          runId: runId,
-          sessionId: sessionId,
-          chatId: message.chatId,
-          triggerMessageId: triggerMessageId,
-          grant: grant
-        )
-      } catch StoreError.diskFull {
-        runLog.error("turn stopped by storage full after enqueue")
-      } catch {
-        runLog.error("turn run error (handled in-band): \(error)")
-      }
-    }
+    await enqueuer.enqueue(
+      runId: runId,
+      sessionId: sessionId,
+      chatId: message.chatId,
+      triggerMessageId: triggerMessageId,
+      grant: grant,
+      log: runLog
+    )
 
     return .processed
   }
 
   // MARK: - Outbound Replies
 
-  func sendCommandAck(
-    rawUpdate: RawUpdate,
-    chatId: Int64,
-    text: String
-  ) async -> HandleOutcome {
-    do {
-      _ = try await transport.sendMessage(chatId: chatId, text: text)
-    } catch {
-      logger.error("command ack send failed for update \(rawUpdate.updateId): \(error)")
-    }
-    return .processed
+  func sendCommandAck(rawUpdate: RawUpdate, chatId: Int64, text: String) async -> HandleOutcome {
+    await replies.sendCommandAck(updateId: rawUpdate.updateId, chatId: chatId, text: text)
   }
 
-  func sendPrivateBotReply(rawUpdate: RawUpdate, chatId: Int64) async -> HandleOutcome {
-    await sendCanned(rawUpdate: rawUpdate, chatId: chatId, text: Self.privateBotText)
+  func sendCanned(rawUpdate: RawUpdate, chatId: Int64, text: String) async -> HandleOutcome {
+    await replies.sendCanned(updateId: rawUpdate.updateId, chatId: chatId, text: text)
   }
 
-  /// A direct canned reply, deduped via `claimUpdate` so a redelivery doesn't double-send it.
-  func sendCanned(
-    rawUpdate: RawUpdate,
-    chatId: Int64,
-    text: String
-  ) async -> HandleOutcome {
-    let claimed: Bool
-    do {
-      claimed = try processed.claimUpdate(updateId: rawUpdate.updateId)
-    } catch StoreError.diskFull {
-      return await storageFull(chatId: chatId)
-    } catch {
-      logger.error("claim failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    guard claimed else {
-      logger.debug("duplicate update \(rawUpdate.updateId), skipping")
-      return .skipped
-    }
-
-    do {
-      _ = try await transport.sendMessage(chatId: chatId, text: text)
-    } catch {
-      logger.error("send failed for update \(rawUpdate.updateId): \(error)")
-      return .transientFailure
-    }
-
-    return .processed
-  }
-
-  /// Best-effort "storage full" notice (the send may still succeed — a full disk doesn't break the
-  /// network) and the signal for the poller to back off without advancing the offset (F23).
   func storageFull(chatId: Int64) async -> HandleOutcome {
-    do {
-      _ = try await transport.sendMessage(chatId: chatId, text: Degradation.storageFull)
-    } catch {
-      logger.error("failed to send storage-full notice: \(error)")
-    }
-    return .storageFull
+    await replies.storageFull(chatId: chatId)
   }
 }

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -505,55 +505,15 @@ private extension MessageRouter {
           chatId: message.chatId,
           text: ScheduleReplies.confirmPrompt(
             schedule: validated,
-            nextFires: nextFires(for: validated, from: nowDate)
+            nextFires: schedule.policy.confirmPreview(
+              for: validated,
+              from: nowDate,
+              limit: ScheduleReplies.confirmPreviewCount
+            )
           )
         )
       }
     }
-  }
-
-  /// The confirm preview's fire times. The SAME `nowDate` that validation used seeds the
-  /// calculator, so the preview's first entry IS the parked `firstOccurrence`.
-  func nextFires(for validated: ValidatedSchedule, from nowDate: Date) -> [Date] {
-    guard
-      let envelope = validated.recurrence,
-      let timezone = TimeZone(identifier: validated.timezone)
-    else {
-      return [validated.firstOccurrence]
-    }
-    return schedule.calculator.occurrences(
-      rule: envelope.rule,
-      timezone: timezone,
-      anchor: nowDate,
-      after: nowDate,
-      limit: ScheduleReplies.confirmPreviewCount
-    )
-  }
-
-  /// The fire time to arm with. Anchoring on the parked `firstOccurrence` (not arm-time `now`)
-  /// keeps the previewed everyNMinutes phase intact (preamble deviation #1: phase-continuous from
-  /// preview through every fire) — mirroring `resumeNextOccurrence`, which anchors on the stored
-  /// occurrence rather than `now` for the same reason. `after: nowDate` still does the M1 job: it
-  /// skips any occurrence already past by confirm time, so a draft confirmed long after its
-  /// preview can't arm an already-past occurrence (a one-shot would silently misfire to COMPLETED;
-  /// a recurring one would fire immediately). This re-runs the SAME parked rule — not a re-parse
-  /// (§8): label/prompt/rule/timezone are still the parked draft's. Returns nil when nothing valid
-  /// remains to arm: a one-shot whose instant has passed, or (pathological) a rule with no
-  /// upcoming occurrence.
-  func armNextOccurrence(for validated: ValidatedSchedule, now nowDate: Date) -> Date? {
-    guard let envelope = validated.recurrence else {
-      return validated.firstOccurrence > nowDate ? validated.firstOccurrence : nil
-    }
-    guard let timezone = TimeZone(identifier: validated.timezone) else {
-      return validated.firstOccurrence > nowDate ? validated.firstOccurrence : nil
-    }
-    return schedule.calculator.occurrences(
-      rule: envelope.rule,
-      timezone: timezone,
-      anchor: validated.firstOccurrence,
-      after: nowDate,
-      limit: 1
-    ).first
   }
 
   /// `/schedule list` (spec §9): read-only, deduped via the canned-reply claim like
@@ -678,7 +638,7 @@ private extension MessageRouter {
       }
       resumed = try schedule.jobs.resume(
         id: jobId,
-        nextOccurrence: resumeNextOccurrence(job: job, from: now()),
+        nextOccurrence: schedule.policy.resumeOccurrence(for: job, from: now()),
         now: now()
       )
     } catch StoreError.diskFull {
@@ -694,31 +654,6 @@ private extension MessageRouter {
 
     let reply = resumed.map(ScheduleReplies.resumed) ?? ScheduleReplies.notFound(id: jobId)
     return await sendCommandAck(rawUpdate: rawUpdate, chatId: message.chatId, text: reply)
-  }
-
-  /// Resume's next fire: recurring ⇒ the calculator's next occurrence after now (anchored at
-  /// the job's createdTs like every other occurrence read); one-shot ⇒ its stored instant if
-  /// still ahead, else nothing left to fire.
-  func resumeNextOccurrence(job: ScheduledJob, from nowDate: Date) -> Date? {
-    guard
-      let envelope = job.recurrence,
-      let timezone = TimeZone(identifier: job.timezone)
-    else {
-      guard let instant = job.nextOccurrence, instant > nowDate else {
-        return nil
-      }
-      return instant
-    }
-    // Anchor = the stale stored next (pause leaves next_occurrence untouched): the recompute
-    // stays on the armed chain — everyNMinutes keeps its phase — while `after: nowDate` skips
-    // everything inside the paused window (§5.4: pause = "be quiet", never catch up).
-    return schedule.calculator.occurrences(
-      rule: envelope.rule,
-      timezone: timezone,
-      anchor: job.nextOccurrence ?? job.createdTs,
-      after: nowDate,
-      limit: 1
-    ).first
   }
 
   func handleRunNow(
@@ -881,12 +816,12 @@ private extension MessageRouter {
     message: IncomingMessage
   ) async -> HandleOutcome {
     // A parked schedule can be confirmed long after its preview; recompute the fire time from the
-    // parked rule against the arm-time clock (details in armNextOccurrence). A one-shot whose
-    // instant has passed cannot be salvaged — reject it so the owner reschedules rather than
-    // arming a job that silently never fires.
+    // parked rule against the arm-time clock (details in OccurrencePolicy.armOccurrence). A
+    // one-shot whose instant has passed cannot be salvaged — reject it so the owner reschedules
+    // rather than arming a job that silently never fires.
     var scheduleArmNext: Date?
     if case .scheduleArm(let validated) = entry {
-      guard let recomputed = armNextOccurrence(for: validated, now: now()) else {
+      guard let recomputed = schedule.policy.armOccurrence(for: validated, at: now()) else {
         return await rejectStaleArm(sessionId: sessionId, rawUpdate: rawUpdate, message: message)
       }
       scheduleArmNext = recomputed

--- a/Sources/ClawGateway/Routing/PendingConfirmationRegistry.swift
+++ b/Sources/ClawGateway/Routing/PendingConfirmationRegistry.swift
@@ -1,11 +1,20 @@
 import ClawCore
 import Foundation
 
-public enum PendingConfirmation: Sendable, Equatable {
+/// A parked command effect awaiting the owner's yes/no (single slot per session, §9).
+public enum CommandConfirmation: Sendable, Equatable {
   case rememberWrite(MemoryWriteRequest)
   case deleteItem(id: Int64)
-  case toolApproval(ToolApprovalRequest)
   case scheduleArm(ValidatedSchedule)
+}
+
+/// What the confirmation slot can hold. Command confirmations resolve through the yes/no
+/// commit/cancel switch; a tool approval resolves by dispatching the reply as an ordinary
+/// persisted turn (§14). Two types, so each resolver switch is exhaustive over only the cases
+/// it can legally see — no "unreachable by ordering" arms.
+public enum PendingConfirmation: Sendable, Equatable {
+  case command(CommandConfirmation)
+  case toolApproval(ToolApprovalRequest)
 }
 
 public actor PendingConfirmationRegistry {

--- a/Sources/ClawGateway/Routing/ReplySender.swift
+++ b/Sources/ClawGateway/Routing/ReplySender.swift
@@ -23,6 +23,7 @@ enum StoreFailureReply: Sendable {
 struct ReplySender: Sendable {
   let processed: any ProcessedUpdateStore
   let transport: any TelegramTransport
+
   let logger: Logger
 
   /// Runs one store operation, mapping the failure classes every handler shares.
@@ -57,7 +58,7 @@ struct ReplySender: Sendable {
     let claimed = try await perform("update claim", updateId: updateId, chatId: chatId) {
       try processed.claimUpdate(updateId: updateId)
     }
-    guard claimed else {
+    if !claimed {
       throw RoutingHalt(outcome: skipDuplicate(updateId: updateId))
     }
   }

--- a/Sources/ClawGateway/Routing/ReplySender.swift
+++ b/Sources/ClawGateway/Routing/ReplySender.swift
@@ -1,0 +1,114 @@
+import ClawCore
+import Foundation
+import Logging
+
+/// A routing decision that is already final — the failure was mapped, any notice sent — thrown so
+/// handlers unwind straight to `MessageRouter.handle`, the single place the outcome is returned
+/// to the poller.
+struct RoutingHalt: Error {
+  let outcome: HandleOutcome
+}
+
+/// How a handler recovers from a non-disk store failure: `retryUpdate` when nothing durable
+/// happened yet (do not advance the cursor; the poller redelivers), `ack` when the effect's own
+/// claim may have landed and the owner must be told the command failed so they can re-issue it.
+enum StoreFailureReply: Sendable {
+  case retryUpdate
+  case ack(String)
+}
+
+/// Outbound plumbing shared by every handler family: dedup-claimed canned replies, command acks,
+/// the storage-full notice, and — in `perform` — the ONE spelling of the router's two-tier
+/// store-error contract (diskFull → notice + poller backoff; anything else → per-site recovery).
+struct ReplySender: Sendable {
+  let processed: any ProcessedUpdateStore
+  let transport: any TelegramTransport
+  let logger: Logger
+
+  /// Runs one store operation, mapping the failure classes every handler shares.
+  func perform<Value: Sendable>(
+    _ operation: String,
+    updateId: Int64,
+    chatId: Int64,
+    onFailure: StoreFailureReply = .retryUpdate,
+    body: () throws -> Value
+  ) async throws(RoutingHalt) -> Value {
+    do {
+      return try body()
+    } catch StoreError.diskFull {
+      throw RoutingHalt(outcome: await storageFull(chatId: chatId))
+    } catch {
+      logger.error("\(operation) failed for update \(updateId): \(error)")
+      switch onFailure {
+      case .retryUpdate:
+        throw RoutingHalt(outcome: .transientFailure)
+      case .ack(let text):
+        throw RoutingHalt(
+          outcome: await sendCommandAck(updateId: updateId, chatId: chatId, text: text)
+        )
+      }
+    }
+  }
+
+  /// Claims the update for a direct effect (canned reply, verb, confirmation cancel) so a
+  /// redelivery applies once. Returning normally means newly claimed — proceed; a duplicate or
+  /// failed claim halts with the outcome the handler must return.
+  func claimUpdate(updateId: Int64, chatId: Int64) async throws(RoutingHalt) {
+    let claimed = try await perform("update claim", updateId: updateId, chatId: chatId) {
+      try processed.claimUpdate(updateId: updateId)
+    }
+    guard claimed else {
+      throw RoutingHalt(outcome: skipDuplicate(updateId: updateId))
+    }
+  }
+
+  /// The one spelling of the duplicate-update outcome (dedup claims lose exactly one way).
+  func skipDuplicate(updateId: Int64) -> HandleOutcome {
+    logger.debug("duplicate update \(updateId), skipping")
+    return .skipped
+  }
+
+  /// A direct canned reply, deduped via `claimUpdate` so a redelivery doesn't double-send it.
+  func sendCanned(updateId: Int64, chatId: Int64, text: String) async -> HandleOutcome {
+    do {
+      try await claimUpdate(updateId: updateId, chatId: chatId)
+    } catch {
+      return error.outcome
+    }
+
+    do {
+      _ = try await transport.sendMessage(chatId: chatId, text: text)
+    } catch {
+      logger.error("send failed for update \(updateId): \(error)")
+      return .transientFailure
+    }
+
+    return .processed
+  }
+
+  /// Ack for a command whose effect already claimed the update; the send is best-effort — a lost
+  /// ack must not re-run the effect.
+  func sendCommandAck(updateId: Int64, chatId: Int64, text: String) async -> HandleOutcome {
+    do {
+      _ = try await transport.sendMessage(chatId: chatId, text: text)
+    } catch {
+      logger.error("command ack send failed for update \(updateId): \(error)")
+    }
+    return .processed
+  }
+
+  func sendPrivateBot(updateId: Int64, chatId: Int64) async -> HandleOutcome {
+    await sendCanned(updateId: updateId, chatId: chatId, text: MessageRouter.privateBotText)
+  }
+
+  /// Best-effort "storage full" notice (the send may still succeed — a full disk doesn't break
+  /// the network) and the signal for the poller to back off without advancing the offset (F23).
+  func storageFull(chatId: Int64) async -> HandleOutcome {
+    do {
+      _ = try await transport.sendMessage(chatId: chatId, text: Degradation.storageFull)
+    } catch {
+      logger.error("failed to send storage-full notice: \(error)")
+    }
+    return .storageFull
+  }
+}

--- a/Sources/ClawGateway/Routing/ScheduleHandlers.swift
+++ b/Sources/ClawGateway/Routing/ScheduleHandlers.swift
@@ -277,9 +277,9 @@ private extension ScheduleHandlers {
   /// so the list can never disagree with what actually fires (spec §9's single-source rule),
   /// including everyNMinutes phase. Non-ACTIVE rows show none.
   func displayNextFire(_ job: ScheduledJob) -> Date? {
-    guard job.status == .active else {
-      return nil
+    if job.status == .active {
+      return job.nextOccurrence
     }
-    return job.nextOccurrence
+    return nil
   }
 }

--- a/Sources/ClawGateway/Routing/ScheduleHandlers.swift
+++ b/Sources/ClawGateway/Routing/ScheduleHandlers.swift
@@ -1,0 +1,285 @@
+import ClawCore
+import Foundation
+import Logging
+
+/// The /schedule family (spec §7–§9): create parses ONE draft and parks it; list is read-only;
+/// pause/resume/runnow/cancel claim the update BEFORE their effect so a redelivered command
+/// applies once (§5.4). Occurrence anchoring is `schedule.policy`'s — never recomputed here.
+struct ScheduleHandlers: Sendable {
+  let schedule: ScheduleSurface
+  let sessionMessages: any SessionMessageStore
+  let pendingConfirmations: PendingConfirmationRegistry
+  let replies: ReplySender
+  let enqueuer: TurnEnqueuer
+  let now: @Sendable () -> Date
+  let logger: Logger
+
+  /// `/schedule <text>` (spec §7/§8): claim the update, run the ONE parse call, validate
+  /// deterministically, park the validated draft, and send the gateway-authored confirm prompt.
+  /// Nothing is armed here; every failure is a plain-language reply and parks nothing.
+  func create(
+    rawUpdate: RawUpdate,
+    message: IncomingMessage,
+    text: String
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    let claim = try await replies.perform(
+      "schedule claim",
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId
+    ) {
+      try sessionMessages.claimCommandUpdate(
+        updateId: rawUpdate.updateId,
+        sessionKey: SessionKey.telegramDM(chatId: message.chatId),
+        now: now()
+      )
+    }
+
+    guard case .claimed(let sessionId) = claim else {
+      return replies.skipDuplicate(updateId: rawUpdate.updateId)
+    }
+
+    switch await schedule.parser.parse(ownerText: text) {
+    case .providerUnavailable:
+      // DEG-01: an LLM/API failure degrades exactly like any turn; nothing armed.
+      return await replies.sendCommandAck(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: Degradation.providerUnavailable
+      )
+    case .unparseable:
+      return await replies.sendCommandAck(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: ScheduleReplies.parseFailed
+      )
+    case .draft(let draft):
+      let nowDate = now()
+      switch schedule.validator.validate(draft, now: nowDate) {
+      case .failure(let problem):
+        return await replies.sendCommandAck(
+          updateId: rawUpdate.updateId,
+          chatId: message.chatId,
+          text: problem.ownerReply
+        )
+      case .success(let validated):
+        // Single slot per session: a second /schedule visibly displaces the older draft (§9).
+        await pendingConfirmations.park(.command(.scheduleArm(validated)), sessionId: sessionId)
+        return await replies.sendCommandAck(
+          updateId: rawUpdate.updateId,
+          chatId: message.chatId,
+          text: ScheduleReplies.confirmPrompt(
+            schedule: validated,
+            nextFires: schedule.policy.confirmPreview(
+              for: validated,
+              from: nowDate,
+              limit: ScheduleReplies.confirmPreviewCount
+            )
+          )
+        )
+      }
+    }
+  }
+
+  /// `/schedule list` (spec §9): read-only, deduped via the canned-reply claim like
+  /// `CommandHandlers.memoryReview`.
+  func list(rawUpdate: RawUpdate, chatId: Int64) async throws(RoutingHalt) -> HandleOutcome {
+    let jobs = try await replies.perform(
+      "schedule list",
+      updateId: rawUpdate.updateId,
+      chatId: chatId
+    ) {
+      try schedule.jobs.listAll()
+    }
+
+    guard jobs.isEmpty == false else {
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
+        chatId: chatId,
+        text: ScheduleReplies.emptyList
+      )
+    }
+
+    let rows = jobs.map { job in
+      (job: job, nextFire: displayNextFire(job))
+    }
+    return await replies.sendCanned(
+      updateId: rawUpdate.updateId,
+      chatId: chatId,
+      text: ScheduleReplies.listLines(rows)
+    )
+  }
+
+  func pause(
+    rawUpdate: RawUpdate,
+    message: IncomingMessage,
+    jobId: Int64?
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    guard let jobId else {
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: ScheduleReplies.pauseUsage
+      )
+    }
+    try await replies.claimUpdate(updateId: rawUpdate.updateId, chatId: message.chatId)
+
+    let paused = try await replies.perform(
+      "pause",
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      onFailure: .ack(ScheduleReplies.verbFailed)
+    ) {
+      try schedule.jobs.pause(id: jobId, now: now())
+    }
+
+    let reply = paused.map(ScheduleReplies.paused) ?? ScheduleReplies.notFound(id: jobId)
+    return await replies.sendCommandAck(
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      text: reply
+    )
+  }
+
+  func resume(
+    rawUpdate: RawUpdate,
+    message: IncomingMessage,
+    jobId: Int64?
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    guard let jobId else {
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: ScheduleReplies.resumeUsage
+      )
+    }
+    try await replies.claimUpdate(updateId: rawUpdate.updateId, chatId: message.chatId)
+
+    // The CALLER recomputes next-from-now (preamble contract): occurrences inside the paused
+    // window are skipped, never caught up (§5.4). No race with the ticker: the row is PAUSED
+    // until `resume` commits, and the ticker's scan predicate excludes PAUSED.
+    let job = try await replies.perform(
+      "resume lookup",
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      onFailure: .ack(ScheduleReplies.verbFailed)
+    ) {
+      try schedule.jobs.job(id: jobId)
+    }
+
+    guard let job else {
+      return await replies.sendCommandAck(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: ScheduleReplies.notFound(id: jobId)
+      )
+    }
+
+    let resumed = try await replies.perform(
+      "resume",
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      onFailure: .ack(ScheduleReplies.verbFailed)
+    ) {
+      try schedule.jobs.resume(
+        id: jobId,
+        nextOccurrence: schedule.policy.resumeOccurrence(for: job, from: now()),
+        now: now()
+      )
+    }
+
+    let reply = resumed.map(ScheduleReplies.resumed) ?? ScheduleReplies.notFound(id: jobId)
+    return await replies.sendCommandAck(
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      text: reply
+    )
+  }
+
+  func runNow(
+    rawUpdate: RawUpdate,
+    message: IncomingMessage,
+    jobId: Int64?
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    guard let jobId else {
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: ScheduleReplies.runNowUsage
+      )
+    }
+    try await replies.claimUpdate(updateId: rawUpdate.updateId, chatId: message.chatId)
+
+    let fire = try await replies.perform(
+      "run-now",
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      onFailure: .ack(ScheduleReplies.verbFailed)
+    ) {
+      try schedule.jobs.fireNow(jobId: jobId, now: now())
+    }
+
+    guard let fire else {
+      return await replies.sendCommandAck(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: ScheduleReplies.notFound(id: jobId)
+      )
+    }
+
+    // The fused fireNow already created the session, trigger message, PENDING run, and
+    // jobExecuted audit; TurnEnqueuer gives the run ordering and cancellability (D1).
+    await enqueuer.enqueue(fire: fire)
+
+    return await replies.sendCommandAck(
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      text: ScheduleReplies.runningNow(id: jobId)
+    )
+  }
+
+  func cancelJob(
+    rawUpdate: RawUpdate,
+    message: IncomingMessage,
+    jobId: Int64?
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    guard let jobId else {
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
+        chatId: message.chatId,
+        text: ScheduleReplies.cancelUsage
+      )
+    }
+    try await replies.claimUpdate(updateId: rawUpdate.updateId, chatId: message.chatId)
+
+    let cancelled = try await replies.perform(
+      "cancel",
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      onFailure: .ack(ScheduleReplies.verbFailed)
+    ) {
+      try schedule.jobs.cancel(id: jobId, now: now())
+    }
+
+    let reply = cancelled.map(ScheduleReplies.cancelled) ?? ScheduleReplies.notFound(id: jobId)
+    return await replies.sendCommandAck(
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId,
+      text: reply
+    )
+  }
+}
+
+// MARK: - List Rendering
+
+private extension ScheduleHandlers {
+  /// The list's next-fire column: the stored `next_occurrence`, which is itself
+  /// calculator-produced — materialized at arm time and advanced only inside the claim (§4.1) —
+  /// so the list can never disagree with what actually fires (spec §9's single-source rule),
+  /// including everyNMinutes phase. Non-ACTIVE rows show none.
+  func displayNextFire(_ job: ScheduledJob) -> Date? {
+    guard job.status == .active else {
+      return nil
+    }
+    return job.nextOccurrence
+  }
+}

--- a/Sources/ClawGateway/Routing/ScheduleSurface.swift
+++ b/Sources/ClawGateway/Routing/ScheduleSurface.swift
@@ -2,10 +2,12 @@ import ClawCore
 
 /// The scheduling collaborators the router needs, bundled so `MessageRouter.init` grows one
 /// parameter instead of five. Composition builds exactly one; tests swap the parser for a fake.
+/// The init takes the raw calculator (the actual injectable dependency) and derives the policy —
+/// pure logic — itself, so construction sites stay one-liner-simple.
 public struct ScheduleSurface: Sendable {
   public let parser: any ScheduleDraftParsing
   public let validator: ScheduleDraftValidator
-  public let calculator: OccurrenceCalculator
+  public let policy: OccurrencePolicy
   public let jobs: any ScheduledJobStore
   public let commands: any ScheduleCommandStore
 
@@ -18,7 +20,7 @@ public struct ScheduleSurface: Sendable {
   ) {
     self.parser = parser
     self.validator = validator
-    self.calculator = calculator
+    self.policy = OccurrencePolicy(calculator: calculator)
     self.jobs = jobs
     self.commands = commands
   }

--- a/Sources/ClawGateway/Routing/TurnDispatch.swift
+++ b/Sources/ClawGateway/Routing/TurnDispatch.swift
@@ -1,0 +1,70 @@
+import ClawCore
+import Foundation
+import Logging
+
+/// The inbound plain-text → durable run bridge: fuses claim + persistence, then enqueues the
+/// run and returns without awaiting it. Persistence failure prevents cursor advancement;
+/// background turn failures are logged in-band by `TurnEnqueuer`.
+struct TurnDispatch: Sendable {
+  let sessionMessages: any SessionMessageStore
+  let enqueuer: TurnEnqueuer
+  let replies: ReplySender
+  let now: @Sendable () -> Date
+  let logger: Logger
+
+  func dispatch(
+    rawUpdate: RawUpdate,
+    message: IncomingMessage,
+    text: String,
+    grant: OneTurnGrant? = nil
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    let inbound = InboundMessage(
+      updateId: rawUpdate.updateId,
+      sessionKey: SessionKey.telegramDM(chatId: message.chatId),
+      chatId: message.chatId,
+      userId: message.userId,
+      text: text,
+      isEdited: message.isEdited,
+      ts: now()
+    )
+
+    let claim = try await replies.perform(
+      "inbound persist",
+      updateId: rawUpdate.updateId,
+      chatId: message.chatId
+    ) {
+      try sessionMessages.claimAndPersistInbound(inbound)
+    }
+
+    guard
+      claim.newlyClaimed,
+      let sessionId = claim.sessionId,
+      let runId = claim.runId,
+      let triggerMessageId = claim.triggerMessageId
+    else {
+      return replies.skipDuplicate(updateId: rawUpdate.updateId)
+    }
+
+    // The inbound → run bridge: the one INFO line that shows a real message was accepted and
+    // which run it became. run/session/update ride as metadata so the whole lifecycle greps by
+    // `run=<id>`; only the message SIZE is logged, never its text.
+    var runLog = logger
+    runLog[metadataKey: "run"] = "\(runId)"
+    runLog[metadataKey: "session"] = "\(sessionId)"
+    runLog[metadataKey: "update"] = "\(rawUpdate.updateId)"
+    runLog.info(
+      "message accepted; dispatching run (chars=\(text.count) edited=\(message.isEdited))"
+    )
+
+    await enqueuer.enqueue(
+      runId: runId,
+      sessionId: sessionId,
+      chatId: message.chatId,
+      triggerMessageId: triggerMessageId,
+      grant: grant,
+      log: runLog
+    )
+
+    return .processed
+  }
+}

--- a/Sources/ClawGateway/Routing/TurnEnqueuer.swift
+++ b/Sources/ClawGateway/Routing/TurnEnqueuer.swift
@@ -1,0 +1,56 @@
+import ClawAgent
+import ClawCore
+import Logging
+
+/// The one place a durable PENDING run becomes lane work (inbound turns, /runnow, the scheduler
+/// tick). The lane closure cannot rethrow and `TurnDispatching.run` resolves every failure
+/// in-band except `StoreError.diskFull` (D1), so this body is the single spelling of that
+/// contract.
+struct TurnEnqueuer: Sendable {
+  let lanes: SessionLaneRegistry
+  let turns: any TurnDispatching
+  let logger: Logger
+
+  /// `log` lets the inbound path pass its run/session/update-stamped logger so lifecycle greps
+  /// by `run=<id>` keep working; other initiators use the component logger.
+  func enqueue(
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    triggerMessageId: Int64,
+    grant: OneTurnGrant?,
+    log: Logger? = nil
+  ) async {
+    let runLog = log ?? logger
+    let runner = turns
+    let lane = await lanes.actor(for: sessionId)
+
+    await lane.enqueue(runId: runId) {
+      do {
+        try await runner.run(
+          runId: runId,
+          sessionId: sessionId,
+          chatId: chatId,
+          triggerMessageId: triggerMessageId,
+          grant: grant
+        )
+      } catch StoreError.diskFull {
+        runLog.error("run \(runId) stopped by storage full after enqueue")
+      } catch {
+        runLog.error("run \(runId) error (handled in-band): \(error)")
+      }
+    }
+  }
+
+  /// A claimed scheduler/run-now fire is a first-class lane citizen — ordered and cancellable
+  /// like any turn (D1).
+  func enqueue(fire: ClaimedFire) async {
+    await enqueue(
+      runId: fire.runId,
+      sessionId: fire.sessionId,
+      chatId: fire.ownerChatId,
+      triggerMessageId: fire.triggerMessageId,
+      grant: nil
+    )
+  }
+}

--- a/Sources/ClawGateway/Services/Heartbeat/SchedulerService.swift
+++ b/Sources/ClawGateway/Services/Heartbeat/SchedulerService.swift
@@ -16,8 +16,7 @@ public struct SchedulerService: Service {
   public static let tickInterval: Duration = .seconds(60)
 
   private let jobs: any ScheduledJobStore
-  private let lanes: SessionLaneRegistry
-  private let turns: any TurnDispatching
+  private let enqueuer: TurnEnqueuer
   private let calculator: OccurrenceCalculator
   private let catchUpMaxAge: Duration
   private let heartbeat: HeartbeatSettings
@@ -42,8 +41,6 @@ public struct SchedulerService: Service {
     logger: Logger
   ) {
     self.jobs = jobs
-    self.lanes = lanes
-    self.turns = turns
     self.calculator = calculator
     self.catchUpMaxAge = catchUpMaxAge
     self.heartbeat = heartbeat
@@ -52,6 +49,7 @@ public struct SchedulerService: Service {
     self.now = now
     self.sleep = sleep
     self.logger = logger
+    self.enqueuer = TurnEnqueuer(lanes: lanes, turns: turns, logger: logger)
   }
 
   public func run() async throws {
@@ -159,7 +157,7 @@ private extension SchedulerService {
         return  // CAS matched no row: claimed elsewhere / job mutated — no fire
       }
 
-      await enqueue(fire)
+      await enqueuer.enqueue(fire: fire)
     } catch {
       logger.error("scheduler fire failed for job \(job.id): \(error)")
     }
@@ -210,30 +208,6 @@ private extension SchedulerService {
         after: after,
         limit: 1
       ).first
-    }
-  }
-
-  /// D1: a claimed fire is a first-class lane citizen — ordered and cancellable like any turn.
-  func enqueue(_ fire: ClaimedFire) async {
-    let runner = turns
-    let log = logger
-
-    let lane = await lanes.actor(for: fire.sessionId)
-
-    await lane.enqueue(runId: fire.runId) {
-      do {
-        try await runner.run(
-          runId: fire.runId,
-          sessionId: fire.sessionId,
-          chatId: fire.ownerChatId,
-          triggerMessageId: fire.triggerMessageId,
-          grant: nil
-        )
-      } catch {
-        // run() may throw only StoreError.diskFull; the lane closure cannot rethrow, so log it —
-        // the PENDING run stays durable and boot reconciliation resolves it (§5.2).
-        log.error("scheduled run \(fire.runId) failed with a storage error: \(error)")
-      }
     }
   }
 }
@@ -304,7 +278,7 @@ private extension SchedulerService {
         day: day
       )
       await skipEpisode.end()
-      await enqueue(fire)
+      await enqueuer.enqueue(fire: fire)
     } catch {
       logger.error("heartbeat fire failed: \(error)")
     }

--- a/Sources/ClawGateway/Services/Heartbeat/SchedulerService.swift
+++ b/Sources/ClawGateway/Services/Heartbeat/SchedulerService.swift
@@ -17,7 +17,7 @@ public struct SchedulerService: Service {
 
   private let jobs: any ScheduledJobStore
   private let enqueuer: TurnEnqueuer
-  private let calculator: OccurrenceCalculator
+  private let policy: OccurrencePolicy
   private let catchUpMaxAge: Duration
   private let heartbeat: HeartbeatSettings
   private let workspace: any WorkspaceReading
@@ -41,7 +41,7 @@ public struct SchedulerService: Service {
     logger: Logger
   ) {
     self.jobs = jobs
-    self.calculator = calculator
+    self.policy = OccurrencePolicy(calculator: calculator)
     self.catchUpMaxAge = catchUpMaxAge
     self.heartbeat = heartbeat
     self.workspace = workspace
@@ -123,21 +123,13 @@ private extension SchedulerService {
       let fireAt: Date
       if lateness <= Double(Self.tickInterval.components.seconds) {
         fireAt = due  // on time / one tick late
-      } else if let envelope = job.recurrence {
-        // Coalesce: N missed occurrences inside the window fire ONCE, at the latest missed
-        // occurrence ≤ now; the CAS still matches the stored due (§5.2 — due vs T_fire).
-        // Anchor = the stored due: every advance stays on the chain the confirm preview
-        // showed (for everyNMinutes the phase is due + k·N; time-of-day rules are anchor-inert).
-        fireAt =
-          calculator.latestOccurrence(
-            rule: envelope.rule,
-            timezone: timezone,
-            anchor: due,
-            after: due.addingTimeInterval(-1),
-            atOrBefore: tickTime
-          ) ?? due
       } else {
-        fireAt = due  // a one-shot has exactly one occurrence: the stored one
+        fireAt = policy.coalescedFireTime(
+          for: job,
+          timezone: timezone,
+          due: due,
+          atOrBefore: tickTime
+        )
       }
 
       guard
@@ -145,7 +137,7 @@ private extension SchedulerService {
           jobId: job.id,
           due: due,
           fireAt: fireAt,
-          nextOccurrence: nextOccurrence(
+          nextOccurrence: policy.advance(
             for: job,
             timezone: timezone,
             anchor: due,
@@ -169,46 +161,21 @@ private extension SchedulerService {
     timezone: TimeZone,
     tickTime: Date
   ) throws {
-    let skippedCount =
-      job.recurrence.map { envelope in
-        calculator.occurrences(
-          rule: envelope.rule,
-          timezone: timezone,
-          anchor: due,
-          after: due.addingTimeInterval(-1),
-          limit: Self.misfireCountLimit
-        ).filter { occurrence in
-          occurrence <= tickTime
-        }.count
-      } ?? 1
+    let skippedCount = policy.missedOccurrenceCount(
+      for: job,
+      timezone: timezone,
+      due: due,
+      atOrBefore: tickTime,
+      limit: Self.misfireCountLimit
+    )
 
     _ = try jobs.skipMisfire(
       jobId: job.id,
       due: due,
-      nextOccurrence: nextOccurrence(for: job, timezone: timezone, anchor: due, after: tickTime),
+      nextOccurrence: policy.advance(for: job, timezone: timezone, anchor: due, after: tickTime),
       skippedCount: skippedCount,
       now: tickTime
     )
-  }
-
-  /// The advanced next_occurrence: strictly after `after`; nil for a one-shot (→ COMPLETED).
-  /// `anchor` is the occurrence being advanced from (the claimed/skipped due) — advances stay
-  /// on the armed chain, so /schedule's confirm preview can never disagree with actual fires.
-  func nextOccurrence(
-    for job: ScheduledJob,
-    timezone: TimeZone,
-    anchor: Date,
-    after: Date
-  ) -> Date? {
-    job.recurrence.flatMap { envelope in
-      calculator.occurrences(
-        rule: envelope.rule,
-        timezone: timezone,
-        anchor: anchor,
-        after: after,
-        limit: 1
-      ).first
-    }
   }
 }
 

--- a/Tests/ClawCoreTests/Domain/Scheduling/OccurrencePolicyTests.swift
+++ b/Tests/ClawCoreTests/Domain/Scheduling/OccurrencePolicyTests.swift
@@ -1,0 +1,253 @@
+import Foundation
+import Testing
+
+@testable import ClawCore
+
+@Suite struct OccurrencePolicyTests {
+  private let policy = OccurrencePolicy()
+  private let utc = TimeZone(identifier: "UTC")
+
+  /// 2026-07-07 12:00:00 UTC — a fixed, DST-free reference instant.
+  private let noon = Date(timeIntervalSince1970: 1_783_339_200)
+
+  private func everyTenMinutesRule() throws -> Calendar.RecurrenceRule {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try #require(utc)
+    return Calendar.RecurrenceRule(calendar: calendar, frequency: .minutely, interval: 10)
+  }
+
+  private func validated(
+    recurrence: RecurrenceEnvelope?,
+    firstOccurrence: Date,
+    timezone: String = "UTC"
+  ) -> ValidatedSchedule {
+    ValidatedSchedule(
+      label: "standup",
+      prompt: "post the standup summary",
+      recurrence: recurrence,
+      timezone: timezone,
+      firstOccurrence: firstOccurrence,
+      recurrenceInWords: "every 10 minutes"
+    )
+  }
+
+  private func job(
+    recurrence: RecurrenceEnvelope?,
+    nextOccurrence: Date?,
+    timezone: String = "UTC"
+  ) -> ScheduledJob {
+    ScheduledJob(
+      id: 1,
+      ownerChatId: 7,
+      label: "standup",
+      prompt: "post the standup summary",
+      recurrence: recurrence,
+      timezone: timezone,
+      nextOccurrence: nextOccurrence,
+      lastFiredAt: nil,
+      status: .paused,
+      sessionId: nil,
+      createdTs: noon.addingTimeInterval(-86_400),
+      updatedTs: noon
+    )
+  }
+
+  private func envelope() throws -> RecurrenceEnvelope {
+    RecurrenceEnvelope(
+      schemaVersion: RecurrenceEnvelope.currentSchemaVersion,
+      rule: try everyTenMinutesRule()
+    )
+  }
+
+  // MARK: - confirmPreview
+
+  @Test func oneShotPreviewIsItsSingleInstant() {
+    // given
+    let schedule = validated(recurrence: nil, firstOccurrence: noon.addingTimeInterval(3_600))
+
+    // when
+    let preview = policy.confirmPreview(for: schedule, from: noon, limit: 3)
+
+    // then
+    #expect(preview == [schedule.firstOccurrence])
+  }
+
+  @Test func unknownTimezonePreviewFallsBackToTheFirstOccurrence() throws {
+    // given — fail-safe, matching the arm fallback: never an empty preview for a valid draft
+    let schedule = validated(
+      recurrence: try envelope(),
+      firstOccurrence: noon.addingTimeInterval(600),
+      timezone: "Not/AZone"
+    )
+
+    // when
+    let preview = policy.confirmPreview(for: schedule, from: noon, limit: 3)
+
+    // then
+    #expect(preview == [schedule.firstOccurrence])
+  }
+
+  @Test func recurringPreviewSeedsThePhaseFromTheValidationClock() throws {
+    // given
+    let schedule = validated(
+      recurrence: try envelope(),
+      firstOccurrence: noon.addingTimeInterval(600)
+    )
+
+    // when — the SAME nowDate that validation used seeds the calculator
+    let preview = policy.confirmPreview(for: schedule, from: noon, limit: 3)
+
+    // then — the preview's first entry IS the parked firstOccurrence, phase noon + k·10min
+    #expect(preview.count == 3)
+    #expect(preview[0] == noon.addingTimeInterval(600))
+    #expect(preview[1] == noon.addingTimeInterval(1_200))
+    #expect(preview[2] == noon.addingTimeInterval(1_800))
+  }
+
+  // MARK: - armOccurrence
+
+  @Test func oneShotStillAheadArmsItsInstant() {
+    // given
+    let schedule = validated(recurrence: nil, firstOccurrence: noon.addingTimeInterval(3_600))
+
+    // when / then
+    #expect(policy.armOccurrence(for: schedule, at: noon) == schedule.firstOccurrence)
+  }
+
+  @Test func oneShotWhoseInstantPassedArmsNothing() {
+    // given — a draft confirmed long after its preview cannot arm an already-past occurrence
+    let schedule = validated(recurrence: nil, firstOccurrence: noon.addingTimeInterval(-60))
+
+    // when / then
+    #expect(policy.armOccurrence(for: schedule, at: noon) == nil)
+  }
+
+  @Test func lateConfirmKeepsThePreviewedPhaseAndSkipsPastOccurrences() throws {
+    // given — parked at noon+10min, confirmed 25 minutes later
+    let schedule = validated(
+      recurrence: try envelope(),
+      firstOccurrence: noon.addingTimeInterval(600)
+    )
+    let confirmTime = noon.addingTimeInterval(1_500)
+
+    // when — anchor = parked firstOccurrence (phase continuity), after = confirm-time now
+    let armed = policy.armOccurrence(for: schedule, at: confirmTime)
+
+    // then — next on the previewed chain strictly after confirm time: noon+30min, not noon+35min
+    #expect(armed == noon.addingTimeInterval(1_800))
+  }
+
+  // MARK: - resumeOccurrence
+
+  @Test func resumedOneShotStillAheadKeepsItsInstant() {
+    // given
+    let paused = job(recurrence: nil, nextOccurrence: noon.addingTimeInterval(3_600))
+
+    // when / then
+    #expect(policy.resumeOccurrence(for: paused, from: noon) == paused.nextOccurrence)
+  }
+
+  @Test func resumedOneShotWhoseInstantPassedHasNothingLeftToFire() {
+    // given
+    let paused = job(recurrence: nil, nextOccurrence: noon.addingTimeInterval(-60))
+
+    // when / then
+    #expect(policy.resumeOccurrence(for: paused, from: noon) == nil)
+  }
+
+  @Test func resumeSkipsThePausedWindowButKeepsThePhase() throws {
+    // given — stale stored next at noon, resumed 25 minutes later
+    let paused = job(recurrence: try envelope(), nextOccurrence: noon)
+
+    // when — anchor = the stale stored next; after = now (pause = "be quiet", never catch up)
+    let resumed = policy.resumeOccurrence(for: paused, from: noon.addingTimeInterval(1_500))
+
+    // then — next on the armed chain after the window: noon+30min
+    #expect(resumed == noon.addingTimeInterval(1_800))
+  }
+
+  // MARK: - advance / coalescedFireTime / missedOccurrenceCount
+
+  @Test func advanceYieldsTheNextChainOccurrenceAndNilForOneShots() throws {
+    // given
+    let recurring = job(recurrence: try envelope(), nextOccurrence: noon)
+    let oneShot = job(recurrence: nil, nextOccurrence: noon)
+    let timezone = try #require(utc)
+
+    // when / then — a one-shot has no next (→ COMPLETED); recurring stays on the due chain
+    #expect(
+      policy.advance(
+        for: recurring,
+        timezone: timezone,
+        anchor: noon,
+        after: noon.addingTimeInterval(90)
+      )
+        == noon.addingTimeInterval(600)
+    )
+    #expect(policy.advance(for: oneShot, timezone: timezone, anchor: noon, after: noon) == nil)
+  }
+
+  @Test func coalesceFiresOnceAtTheLatestMissedOccurrence() throws {
+    // given — due at noon, tick arrives 25 minutes late: noon, +10, +20 were missed
+    let recurring = job(recurrence: try envelope(), nextOccurrence: noon)
+    let timezone = try #require(utc)
+
+    // when
+    let fireAt = policy.coalescedFireTime(
+      for: recurring,
+      timezone: timezone,
+      due: noon,
+      atOrBefore: noon.addingTimeInterval(1_500)
+    )
+
+    // then — the latest missed occurrence ≤ now, still on the due chain (§5.3)
+    #expect(fireAt == noon.addingTimeInterval(1_200))
+  }
+
+  @Test func coalesceForAOneShotIsItsStoredDue() throws {
+    // given
+    let oneShot = job(recurrence: nil, nextOccurrence: noon)
+    let timezone = try #require(utc)
+
+    // when / then — a one-shot has exactly one occurrence: the stored one
+    #expect(
+      policy.coalescedFireTime(
+        for: oneShot,
+        timezone: timezone,
+        due: noon,
+        atOrBefore: noon.addingTimeInterval(1_500)
+      )
+        == noon
+    )
+  }
+
+  @Test func missedCountCoversTheWindowAndIsOneForOneShots() throws {
+    // given
+    let recurring = job(recurrence: try envelope(), nextOccurrence: noon)
+    let oneShot = job(recurrence: nil, nextOccurrence: noon)
+    let timezone = try #require(utc)
+    let tickTime = noon.addingTimeInterval(1_500)
+
+    // when / then — noon, +10, +20 missed ⇒ 3; a one-shot misfire is always exactly 1
+    #expect(
+      policy.missedOccurrenceCount(
+        for: recurring,
+        timezone: timezone,
+        due: noon,
+        atOrBefore: tickTime,
+        limit: 1_000
+      )
+        == 3
+    )
+    #expect(
+      policy.missedOccurrenceCount(
+        for: oneShot,
+        timezone: timezone,
+        due: noon,
+        atOrBefore: tickTime,
+        limit: 1_000
+      )
+        == 1
+    )
+  }
+}

--- a/Tests/ClawGatewayTests/Routing/ConfirmationResolutionTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ConfirmationResolutionTests.swift
@@ -108,7 +108,10 @@ import Testing
     let harness = try MemoryRoutingHarness.make()
     let seeded = try harness.seedItem(text: "obsolete fact", kind: .user)
     let sessionId = try harness.ownerSessionId()
-    await harness.pendingConfirmations.park(.deleteItem(id: seeded.id), sessionId: sessionId)
+    await harness.pendingConfirmations.park(
+      .command(.deleteItem(id: seeded.id)),
+      sessionId: sessionId
+    )
 
     // when
     let outcome = await harness.router.handle(rawUpdate: textUpdate(id: 9, from: 42, text: "yes"))

--- a/Tests/ClawGatewayTests/Routing/MemoryCommandRoutingTests.swift
+++ b/Tests/ClawGatewayTests/Routing/MemoryCommandRoutingTests.swift
@@ -136,7 +136,8 @@ import Testing
     )
     let sessionId = try harness.ownerSessionId()
     #expect(
-      await harness.pendingConfirmations.pending(sessionId: sessionId) == .deleteItem(id: item.id)
+      await harness.pendingConfirmations.pending(sessionId: sessionId)
+        == .command(.deleteItem(id: item.id))
     )
     #expect(await harness.dispatcher.calls.isEmpty)
   }

--- a/Tests/ClawGatewayTests/Routing/PendingConfirmationRegistryTests.swift
+++ b/Tests/ClawGatewayTests/Routing/PendingConfirmationRegistryTests.swift
@@ -8,7 +8,7 @@ import Testing
   @Test func parkedEntryIsReadableUntilCleared() async throws {
     // given
     let registry = PendingConfirmationRegistry()
-    let entry = try PendingConfirmation.rememberWrite(memoryWriteRequest(sessionId: 42))
+    let entry = try PendingConfirmation.command(.rememberWrite(memoryWriteRequest(sessionId: 42)))
 
     // when
     await registry.park(entry, sessionId: 42)
@@ -24,8 +24,8 @@ import Testing
   @Test func reparkingReplacesPreviousEntryForSameSession() async throws {
     // given
     let registry = PendingConfirmationRegistry()
-    let first = try PendingConfirmation.rememberWrite(memoryWriteRequest(sessionId: 42))
-    let second = PendingConfirmation.deleteItem(id: 7)
+    let first = try PendingConfirmation.command(.rememberWrite(memoryWriteRequest(sessionId: 42)))
+    let second = PendingConfirmation.command(.deleteItem(id: 7))
 
     // when
     await registry.park(first, sessionId: 42)
@@ -38,8 +38,8 @@ import Testing
   @Test func sessionsAreIsolated() async throws {
     // given
     let registry = PendingConfirmationRegistry()
-    let first = try PendingConfirmation.rememberWrite(memoryWriteRequest(sessionId: 42))
-    let second = PendingConfirmation.deleteItem(id: 7)
+    let first = try PendingConfirmation.command(.rememberWrite(memoryWriteRequest(sessionId: 42)))
+    let second = PendingConfirmation.command(.deleteItem(id: 7))
 
     // when
     await registry.park(first, sessionId: 42)

--- a/Tests/ClawGatewayTests/Routing/RememberRoutingTests.swift
+++ b/Tests/ClawGatewayTests/Routing/RememberRoutingTests.swift
@@ -25,7 +25,7 @@ import Testing
     #expect(try harness.memoryItemCount() == 0)
     let sessionId = try harness.ownerSessionId()
     let entry = await harness.pendingConfirmations.pending(sessionId: sessionId)
-    guard case .rememberWrite(let request) = try #require(entry) else {
+    guard case .command(.rememberWrite(let request)) = try #require(entry) else {
       Issue.record("expected a parked remember entry, got \(String(describing: entry))")
       return
     }
@@ -47,7 +47,7 @@ import Testing
     // then
     let sessionId = try harness.ownerSessionId()
     let entry = await harness.pendingConfirmations.pending(sessionId: sessionId)
-    guard case .rememberWrite(let request) = try #require(entry) else {
+    guard case .command(.rememberWrite(let request)) = try #require(entry) else {
       Issue.record("expected a parked remember entry, got \(String(describing: entry))")
       return
     }
@@ -136,7 +136,7 @@ import Testing
     // then
     let sessionId = try harness.ownerSessionId()
     let entry = await harness.pendingConfirmations.pending(sessionId: sessionId)
-    guard case .rememberWrite(let request) = try #require(entry) else {
+    guard case .command(.rememberWrite(let request)) = try #require(entry) else {
       Issue.record("expected a parked remember entry, got \(String(describing: entry))")
       return
     }

--- a/Tests/ClawGatewayTests/Routing/ScheduleRoutingTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ScheduleRoutingTests.swift
@@ -186,7 +186,7 @@ import Testing
       firstOccurrence: Self.fixedNow.addingTimeInterval(-86_400),
       recurrenceInWords: "every weekday at 07:00"
     )
-    await harness.pending.park(.scheduleArm(stale), sessionId: sessionId)
+    await harness.pending.park(.command(.scheduleArm(stale)), sessionId: sessionId)
 
     // when
     let outcome = await harness.router.handle(rawUpdate: textUpdate(id: 2, from: 42, text: "yes"))
@@ -232,7 +232,7 @@ import Testing
       firstOccurrence: Date(timeIntervalSince1970: 1_783_337_700),
       recurrenceInWords: "every 30 minutes"
     )
-    await harness.pending.park(.scheduleArm(stale), sessionId: sessionId)
+    await harness.pending.park(.command(.scheduleArm(stale)), sessionId: sessionId)
 
     // when
     let outcome = await harness.router.handle(rawUpdate: textUpdate(id: 2, from: 42, text: "yes"))
@@ -266,7 +266,7 @@ import Testing
       firstOccurrence: Self.fixedNow.addingTimeInterval(-3_600),
       recurrenceInWords: "once"
     )
-    await harness.pending.park(.scheduleArm(stale), sessionId: sessionId)
+    await harness.pending.park(.command(.scheduleArm(stale)), sessionId: sessionId)
 
     // when
     let outcome = await harness.router.handle(rawUpdate: textUpdate(id: 2, from: 42, text: "yes"))

--- a/docs/research/architecture-review-2026-07-06.md
+++ b/docs/research/architecture-review-2026-07-06.md
@@ -11,6 +11,8 @@
 
 Verdicts are marked CONFIRMED or PLAUSIBLE; two findings were downgraded during adversarial verification and are presented with those corrections.
 
+> **Progress (updated 2026-07-07).** Risk 2 (the `MessageRouter` split) and Stage 2 item 1 of the refactoring plan are done, landed on branch `split-message-router` (PR [#30](https://github.com/ivan-magda/swift-claw/pull/30)). The rest of the register stands as written. See the "Resolved" callout under Risk 2 for what shipped.
+
 ---
 
 ## 1. Architecture map
@@ -61,7 +63,17 @@ Tradeoffs: An abandoned tool task keeps running detached until its I/O returns, 
 
 ### Risk 2: MessageRouter is a 1,176-line convergence point whose invariants are enforced by comments and ordering
 
-Severity: High · Confidence: High · **CONFIRMED** (verified first-hand)
+Severity: High · Confidence: High · **CONFIRMED** (verified first-hand) · **RESOLVED (2026-07-07)**
+
+> **Resolved (2026-07-07, PR [#30](https://github.com/ivan-magda/swift-claw/pull/30), branch `split-message-router`).** Behavior-preserving split; the full suite passes with no test changes beyond mechanical `PendingConfirmation` case-path updates and one new `OccurrencePolicyTests.swift`. `MessageRouter` is now a 235-line dispatcher over internally-constructed `Sendable` structs:
+> - **`ReplySender`** + a `RoutingHalt` error collapse the 23 copied `catch StoreError.diskFull` blocks into one `perform` that spells the two-tier store-error contract once and unwinds to the single `handle` catch point.
+> - **`TurnEnqueuer`** replaces the three near-verbatim lane-enqueue closures (two of which were the cross-module copies cited below).
+> - **`TurnDispatch`** (claim-and-persist inbound), **`CommandHandlers`** (stop/new/remember/memory), **`ScheduleHandlers`** (the six-verb schedule family), **`ConfirmationResolver`** (parked-confirmation resolution).
+> - `PendingConfirmation` splits into `CommandConfirmation` vs tool-approval, so each resolver switch is exhaustive over only the cases it can legally see. Both `preconditionFailure` arms are deleted, not moved.
+> - The occurrence-anchoring math moves into a pure `OccurrencePolicy` in `ClawCore/Domain/Scheduling` beside `OccurrenceCalculator`, consumed by both the gateway and `SchedulerService` so the confirm preview and actual fires cannot drift apart.
+> - The per-arm `guard isAllowed` copies collapse into one `denyAccess` gate.
+>
+> Net: `MessageRouter.swift` holds 0 `catch StoreError.diskFull` and 0 `preconditionFailure`; public API (`MessageRouter.init`, `ScheduleSurface.init`, `SchedulerService.init`, `PendingConfirmationRegistry`, `HandleOutcome`) is unchanged. The original evidence, preserved below, describes the pre-split state.
 
 Evidence:
 
@@ -298,7 +310,7 @@ Evidence: quiet heartbeat runs visibly type (`AgentRuntime.swift:264`, unconditi
 
 **New tool — clean** (one struct + one array line, automatic auditing and budget caps) **unless it needs policy**, in which case you must know to edit `egressTools` (Risk 3). A confirmation-gated tool is **clean** — Scenario 3 traced the whole park/prompt/resolve/grant loop as tool-agnostic; only the gate branch and one `ApprovalReason` case (compiler-forced copy) are added.
 
-**New domain module — awkward but honest.** The scheduling precedent measured 98.7% additive (1,443 insertions, 18 deletions, 5 new files, 7 small compiler-guided edits to shared files). The open/closed story is: domain, store, replies are additive; `Command`, `PendingConfirmation`, `AuditAction`, `ClawStores`, the migrator are small forced edits; **MessageRouter absorbs the dominant edit** (+489 lines for scheduling). The router split (Risk 2) is what turns this "awkward" into "clean."
+**New domain module — awkward but honest.** The scheduling precedent measured 98.7% additive (1,443 insertions, 18 deletions, 5 new files, 7 small compiler-guided edits to shared files). The open/closed story is: domain, store, replies are additive; `Command`, `PendingConfirmation`, `AuditAction`, `ClawStores`, the migrator are small forced edits; **MessageRouter absorbs the dominant edit** (+489 lines for scheduling). The router split (Risk 2) is what turns this "awkward" into "clean" — now done (PR [#30](https://github.com/ivan-magda/swift-claw/pull/30)), so a new domain's handlers land in their own family file rather than growing the dispatcher.
 
 **New LLM provider — clean.** Scenario 2's full trace: a new `AnthropicMessagesProvider` module, finish-reason normalization, one composition-root discriminator, pricing rows. No changes to the loop, history model, or migrations. The optional payoffs (cache-token accounting, typed stop reasons) are additive.
 
@@ -351,7 +363,7 @@ Plus the one-line input-token preflight guard (Risk 8). Do **not** touch: the se
 
 **Stage 2 — medium cleanup, ideally interleaved with Inc 5 planning.**
 
-1. Split `MessageRouter` (CommandHandlers / ScheduleHandlers / ConfirmationResolver), extract the claim/error-mapping helper, split `PendingConfirmation` into command-confirmation vs tool-approval types, and move `armNextOccurrence`/`resumeNextOccurrence`/`nextFires` into an `OccurrencePolicy` domain type also consumed by `SchedulerService` (Risk 2).
+1. ~~Split `MessageRouter` (CommandHandlers / ScheduleHandlers / ConfirmationResolver), extract the claim/error-mapping helper, split `PendingConfirmation` into command-confirmation vs tool-approval types, and move `armNextOccurrence`/`resumeNextOccurrence`/`nextFires` into an `OccurrencePolicy` domain type also consumed by `SchedulerService` (Risk 2).~~ **Done (2026-07-07, PR [#30](https://github.com/ivan-magda/swift-claw/pull/30)).** Shipped as above, plus a `TurnEnqueuer` and `TurnDispatch` extraction and the `denyAccess` gate hoist.
 2. Split `TelegramTransport` into intake + delivery protocols; delete or adopt `OutgoingReply` (Risk 10).
 3. Add exchanges to `DegradedTurn` with a decided `HistoryHygiene` replay rule (Risk 7).
 4. Move the `/schedule` parse onto the lane (or deadline-bound it) and give it a usage row + day-cap check (Risk 9).
@@ -369,7 +381,7 @@ Do **not** start: any second-channel schema work.
 
 ## 8. Final recommendation
 
-**Three most important things to fix** (all before or with Increment 5): (1) make tool policy *declared on the tool contract* instead of a fail-open string set — it converts the architecture's one silent-bypass seam into the compile-error discipline the rest of the codebase already practices; (2) make the tool timeout real and move blocking DNS off the cooperative pool — the single-owner bot's availability currently hangs on the goodwill of any hostile URL the model fetches; (3) split `MessageRouter` and relocate its scheduling math — not for aesthetics, but because Inc 5's callback approvals land in its most invariant-dense region and every invariant there is currently enforced by comments.
+**Three most important things to fix** (all before or with Increment 5): (1) make tool policy *declared on the tool contract* instead of a fail-open string set — it converts the architecture's one silent-bypass seam into the compile-error discipline the rest of the codebase already practices; (2) make the tool timeout real and move blocking DNS off the cooperative pool — the single-owner bot's availability currently hangs on the goodwill of any hostile URL the model fetches; (3) split `MessageRouter` and relocate its scheduling math — not for aesthetics, but because Inc 5's callback approvals land in its most invariant-dense region and every invariant there is currently enforced by comments. **[Done 2026-07-07, PR [#30](https://github.com/ivan-magda/swift-claw/pull/30).]**
 
 **Three things not to over-engineer:** (1) multi-channel infrastructure — do the cheap transport-protocol split and stop; no channel columns, no address abstraction, no neutral streaming event bus until a second channel is actually chosen, or you'll design the wrong abstraction against zero real consumers; (2) the provider layer — the OpenAI-shaped internal model is a documented, verified-cheap bet; don't build a provider-neutral message model or multi-provider fallback speculatively; (3) audit forensics — a per-run content fingerprint is enough; tamper-evident chains and prompt-version registries are enterprise theater for a single-owner daemon whose workspace can simply live in git.
 


### PR DESCRIPTION
## What

Splits the 1,190-line `MessageRouter.swift` into compiler-checked handler components and moves its scheduling occurrence math into a pure `ClawCore` domain type. This implements Risk 2 / Stage 2.1 of `docs/research/architecture-review-2026-07-06.md`, landing before Increment 5 adds new update shapes and approval paths in this file.

Behavior-preserving throughout: the full suite passes with no test changes beyond the mechanical `PendingConfirmation` case-path updates (5 files) and one new `OccurrencePolicyTests.swift`.

## How

`MessageRouter` keeps its public `init` and `handle(rawUpdate:)` contract but becomes a thin dispatcher over internally-constructed `Sendable` structs:

- **`ReplySender`**: shared claim / reply / error-mapping plumbing. The 23 copied `catch StoreError.diskFull` blocks collapse into one `perform`, which spells the two-tier store-error contract once (`diskFull` → storage-full notice + `.storageFull`; other errors → per-site recovery). Handlers unwind mapped failures via a `RoutingHalt` that surfaces at the single `handle` catch point.
- **`TurnEnqueuer`**: replaces three near-verbatim copies of the lane-enqueue closure across two files.
- **`TurnDispatch`**: claim-and-persist inbound, then enqueue.
- **`CommandHandlers`**: `/stop`, `/new`, `/remember`, `/memory`.
- **`ScheduleHandlers`**: the six-verb `/schedule` family.
- **`ConfirmationResolver`**: parked-confirmation resolution.

`PendingConfirmation` splits into `CommandConfirmation` vs tool-approval, so each resolver switch is exhaustive over only the cases it can legally see. The split deletes both `preconditionFailure` arms rather than moving them.

The occurrence-anchoring policy (`nextFires` / `armNextOccurrence` / `resumeNextOccurrence` plus the scheduler's advance / coalesce / misfire-count math) moves into a new pure `OccurrencePolicy` beside `OccurrenceCalculator` in `ClawCore/Domain/Scheduling`, consumed by both the gateway and the scheduler so the confirm preview and actual fires cannot drift apart.

The per-arm `guard isAllowed` copies collapse into one `denyAccess` gate applied before the command fan-out.

## Result

- `MessageRouter.swift`: 1,190 → 235 lines; 0 `catch StoreError.diskFull`, 0 `preconditionFailure`.
- Public API unchanged: `MessageRouter.init`, `ScheduleSurface.init`, `SchedulerService.init`, `PendingConfirmationRegistry`, `HandleOutcome`.
- 784 tests pass; `scripts/lint.sh` clean.

## Review notes

- Every task passed a spec + quality review; a whole-branch review found no correctness regressions across the six cross-cutting seams (single claim per update, one-spelled store-error contract, clean `RoutingHalt` unwind, shared enqueuer/replies/clock instances, non-divergent `OccurrencePolicy`, intact default-deny access).
- `ARCHITECTURE.md` names the router only generically, so this needs no spec edit.
