### PR TITLE
Add release pipeline 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,9 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      id-token: write      # Sigstore OIDC for attestations
-      attestations: write  # write build provenance
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -35,23 +36,22 @@ jobs:
           cp .build/release/clawd clawd-linux-x86_64
           sha256sum clawd-linux-x86_64 > clawd-linux-x86_64.sha256
       - name: Attest provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest@v4
         with:
           subject-path: clawd-linux-x86_64
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: linux
           path: clawd-linux-x86_64*
 
   macos-binary:
-    # macos-26 (preview) is the only hosted image with a Swift 6.3.x Xcode (26.6 = 6.3.3);
-    # macos-15 tops out at Swift 6.2.4. Keeps release binaries on the same toolchain as CI.
     runs-on: macos-26
     timeout-minutes: 30
     permissions:
       contents: read
-      id-token: write      # Sigstore OIDC for attestations
-      attestations: write  # write build provenance
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -71,10 +71,10 @@ jobs:
           cp .build/release/clawd clawd-macos-arm64
           shasum -a 256 clawd-macos-arm64 > clawd-macos-arm64.sha256
       - name: Attest provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest@v4
         with:
           subject-path: clawd-macos-arm64
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: macos
           path: clawd-macos-arm64*
@@ -84,9 +84,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write  # create the GitHub Release
+      contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
       - name: Assemble SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,9 @@ jobs:
           path: clawd-linux-x86_64*
 
   macos-binary:
-    runs-on: macos-15
+    # macos-26 (preview) is the only hosted image with a Swift 6.3.x Xcode (26.6 = 6.3.3);
+    # macos-15 tops out at Swift 6.2.4. Keeps release binaries on the same toolchain as CI.
+    runs-on: macos-26
     timeout-minutes: 30
     permissions:
       contents: read
@@ -55,7 +57,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Select Swift 6.3 toolchain
-        run: sudo xcode-select -s /Applications/Xcode_26.app
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.6.app
+          swift --version
+          swift --version 2>&1 | grep -qF "Swift version 6.3" \
+            || { echo "::error::Expected a Swift 6.3.x toolchain on this runner"; exit 1; }
       - name: Stamp version
         run: printf 'enum ClawdVersion {\n  static let current = "%s"\n}\n' "${GITHUB_REF_NAME#v}" > Sources/clawd/Version.swift
       - name: Build release binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: write      # Sigstore OIDC for attestations
       attestations: write  # write build provenance
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Install system dependencies
@@ -35,10 +35,10 @@ jobs:
           cp .build/release/clawd clawd-linux-x86_64
           sha256sum clawd-linux-x86_64 > clawd-linux-x86_64.sha256
       - name: Attest provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
+        uses: actions/attest-build-provenance@v2
         with:
           subject-path: clawd-linux-x86_64
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+      - uses: actions/upload-artifact@v4
         with:
           name: linux
           path: clawd-linux-x86_64*
@@ -51,7 +51,7 @@ jobs:
       id-token: write      # Sigstore OIDC for attestations
       attestations: write  # write build provenance
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Select Swift 6.3 toolchain
@@ -65,10 +65,10 @@ jobs:
           cp .build/release/clawd clawd-macos-arm64
           shasum -a 256 clawd-macos-arm64 > clawd-macos-arm64.sha256
       - name: Attest provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
+        uses: actions/attest-build-provenance@v2
         with:
           subject-path: clawd-macos-arm64
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+      - uses: actions/upload-artifact@v4
         with:
           name: macos
           path: clawd-macos-arm64*
@@ -80,7 +80,7 @@ jobs:
     permissions:
       contents: write  # create the GitHub Release
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+      - uses: actions/download-artifact@v4
         with:
           path: dist
       - name: Assemble SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  linux-binary:
