### PR TITLE
Convention-to-structure hardening

### DIFF
--- a/Sources/ClawAgent/Runtime/AgentRuntime.swift
+++ b/Sources/ClawAgent/Runtime/AgentRuntime.swift
@@ -103,7 +103,7 @@ public struct AgentRuntime: Sendable {
   /// DELIBERATE SOFTENING of Inc 1's "no persistence here": `usageStore`/`auditLog` are injected
   /// so mid-run rows survive a crash (D6/review H1). Throws ONLY `StoreError.diskFull`; every
   /// other failure resolves in-band to a `TurnResult`.
-  // swiftlint:disable:next function_parameter_count function_body_length
+  // swiftlint:disable:next function_parameter_count function_body_length cyclomatic_complexity
   public func runTurn(
     runId: Int64,
     sessionId: Int64,
@@ -160,6 +160,14 @@ public struct AgentRuntime: Sendable {
     for roundTripIndex in 1...max(1, budget.maxTurns) {
       // Per-round-trip preflight (§6.2): day totals at run start + everything this run recorded.
       let inputTokens = TokenEstimator.estimateInputTokens(wire)
+      // The loop is the one component that grows provider input (proposals + fenced
+      // observations, §6.5) and nothing re-fits the wire mid-run — without this check the
+      // provider's context window is the de facto enforcement: an HTTP 400 classified terminal,
+      // surfacing as an undiagnosable "provider unavailable". `budget.maxInputTokens` otherwise
+      // binds only at assembly (§9), which cannot see mid-run growth.
+      if inputTokens > budget.maxInputTokens {
+        return outcome(.budgetStopped(cap: BudgetGate.perRunInputTokenCap))
+      }
       let estimate = inputTokens + budget.maxOutputTokens
       let estimatedCost = costResolver.resolve(
         model: model,

--- a/Sources/ClawCore/Domain/Tools/ToolContracts.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolContracts.swift
@@ -120,16 +120,47 @@ extension JSONValue {
   }
 }
 
+/// How a tool's arguments can leave the machine (§18-H's sink classification). Declared on the
+/// contract — with no default — so a new tool cannot compile without classifying itself; the
+/// gate consumes this declaration instead of a name set, making a forgotten classification a
+/// compile error rather than a silent arg-guard bypass.
+public enum ToolEgressClass: Sendable, Equatable {
+  /// Nothing egresses (file_read): args are redaction-RENDERED for audit only.
+  case none
+  /// Args egress to one owner-pinned endpoint (web_search): the blocking arg-guard tiers apply;
+  /// no per-target approval exists because the destination is fixed at composition.
+  case fixedEndpoint
+  /// Args choose the destination (web_fetch): arg-guard tiers plus the trifecta approval, keyed
+  /// on the canonical target resolved via `Tool.canonicalTarget(arguments:)`.
+  case arbitraryDestination
+}
+
+/// The outcome of resolving an `.arbitraryDestination` tool's target: the canonical form the
+/// gate authorizes (and hands into `execute`), or the owner-facing refusal copy (URL policy,
+/// missing argument).
+public enum CanonicalTargetResolution: Sendable, Equatable {
+  case resolved(String)
+  case refused(reason: String)
+}
+
 /// What the registry advertises to the provider (wire `tools` entry).
 public struct ToolDefinition: Sendable, Equatable {
   public let name: String
   public let description: String
   public let parameters: JSONValue  // JSON-Schema object
+  /// The declared policy class the gate enforces. NOT advertised on the wire.
+  public let egressClass: ToolEgressClass
 
-  public init(name: String, description: String, parameters: JSONValue) {
+  public init(
+    name: String,
+    description: String,
+    parameters: JSONValue,
+    egressClass: ToolEgressClass
+  ) {
     self.name = name
     self.description = description
     self.parameters = parameters
+    self.egressClass = egressClass
   }
 }
 
@@ -202,12 +233,22 @@ public struct ToolObservation: Sendable, Equatable {
 }
 
 /// The tool seam. Gate checks happen BEFORE dispatch (ToolPolicyGate); an executing tool only
-/// ever sees already-authorized, parsed args.
+/// ever sees already-authorized, parsed args. Tools DECLARE their policy class
+/// (`definition.egressClass`) and, for `.arbitraryDestination`, HOW to resolve the target —
+/// enforcement lives exclusively in the gate.
 public protocol Tool: Sendable {
   var definition: ToolDefinition { get }
   var timeout: Duration { get }
 
-  func execute(arguments: JSONValue) async -> ToolPayload
+  /// The canonical, owner-visible target this call would act on — REQUIRED for
+  /// `.arbitraryDestination` tools (the gate keys grants/approvals on it and hands the resolved
+  /// form to `execute`); `nil` for `.none`/`.fixedEndpoint` tools. No default implementation:
+  /// every tool decides explicitly.
+  func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution?
+
+  /// `canonicalTarget` is the gate-resolved form for `.arbitraryDestination` tools — act on
+  /// exactly what was authorized, never re-derive it; `nil` for the other classes.
+  func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload
 }
 
 /// The search seam (D2). One v1 impl: ExaSearchProvider (§7.4, research-settled).

--- a/Sources/ClawCore/LLM/RunBudget.swift
+++ b/Sources/ClawCore/LLM/RunBudget.swift
@@ -84,6 +84,7 @@ public struct BudgetGate: Sendable {
   public static let perDaySpendCap = "per-day spend"
   public static let perDayTokenCap = "per-day token"
   public static let perRunSpendCap = "per-run spend"
+  public static let perRunInputTokenCap = "per-run input-token"
 
   public let budget: RunBudget
 

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -20,12 +20,14 @@ public enum CommandClaim: Sendable, Equatable {
 public struct StopCommandResult: Sendable, Equatable {
   public let newlyClaimed: Bool
   public let sessionId: Int64?
-  public let cancelledRunId: Int64?
+  /// Every run `/stop` terminated — the RUNNING turn AND any queued PENDING turns (spec FSM:
+  /// PENDING + /stop → CANCELLED). Empty when there was nothing to stop.
+  public let cancelledRunIds: [Int64]
 
-  public init(newlyClaimed: Bool, sessionId: Int64?, cancelledRunId: Int64?) {
+  public init(newlyClaimed: Bool, sessionId: Int64?, cancelledRunIds: [Int64]) {
     self.newlyClaimed = newlyClaimed
     self.sessionId = sessionId
-    self.cancelledRunId = cancelledRunId
+    self.cancelledRunIds = cancelledRunIds
   }
 }
 
@@ -42,7 +44,8 @@ public struct NewCommandResult: Sendable, Equatable {
 }
 
 public protocol CommandStore: Sendable {
-  /// Atomic `/stop`: claim update + resolve session + RUNNING→CANCELLED + audit in one write.
+  /// Atomic `/stop`: claim update + resolve session + every PENDING/RUNNING→CANCELLED + one
+  /// audit row per cancelled run, in one write.
   func applyStop(updateId: Int64, sessionKey: String, now: Date) throws -> StopCommandResult
   /// Atomic `/new`: claim update + resolve session + RUNNING/PENDING→SUPERSEDED +
   /// resetWindowAndDetaint + audit in one write.

--- a/Sources/ClawData/Database/ClawDatabase.swift
+++ b/Sources/ClawData/Database/ClawDatabase.swift
@@ -225,29 +225,3 @@ public enum ClawDatabase {
     }
   }
 }
-
-extension DatabaseReader {
-  /// A store read whose GRDB failures are translated to domain `StoreError`s at the seam, so a raw
-  /// `DatabaseError` never leaks past the store boundary. Drop-in for `read` — same call-site
-  /// shape, no nesting. `DatabaseWriter` refines `DatabaseReader`, so writers inherit this too.
-  func readMapping<Value>(_ value: (Database) throws -> Value) throws -> Value {
-    do {
-      return try read(value)
-    } catch {
-      throw ClawDatabase.classifyError(error)
-    }
-  }
-}
-
-extension DatabaseWriter {
-  /// A store write whose GRDB failures are translated to domain `StoreError`s at the seam (e.g. a
-  /// full disk → `StoreError.diskFull`, F23). Drop-in for `write` — same call-site shape, no
-  /// nesting; a new turn-path write gets domain-error handling just by choosing this method.
-  func writeMapping<Value>(_ updates: (Database) throws -> Value) throws -> Value {
-    do {
-      return try write(updates)
-    } catch {
-      throw ClawDatabase.classifyError(error)
-    }
-  }
-}

--- a/Sources/ClawData/Database/MappedDatabase.swift
+++ b/Sources/ClawData/Database/MappedDatabase.swift
@@ -1,0 +1,34 @@
+import ClawCore
+import Foundation
+import GRDB
+
+/// The only database handle a store holds. It exposes exactly the two seam methods —
+/// `writeMapping`/`readMapping` — so the raw `write`/`read` (which would leak a GRDB
+/// `DatabaseError` past the store boundary, F23) is structurally unreachable from store code,
+/// not merely forbidden by convention.
+struct MappedDatabase: Sendable {
+  private let writer: any DatabaseWriter
+
+  init(writer: any DatabaseWriter) {
+    self.writer = writer
+  }
+
+  /// A store write whose GRDB failures are translated to domain `StoreError`s at the seam
+  /// (e.g. a full disk → `StoreError.diskFull`, F23).
+  func writeMapping<Value>(_ updates: (Database) throws -> Value) throws -> Value {
+    do {
+      return try writer.write(updates)
+    } catch {
+      throw ClawDatabase.classifyError(error)
+    }
+  }
+
+  /// A store read whose GRDB failures are translated to domain `StoreError`s at the seam.
+  func readMapping<Value>(_ value: (Database) throws -> Value) throws -> Value {
+    do {
+      return try writer.read(value)
+    } catch {
+      throw ClawDatabase.classifyError(error)
+    }
+  }
+}

--- a/Sources/ClawData/Stores/Bot/AllowlistStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Bot/AllowlistStoreGRDB.swift
@@ -3,14 +3,14 @@ import Foundation
 import GRDB
 
 public struct AllowlistStoreGRDB: AllowlistStore {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
 
   public init(writer: any DatabaseWriter) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
   }
 
   public func seedAllowlist(userIds: [Int64]) throws {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       for userId in userIds {
         try db.execute(
           sql: "INSERT OR IGNORE INTO allowlist(user_id, added_at) VALUES (?, ?)",
@@ -21,7 +21,7 @@ public struct AllowlistStoreGRDB: AllowlistStore {
   }
 
   public func allowlistContains(userId: Int64) throws -> Bool {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       try Bool.fetchOne(
         db,
         sql: "SELECT EXISTS(SELECT 1 FROM allowlist WHERE user_id = ?)",
@@ -31,7 +31,7 @@ public struct AllowlistStoreGRDB: AllowlistStore {
   }
 
   public func allowlistCount() throws -> Int {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM allowlist") ?? 0
     }
   }

--- a/Sources/ClawData/Stores/Bot/CommandStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Bot/CommandStoreGRDB.swift
@@ -3,7 +3,7 @@ import Foundation
 import GRDB
 
 public struct CommandStoreGRDB: CommandStore {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
   private let afterClaimForTesting: @Sendable () throws -> Void
 
   public init(writer: any DatabaseWriter) {
@@ -14,7 +14,7 @@ public struct CommandStoreGRDB: CommandStore {
     writer: any DatabaseWriter,
     afterClaimForTesting: @Sendable @escaping () throws -> Void
   ) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
     self.afterClaimForTesting = afterClaimForTesting
   }
 
@@ -23,7 +23,7 @@ public struct CommandStoreGRDB: CommandStore {
     sessionKey: String,
     now: Date
   ) throws -> StopCommandResult {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       let newlyClaimed = try ProcessedUpdateStoreGRDB.claimUpdate(
         db: db,
         updateId: updateId,
@@ -77,7 +77,7 @@ public struct CommandStoreGRDB: CommandStore {
     sessionKey: String,
     now: Date
   ) throws -> NewCommandResult {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       let newlyClaimed = try ProcessedUpdateStoreGRDB.claimUpdate(
         db: db,
         updateId: updateId,

--- a/Sources/ClawData/Stores/Bot/CommandStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Bot/CommandStoreGRDB.swift
@@ -30,7 +30,7 @@ public struct CommandStoreGRDB: CommandStore {
         claimedAt: now
       )
       guard newlyClaimed else {
-        return StopCommandResult(newlyClaimed: false, sessionId: nil, cancelledRunId: nil)
+        return StopCommandResult(newlyClaimed: false, sessionId: nil, cancelledRunIds: [])
       }
 
       try afterClaimForTesting()
@@ -40,34 +40,50 @@ public struct CommandStoreGRDB: CommandStore {
         sessionKey: sessionKey,
         now: now
       )
-      let runId = try RunStoreGRDB.fetchActiveRunId(db, sessionId: sessionId)
+      let cancelledRunIds = try RunStoreGRDB.cancelRuns(db, sessionId: sessionId, now: now)
+      try Self.insertStopAudits(db, sessionId: sessionId, runIds: cancelledRunIds, now: now)
 
-      // swift-format-ignore
-      let cancelledRunId: Int64? =
-        if let runId,
-          try RunStoreGRDB.transitionRun(db, runId: runId, event: .cancel, now: now) != nil {
-          runId
-        } else {
-          nil
-        }
+      return StopCommandResult(
+        newlyClaimed: true,
+        sessionId: sessionId,
+        cancelledRunIds: cancelledRunIds
+      )
+    }
+  }
 
+  private static func insertStopAudits(
+    _ db: Database,
+    sessionId: Int64,
+    runIds: [Int64],
+    now: Date
+  ) throws {
+    guard !runIds.isEmpty else {
       try AuditLogGRDB.insertAudit(
         db,
         AuditEvent(
           actor: .owner,
           action: .turnCancelled,
           argsRedacted: "/stop",
-          decision: cancelledRunId == nil ? "nothing_to_stop" : "cancelled",
-          runId: cancelledRunId,
+          decision: "nothing_to_stop",
           sessionId: sessionId,
           ts: now
         )
       )
+      return
+    }
 
-      return StopCommandResult(
-        newlyClaimed: true,
-        sessionId: sessionId,
-        cancelledRunId: cancelledRunId
+    for runId in runIds {
+      try AuditLogGRDB.insertAudit(
+        db,
+        AuditEvent(
+          actor: .owner,
+          action: .turnCancelled,
+          argsRedacted: "/stop",
+          decision: "cancelled",
+          runId: runId,
+          sessionId: sessionId,
+          ts: now
+        )
       )
     }
   }

--- a/Sources/ClawData/Stores/Delivery/OutboxStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Delivery/OutboxStoreGRDB.swift
@@ -3,10 +3,10 @@ import Foundation
 import GRDB
 
 public struct OutboxStoreGRDB: OutboxStore {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
 
   public init(writer: any DatabaseWriter) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
   }
 
   public func claimOutbound(
@@ -16,7 +16,7 @@ public struct OutboxStoreGRDB: OutboxStore {
     payload: String,
     payloadHash: String
   ) throws -> Bool {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try RunStoreGRDB.insertOutbox(
         db,
         runId: runId,
@@ -38,7 +38,7 @@ public struct OutboxStoreGRDB: OutboxStore {
     payload: String,
     payloadHash: String
   ) throws -> Bool {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try db.execute(
         sql: """
           INSERT OR IGNORE INTO outbound_deliveries(
@@ -66,7 +66,7 @@ public struct OutboxStoreGRDB: OutboxStore {
   }
 
   public func markSent(runId: Int64, stepIndex: Int, telegramMessageId: Int64, now: Date) throws {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try db.execute(
         sql: """
           UPDATE outbound_deliveries SET status = 'SENT', telegram_message_id = ?, sent_ts = ?
@@ -78,7 +78,7 @@ public struct OutboxStoreGRDB: OutboxStore {
   }
 
   public func pendingOutbound() throws -> [OutboxRow] {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       try Row.fetchAll(
         db,
         sql: """

--- a/Sources/ClawData/Stores/Memory/MemoryCommandStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Memory/MemoryCommandStoreGRDB.swift
@@ -3,7 +3,7 @@ import Foundation
 import GRDB
 
 public struct MemoryCommandStoreGRDB: MemoryCommandStore {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
   private let afterClaimForTesting: @Sendable () throws -> Void
 
   public init(writer: any DatabaseWriter) {
@@ -14,7 +14,7 @@ public struct MemoryCommandStoreGRDB: MemoryCommandStore {
     writer: any DatabaseWriter,
     afterClaimForTesting: @Sendable @escaping () throws -> Void
   ) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
     self.afterClaimForTesting = afterClaimForTesting
   }
 
@@ -23,7 +23,7 @@ public struct MemoryCommandStoreGRDB: MemoryCommandStore {
     item: NewMemoryItem,
     now: Date
   ) throws -> MemoryCommandResult {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       let newlyClaimed = try ProcessedUpdateStoreGRDB.claimUpdate(
         db: db,
         updateId: updateId,
@@ -58,7 +58,7 @@ public struct MemoryCommandStoreGRDB: MemoryCommandStore {
     itemId: Int64,
     now: Date
   ) throws -> MemoryCommandResult {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       let newlyClaimed = try ProcessedUpdateStoreGRDB.claimUpdate(
         db: db,
         updateId: updateId,

--- a/Sources/ClawData/Stores/Memory/MemoryStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Memory/MemoryStoreGRDB.swift
@@ -3,20 +3,20 @@ import Foundation
 import GRDB
 
 public struct MemoryStoreGRDB: MemoryStore {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
 
   public init(writer: any DatabaseWriter) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
   }
 
   public func append(_ newItem: NewMemoryItem, now: Date) throws -> MemoryItem {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try Self.insertItem(db, item: newItem, now: now)
     }
   }
 
   public func list(kind: MemoryKind?, limit: Int) throws -> [MemoryItem] {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       let rows: [Row]
       if let kind {
         rows = try Row.fetchAll(
@@ -41,7 +41,7 @@ public struct MemoryStoreGRDB: MemoryStore {
   }
 
   public func get(id: Int64) throws -> MemoryItem? {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       guard
         let row = try Row.fetchOne(
           db,
@@ -56,14 +56,14 @@ public struct MemoryStoreGRDB: MemoryStore {
   }
 
   public func delete(id: Int64) throws -> Bool {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try db.execute(sql: "DELETE FROM memory_items WHERE id = ?", arguments: [id])
       return db.changesCount > 0
     }
   }
 
   public func fetchRanked(excludeSensitive: Bool, limit: Int) throws -> [MemoryItem] {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       // Pure SQL ordering; the grapheme/budget fill is MemoryRanker's job (spec §10.1).
       let sensitivityFilter = excludeSensitive ? "WHERE sensitivity = 'normal'" : ""
       let rows = try Row.fetchAll(

--- a/Sources/ClawData/Stores/Memory/RetrieverGRDB.swift
+++ b/Sources/ClawData/Stores/Memory/RetrieverGRDB.swift
@@ -3,10 +3,10 @@ import Foundation
 import GRDB
 
 public struct RetrieverGRDB: Retriever {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
 
   public init(writer: any DatabaseWriter) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
   }
 
   public func searchRelevantMessages(
@@ -21,7 +21,7 @@ public struct RetrieverGRDB: Retriever {
       return []
     }
 
-    return try writer.readMapping { db in
+    return try database.readMapping { db in
       // messages_fts.rowid == messages.id (external content). BM25 is negative; lower = better, so
       // ORDER BY is ASC. RecallScore negates it back so higher = better for policy/telemetry.
       var sql = """

--- a/Sources/ClawData/Stores/Memory/RetrieverGRDB.swift
+++ b/Sources/ClawData/Stores/Memory/RetrieverGRDB.swift
@@ -49,11 +49,16 @@ public struct RetrieverGRDB: Retriever {
       arguments += [limit]
 
       let rows = try Row.fetchAll(db, sql: sql, arguments: arguments)
-      return rows.map { row in
-        RecallHit(
+      return try rows.map { row in
+        // The SQL filters `role IN ('user','assistant')`, so an unknown role is unreachable
+        // today — the guard keeps the decode direction fail-closed if that filter ever moves.
+        guard let role = MessageRole(rawValue: row["role"]) else {
+          throw StoreError.unexpected("messages row \(row["id"] as Int64) has an unrecognized role")
+        }
+        return RecallHit(
           id: row["id"],
           sessionId: row["session_id"],
-          role: MessageRole(rawValue: row["role"]) ?? .user,
+          role: role,
           content: row["content"],
           score: RecallScore(sqliteBM25: row["bm25_score"]),
           createdAt: row["ts"]

--- a/Sources/ClawData/Stores/Observability/AuditLogGRDB.swift
+++ b/Sources/ClawData/Stores/Observability/AuditLogGRDB.swift
@@ -3,14 +3,14 @@ import Foundation
 import GRDB
 
 public struct AuditLogGRDB: AuditLog {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
 
   public init(writer: any DatabaseWriter) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
   }
 
   public func appendAudit(_ event: AuditEvent) throws {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try Self.insertAudit(db, event)
     }
   }

--- a/Sources/ClawData/Stores/Observability/UsageStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Observability/UsageStoreGRDB.swift
@@ -3,21 +3,21 @@ import Foundation
 import GRDB
 
 public struct UsageStoreGRDB: UsageStore {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
 
   public init(writer: any DatabaseWriter) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
   }
 
   public func recordUsage(_ usage: ProviderUsage) throws {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try RunStoreGRDB.insertUsage(db, usage)
     }
   }
 
   public func todayTokensAndCost(now: Date) throws -> (tokens: Int, costUSD: Double) {
     let dayStart = now.startOfUTCDay
-    return try writer.readMapping { db in
+    return try database.readMapping { db in
       // GRDB stores Date as a UTC "yyyy-MM-dd HH:mm:ss.SSS" string, so `ts >= ?` is a correct
       // chronological range scan over the calendar-day-UTC window.
       let row = try Row.fetchOne(
@@ -48,7 +48,7 @@ public struct UsageStoreGRDB: UsageStore {
 
     let dayStart = now.startOfUTCDay
 
-    return try writer.readMapping { db in
+    return try database.readMapping { db in
       // databaseQuestionMarks is GRDB's public helper (GRDB/Utils/Utils.swift), not a
       // project symbol — it renders "?,?,?" for the IN clause.
       let placeholders = databaseQuestionMarks(count: origins.count)
@@ -75,7 +75,7 @@ public struct UsageStoreGRDB: UsageStore {
 
   public func costSourceMix(now: Date) throws -> [CostSource: Int] {
     let dayStart = now.startOfUTCDay
-    return try writer.readMapping { db in
+    return try database.readMapping { db in
       let rows = try Row.fetchAll(
         db,
         sql: """

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -15,14 +15,19 @@ public struct RunStoreGRDB: RunStore {
         return nil
       }
 
-      let rawOrigin =
-        try String.fetchOne(
-          db,
-          sql: "SELECT origin FROM runs WHERE id = ?",
-          arguments: [runId]
-        ) ?? RunOrigin.interactive.rawValue
+      let rawOrigin = try String.fetchOne(
+        db,
+        sql: "SELECT origin FROM runs WHERE id = ?",
+        arguments: [runId]
+      )
+      // Fail closed on a corrupted origin (same rule as decodeItem): a mislabeled origin would
+      // silently re-route budget pools and delivery policy. The throw rolls back the pickUp
+      // transition, so the run stays PENDING for the boot sweep.
+      guard let rawOrigin, let origin = RunOrigin(rawValue: rawOrigin) else {
+        throw StoreError.unexpected("runs row \(runId) has an unrecognized origin")
+      }
 
-      return RunOrigin(rawValue: rawOrigin) ?? .scheduled
+      return origin
     }
   }
 

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -3,14 +3,14 @@ import Foundation
 import GRDB
 
 public struct RunStoreGRDB: RunStore {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
 
   public init(writer: any DatabaseWriter) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
   }
 
   public func pickUp(runId: Int64, now: Date) throws -> RunOrigin? {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       guard try Self.transitionRun(db, runId: runId, event: .pickUp, now: now) != nil else {
         return nil
       }
@@ -31,7 +31,7 @@ public struct RunStoreGRDB: RunStore {
     reason: CancelReason,
     now: Date
   ) throws -> Int64? {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       guard let runId = try Self.fetchActiveRunId(db, sessionId: sessionId) else {
         return nil
       }
@@ -50,13 +50,13 @@ public struct RunStoreGRDB: RunStore {
   }
 
   public func supersedeSessionRuns(sessionId: Int64, now: Date) throws -> [Int64] {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try Self.supersedeRuns(db, sessionId: sessionId, now: now)
     }
   }
 
   public func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws -> RunCommitResult {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       guard let currentState = try Self.currentRunState(db, runId: turn.runId) else {
         return .ignored
       }
@@ -135,7 +135,7 @@ public struct RunStoreGRDB: RunStore {
   }
 
   public func commitDegradedTurn(_ turn: DegradedTurn, now: Date) throws -> RunCommitResult {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       guard let currentState = try Self.currentRunState(db, runId: turn.runId) else {
         return .ignored
       }
@@ -176,7 +176,7 @@ public struct RunStoreGRDB: RunStore {
   }
 
   public func failRun(runId: Int64, now: Date) throws {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       guard try Self.transitionRun(db, runId: runId, event: .fail, now: now) != nil else {
         return
       }
@@ -189,7 +189,7 @@ public struct RunStoreGRDB: RunStore {
     degradationText: String,
     heartbeatNoticeChatId: Int64?
   ) throws -> [DegradationReply] {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       let stale = try Row.fetchAll(
         db,
         sql: """
@@ -256,7 +256,7 @@ public struct RunStoreGRDB: RunStore {
   }
 
   public func runsHealth(now: Date) throws -> RunsHealth {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       let activeStates = [RunState.pending.rawValue, RunState.running.rawValue]
       let inFlight =
         try Int.fetchOne(

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -357,6 +357,21 @@ extension RunStoreGRDB {
   }
 
   static func supersedeRuns(_ db: Database, sessionId: Int64, now: Date) throws -> [Int64] {
+    try terminateActiveRuns(db, sessionId: sessionId, event: .supersede, now: now)
+  }
+
+  /// `/stop`'s plural arm: every PENDING and RUNNING run for the session → CANCELLED. Mirrors
+  /// `supersedeRuns` so `/stop` and `/new` share one definition of "active".
+  static func cancelRuns(_ db: Database, sessionId: Int64, now: Date) throws -> [Int64] {
+    try terminateActiveRuns(db, sessionId: sessionId, event: .cancel, now: now)
+  }
+
+  private static func terminateActiveRuns(
+    _ db: Database,
+    sessionId: Int64,
+    event: RunEvent,
+    now: Date
+  ) throws -> [Int64] {
     let rows = try Row.fetchAll(
       db,
       sql: """
@@ -370,7 +385,7 @@ extension RunStoreGRDB {
     var affected: [Int64] = []
     for row in rows {
       let runId: Int64 = row["id"]
-      if try transitionRun(db, runId: runId, event: .supersede, now: now) != nil {
+      if try transitionRun(db, runId: runId, event: event, now: now) != nil {
         affected.append(runId)
       }
     }

--- a/Sources/ClawData/Stores/Scheduling/ScheduleCommandStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Scheduling/ScheduleCommandStoreGRDB.swift
@@ -6,10 +6,10 @@ import GRDB
 /// ONE transaction, `MemoryCommandStoreGRDB` pattern) applied to job creation. A replayed `yes`
 /// fails the claim and creates nothing.
 public struct ScheduleCommandStoreGRDB: ScheduleCommandStore {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
 
   public init(writer: any DatabaseWriter) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
   }
 
   public func applyArm(
@@ -17,7 +17,7 @@ public struct ScheduleCommandStoreGRDB: ScheduleCommandStore {
     job: NewScheduledJob,
     now: Date
   ) throws -> ScheduleArmResult {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       let newlyClaimed = try ProcessedUpdateStoreGRDB.claimUpdate(
         db: db,
         updateId: updateId,

--- a/Sources/ClawData/Stores/Scheduling/ScheduledJobStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Scheduling/ScheduledJobStoreGRDB.swift
@@ -8,14 +8,14 @@ import GRDB
 /// conformance is declared once every method exists (end of this file's build-out); `Sendable`
 /// is declared NOW because Cycle B's task-group race test captures the store in `@Sendable`
 /// child tasks — strict concurrency rejects that until the conformance exists (the only stored
-/// property is the `Sendable` `any DatabaseWriter`). Method groups live in same-type extensions
+/// property is the `Sendable` `MappedDatabase`). Method groups live in same-type extensions
 /// below purely to keep each extension's body under the project's `type_body_length` gate; the
 /// store is still one type with one stored property.
 public struct ScheduledJobStoreGRDB: Sendable {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
 
   public init(writer: any DatabaseWriter) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
   }
 }
 
@@ -23,7 +23,7 @@ public struct ScheduledJobStoreGRDB: Sendable {
 
 extension ScheduledJobStoreGRDB {
   public func create(_ job: NewScheduledJob, now: Date) throws -> ScheduledJob {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try Self.insertJob(db, job, now: now)
     }
   }
@@ -69,20 +69,20 @@ extension ScheduledJobStoreGRDB {
   }
 
   public func job(id: Int64) throws -> ScheduledJob? {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       try Self.fetchJob(db, id: id)
     }
   }
 
   public func listAll() throws -> [ScheduledJob] {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       let rows = try Row.fetchAll(db, sql: "SELECT * FROM scheduled_jobs ORDER BY id ASC")
       return try rows.map { row in try Self.jobFromRow(row) }
     }
   }
 
   public func dueJobs(now: Date) throws -> [ScheduledJob] {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       let rows = try Row.fetchAll(
         db,
         sql: """
@@ -163,7 +163,7 @@ extension ScheduledJobStoreGRDB {
     nextOccurrence: Date?,
     now: Date
   ) throws -> ClaimedFire? {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       // Step 1: the compare-and-advance. This IS the atomic claim of ARCHITECTURE §6.3/§14
       // expressed on the occurrence: the WHERE arms (id, stored due, ACTIVE) make two racers
       // for the same (job, due) structurally single-winner.
@@ -297,7 +297,7 @@ extension ScheduledJobStoreGRDB {
 
 extension ScheduledJobStoreGRDB {
   public func fireNow(jobId: Int64, now: Date) throws -> ClaimedFire? {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       let rawStatus = try String.fetchOne(
         db,
         sql: "SELECT status FROM scheduled_jobs WHERE id = ?",
@@ -328,7 +328,7 @@ extension ScheduledJobStoreGRDB {
     skippedCount: Int,
     now: Date
   ) throws -> Bool {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       // The same CAS predicate as the claim — a concurrently-mutated job means no skip.
       if let nextOccurrence {
         try db.execute(
@@ -393,7 +393,7 @@ extension ScheduledJobStoreGRDB {
 
 extension ScheduledJobStoreGRDB {
   public func schedulerState() throws -> SchedulerState {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       guard
         let row = try Row.fetchOne(db, sql: "SELECT * FROM scheduler_state WHERE id = 1")
       else {
@@ -418,7 +418,7 @@ extension ScheduledJobStoreGRDB {
   }
 
   public func recordTick(at tickTime: Date) throws {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try db.execute(
         sql: """
           INSERT INTO scheduler_state(id, last_tick_at) VALUES (1, ?)
@@ -434,7 +434,7 @@ extension ScheduledJobStoreGRDB {
 
 extension ScheduledJobStoreGRDB {
   public func pause(id: Int64, now: Date) throws -> ScheduledJob? {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       guard let current = try Self.fetchJob(db, id: id) else {
         return nil
       }
@@ -468,7 +468,7 @@ extension ScheduledJobStoreGRDB {
   }
 
   public func resume(id: Int64, nextOccurrence: Date?, now: Date) throws -> ScheduledJob? {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       guard let current = try Self.fetchJob(db, id: id) else {
         return nil
       }
@@ -506,7 +506,7 @@ extension ScheduledJobStoreGRDB {
   }
 
   public func cancel(id: Int64, now: Date) throws -> ScheduledJob? {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       guard let current = try Self.fetchJob(db, id: id) else {
         return nil
       }
@@ -568,7 +568,7 @@ extension ScheduledJobStoreGRDB {
     now: Date,
     day: String
   ) throws -> ClaimedFire {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       let sessionId = try SessionMessageStoreGRDB.upsertSession(
         db,
         sessionKey: SessionKey.heartbeat,

--- a/Sources/ClawData/Stores/Session/ProcessedUpdateStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Session/ProcessedUpdateStoreGRDB.swift
@@ -3,14 +3,14 @@ import Foundation
 import GRDB
 
 public struct ProcessedUpdateStoreGRDB: ProcessedUpdateStore {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
 
   public init(writer: any DatabaseWriter) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
   }
 
   public func claimUpdate(updateId: Int64) throws -> Bool {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try Self.claimUpdate(db: db, updateId: updateId, claimedAt: Date())
     }
   }

--- a/Sources/ClawData/Stores/Session/SessionMessageStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Session/SessionMessageStoreGRDB.swift
@@ -3,14 +3,14 @@ import Foundation
 import GRDB
 
 public struct SessionMessageStoreGRDB: SessionMessageStore {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
 
   public init(writer: any DatabaseWriter) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
   }
 
   public func loadOrCreateSession(sessionKey: String, now: Date) throws -> Int64 {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try Self.upsertSession(db, sessionKey: sessionKey, now: now)
     }
   }
@@ -20,7 +20,7 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
     sessionKey: String,
     now: Date
   ) throws -> CommandClaim {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       let newlyClaimed = try ProcessedUpdateStoreGRDB.claimUpdate(
         db: db,
         updateId: updateId,
@@ -37,7 +37,7 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
   }
 
   public func findSession(sessionKey: String) throws -> Int64? {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       try Int64.fetchOne(
         db,
         sql: "SELECT id FROM sessions WHERE session_key = ?",
@@ -47,7 +47,7 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
   }
 
   public func claimAndPersistInbound(_ inbound: InboundMessage) throws -> ClaimResult {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       let newlyClaimed = try ProcessedUpdateStoreGRDB.claimUpdate(
         db: db,
         updateId: inbound.updateId,
@@ -118,7 +118,7 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
     throughMessageId: Int64,
     limit: Int
   ) throws -> SessionContextSnapshot {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       let session = try Row.fetchOne(
         db,
         sql: "SELECT window_start_message_id, tainted FROM sessions WHERE id = ?",
@@ -188,7 +188,7 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
   }
 
   public func resetWindowAndDetaint(sessionId: Int64, now: Date) throws {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try Self.resetWindowAndDetaint(db, sessionId: sessionId, now: now)
     }
   }

--- a/Sources/ClawData/Stores/Session/SessionMessageStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Session/SessionMessageStoreGRDB.swift
@@ -163,15 +163,7 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
         arguments: [sessionId, windowStart, throughMessageId, boundaryId]
       )
 
-      let history = rows.map { row in
-        StoredMessage(
-          role: MessageRole(rawValue: row["role"]) ?? .user,
-          content: row["content"],
-          provenance: Provenance(rawValue: row["provenance"]) ?? .trusted,
-          toolCallsJSON: row["tool_calls"],
-          toolCallId: row["tool_call_id"]
-        )
-      }
+      let history = try rows.map(Self.decodeStoredMessage)
 
       // The new SELECT already returns `id`, so the id remap stays valid.
       let messageIds = rows.map { row in
@@ -235,5 +227,28 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
     }
 
     return sessionId
+  }
+
+  /// Decodes a `messages` row, failing **closed** on an unrecognized persisted enum value:
+  /// `provenance` is the §12 trust tier — a corrupted value must not silently become the
+  /// permissive `.trusted` and unfence content the moment assembly keys off it. Same rule as
+  /// `MemoryStoreGRDB.decodeItem`.
+  static func decodeStoredMessage(_ row: Row) throws -> StoredMessage {
+    let rowId: Int64 = row["id"]
+
+    guard
+      let role = MessageRole(rawValue: row["role"]),
+      let provenance = Provenance(rawValue: row["provenance"])
+    else {
+      throw StoreError.unexpected("messages row \(rowId) has an unrecognized role or provenance")
+    }
+
+    return StoredMessage(
+      role: role,
+      content: row["content"],
+      provenance: provenance,
+      toolCallsJSON: row["tool_calls"],
+      toolCallId: row["tool_call_id"]
+    )
   }
 }

--- a/Sources/ClawData/Stores/Session/UpdateCursorStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Session/UpdateCursorStoreGRDB.swift
@@ -3,14 +3,14 @@ import GRDB
 
 /// Single-row (id = 0) cursor holding the last confirmed update id.
 public struct UpdateCursorStoreGRDB: UpdateCursorStore {
-  private let writer: any DatabaseWriter
+  private let database: MappedDatabase
 
   public init(writer: any DatabaseWriter) {
-    self.writer = writer
+    database = MappedDatabase(writer: writer)
   }
 
   public func loadCursor() throws -> Int64? {
-    try writer.readMapping { db in
+    try database.readMapping { db in
       try Int64.fetchOne(
         db,
         sql: "SELECT last_update_id FROM update_cursor WHERE id = 0"
@@ -19,7 +19,7 @@ public struct UpdateCursorStoreGRDB: UpdateCursorStore {
   }
 
   public func advanceCursor(to updateId: Int64) throws {
-    try writer.writeMapping { db in
+    try database.writeMapping { db in
       try db.execute(
         sql: """
           INSERT INTO update_cursor(id, last_update_id) VALUES (0, ?)

--- a/Sources/ClawGateway/Routing/CommandHandlers.swift
+++ b/Sources/ClawGateway/Routing/CommandHandlers.swift
@@ -35,12 +35,15 @@ struct CommandHandlers: Sendable {
       return replies.skipDuplicate(updateId: rawUpdate.updateId)
     }
 
-    if let sessionId = result.sessionId, let runId = result.cancelledRunId {
+    if let sessionId = result.sessionId, result.cancelledRunIds.isEmpty == false {
       let lane = await lanes.actor(for: sessionId)
-      await lane.cancel(runId: runId)
+      for runId in result.cancelledRunIds {
+        await lane.cancel(runId: runId)
+      }
     }
 
-    let reply = result.cancelledRunId == nil ? CommandReplies.nothingToStop : CommandReplies.stopped
+    let reply =
+      result.cancelledRunIds.isEmpty ? CommandReplies.nothingToStop : CommandReplies.stopped
     return await replies.sendCommandAck(
       updateId: rawUpdate.updateId,
       chatId: message.chatId,

--- a/Sources/ClawTools/Policy/SSRFGuard.swift
+++ b/Sources/ClawTools/Policy/SSRFGuard.swift
@@ -1,3 +1,4 @@
+import Dispatch
 import Foundation
 
 #if canImport(Glibc)
@@ -143,8 +144,11 @@ public enum AddressResolutionError: Error, Sendable, Equatable {
   case unresolvable(host: String)
 }
 
-/// The system resolver via `getaddrinfo` — works on macOS and Linux behind the one seam. The call
-/// is synchronous inside the async method; resolver latency is bounded by the tool timeout above.
+/// The system resolver via `getaddrinfo` — works on macOS and Linux behind the one seam.
+/// `getaddrinfo` is a BLOCKING syscall that never observes cancellation, so it runs on a
+/// Dispatch worker thread, not the cooperative pool: after the tool timeout abandons this task,
+/// a stalled resolve must not pin one of the pool's fixed threads for its OS-level retry window
+/// (commonly 30 s–2 min against a DNS blackhole).
 public struct SystemAddressResolver: AddressResolving {
   public init() {}
 
@@ -154,6 +158,14 @@ public struct SystemAddressResolver: AddressResolving {
       return [literal]
     }
 
+    return try await withCheckedThrowingContinuation { continuation in
+      DispatchQueue.global(qos: .utility).async {
+        continuation.resume(with: Result { try Self.blockingResolve(host: host) })
+      }
+    }
+  }
+
+  private static func blockingResolve(host: String) throws -> [ResolvedAddress] {
     var hints = addrinfo()
     #if canImport(Glibc)
       // Glibc types SOCK_STREAM as the `__socket_type` enum; ai_socktype is a plain CInt.

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -140,6 +140,7 @@ public struct ToolPolicyGate: Sendable {
     guard tool.definition.egressClass == .arbitraryDestination else {
       return .action(nil)
     }
+
     guard let arguments = JSONValue.parse(call.argumentsJSON) else {
       return .blocked(
         ToolPayload(
@@ -149,6 +150,7 @@ public struct ToolPolicyGate: Sendable {
         )
       )
     }
+
     switch tool.canonicalTarget(arguments: arguments) {
     case .resolved(let target):
       return .action(ToolAction(tool: call.name, target: target))

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -150,10 +150,17 @@ public struct ToolPolicyGate: Sendable {
 public struct GatedToolDispatcher: ToolDispatching {
   private let registry: ToolRegistry
   private let gate: ToolPolicyGate
+  /// Injected so tests drive the timeout race deterministically (same seam as `AgentRuntime`).
+  private let sleep: @Sendable (Duration) async throws -> Void
 
-  public init(registry: ToolRegistry, gate: ToolPolicyGate) {
+  public init(
+    registry: ToolRegistry,
+    gate: ToolPolicyGate,
+    sleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+  ) {
     self.registry = registry
     self.gate = gate
+    self.sleep = sleep
   }
 
   public var definitions: [ToolDefinition] {
@@ -179,7 +186,7 @@ public struct GatedToolDispatcher: ToolDispatching {
       )
     case .allow(let argsRedacted, let consumedGrant):
       // (4) execute under the tool's own timeout
-      let payload = await Self.executeWithTimeout(tool: tool, arguments: arguments)
+      let payload = await executeWithTimeout(tool: tool, arguments: arguments)
       return ToolDispatchOutcome(
         observation: ToolObservation(call: call, payload: payload),
         argsRedacted: argsRedacted,
@@ -188,35 +195,42 @@ public struct GatedToolDispatcher: ToolDispatching {
     }
   }
 
-  /// First finisher wins: the tool's result or the timeout observation. The loser is cancelled.
-  private static func executeWithTimeout(
+  /// First finisher wins and the LOSER IS ABANDONED, never awaited: a task group always awaits
+  /// its children (the pitfall `sendDraftBounded` documents), so a wedged tool — a blocking
+  /// syscall, hung I/O — would otherwise hold the strict-FIFO session lane hostage far past its
+  /// declared timeout, beyond `/stop`'s reach. The abandoned execute task keeps running detached
+  /// until its I/O returns; today's tools are read-only, so a post-timeout side effect is
+  /// harmless — Inc 5's write tools must revisit this contract explicitly.
+  private func executeWithTimeout(
     tool: any Tool,
     arguments: JSONValue
   ) async -> ToolPayload {
-    await withTaskGroup(of: ToolPayload.self) { group in
-      group.addTask {
-        await tool.execute(arguments: arguments)
-      }
-      group.addTask {
-        try? await Task.sleep(for: tool.timeout)
-        return ToolPayload(
-          content: "The \(tool.definition.name) call timed out.",
-          status: .error,
-          ingestedUntrusted: false
-        )
-      }
+    let timeoutPayload = ToolPayload(
+      content: "The \(tool.definition.name) call timed out.",
+      status: .error,
+      ingestedUntrusted: false
+    )
 
-      let winner =
-        await group.next()
-        ?? ToolPayload(
-          content: "The \(tool.definition.name) call produced no result.",
-          status: .error,
-          ingestedUntrusted: false
-        )
-      group.cancelAll()
-
-      return winner
+    let firstResult = AsyncStream<ToolPayload> { continuation in
+      let executeTask = Task {
+        continuation.yield(await tool.execute(arguments: arguments))
+        continuation.finish()
+      }
+      let timeoutTask = Task { [sleep] in
+        try? await sleep(tool.timeout)
+        continuation.yield(timeoutPayload)
+        continuation.finish()
+      }
+      continuation.onTermination = { @Sendable _ in
+        executeTask.cancel()
+        timeoutTask.cancel()
+      }
     }
+
+    for await payload in firstResult {
+      return payload
+    }
+    return timeoutPayload
   }
 
   private func errorOutcome(call: ToolCall, reason: String) -> ToolDispatchOutcome {

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -5,12 +5,11 @@ import Foundation
 /// disk-time substring check, and the web_fetch grant/approval decision. Pure — every input
 /// arrives via the call/context; tier-3 texts via the injected loader (disk at gate time).
 public struct ToolPolicyGate: Sendable {
-  /// The outbound sinks the arg-guard tiers cover (§9.1 step 2 note, §18-H). `file_read` is not
-  /// an egress sink; its args are only redaction-RENDERED for audit.
-  static let egressTools: Set<String> = ["web_fetch", "web_search"]
-
   public enum Verdict: Sendable, Equatable {
-    case allow(argsRedacted: String, consumedGrant: Bool)
+    /// `action` is the gate-resolved canonical action for `.arbitraryDestination` tools — the
+    /// dispatcher hands its target into `execute` so the tool acts on exactly the form the gate
+    /// authorized; `nil` for the other classes.
+    case allow(argsRedacted: String, consumedGrant: Bool, action: ToolAction?)
     case block(payload: ToolPayload, argsRedacted: String, pendingApproval: ToolApprovalRequest?)
   }
 
@@ -22,15 +21,20 @@ public struct ToolPolicyGate: Sendable {
     self.privateFileLoader = privateFileLoader
   }
 
-  public func evaluate(call: ToolCall, context: ToolDispatchContext) -> Verdict {
-    guard Self.egressTools.contains(call.name) else {
+  public func evaluate(
+    call: ToolCall,
+    tool: any Tool,
+    context: ToolDispatchContext
+  ) -> Verdict {
+    guard tool.definition.egressClass != .none else {
       return .allow(
         argsRedacted: argGuard.renderRedacted(argsJSON: call.argumentsJSON),
-        consumedGrant: false
+        consumedGrant: false,
+        action: nil
       )
     }
 
-    // (2) unconditional tier — BLOCKING per FR-T6, fetch AND search
+    // (2) unconditional tier — BLOCKING per FR-T6, every egress class
     let unconditional = argGuard.evaluateUnconditional(argsJSON: call.argumentsJSON)
     if let rule = unconditional.blockedRule {
       return blockedArgs(rule: rule, argsRedacted: unconditional.redactedArgs)
@@ -40,7 +44,20 @@ public struct ToolPolicyGate: Sendable {
     let tainted = context.sessionTainted || context.runIngestedUntrusted
     let privateData = context.assemblyPrivateData || context.runPrivateData
     guard tainted && privateData else {
-      return .allow(argsRedacted: unconditional.redactedArgs, consumedGrant: false)
+      switch resolveAction(call: call, tool: tool) {
+      case .action(let action):
+        return .allow(
+          argsRedacted: unconditional.redactedArgs,
+          consumedGrant: false,
+          action: action
+        )
+      case .blocked(let payload):
+        return .block(
+          payload: payload,
+          argsRedacted: unconditional.redactedArgs,
+          pendingApproval: nil
+        )
+      }
     }
 
     // (3a) conditional tier — redaction-block WINS over approval (FR-T6); disk at gate time
@@ -52,43 +69,20 @@ public struct ToolPolicyGate: Sendable {
       return blockedArgs(rule: rule, argsRedacted: conditional.redactedArgs)
     }
 
-    // (3b) web_fetch only — the arbitrary-destination egress class (§18-H)
-    guard call.name == "web_fetch" else {
-      return .allow(argsRedacted: conditional.redactedArgs, consumedGrant: false)
+    // (3b) the arbitrary-destination egress class (§18-H): grant match or approval
+    let action: ToolAction?
+    switch resolveAction(call: call, tool: tool) {
+    case .action(let resolved):
+      action = resolved
+    case .blocked(let payload):
+      return .block(payload: payload, argsRedacted: conditional.redactedArgs, pendingApproval: nil)
     }
-    guard let rawURL = JSONValue.parse(call.argumentsJSON)?.objectValue?["url"]?.stringValue else {
-      return .block(
-        payload: ToolPayload(
-          content: "web_fetch needs a \"url\" argument.",
-          status: .error,
-          ingestedUntrusted: false
-        ),
-        argsRedacted: conditional.redactedArgs,
-        pendingApproval: nil
-      )
+    guard let action else {
+      return .allow(argsRedacted: conditional.redactedArgs, consumedGrant: false, action: nil)
     }
 
-    let canonical: String
-    switch CanonicalURL.canonicalize(rawURL) {
-    case .success(let value):
-      canonical = value
-    case .failure:
-      // URL-policy refusal BEFORE any prompt is built (§9.2 — userinfo/IDN/scheme/port)
-      return .block(
-        payload: ToolPayload(
-          content:
-            "That URL is not allowed (credentials, non-ASCII host, or unsupported scheme/port).",
-          status: .error,
-          ingestedUntrusted: false
-        ),
-        argsRedacted: conditional.redactedArgs,
-        pendingApproval: nil
-      )
-    }
-
-    let action = ToolAction(tool: call.name, target: canonical)
     if context.grant?.action == action {
-      return .allow(argsRedacted: conditional.redactedArgs, consumedGrant: true)
+      return .allow(argsRedacted: conditional.redactedArgs, consumedGrant: true, action: action)
     }
 
     if context.nonInteractive {
@@ -99,7 +93,7 @@ public struct ToolPolicyGate: Sendable {
       return .block(
         payload: ToolPayload(
           content: """
-            skipped \(call.name) of \(canonical) — it needs your approval; \
+            skipped \(call.name) of \(action.target) — it needs your approval; \
             run it interactively.
             """,
           status: .error,
@@ -129,6 +123,43 @@ public struct ToolPolicyGate: Sendable {
   /// raw secret, whatever the outcome.
   public func renderRedacted(argsJSON: String) -> String {
     argGuard.renderRedacted(argsJSON: argsJSON)
+  }
+
+  private enum ActionResolution {
+    case action(ToolAction?)
+    case blocked(ToolPayload)
+  }
+
+  /// Resolves the canonical action for `.arbitraryDestination` tools (`.action(nil)` for the
+  /// classes with no destination). A declared arbitrary-destination tool that resolves nothing
+  /// is a contract violation and fails CLOSED — never a silent walk past the approval tier.
+  private func resolveAction(call: ToolCall, tool: any Tool) -> ActionResolution {
+    guard tool.definition.egressClass == .arbitraryDestination else {
+      return .action(nil)
+    }
+    guard let arguments = JSONValue.parse(call.argumentsJSON) else {
+      return .blocked(
+        ToolPayload(
+          content: "Malformed arguments for \(call.name).",
+          status: .error,
+          ingestedUntrusted: false
+        )
+      )
+    }
+    switch tool.canonicalTarget(arguments: arguments) {
+    case .resolved(let target):
+      return .action(ToolAction(tool: call.name, target: target))
+    case .refused(let reason):
+      return .blocked(ToolPayload(content: reason, status: .error, ingestedUntrusted: false))
+    case nil:
+      return .blocked(
+        ToolPayload(
+          content: "\(call.name) is declared arbitrary-destination but resolved no target.",
+          status: .error,
+          ingestedUntrusted: false
+        )
+      )
+    }
   }
 
   private func blockedArgs(rule: String, argsRedacted: String) -> Verdict {
@@ -177,16 +208,20 @@ public struct GatedToolDispatcher: ToolDispatching {
       return errorOutcome(call: call, reason: "Malformed arguments for \(call.name).")
     }
     // (2)/(3) the gate
-    switch gate.evaluate(call: call, context: context) {
+    switch gate.evaluate(call: call, tool: tool, context: context) {
     case .block(let payload, let argsRedacted, let pendingApproval):
       return ToolDispatchOutcome(
         observation: ToolObservation(call: call, payload: payload),
         argsRedacted: argsRedacted,
         pendingApproval: pendingApproval
       )
-    case .allow(let argsRedacted, let consumedGrant):
-      // (4) execute under the tool's own timeout
-      let payload = await executeWithTimeout(tool: tool, arguments: arguments)
+    case .allow(let argsRedacted, let consumedGrant, let action):
+      // (4) execute under the tool's own timeout, on the gate-resolved canonical target
+      let payload = await executeWithTimeout(
+        tool: tool,
+        arguments: arguments,
+        canonicalTarget: action?.target
+      )
       return ToolDispatchOutcome(
         observation: ToolObservation(call: call, payload: payload),
         argsRedacted: argsRedacted,
@@ -203,7 +238,8 @@ public struct GatedToolDispatcher: ToolDispatching {
   /// harmless — Inc 5's write tools must revisit this contract explicitly.
   private func executeWithTimeout(
     tool: any Tool,
-    arguments: JSONValue
+    arguments: JSONValue,
+    canonicalTarget: String?
   ) async -> ToolPayload {
     let timeoutPayload = ToolPayload(
       content: "The \(tool.definition.name) call timed out.",
@@ -213,7 +249,9 @@ public struct GatedToolDispatcher: ToolDispatching {
 
     let firstResult = AsyncStream<ToolPayload> { continuation in
       let executeTask = Task {
-        continuation.yield(await tool.execute(arguments: arguments))
+        continuation.yield(
+          await tool.execute(arguments: arguments, canonicalTarget: canonicalTarget)
+        )
         continuation.finish()
       }
       let timeoutTask = Task { [sleep] in

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -106,8 +106,11 @@ public struct ToolPolicyGate: Sendable {
 
     return .block(
       payload: ToolPayload(
-        content:
-          "BLOCKED_PENDING_APPROVAL: this fetch needs the owner's approval because this session has read external content and holds private data. Explain briefly why you want to fetch it and finish your reply.",
+        content: """
+          BLOCKED_PENDING_APPROVAL: this fetch needs the owner's approval because \
+          this session has read external content and holds private data. \
+          Explain briefly why you want to fetch it and finish your reply.
+          """,
         status: .blockedPendingApproval,
         ingestedUntrusted: false
       ),

--- a/Sources/ClawTools/Tools/FileReadTool.swift
+++ b/Sources/ClawTools/Tools/FileReadTool.swift
@@ -39,13 +39,18 @@ public struct FileReadTool: Tool {
           ])
         ]),
         "required": .array([.string("path")]),
-      ])
+      ]),
+      egressClass: .none
     )
   }
 
   public var timeout: Duration { .seconds(5) }
 
-  public func execute(arguments: JSONValue) async -> ToolPayload {
+  public func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? {
+    nil  // nothing egresses; containment is enforced inside execute (FR-T4)
+  }
+
+  public func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
     guard
       let path = arguments.objectValue?["path"]?.stringValue,
       path.isEmpty == false

--- a/Sources/ClawTools/Tools/WebFetchTool.swift
+++ b/Sources/ClawTools/Tools/WebFetchTool.swift
@@ -47,24 +47,32 @@ public struct WebFetchTool: Tool {
           ])
         ]),
         "required": .array([.string("url")]),
-      ])
+      ]),
+      egressClass: .arbitraryDestination
     )
   }
 
   public var timeout: Duration { .seconds(30) }
 
-  public func execute(arguments: JSONValue) async -> ToolPayload {
+  public func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? {
     guard let rawURL = arguments.objectValue?["url"]?.stringValue, rawURL.isEmpty == false else {
-      return errorPayload("web_fetch needs a non-empty \"url\" argument.")
+      return .refused(reason: "web_fetch needs a non-empty \"url\" argument.")
     }
-
-    var currentURL: String
     switch CanonicalURL.canonicalize(rawURL) {
     case .success(let canonical):
-      currentURL = canonical
+      return .resolved(canonical)
     case .failure(let policyError):
-      return errorPayload(Self.describe(policyError))
+      return .refused(reason: Self.describe(policyError))
     }
+  }
+
+  public func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+    // The gate resolved and authorized exactly this canonical URL (§9.1); re-deriving it here
+    // could drift byte-for-byte from what the owner approved.
+    guard let canonicalTarget else {
+      return errorPayload("web_fetch was dispatched without a gate-resolved URL.")
+    }
+    var currentURL = canonicalTarget
 
     let deadline = ContinuousClock.now + timeout
     var hopsRemaining = maxHops

--- a/Sources/ClawTools/Tools/WebSearchTool.swift
+++ b/Sources/ClawTools/Tools/WebSearchTool.swift
@@ -32,13 +32,18 @@ public struct WebSearchTool: Tool {
           ]),
         ]),
         "required": .array([.string("query")]),
-      ])
+      ]),
+      egressClass: .fixedEndpoint
     )
   }
 
   public var timeout: Duration { .seconds(15) }
 
-  public func execute(arguments: JSONValue) async -> ToolPayload {
+  public func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? {
+    nil  // fixed-endpoint: the destination is pinned at composition, not chosen by args
+  }
+
+  public func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
     guard
       let query = arguments.objectValue?["query"]?.stringValue,
       query.isEmpty == false

--- a/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
@@ -106,7 +106,8 @@ import Testing
     let definition = ToolDefinition(
       name: "web_fetch",
       description: "d",
-      parameters: .object(["type": .string("object")])
+      parameters: .object(["type": .string("object")]),
+      egressClass: .none
     )
     let provider = SequenceProvider([okResponse()])
     let dispatcher = ScriptedDispatcher(definitions: [definition], respond: okOutcome())

--- a/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
@@ -359,6 +359,35 @@ import Testing
     #expect(await provider.requests.count == 1)
   }
 
+  @Test func wireGrowthPastTheInputCapStopsBeforeTheNextProviderCall() async throws {
+    // given — round-trip 1 proposes a tool call whose observation blows far past maxInputTokens
+    let provider = SequenceProvider([
+      toolCallResponse([fetchProposal()]),
+      okResponse(content: "never reached"),
+    ])
+    let hugeObservation = String(repeating: "x", count: 40_000)  // ≈12.5k estimated tokens
+    let dispatcher = ScriptedDispatcher(respond: okOutcome(content: hugeObservation))
+    let budget = RunBudget(
+      maxInputTokens: 1_000,
+      maxOutputTokens: 64,
+      wallClockDeadlineSeconds: 60,
+      retryBudget: 0,
+      perRunUSD: 10,
+      perDayUSD: 100,
+      proactivePerDayUSD: 2,
+      referenceUSDPerToken: 0.000_015
+    )
+    let runtime = makeRuntime(provider: provider, budget: budget, toolDispatcher: dispatcher)
+
+    // when
+    let outcome = try await run(runtime)
+
+    // then — stopped offline at the input cap; the second provider call never happens
+    #expect(outcome.result == .budgetStopped(cap: BudgetGate.perRunInputTokenCap))
+    #expect(await provider.requests.count == 1)
+    #expect(outcome.exchanges.count == 1)  // the executed exchange still rides the commit
+  }
+
   @Test func deadlineSpansToolExecutionToo() async throws {
     // given — a dispatcher slower than the whole-run deadline
     let provider = SequenceProvider([

--- a/Tests/ClawDataTests/Database/DiskFullMappingTests.swift
+++ b/Tests/ClawDataTests/Database/DiskFullMappingTests.swift
@@ -16,9 +16,9 @@ import Testing
     #expect(classified as? StoreError == .diskFull)
 
     // and the write seam surfaces the same typed error when a write throws SQLITE_FULL
-    let writer = try ClawDatabase.makeInMemoryQueue()
+    let database = MappedDatabase(writer: try ClawDatabase.makeInMemoryQueue())
     #expect(throws: StoreError.diskFull) {
-      try writer.writeMapping { (_: Database) in throw sqliteFull }
+      try database.writeMapping { (_: Database) in throw sqliteFull }
     }
   }
 
@@ -41,9 +41,25 @@ import Testing
     }
 
     // and the write seam surfaces a domain StoreError, never a raw DatabaseError
-    let writer = try ClawDatabase.makeInMemoryQueue()
+    let database = MappedDatabase(writer: try ClawDatabase.makeInMemoryQueue())
     #expect(throws: StoreError.self) {
-      try writer.writeMapping { (_: Database) in throw constraint }
+      try database.writeMapping { (_: Database) in throw constraint }
+    }
+  }
+
+  @Test func mappedDatabaseTranslatesFailuresOnBothSeams() throws {
+    // given
+    let sqliteFull = DatabaseError(resultCode: .SQLITE_FULL, message: "database or disk is full")
+    let database = MappedDatabase(writer: try ClawDatabase.makeInMemoryQueue())
+
+    // when / then — the write seam surfaces the domain error
+    #expect(throws: StoreError.diskFull) {
+      try database.writeMapping { (_: Database) in throw sqliteFull }
+    }
+
+    // and the read seam classifies identically
+    #expect(throws: StoreError.diskFull) {
+      try database.readMapping { (_: Database) in throw sqliteFull }
     }
   }
 

--- a/Tests/ClawDataTests/Stores/Bot/CommandStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Bot/CommandStoreTests.swift
@@ -53,8 +53,8 @@ import Testing
     )
   }
 
-  @Test func stopCancelsOnlyRunningRunAndAuditsCancellation() throws {
-    // given
+  @Test func stopCancelsRunningAndQueuedPendingRunsAndAuditsEach() throws {
+    // given — one RUNNING turn and one queued PENDING turn behind it
     let env = try fixture()
     _ = try #require(
       try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10))
@@ -68,30 +68,31 @@ import Testing
     // when
     let result = try env.commands.applyStop(updateId: 100, sessionKey: env.sessionKey, now: now)
 
-    // then
+    // then — BOTH terminate (spec FSM table: PENDING + /stop → CANCELLED)
     #expect(
       result
         == StopCommandResult(
           newlyClaimed: true,
           sessionId: env.sessionId,
-          cancelledRunId: env.firstRunId
+          cancelledRunIds: [env.firstRunId, queuedRunId]
         )
     )
     let states = try runStates(env.queue)
     #expect(states[env.firstRunId] == RunState.cancelled.rawValue)
-    #expect(states[queuedRunId] == RunState.pending.rawValue)
+    #expect(states[queuedRunId] == RunState.cancelled.rawValue)
     #expect(try processedCount(env.queue, updateId: 100) == 1)
     #expect(try messageCount(env.queue, content: "/stop") == 0)
 
     let audits = try auditRows(env.queue)
-    #expect(audits.count == 1)
-    let audit = try #require(audits.first)
-    #expect(audit["actor"] as String == AuditActor.owner.rawValue)
-    #expect(audit["action"] as String == AuditAction.turnCancelled.rawValue)
-    #expect(audit["args_redacted"] as String == "/stop")
-    #expect(audit["decision"] as String == "cancelled")
-    #expect(audit["run_id"] as Int64? == env.firstRunId)
-    #expect(audit["session_id"] as Int64? == env.sessionId)
+    #expect(audits.count == 2)
+    #expect(audits.compactMap { $0["run_id"] as Int64? } == [env.firstRunId, queuedRunId])
+    for audit in audits {
+      #expect(audit["actor"] as String == AuditActor.owner.rawValue)
+      #expect(audit["action"] as String == AuditAction.turnCancelled.rawValue)
+      #expect(audit["args_redacted"] as String == "/stop")
+      #expect(audit["decision"] as String == "cancelled")
+      #expect(audit["session_id"] as Int64? == env.sessionId)
+    }
   }
 
   @Test func newSupersedesActiveRunsResetsWindowDetaintsAndAudits() throws {
@@ -175,9 +176,9 @@ import Testing
     let duplicate = try env.commands.applyStop(updateId: 300, sessionKey: env.sessionKey, now: now)
 
     // then
-    #expect(first.cancelledRunId == env.firstRunId)
+    #expect(first.cancelledRunIds == [env.firstRunId])
     #expect(
-      duplicate == StopCommandResult(newlyClaimed: false, sessionId: nil, cancelledRunId: nil)
+      duplicate == StopCommandResult(newlyClaimed: false, sessionId: nil, cancelledRunIds: [])
     )
     #expect(try processedCount(env.queue, updateId: 300) == 1)
     #expect(try auditRows(env.queue).count == 1)
@@ -207,7 +208,7 @@ import Testing
     #expect(try runStates(env.queue)[env.firstRunId] == RunState.running.rawValue)
 
     let retry = try env.commands.applyStop(updateId: 400, sessionKey: env.sessionKey, now: now)
-    #expect(retry.cancelledRunId == env.firstRunId)
+    #expect(retry.cancelledRunIds == [env.firstRunId])
     #expect(try processedCount(env.queue, updateId: 400) == 1)
     #expect(try runStates(env.queue)[env.firstRunId] == RunState.cancelled.rawValue)
   }

--- a/Tests/ClawDataTests/Stores/Run/RunStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/RunStoreTests.swift
@@ -344,4 +344,36 @@ import Testing
     #expect(state == RunState.running.rawValue)  // NOT flipped to DONE
     #expect(usageCount == 0)
   }
+
+  @Test func corruptOriginFailsClosedAtPickup() throws {
+    // given — a PENDING run whose origin left the vocabulary
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let runs = RunStoreGRDB(writer: queue)
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: 42),
+        chatId: 42,
+        userId: 42,
+        text: "hello",
+        isEdited: false,
+        ts: Date(timeIntervalSince1970: 1)
+      )
+    )
+    let runId = try #require(claim.runId)
+    try queue.write { db in
+      try db.execute(sql: "UPDATE runs SET origin = 'webhook' WHERE id = ?", arguments: [runId])
+    }
+
+    // when / then — pickUp throws and the transaction rolls back: the run stays PENDING
+    #expect(throws: StoreError.self) {
+      _ = try runs.pickUp(runId: runId, now: Date(timeIntervalSince1970: 10))
+    }
+    let state = try queue.read { db in
+      try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [runId])
+    }
+    #expect(state == RunState.pending.rawValue)
+  }
 }

--- a/Tests/ClawDataTests/Stores/Session/SessionMessageStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Session/SessionMessageStoreTests.swift
@@ -283,4 +283,54 @@ import Testing
     #expect(counts.messages == 0)
     #expect(counts.runs == 0)
   }
+
+  @Test func corruptProvenanceFailsClosedInsteadOfDecodingTrusted() throws {
+    // given — a persisted message whose provenance left the vocabulary (rollback / hand-edit)
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let store = SessionMessageStoreGRDB(writer: queue)
+    let claim = try store.claimAndPersistInbound(inbound(updateId: 1, text: "hello"))
+    let sessionId = try #require(claim.sessionId)
+    let messageId = try #require(claim.messageId)
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE messages SET provenance = 'quarantined' WHERE id = ?",
+        arguments: [messageId]
+      )
+    }
+
+    // when / then — the load throws; it must never render the row as trusted (§12)
+    #expect(throws: StoreError.self) {
+      _ = try store.loadContextSnapshot(
+        sessionId: sessionId,
+        throughMessageId: messageId,
+        limit: 10
+      )
+    }
+  }
+
+  @Test func corruptRoleFailsClosedInsteadOfDecodingUser() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let store = SessionMessageStoreGRDB(writer: queue)
+    let claim = try store.claimAndPersistInbound(inbound(updateId: 1, text: "hello"))
+    let sessionId = try #require(claim.sessionId)
+    let messageId = try #require(claim.messageId)
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE messages SET role = 'oracle' WHERE id = ?",
+        arguments: [messageId]
+      )
+    }
+
+    // when / then
+    #expect(throws: StoreError.self) {
+      _ = try store.loadContextSnapshot(
+        sessionId: sessionId,
+        throughMessageId: messageId,
+        limit: 10
+      )
+    }
+  }
 }

--- a/Tests/ClawLLMTests/Provider/ToolWireCodingTests.swift
+++ b/Tests/ClawLLMTests/Provider/ToolWireCodingTests.swift
@@ -66,7 +66,8 @@ import Testing
         "type": .string("object"),
         "properties": .object(["url": .object(["type": .string("string")])]),
         "required": .array([.string("url")]),
-      ])
+      ]),
+      egressClass: .none
     )
     let request = ChatRequest(
       model: "m",

--- a/Tests/ClawToolsTests/Policy/SSRFGuardTests.swift
+++ b/Tests/ClawToolsTests/Policy/SSRFGuardTests.swift
@@ -81,4 +81,15 @@ import Testing
     #expect(addresses.isEmpty == false)
     #expect(addresses.allSatisfy { address in SSRFGuard.isPublic(address) == false })
   }
+
+  @Test func systemResolverShortCircuitsLiteralsWithoutDNS() async throws {
+    // given
+    let resolver = SystemAddressResolver()
+
+    // when
+    let addresses = try await resolver.resolve(host: "127.0.0.1")
+
+    // then — a literal parses locally; it must never hit the resolver
+    #expect(addresses == [ResolvedAddress.parse("127.0.0.1")])
+  }
 }

--- a/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
+++ b/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
@@ -306,14 +306,16 @@ import Testing
 @Suite struct GatedToolDispatcherTests {
   private func makeDispatcher(
     tools: [any Tool],
-    privateFiles: [String] = []
+    privateFiles: [String] = [],
+    sleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
   ) -> GatedToolDispatcher {
     GatedToolDispatcher(
       registry: ToolRegistry(tools: tools),
       gate: ToolPolicyGate(
         argGuard: ExfilArgGuard(secretValues: []),
         privateFileLoader: { privateFiles }
-      )
+      ),
+      sleep: sleep
     )
   }
 
@@ -426,5 +428,62 @@ import Testing
     #expect(outcome.observation.status == .error)
     #expect(outcome.observation.content.contains("timed out"))
     #expect(outcome.observation.ingestedUntrusted == false)
+  }
+
+  @Test(.timeLimit(.minutes(1)))
+  func wedgedToolIsAbandonedAtTimeoutNotAwaited() async {
+    // given — a tool that never returns and ignores cancellation; the injected sleep makes the
+    // timeout arm fire immediately, so no wall clock is involved on the green path
+    let release = WedgeRelease()
+    let dispatcher = makeDispatcher(tools: [WedgedTool(release: release)], sleep: { _ in })
+
+    // when — under group-await semantics this call would NEVER return (the group awaits the
+    // wedged child); the time limit converts that hang into a failure
+    let outcome = await dispatcher.dispatch(
+      call: ToolCall(id: "c1", name: "wedged", argumentsJSON: "{}"),
+      context: openContext
+    )
+
+    // then — the timeout observation returns while the tool is still wedged
+    #expect(outcome.observation.status == .error)
+    #expect(outcome.observation.content.contains("timed out"))
+
+    // release the abandoned task so it finishes before the suite exits
+    await release.release()
+  }
+}
+
+/// Blocks until released and IGNORES task cancellation — models a blocking syscall
+/// (`getaddrinfo`) or hung I/O that cooperative cancellation cannot interrupt.
+actor WedgeRelease {
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+  private var released = false
+
+  func wait() async {
+    if released { return }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+
+  func release() {
+    released = true
+    for waiter in waiters {
+      waiter.resume()
+    }
+    waiters.removeAll()
+  }
+}
+
+struct WedgedTool: Tool {
+  let release: WedgeRelease
+  let definition = ToolDefinition(
+    name: "wedged",
+    description: "wedged",
+    parameters: .object(["type": .string("object")])
+  )
+  let timeout: Duration = .seconds(30)
+
+  func execute(arguments: JSONValue) async -> ToolPayload {
+    await release.wait()
+    return ToolPayload(content: "late", status: .ok, ingestedUntrusted: false)
   }
 }

--- a/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
+++ b/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
@@ -4,6 +4,56 @@ import Testing
 
 @testable import ClawTools
 
+/// Gate-test stand-ins declaring each egress class. `FetchLikeTool` resolves its target the way
+/// web_fetch does (CanonicalURL + owner-facing refusal copy), so gate tests exercise the real
+/// resolution contract without HTTP plumbing.
+struct FetchLikeTool: Tool {
+  var name = "web_fetch"
+
+  var definition: ToolDefinition {
+    ToolDefinition(
+      name: name,
+      description: "stub",
+      parameters: .object(["type": .string("object")]),
+      egressClass: .arbitraryDestination
+    )
+  }
+
+  let timeout: Duration = .seconds(1)
+
+  func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? {
+    guard let rawURL = arguments.objectValue?["url"]?.stringValue, rawURL.isEmpty == false else {
+      return .refused(reason: "\(name) needs a non-empty \"url\" argument.")
+    }
+    switch CanonicalURL.canonicalize(rawURL) {
+    case .success(let canonical):
+      return .resolved(canonical)
+    case .failure:
+      return .refused(reason: "That is not a valid URL.")
+    }
+  }
+
+  func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+    ToolPayload(content: "fetched", status: .ok, ingestedUntrusted: true)
+  }
+}
+
+struct SearchLikeTool: Tool {
+  let definition = ToolDefinition(
+    name: "web_search",
+    description: "stub",
+    parameters: .object(["type": .string("object")]),
+    egressClass: .fixedEndpoint
+  )
+  let timeout: Duration = .seconds(1)
+
+  func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? { nil }
+
+  func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+    ToolPayload(content: "results", status: .ok, ingestedUntrusted: true)
+  }
+}
+
 @Suite struct ToolPolicyGateTests {
   private static let memoryText = "The owner's private project is called Operation Nightjar Falcon."
 
@@ -40,15 +90,42 @@ import Testing
     ToolCall(id: "c1", name: "web_fetch", argumentsJSON: #"{"url":"\#(url)"}"#)
   }
 
+  @Test func classDeclarationNotToolNameDrivesTheApprovalTier() {
+    // given — an egress tool the gate has never heard of by name, declared arbitrary-destination
+    let webhookTool = FetchLikeTool(name: "send_webhook")
+
+    // when
+    let verdict = makeGate().evaluate(
+      call: ToolCall(
+        id: "c1",
+        name: "send_webhook",
+        argumentsJSON: #"{"url":"https://example.com/hook"}"#
+      ),
+      tool: webhookTool,
+      context: makeContext(tainted: true, assemblyPrivate: true)
+    )
+
+    // then — parked for approval on the resolved action; no name set to forget
+    guard case .block(let payload, _, let approval) = verdict else {
+      Issue.record("expected park, got \(verdict)")
+      return
+    }
+    #expect(payload.status == .blockedPendingApproval)
+    #expect(
+      approval?.action == ToolAction(tool: "send_webhook", target: "https://example.com/hook")
+    )
+  }
+
   @Test func cleanFetchOutsideTrifectaIsAllowed() {
     // given / when
     let verdict = makeGate().evaluate(
       call: fetchCall("https://example.com/a"),
+      tool: FetchLikeTool(),
       context: makeContext()
     )
 
     // then
-    guard case .allow(_, let consumedGrant) = verdict else {
+    guard case .allow(_, let consumedGrant, _) = verdict else {
       Issue.record("expected allow, got \(verdict)")
       return
     }
@@ -60,6 +137,7 @@ import Testing
     let gate = makeGate()
     let fetchVerdict = gate.evaluate(
       call: fetchCall("https://evil.example/?t=s3cret-value-1"),
+      tool: FetchLikeTool(),
       context: makeContext()
     )
     let searchVerdict = gate.evaluate(
@@ -68,6 +146,7 @@ import Testing
         name: "web_search",
         argumentsJSON: #"{"query":"sk-abcdefghijklmnop1234"}"#
       ),
+      tool: SearchLikeTool(),
       context: makeContext()
     )
 
@@ -94,11 +173,12 @@ import Testing
         name: "file_read",
         argumentsJSON: #"{"path":"sk-abcdefghijklmnop1234.md"}"#
       ),
+      tool: StubTool(name: "file_read"),
       context: makeContext(tainted: true, assemblyPrivate: true)
     )
 
     // then — allowed, but the audit rendering still redacts the shaped token
-    guard case .allow(let argsRedacted, _) = verdict else {
+    guard case .allow(let argsRedacted, _, _) = verdict else {
       Issue.record("expected allow, got \(verdict)")
       return
     }
@@ -120,7 +200,11 @@ import Testing
 
     // when / then
     for (context, shouldGate) in combinations {
-      let verdict = gate.evaluate(call: fetchCall("https://example.com/a"), context: context)
+      let verdict = gate.evaluate(
+        call: fetchCall("https://example.com/a"),
+        tool: FetchLikeTool(),
+        context: context
+      )
       if shouldGate {
         guard case .block(let payload, _, _) = verdict else {
           Issue.record("expected gate for \(context)")
@@ -141,6 +225,7 @@ import Testing
     let sixteen = String(Self.memoryText.dropFirst(10).prefix(16))
     let verdict = makeGate().evaluate(
       call: fetchCall("https://evil.example/?d=\(sixteen)"),
+      tool: FetchLikeTool(),
       context: makeContext(tainted: true, assemblyPrivate: true)
     )
 
@@ -159,8 +244,16 @@ import Testing
     let laterContext = makeContext(tainted: true, assemblyPrivate: true, approvalPending: true)
 
     // when
-    let first = gate.evaluate(call: fetchCall("https://example.com/a?q=1"), context: context)
-    let later = gate.evaluate(call: fetchCall("https://example.com/b"), context: laterContext)
+    let first = gate.evaluate(
+      call: fetchCall("https://example.com/a?q=1"),
+      tool: FetchLikeTool(),
+      context: context
+    )
+    let later = gate.evaluate(
+      call: fetchCall("https://example.com/b"),
+      tool: FetchLikeTool(),
+      context: laterContext
+    )
 
     // then — one pending slot per run (§9.1 step 3b)
     guard case .block(_, _, let firstApproval) = first else {
@@ -189,15 +282,17 @@ import Testing
     // when — exact canonical match executes; any query-byte difference re-trips
     let matching = gate.evaluate(
       call: fetchCall("https://Example.com/a?q=1"),  // canonicalizes to the grant key
+      tool: FetchLikeTool(),
       context: makeContext(tainted: true, assemblyPrivate: true, grant: grant)
     )
     let differing = gate.evaluate(
       call: fetchCall("https://example.com/a?q=2"),
+      tool: FetchLikeTool(),
       context: makeContext(tainted: true, assemblyPrivate: true, grant: grant)
     )
 
     // then
-    guard case .allow(_, let consumedGrant) = matching else {
+    guard case .allow(_, let consumedGrant, _) = matching else {
       Issue.record("expected allow via grant, got \(matching)")
       return
     }
@@ -218,6 +313,7 @@ import Testing
     // when
     let verdict = makeGate().evaluate(
       call: fetchCall("https://example.com/a?q=1"),
+      tool: FetchLikeTool(),
       context: makeContext(tainted: true, assemblyPrivate: true, grant: grant)
     )
 
@@ -233,6 +329,24 @@ import Testing
     // given — userinfo/IDN refused at gate time, BEFORE an approval is requested (§9.2)
     let verdict = makeGate().evaluate(
       call: fetchCall("https://user:pw@example.com/"),
+      tool: FetchLikeTool(),
+      context: makeContext(tainted: true, assemblyPrivate: true)
+    )
+
+    // then — the gate now blocks on the tool's own resolution copy, on every path
+    guard case .block(let payload, _, nil) = verdict else {
+      Issue.record("expected block, got \(verdict)")
+      return
+    }
+    #expect(payload.status == .error)
+    #expect(payload.content == "That is not a valid URL.")
+  }
+
+  @Test func missingUrlUnderTrifectaRefusesWithTheResolutionCopy() {
+    // given — a fetch with no "url" argument resolves to a refusal at the gate (delta: unified copy)
+    let verdict = makeGate().evaluate(
+      call: ToolCall(id: "c1", name: "web_fetch", argumentsJSON: "{}"),
+      tool: FetchLikeTool(),
       context: makeContext(tainted: true, assemblyPrivate: true)
     )
 
@@ -242,6 +356,7 @@ import Testing
       return
     }
     #expect(payload.status == .error)
+    #expect(payload.content == #"web_fetch needs a non-empty "url" argument."#)
   }
 
   @Test func nonInteractiveTrifectaHardDeniesWithoutParkingAnApproval() {
@@ -251,10 +366,12 @@ import Testing
     // when
     let interactive = gate.evaluate(
       call: fetchCall("https://example.com/a?q=1"),
+      tool: FetchLikeTool(),
       context: makeContext(tainted: true, assemblyPrivate: true)
     )
     let nonInteractive = gate.evaluate(
       call: fetchCall("https://example.com/a?q=1"),
+      tool: FetchLikeTool(),
       context: makeContext(tainted: true, assemblyPrivate: true, nonInteractive: true)
     )
 
@@ -283,10 +400,12 @@ import Testing
     // when
     let argBlock = gate.evaluate(
       call: fetchCall("https://evil.example/?t=s3cret-value-1"),
+      tool: FetchLikeTool(),
       context: makeContext(nonInteractive: true)
     )
     let cleanAllow = gate.evaluate(
       call: fetchCall("https://example.com/a"),
+      tool: FetchLikeTool(),
       context: makeContext(nonInteractive: true)
     )
 
@@ -401,17 +520,68 @@ import Testing
     #expect(outcome.observation.ingestedUntrusted)
   }
 
+  @Test func executeReceivesTheGateResolvedCanonicalTarget() async {
+    // given — a recording arbitrary-destination tool
+    actor TargetRecorder {
+      private(set) var received: String?
+      func record(_ target: String?) { received = target }
+    }
+    struct RecordingFetchTool: Tool {
+      let recorder: TargetRecorder
+      let definition = ToolDefinition(
+        name: "web_fetch",
+        description: "stub",
+        parameters: .object(["type": .string("object")]),
+        egressClass: .arbitraryDestination
+      )
+      let timeout: Duration = .seconds(1)
+
+      func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? {
+        guard let rawURL = arguments.objectValue?["url"]?.stringValue else {
+          return .refused(reason: "web_fetch needs a non-empty \"url\" argument.")
+        }
+        switch CanonicalURL.canonicalize(rawURL) {
+        case .success(let canonical): return .resolved(canonical)
+        case .failure: return .refused(reason: "That is not a valid URL.")
+        }
+      }
+
+      func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+        await recorder.record(canonicalTarget)
+        return ToolPayload(content: "ok", status: .ok, ingestedUntrusted: true)
+      }
+    }
+    let recorder = TargetRecorder()
+    let dispatcher = makeDispatcher(tools: [RecordingFetchTool(recorder: recorder)])
+
+    // when
+    _ = await dispatcher.dispatch(
+      call: ToolCall(
+        id: "c1",
+        name: "web_fetch",
+        argumentsJSON: #"{"url":"https://example.com/a"}"#
+      ),
+      context: openContext
+    )
+
+    // then — the tool acted on the gate-resolved form, not a re-derived one
+    #expect(await recorder.received == "https://example.com/a")
+  }
+
   @Test func slowToolTimesOutWithAnErrorObservation() async {
     // given — a tool that sleeps past its own tiny timeout
     struct SlowTool: Tool {
       let definition = ToolDefinition(
         name: "slow",
         description: "slow",
-        parameters: .object(["type": .string("object")])
+        parameters: .object(["type": .string("object")]),
+        egressClass: .none
       )
       let timeout: Duration = .milliseconds(20)
 
-      func execute(arguments: JSONValue) async -> ToolPayload {
+      func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? { nil }
+
+      func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
         try? await Task.sleep(for: .seconds(10))
         return ToolPayload(content: "late", status: .ok, ingestedUntrusted: true)
       }
@@ -478,11 +648,14 @@ struct WedgedTool: Tool {
   let definition = ToolDefinition(
     name: "wedged",
     description: "wedged",
-    parameters: .object(["type": .string("object")])
+    parameters: .object(["type": .string("object")]),
+    egressClass: .none
   )
   let timeout: Duration = .seconds(30)
 
-  func execute(arguments: JSONValue) async -> ToolPayload {
+  func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? { nil }
+
+  func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
     await release.wait()
     return ToolPayload(content: "late", status: .ok, ingestedUntrusted: false)
   }

--- a/Tests/ClawToolsTests/Tools/FileReadToolTests.swift
+++ b/Tests/ClawToolsTests/Tools/FileReadToolTests.swift
@@ -35,7 +35,7 @@ import Testing
   }
 
   private func execute(_ tool: FileReadTool, path: String) async -> ToolPayload {
-    await tool.execute(arguments: .object(["path": .string(path)]))
+    await tool.execute(arguments: .object(["path": .string(path)]), canonicalTarget: nil)
   }
 
   @Test func readsARelativeFileAndSetsUntrusted() async throws {

--- a/Tests/ClawToolsTests/Tools/ToolRegistryTests.swift
+++ b/Tests/ClawToolsTests/Tools/ToolRegistryTests.swift
@@ -13,18 +13,22 @@ struct StubTool: Tool {
   init(
     name: String,
     timeout: Duration = .seconds(1),
+    egressClass: ToolEgressClass = .none,
     payload: ToolPayload = ToolPayload(content: "ok", status: .ok, ingestedUntrusted: false)
   ) {
     definition = ToolDefinition(
       name: name,
       description: "stub",
-      parameters: .object(["type": .string("object")])
+      parameters: .object(["type": .string("object")]),
+      egressClass: egressClass
     )
     self.timeout = timeout
     self.payload = payload
   }
 
-  func execute(arguments: JSONValue) async -> ToolPayload {
+  func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? { nil }
+
+  func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
     payload
   }
 }

--- a/Tests/ClawToolsTests/Tools/WebFetchToolTests.swift
+++ b/Tests/ClawToolsTests/Tools/WebFetchToolTests.swift
@@ -79,8 +79,20 @@ struct ScriptedResolver: AddressResolving {
     )
   }
 
+  /// The gate resolves the canonical URL and hands it to `execute`; these tests stand in for the
+  /// gate by canonicalizing the raw URL the same way before dispatch.
   private func fetch(_ tool: WebFetchTool, url: String) async -> ToolPayload {
-    await tool.execute(arguments: .object(["url": .string(url)]))
+    let canonicalTarget: String
+    switch CanonicalURL.canonicalize(url) {
+    case .success(let canonical):
+      canonicalTarget = canonical
+    case .failure:
+      canonicalTarget = url
+    }
+    return await tool.execute(
+      arguments: .object(["url": .string(url)]),
+      canonicalTarget: canonicalTarget
+    )
   }
 
   @Test func fetchesExtractsAndRedactsHTML() async throws {
@@ -237,17 +249,49 @@ struct ScriptedResolver: AddressResolving {
     #expect((await fetch(tool, url: "https://example.com/feed")).status == .ok)
   }
 
-  @Test func urlPolicyRefusalsAreErrorsNotSSRF() async throws {
-    // given
+  @Test func urlPolicyRefusalsAreRefusedAtResolutionNotDispatched() async throws {
+    // given — scheme/port/userinfo/IDN refusals come from CanonicalURL, at the gate's resolution
+    // step (the tool no longer re-canonicalizes in execute), so they never reach dispatch
     let http = ScriptedHTTP(responses: [:])
     let tool = makeTool(http: http, resolver: ScriptedResolver(table: [:]))
 
-    // when / then — scheme/port/userinfo/IDN refusals come from CanonicalURL, pre-dispatch
-    #expect((await fetch(tool, url: "ftp://example.com/")).status == .error)
-    #expect((await fetch(tool, url: "https://user:pw@example.com/")).status == .error)
-    #expect((await fetch(tool, url: "https://example.com:8443/")).status == .error)
-    #expect((await fetch(tool, url: "https://exämple.com/")).status == .error)
+    // when / then — each raw URL resolves to a refusal carrying the specific policy copy
+    func resolution(_ url: String) -> CanonicalTargetResolution? {
+      tool.canonicalTarget(arguments: .object(["url": .string(url)]))
+    }
+    #expect(
+      resolution("ftp://example.com/")
+        == .refused(reason: "Only http and https URLs are supported (got ftp).")
+    )
+    #expect(
+      resolution("https://user:pw@example.com/")
+        == .refused(reason: "URLs with embedded credentials are not allowed.")
+    )
+    #expect(
+      resolution("https://example.com:8443/")
+        == .refused(reason: "Only ports 80 and 443 are allowed (got 8443).")
+    )
+    #expect(
+      resolution("https://exämple.com/")
+        == .refused(reason: "Internationalized (non-ASCII/punycode) hosts are not supported in v1.")
+    )
     #expect(await http.requestedURLs.isEmpty)
+  }
+
+  @Test func missingUrlIsRefusedAtResolution() async throws {
+    // given — the gate's resolution step rejects a missing/empty url with the unified copy
+    let http = ScriptedHTTP(responses: [:])
+    let tool = makeTool(http: http, resolver: ScriptedResolver(table: [:]))
+
+    // when / then
+    #expect(
+      tool.canonicalTarget(arguments: .object([:]))
+        == .refused(reason: #"web_fetch needs a non-empty "url" argument."#)
+    )
+    #expect(
+      tool.canonicalTarget(arguments: .object(["url": .string("")]))
+        == .refused(reason: #"web_fetch needs a non-empty "url" argument."#)
+    )
   }
 
   @Test func nonSuccessStatusIsAnError() async throws {

--- a/Tests/ClawToolsTests/Tools/WebSearchToolTests.swift
+++ b/Tests/ClawToolsTests/Tools/WebSearchToolTests.swift
@@ -39,7 +39,10 @@ struct ScriptedSearch: SearchProviding {
     )
 
     // when
-    let payload = await tool.execute(arguments: .object(["query": .string("swift")]))
+    let payload = await tool.execute(
+      arguments: .object(["query": .string("swift")]),
+      canonicalTarget: nil
+    )
 
     // then — "- title — url\n  snippet" (§7.3); snippets are third-party content
     #expect(payload.status == .ok)
@@ -65,9 +68,15 @@ struct ScriptedSearch: SearchProviding {
     )
 
     // when
-    _ = await tool.execute(arguments: .object(["query": .string("q")]))
-    _ = await tool.execute(arguments: .object(["query": .string("q"), "count": .number(99)]))
-    _ = await tool.execute(arguments: .object(["query": .string("q"), "count": .number(0)]))
+    _ = await tool.execute(arguments: .object(["query": .string("q")]), canonicalTarget: nil)
+    _ = await tool.execute(
+      arguments: .object(["query": .string("q"), "count": .number(99)]),
+      canonicalTarget: nil
+    )
+    _ = await tool.execute(
+      arguments: .object(["query": .string("q"), "count": .number(0)]),
+      canonicalTarget: nil
+    )
 
     // then
     #expect(box.counts == [5, 10, 1])
@@ -92,7 +101,8 @@ struct ScriptedSearch: SearchProviding {
 
     // when
     let payload = await tool.execute(
-      arguments: .object(["query": .string("q"), "count": .number(1e300)])
+      arguments: .object(["query": .string("q"), "count": .number(1e300)]),
+      canonicalTarget: nil
     )
 
     // then — the out-of-range Double clamps to the max instead of trapping on Int(Double)
@@ -109,7 +119,10 @@ struct ScriptedSearch: SearchProviding {
     )
 
     // when
-    let payload = await tool.execute(arguments: .object(["query": .string("q")]))
+    let payload = await tool.execute(
+      arguments: .object(["query": .string("q")]),
+      canonicalTarget: nil
+    )
 
     // then
     #expect(payload.status == .error)
@@ -122,6 +135,6 @@ struct ScriptedSearch: SearchProviding {
     let tool = WebSearchTool(search: ScriptedSearch())
 
     // when / then
-    #expect((await tool.execute(arguments: .object([:]))).status == .error)
+    #expect((await tool.execute(arguments: .object([:]), canonicalTarget: nil)).status == .error)
   }
 }

--- a/docs/research/architecture-review-2026-07-06.md
+++ b/docs/research/architecture-review-2026-07-06.md
@@ -11,7 +11,7 @@
 
 Verdicts are marked CONFIRMED or PLAUSIBLE; two findings were downgraded during adversarial verification and are presented with those corrections.
 
-> **Progress (updated 2026-07-07).** Risk 2 (the `MessageRouter` split) and Stage 2 item 1 of the refactoring plan are done, landed on branch `split-message-router` (PR [#30](https://github.com/ivan-magda/swift-claw/pull/30)). The rest of the register stands as written. See the "Resolved" callout under Risk 2 for what shipped.
+> **Progress (updated 2026-07-07).** Risk 2 (the `MessageRouter` split, Stage 2 item 1) landed first (PR [#30](https://github.com/ivan-magda/swift-claw/pull/30)). Stage 1 has now landed in full on branch `structural-hardening`: Risk 3 (`ToolEgressClass` declared on `ToolDefinition` with no default; the gate consumes the declaration and hands the resolved canonical target into `execute`), Risk 1 (first-finisher-wins timeout that abandons the wedged tool; `getaddrinfo` moved to a Dispatch worker thread), Risk 4 (`applyStop` cancels every PENDING+RUNNING run; `StopCommandResult.cancelledRunIds`), Risk 5 (role/provenance/origin decode throws `StoreError.unexpected`, mirroring `decodeItem`), Risk 6 (`MappedDatabase` wrapper; the raw `write`/`read` extensions are deleted), and the Risk 8 input-token preflight guard (`BudgetGate.perRunInputTokenCap`). The rest of the register (Stage 2 items 2–5, Stage 3) stands as written.
 
 ---
 
@@ -353,13 +353,13 @@ Explicitly *not* in the target for now: a channel-neutral delivery-address table
 
 **Stage 1 — small, high-value, do before Increment 5 starts.** All five are contained, none changes behavior the owner can see:
 
-1. Tool policy class on `ToolDefinition` + gate consumes it + pass the canonical action into `execute` (Risk 3) — touches `ToolContracts.swift`, `ToolPolicyGate.swift`, the three tools, `RunCommand`.
-2. Real timeout abandonment in `executeWithTimeout` (reuse the `sendDraftBounded` pattern) and move `getaddrinfo` off the cooperative pool (Risk 1) — `ToolPolicyGate.swift`, `SSRFGuard.swift`.
-3. `applyStop` cancels PENDING+RUNNING (Risk 4) — `RunStoreGRDB.fetchActiveRunId` → plural, `CommandStoreGRDB`, router `/stop` handler.
-4. Fail-closed provenance/role decode (Risk 5) — `SessionMessageStoreGRDB`, `RetrieverGRDB`, comment or fix the `RunOrigin` fallback.
-5. `MappedDatabase` wrapper replacing `any DatabaseWriter` in stores (Risk 6) — mechanical, 14 inits.
+1. ~~Tool policy class on `ToolDefinition` + gate consumes it + pass the canonical action into `execute` (Risk 3) — touches `ToolContracts.swift`, `ToolPolicyGate.swift`, the three tools, `RunCommand`.~~ **Done (2026-07-07).**
+2. ~~Real timeout abandonment in `executeWithTimeout` (reuse the `sendDraftBounded` pattern) and move `getaddrinfo` off the cooperative pool (Risk 1) — `ToolPolicyGate.swift`, `SSRFGuard.swift`.~~ **Done (2026-07-07).**
+3. ~~`applyStop` cancels PENDING+RUNNING (Risk 4) — `RunStoreGRDB.fetchActiveRunId` → plural, `CommandStoreGRDB`, router `/stop` handler.~~ **Done (2026-07-07).**
+4. ~~Fail-closed provenance/role decode (Risk 5) — `SessionMessageStoreGRDB`, `RetrieverGRDB`, comment or fix the `RunOrigin` fallback.~~ **Done (2026-07-07).**
+5. ~~`MappedDatabase` wrapper replacing `any DatabaseWriter` in stores (Risk 6) — mechanical, 14 inits.~~ **Done (2026-07-07).**
 
-Plus the one-line input-token preflight guard (Risk 8). Do **not** touch: the session lane, the outbox design, the FSM reducer, the provider.
+~~Plus the one-line input-token preflight guard (Risk 8).~~ **Done (2026-07-07).** Do **not** touch: the session lane, the outbox design, the FSM reducer, the provider.
 
 **Stage 2 — medium cleanup, ideally interleaved with Inc 5 planning.**
 


### PR DESCRIPTION
## What this does

Implements Stage 1 of the architecture review (`docs/research/architecture-review-2026-07-06.md`): six changes that turn convention-enforced invariants into structural ones, plus the register update. No new modules, no schema changes, and no owner-visible behavior change beyond the two the review asked for (`/stop` semantics, gate copy).

## Changes

- **Store error seam is structural (Risk 6).** Stores now hold a `MappedDatabase` wrapper that exposes only `writeMapping`/`readMapping`. A raw GRDB `write`/`read` would leak a `DatabaseError` past the store boundary; it's now unreachable from store code rather than discouraged by convention. All 14 stores migrated; the extension loophole is deleted.
- **Fail-closed decode (Risk 5).** `role`, `provenance`, and `origin` now throw `StoreError.unexpected` on an unrecognized persisted value. Before, an unknown value fell through to the most permissive tier. This mirrors the rule `MemoryStoreGRDB.decodeItem` already followed.
- **`/stop` cancels queued runs (Risk 4).** `applyStop` now cancels every PENDING and RUNNING run for the session, matching the FSM spec (`PENDING | /stop → CANCELLED`). Before, a queued message fired anyway. `StopCommandResult.cancelledRunId` became `cancelledRunIds: [Int64]`, and `/stop` and `/new` share one `terminateActiveRuns` body.
- **Wedged tools are abandoned at timeout (Risk 1).** `executeWithTimeout` uses a first-finisher-wins shape that abandons the losing task instead of awaiting it, so a blocking syscall or hung I/O can't hold the session lane past its declared timeout. `getaddrinfo` moves onto a Dispatch worker thread so a stalled resolve can't pin a cooperative-pool thread.
- **Tool egress class on the contract (Risk 3).** `ToolDefinition` declares a `ToolEgressClass` with no default, so a new tool can't compile without classifying itself. The gate reads that declaration instead of a tool-name set, and hands the gate-resolved canonical target into `execute`. A forgotten classification is now a compile error instead of a silent arg-guard bypass.
- **Input-token preflight guard (Risk 8).** The round-trip loop stops a run whose wire outgrows `maxInputTokens` before the next provider call. A context-window overflow now reports a budget stop instead of an undiagnosable "provider unavailable".

## Testing

Full suite green (795 tests); lint clean. New tests cover the abandonment path, the fail-closed decodes, the plural `/stop`, the egress-class-drives-policy contract, the canonical-target handoff, and the input-token stop.

## Out of scope

Stage 2 items 2–5 and all of Stage 3, per the review. The session lane, outbox design, `RunFSM` reducer, and provider internals stay untouched.