+    runs-on: ubuntu-latest
+    container: swift:6.3-noble
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write      # Sigstore OIDC for attestations
+      attestations: write  # write build provenance
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
+      - name: Install system dependencies
+        run: apt-get update && apt-get install -y --no-install-recommends libsqlite3-dev ca-certificates
+      - name: Stamp version
+        run: printf 'enum ClawdVersion {\n  static let current = "%s"\n}\n' "${GITHUB_REF_NAME#v}" > Sources/clawd/Version.swift
+      - name: Build release binary
+        run: swift build -c release --static-swift-stdlib --product clawd
+      - name: Package
+        run: |
+          cp .build/release/clawd clawd-linux-x86_64
+          sha256sum clawd-linux-x86_64 > clawd-linux-x86_64.sha256
+      - name: Attest provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
+        with:
+          subject-path: clawd-linux-x86_64
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: linux
+          path: clawd-linux-x86_64*
+
+  macos-binary:
+    runs-on: macos-15
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write      # Sigstore OIDC for attestations
+      attestations: write  # write build provenance
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
+      - name: Select Swift 6.3 toolchain
+        run: sudo xcode-select -s /Applications/Xcode_26.app
+      - name: Stamp version
+        run: printf 'enum ClawdVersion {\n  static let current = "%s"\n}\n' "${GITHUB_REF_NAME#v}" > Sources/clawd/Version.swift
+      - name: Build release binary
+        run: swift build -c release --product clawd
+      - name: Package
+        run: |
+          cp .build/release/clawd clawd-macos-arm64
+          shasum -a 256 clawd-macos-arm64 > clawd-macos-arm64.sha256
+      - name: Attest provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
+        with:
+          subject-path: clawd-macos-arm64
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: macos
+          path: clawd-macos-arm64*
+
+  publish:
+    needs: [linux-binary, macos-binary]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write  # create the GitHub Release
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          path: dist
+      - name: Assemble SHA256SUMS
+        run: |
+          cd dist
+          cat linux/clawd-linux-x86_64.sha256 macos/clawd-macos-arm64.sha256 > SHA256SUMS
+          cat SHA256SUMS
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2  # zizmor: ignore[superfluous-actions] handles multi-file upload + release notes + prerelease flag more cleanly than a gh release script
+        with:
+          files: |
+            dist/linux/clawd-linux-x86_64
+            dist/macos/clawd-macos-arm64
+            dist/SHA256SUMS
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,11 +89,12 @@ jobs:
           cat linux/clawd-linux-x86_64.sha256 macos/clawd-macos-arm64.sha256 > SHA256SUMS
           cat SHA256SUMS
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2  # zizmor: ignore[superfluous-actions] handles multi-file upload + release notes + prerelease flag more cleanly than a gh release script
-        with:
-          files: |
-            dist/linux/clawd-linux-x86_64
-            dist/macos/clawd-macos-arm64
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          flags=(--generate-notes)
+          [[ "${GITHUB_REF_NAME}" == *-* ]] && flags+=(--prerelease)
+          gh release create "${GITHUB_REF_NAME}" "${flags[@]}" \
+            dist/linux/clawd-linux-x86_64 \
+            dist/macos/clawd-macos-arm64 \
             dist/SHA256SUMS
-          generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ shasum -a 256 -c SHA256SUMS                   # macOS
 gh attestation verify clawd-linux-x86_64 -R ivan-magda/swift-claw
 ```
 
+`-c` checks every entry in `SHA256SUMS`; a `FAILED open or read` line for the platform binary you didn't download is expected.
+
 - **macOS:** first run is blocked by Gatekeeper for an unsigned binary — clear the quarantine flag: `xattr -d com.apple.quarantine ./clawd-macos-arm64`.
 - **Linux:** the binary links the system SQLite — install it if missing: `sudo apt-get install -y libsqlite3-0`.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# swift-claw
+
+A persistent, single-owner personal AI assistant controlled via Telegram, written in pure Swift. The daemon is `clawd`.
+
+> Design docs live in [`docs/`](docs/) — `ARCHITECTURE.md` is the normative spec.
+
+## Install a release binary
+
+Download the binary for your platform from the [latest release](../../releases/latest), then verify it:
+
+```bash
+sha256sum -c SHA256SUMS                      # Linux
+shasum -a 256 -c SHA256SUMS                   # macOS
+gh attestation verify clawd-linux-x86_64 -R ivan-magda/swift-claw
+```
+
+- **macOS:** first run is blocked by Gatekeeper for an unsigned binary — clear the quarantine flag: `xattr -d com.apple.quarantine ./clawd-macos-arm64`.
+- **Linux:** the binary links the system SQLite — install it if missing: `sudo apt-get install -y libsqlite3-0`.
+
+## Build from source
+
+Requires the Swift 6.3.x toolchain.
+
+```bash
+swift build            # debug → .build/debug/clawd
+swift build -c release # release → .build/release/clawd
+swift test             # run the suite
+```
+
+See [`docs/LOCAL_DEV.md`](docs/LOCAL_DEV.md) for running the daemon and [`deploy/README.md`](deploy/README.md) for supervised deployment.

--- a/Sources/clawd/Clawd.swift
+++ b/Sources/clawd/Clawd.swift
@@ -6,6 +6,7 @@ struct Clawd: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "clawd",
     abstract: "swift-claw — single-owner Telegram assistant daemon.",
+    version: ClawdVersion.current,
     subcommands: [
       RunCommand.self,
       DoctorCommand.self,

--- a/Sources/clawd/Version.swift
+++ b/Sources/clawd/Version.swift
@@ -1,0 +1,8 @@
+/// The clawd version string.
+///
+/// Overwritten from the git tag by the release workflow
+/// (`.github/workflows/release.yml`); stays `"0.0.0-dev"` for local and
+/// unreleased builds so `clawd --version` never claims a release it isn't.
+enum ClawdVersion {
+  static let current = "0.0.0-dev"
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,7 +2,7 @@
 
 ## Install
 
-**Option A — release binary (recommended):** download `clawd-<platform>` + `SHA256SUMS` from the [latest release](../../releases/latest), verify with `sha256sum -c SHA256SUMS` and `gh attestation verify <binary> -R ivan-magda/swift-claw`, then `install -m755 clawd-<platform> /usr/local/bin/clawd`. On macOS clear quarantine: `xattr -d com.apple.quarantine /usr/local/bin/clawd`. On Linux ensure `libsqlite3-0` is installed.
+**Option A — release binary (recommended):** download `clawd-<platform>` + `SHA256SUMS` from the [latest release](../../../releases/latest), verify with `sha256sum -c SHA256SUMS` (Linux) or `shasum -a 256 -c SHA256SUMS` (macOS) and `gh attestation verify <binary> -R ivan-magda/swift-claw`, then `install -m755 clawd-<platform> /usr/local/bin/clawd`. `-c` checks every entry in `SHA256SUMS`; a `FAILED open or read` line for the platform binary you didn't download is expected. On macOS clear quarantine: `xattr -d com.apple.quarantine /usr/local/bin/clawd`. On Linux ensure `libsqlite3-0` is installed.
 
 **Option B — build from source:**
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,5 +1,11 @@
 # Deploying clawd
 
+## Install
+
+**Option A — release binary (recommended):** download `clawd-<platform>` + `SHA256SUMS` from the [latest release](../../releases/latest), verify with `sha256sum -c SHA256SUMS` and `gh attestation verify <binary> -R ivan-magda/swift-claw`, then `install -m755 clawd-<platform> /usr/local/bin/clawd`. On macOS clear quarantine: `xattr -d com.apple.quarantine /usr/local/bin/clawd`. On Linux ensure `libsqlite3-0` is installed.
+
+**Option B — build from source:**
+
 1. `swift build -c release` → copy `.build/release/clawd` to `/usr/local/bin/clawd`.
 2. `cp .env.example ~/.swift-claw/clawd.env`, fill in the token + allowlist, `chmod 600 ~/.swift-claw/clawd.env`.
 3. Verify: `clawd doctor` (config first, then DB/allowlist/connectivity).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -493,10 +493,10 @@ A **state machine** persisted in `approvals` so it survives restart. See §7.1 c
 
 ## 17. Deployment & portability
 
-- **Build:** SwiftPM (**platform floor macOS 15** — `Calendar.RecurrenceRule` requires it, Inc 4/§14; verified on-toolchain, Linux availability re-validated at the Inc 6 gate); macOS native binary; **Static Linux SDK** (musl) cross-compiled from the Mac for a single fully-static Linux binary; **distroless/scratch** image (CA certs + tzdata). Escape hatch: `swift-sdk-generator` (glibc) if a dep needs WebSockets/newer TLS/glibc-only C libs.
-- **Portability is a soft guideline through Inc 0–5** with **one hard gate at Inc 6**: the CI Linux build (incl. GRDB + FTS5) must pass before release. Portable protocol seams + AsyncHTTPClient/OpenAI-compat choices are kept throughout; pragmatic macOS-native code is permitted behind a protocol or flagged for the Inc-6 audit.
+- **Build:** SwiftPM (**platform floor macOS 15** — `Calendar.RecurrenceRule` requires it, Inc 4/§14); two release binaries: a **macOS-native `arm64` binary** and a **Linux `x86_64` binary built natively in the `swift:6.3-noble` container** with `--static-swift-stdlib` (the Swift runtime is bundled; the system `libsqlite3` is the sole external runtime dependency). A musl **Static Linux SDK** → fully-static/distroless image is deferred: GRDB v7 declares SQLite as a `.systemLibrary` and the musl SDK ships none, so a musl cross-compile can't link (see §18 Deployment escape hatch).
+- **Portability is enforced continuously:** a **GRDB + FTS5 build+test gate runs on both macOS and Linux on every PR** (`ci.yml`) — the portability gate is live, not deferred. Portable protocol seams + AsyncHTTPClient/OpenAI-compat choices are kept throughout; pragmatic macOS-native code is permitted behind a protocol and covered by the Linux CI gate.
 - **Supervise:** launchd plist (macOS) / systemd unit (Linux), with throttling (§4). Logs to stdout/stderr.
-- **CI:** a Linux build gates releases (catches target-only cross-compile issues) and includes a **GRDB + FTS5 job**.
+- **CI:** the macOS + Linux **GRDB + FTS5 build+test gate** (`ci.yml`) runs on every PR and blocks merge; releases (`release.yml`) publish as **GitHub Releases with SHA256 checksums + build-provenance attestations**, not a container image.
 
 ## 18. Technology decisions
 
@@ -504,7 +504,7 @@ A **state machine** persisted in `approvals` so it survives restart. See §7.1 c
 |---|---|---|---|---|
 | Daemon framework | `swift-service-lifecycle` ServiceGroup / NIO | structured supervised lifecycle; no listen socket | Hummingbird 2 (if REST later) | Low |
 | Telegram client | **thin clean-room client** over AsyncHTTPClient (research **runner-up**; primary was `nerzh/swift-telegram-bot`) | deliberate clean-room provenance, zero bus-factor, full transport + offset-durability control; ~8–10 endpoints (getUpdates, sendMessage, **sendRichMessage**, editMessageText, sendChatAction, answerCallbackQuery, getMe, setMyCommands, getFile) | `nerzh/swift-telegram-bot` | Low–Med |
-| Persistence | GRDB.swift v7 (WAL, FTS5, migrations); **pin GRDB**; vendor SQLite amalgamation (FTS5 + sqlite-vec init compiled in); Linux CI job exercises GRDB+FTS5 | Swift-6 concurrency-native, boring, full-featured | SQLite.swift / raw C | **Low (macOS) / Med (Linux until our own CI exists)** |
+| Persistence | GRDB.swift v7 (WAL, FTS5, migrations); **pin GRDB** via committed `Package.resolved` + Dependabot + the CI gate (the `from:` range is the floor, `Package.resolved` is the pin); links the system `libsqlite3` (vendoring a SQLite amalgamation is deferred — it arrives only with sqlite-vec, §7.6); macOS + Linux CI job exercises GRDB+FTS5 | Swift-6 concurrency-native, boring, full-featured | SQLite.swift / raw C | Low |
 | Vectors | deferred, behind protocol; **requires custom SQLite amalgamation + Linux re-validation** (§7.6) | `sqlite-vec` is alpha; stock migrator can't make a `vec0` table | FTS5/BM25 for v1 | High |
 | LLM provider | **OpenAI-compatible** contract + `LLMProvider` protocol; single-provider v1 | swap providers/models via config; pinned/allowlisted `base_url` | native Anthropic adapter later | Med |
 | Web search backend | Exa (`https://api.exa.ai/search`) behind `SearchProviding` [Inc 3b] | pinned trusted endpoint, documented trust dependency like `base_url` (Exa may use query input/output to provide/improve its services) | unconfigured `Secrets.searchApiKey` ⇒ tool absent, doctor reports info not error | Low |
@@ -514,7 +514,7 @@ A **state machine** persisted in `approvals` so it survives restart. See §7.1 c
 | Scheduling | `Calendar.RecurrenceRule` + custom ticker/store [Inc 4]; **raises the platform floor to macOS 15** | in-toolchain, DST-correct; Codable round-trip + DST suite pinned as toolchain-drift tripwires | SwifCron (vendored) | Low |
 | Concurrency | std-lib actors + stored `currentTurn` Task handle (await-to-order, cancel-to-supersede) | per-session lanes without an external queue lib | `dfed/swift-async-queue` (escape hatch only) | Low |
 | Config files | YAML for SKILL.md frontmatter via Yams | maintained YAML parser | — | Low |
-| Deployment | Static Linux SDK → distroless; launchd + systemd | one static binary, runs anywhere | swift-sdk-generator (glibc) | Low |
+| Deployment | native-container Linux `x86_64` binary (`swift:6.3-noble`, `--static-swift-stdlib`) + macOS-native `arm64` binary; GitHub Releases with SHA256 checksums + provenance attestations; launchd + systemd | Swift runtime bundled; only `libsqlite3` needed at runtime; publishes without a container registry | musl Static Linux SDK → distroless/scratch (blocked today: GRDB links system SQLite, musl SDK ships none) / swift-sdk-generator (glibc) | Low |
 
 ## 19. Cross-cutting concerns
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@
 6. **Secure-by-default, fail-closed.** Dangerous tools off; consequential actions approval-gated; numeric-ID default-deny; access checks and rate limiters deny/throttle on internal error rather than failing open.
 7. **Stop and ask, never go silent.** Every failure mode (provider outage, budget exhaustion, storage full, unsupported input) produces a plain-language user-facing message, never silence or a raw error/stack.
 8. **Boring & legible.** Small, well-bounded modules; a layered dependency DAG; a pure domain core; heavy use of Swift value types + actors.
-9. **Portable, pragmatically.** macOS-primary; Linux-clean is a soft guideline through the early increments and **one hard CI gate at Inc 6** (§20, §17). Portable protocol seams are kept throughout.
+9. **Portable, pragmatically.** macOS-primary; Linux-clean is a soft guideline through the early increments, hardened by a **macOS + Linux GRDB/FTS5 build+test CI gate live on every PR** (`ci.yml`, §17). Portable protocol seams are kept throughout.
 
 ## 2. System context
 
@@ -573,7 +573,7 @@ Re-cut for the approved v1 scope. **Inc 0–3 = the v1 daily-driver milestone**:
 | **3** | Memory & workspace + read-only tools | Workspace files injected at the **untrusted tier** (budgeted, caps, flush-before-compact); durable facts on confirm; `memory_items` + **FTS5 recall** across restarts; `/memory`; `web_search`/`web_fetch` + file READ at **`safe`** tier with the **exfil gate**. |
 | **4** | Scheduler & proactive | "Every weekday 07:00 Europe/Berlin…" fires once per occurrence across restarts/DST; **confirm-before-arm**; reduced-privilege runs; clock-gap catch-up cap; delivery via outbox; opt-in heartbeat with quiet hours. *(Scope reconciliation: the external research roadmap bundles memory/workspace into its "Increment 4" — this repo shipped those in Inc 3a; this increment is scheduler/proactive only.)* |
 | **5** | Write/shell tools + policy + approvals + sandbox | A consequential tool requires explicit approval (**callback auth + ≥128-bit nonce + FSM**); a **forged or third-party callback cannot approve**; untrusted code runs in a per-exec disposable VM (no host FS/network by default); the **enforced lethal-trifecta gate** forces approval on a tainted privileged action. |
-| **6** | Linux portability & deployment | Same source → running, supervised binary on a fresh Linux box (static SDK, distroless, systemd); **CI Linux build incl. GRDB+FTS5 passes** (the one hard portability gate). |
+| **6** | Linux portability & deployment | Same source → running, supervised binary on a fresh Linux box (systemd); the **macOS + Linux GRDB+FTS5 build+test CI gate already landed early** (`ci.yml`, §17), so the remainder here is the **musl Static Linux SDK → distroless packaging, which stays deferred/optional** (§17/§18 escape hatch). |
 
 *(Later/optional: image input to a vision model; native Anthropic adapter w/ prompt caching; Hummingbird `/v1/chat/completions` REST; MCP via official SDK + Linux SSE transport; voice transcription; multi-provider fallback; per-call USD dashboards.)*
 

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -30,6 +30,8 @@ The debug binary lands at `.build/debug/clawd`. For a release build:
 swift build -c release
 ```
 
+> The release binary links the **system** SQLite (GRDB uses `libsqlite3`, not a vendored copy). On Linux the target host needs `libsqlite3-0`; on macOS it's part of the OS. Released Linux binaries are built with `--static-swift-stdlib`, so the Swift runtime is bundled and only `libsqlite3` is an external dependency.
+
 ---
 
 ## Lint


### PR DESCRIPTION
Stacked on #33 (base `ci-build-test-gate`). Adds tagged releases with verifiable binaries for both platforms, plus the docs and spec updates that go with them.

## What's here
- **Version stamping**: a `ClawdVersion` constant wired into `clawd --version`, overwritten from the git tag at release time.
- **`release.yml`**: on a `vX.Y.Z` tag, builds a native-container Linux binary (`swift:6.3-noble`, `--static-swift-stdlib`) and a macOS arm64 binary, generates `SHA256SUMS`, attaches build-provenance attestations, and publishes a GitHub Release via `gh release create`. Per-job least-privilege permissions, no third-party actions.
- **Docs**: a root `README.md`, plus install/verify steps in `deploy/README.md` and `docs/LOCAL_DEV.md` (checksum, `gh attestation verify`, macOS quarantine, Linux libsqlite3).
- **Spec**: reconciled `ARCHITECTURE.md` §17/§18/§1.9/§20 to the native-container build path. The musl Static Linux SDK / distroless route is deferred because GRDB links the system SQLite the musl SDK doesn't ship; it stays documented as an escape hatch.

## Before the first real release
Dry-run a prerelease tag (`v0.0.1-rc1`) to exercise `release.yml` end to end (both binaries, `sha256sum -c`, `gh attestation verify`, `clawd --version`), then delete it.
