### PR TITLE
Durable tool-approval substrate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,7 @@ CLAW_HEARTBEAT_INTERVAL_MINUTES=
 CLAW_HEARTBEAT_QUIET_HOURS=
 # max heartbeats per day (>= 1; default 8)
 CLAW_HEARTBEAT_MAX_PER_DAY=
+
+# Approvals
+# seconds a pending tool approval stays live before auto-deny (60..86400; default 3600)
+CLAW_APPROVAL_EXPIRY=

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,12 @@ let package = Package(
     .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.11.0"),
   ],
   targets: [
-    .target(name: "ClawCore"),
+    .target(
+      name: "ClawCore",
+      dependencies: [
+        .product(name: "Crypto", package: "swift-crypto")
+      ]
+    ),
     .target(
       name: "ClawSecrets",
       dependencies: [

--- a/Sources/ClawAgent/Context/ContextBuilder.swift
+++ b/Sources/ClawAgent/Context/ContextBuilder.swift
@@ -395,10 +395,12 @@ private extension ContextBuilder {
   /// The uncapped raw file text for a system-tier prompt file; missing/unreadable folds in as ""
   /// (spec §3.2). Uncapped because these files load uncapped in `buildFixedSections`.
   func rawPromptText(_ file: WorkspaceFile) -> String {
-    let loaded = workspace.load(file: file, maxGraphemes: nil)
-    switch loaded.outcome {
-    case .present: return loaded.text
-    case .overCap, .missing, .unreadable: return ""
+    let loadedFile = workspace.load(file: file, maxGraphemes: nil)
+    switch loadedFile.outcome {
+    case .present:
+      return loadedFile.text
+    case .overCap, .missing, .unreadable:
+      return ""
     }
   }
 }

--- a/Sources/ClawAgent/Context/ContextBuilder.swift
+++ b/Sources/ClawAgent/Context/ContextBuilder.swift
@@ -25,6 +25,8 @@ public struct ContextBuilder: Sendable {
   private let recallCutoff: any RecallCutoff
   private let budget: ContextBudget
 
+  private let policyStaticSubhash: String
+
   private let now: @Sendable () -> Date
   private let warn: @Sendable (String) -> Void
 
@@ -35,6 +37,7 @@ public struct ContextBuilder: Sendable {
     retriever: any Retriever,
     recallCutoff: any RecallCutoff = CandidateCapRecallCutoff(),
     budget: ContextBudget,
+    policyStaticSubhash: String = "",
     now: @escaping @Sendable () -> Date = Date.init,
     warn: @escaping @Sendable (String) -> Void = { _ in }
   ) {
@@ -44,6 +47,7 @@ public struct ContextBuilder: Sendable {
     self.retriever = retriever
     self.recallCutoff = recallCutoff
     self.budget = budget
+    self.policyStaticSubhash = policyStaticSubhash
     self.now = now
     self.warn = warn
   }
@@ -71,7 +75,8 @@ public struct ContextBuilder: Sendable {
     return BuildResult(
       messages: messages,
       ownerNotices: ownerNotices,
-      hasPrivateDataAccess: hasPrivateDataAccess(fitted)
+      hasPrivateDataAccess: hasPrivateDataAccess(fitted),
+      policyVersion: currentPolicyVersion()
     )
   }
 }
@@ -362,6 +367,39 @@ private extension ContextBuilder {
     formatter.formatOptions = [.withInternetDateTime]
     formatter.timeZone = TimeZone(secondsFromGMT: 0)
     return formatter.string(from: date)
+  }
+}
+
+// MARK: - Policy Fingerprint
+
+public extension ContextBuilder {
+  /// The class-1 prompt materials in the §3.2 pinned order, RAW (pre "## path" wrapping), folded
+  /// into the injected static sub-hash. Reused verbatim at pick-up (the persisted `policy_version`,
+  /// stamped by `TurnRunner`) and at callback resolution (Phase 3 recompute) so the two can never
+  /// diverge. `public` because `TurnRunner` (ClawGateway) stamps with it cross-module and `assemble`
+  /// returns it — a `private` helper would be invisible to both the stamp seam and `@testable`.
+  func currentPolicyVersion() -> String {
+    PolicyFingerprint.combined(
+      staticSubhash: policyStaticSubhash,
+      promptMaterials: [
+        systemPrompt,
+        rawPromptText(.soul),
+        rawPromptText(.agents),
+        rawPromptText(.tools),
+      ]
+    )
+  }
+}
+
+private extension ContextBuilder {
+  /// The uncapped raw file text for a system-tier prompt file; missing/unreadable folds in as ""
+  /// (spec §3.2). Uncapped because these files load uncapped in `buildFixedSections`.
+  func rawPromptText(_ file: WorkspaceFile) -> String {
+    let loaded = workspace.load(file: file, maxGraphemes: nil)
+    switch loaded.outcome {
+    case .present: return loaded.text
+    case .overCap, .missing, .unreadable: return ""
+    }
   }
 }
 

--- a/Sources/ClawCore/Config/AppConfig.swift
+++ b/Sources/ClawCore/Config/AppConfig.swift
@@ -29,6 +29,7 @@ public struct AppConfig: Sendable, Equatable {
     static let heartbeatIntervalMinutes = "CLAW_HEARTBEAT_INTERVAL_MINUTES"
     static let heartbeatQuietHours = "CLAW_HEARTBEAT_QUIET_HOURS"
     static let heartbeatMaxPerDay = "CLAW_HEARTBEAT_MAX_PER_DAY"
+    static let approvalExpiry = "CLAW_APPROVAL_EXPIRY"
   }
 
   private enum EnvDefaults {
@@ -46,6 +47,10 @@ public struct AppConfig: Sendable, Equatable {
     static let heartbeatIntervalMinutes = 60
     static let heartbeatQuietHours = "22:00-09:00"
     static let heartbeatMaxPerDay = 8
+
+    static let approvalExpirySeconds = 3600
+    static let approvalExpiryFloor = 60
+    static let approvalExpiryCeiling = 86_400
   }
 
   private static let stateRootPermissions = 0o700
@@ -66,6 +71,8 @@ public struct AppConfig: Sendable, Equatable {
   public let heartbeatQuietHours: QuietHours
   public let heartbeatMaxPerDay: Int
 
+  public let approvalExpirySeconds: Int
+
   public init(
     allowlist: Set<Int64>,
     stateRoot: URL,
@@ -79,7 +86,8 @@ public struct AppConfig: Sendable, Equatable {
     heartbeatEnabled: Bool,
     heartbeatIntervalMinutes: Int,
     heartbeatQuietHours: QuietHours,
-    heartbeatMaxPerDay: Int
+    heartbeatMaxPerDay: Int,
+    approvalExpirySeconds: Int
   ) {
     self.allowlist = allowlist
     self.stateRoot = stateRoot
@@ -94,6 +102,7 @@ public struct AppConfig: Sendable, Equatable {
     self.heartbeatIntervalMinutes = heartbeatIntervalMinutes
     self.heartbeatQuietHours = heartbeatQuietHours
     self.heartbeatMaxPerDay = heartbeatMaxPerDay
+    self.approvalExpirySeconds = approvalExpirySeconds
   }
 
   /// Loads and validates non-secret config from the environment. Secrets (the bot token / LLM key)
@@ -149,6 +158,8 @@ public struct AppConfig: Sendable, Equatable {
       minimum: 1
     )
 
+    let approvalExpirySeconds = try parseApprovalExpiry(env[EnvKey.approvalExpiry])
+
     return AppConfig(
       allowlist: allowlist,
       stateRoot: stateRoot,
@@ -162,7 +173,8 @@ public struct AppConfig: Sendable, Equatable {
       heartbeatEnabled: heartbeatEnabled,
       heartbeatIntervalMinutes: heartbeatIntervalMinutes,
       heartbeatQuietHours: heartbeatQuietHours,
-      heartbeatMaxPerDay: heartbeatMaxPerDay
+      heartbeatMaxPerDay: heartbeatMaxPerDay,
+      approvalExpirySeconds: approvalExpirySeconds
     )
   }
 }
@@ -430,5 +442,30 @@ private extension AppConfig {
     }
 
     return stateRootURL
+  }
+}
+
+// MARK: - Approval Parsing
+
+private extension AppConfig {
+  /// Seconds a pending tool approval stays live before auto-deny (spec §4.6). Absent/blank falls
+  /// back to the default; a present value must be an integer within `[floor, ceiling]`, else it
+  /// fails closed with the dedicated `invalidApprovalExpiry` case — the scheduling vocabulary
+  /// deliberately is NOT reused (§4.6: "a new `ConfigError` case").
+  static func parseApprovalExpiry(_ raw: String?) throws -> Int {
+    let trimmed = raw?.trimmingCharacters(in: .whitespaces) ?? ""
+    guard !trimmed.isEmpty else {
+      return EnvDefaults.approvalExpirySeconds
+    }
+
+    guard
+      let value = Int(trimmed),
+      value >= EnvDefaults.approvalExpiryFloor,
+      value <= EnvDefaults.approvalExpiryCeiling
+    else {
+      throw ConfigError.invalidApprovalExpiry(trimmed)
+    }
+
+    return value
   }
 }

--- a/Sources/ClawCore/Config/Errors.swift
+++ b/Sources/ClawCore/Config/Errors.swift
@@ -19,6 +19,7 @@ public enum ConfigError: Error, Sendable, Equatable {
   case invalidTimezone(String)
   case invalidQuietHours(String)
   case invalidScheduling(key: String, value: String)
+  case invalidApprovalExpiry(String)
   case heartbeatOwnerUnresolved(allowlistCount: Int)
 
   public var exitCode: Int32 {
@@ -34,6 +35,7 @@ public enum ConfigError: Error, Sendable, Equatable {
     case .invalidTimezone: ClawExitCode.configInvalid.rawValue
     case .invalidQuietHours: ClawExitCode.configInvalid.rawValue
     case .invalidScheduling: ClawExitCode.configInvalid.rawValue
+    case .invalidApprovalExpiry: ClawExitCode.configInvalid.rawValue
     case .heartbeatOwnerUnresolved: ClawExitCode.configInvalid.rawValue
     }
   }

--- a/Sources/ClawCore/Domain/Approval/Approval.swift
+++ b/Sources/ClawCore/Domain/Approval/Approval.swift
@@ -130,11 +130,13 @@ public enum ApprovalNonce {
   public static func generate() -> String {
     var generator = SystemRandomNumberGenerator()
     var bytes = Data(capacity: 16)
+
     for _ in 0..<2 {
       withUnsafeBytes(of: generator.next()) { word in
         bytes.append(contentsOf: word)
       }
     }
+
     return bytes.base64EncodedString()
       .replacingOccurrences(of: "+", with: "-")
       .replacingOccurrences(of: "/", with: "_")
@@ -147,7 +149,9 @@ public enum ApprovalNonce {
 public enum ApprovalArgsHash {
   public static func sha256Hex(_ canonicalArgsJSON: String) -> String {
     SHA256.hash(data: Data(canonicalArgsJSON.utf8))
-      .map { byte in String(format: "%02x", byte) }
+      .map { byte in
+        String(format: "%02x", byte)
+      }
       .joined()
   }
 }

--- a/Sources/ClawCore/Domain/Approval/Approval.swift
+++ b/Sources/ClawCore/Domain/Approval/Approval.swift
@@ -1,0 +1,170 @@
+import Crypto
+import Foundation
+
+/// Why a non-approve resolution happened — the audit `decision` column vocabulary (spec §3.1).
+/// Typed so no call site writes a magic decision string (preamble deviation D9); the persisted
+/// column stays free-text and carries these rawValues.
+public enum ApprovalDecision: String, Sendable, Equatable {
+  case rejected
+  case expired
+  case cancelled
+  case superseded
+  case stalePolicy = "stale_policy"
+}
+
+/// One `approvals` row (spec §4.1).
+public struct Approval: Sendable, Equatable {
+  public let id: Int64
+  public let runId: Int64
+  public let sessionId: Int64
+  public let state: ApprovalState
+  public let tool: String
+  public let canonicalArgsJSON: String
+  public let canonicalTarget: String
+  public let argsHash: String  // SHA-256 hex of canonicalArgsJSON
+  public let policyVersion: String
+  public let ownerUserId: Int64  // the run's delivery chat id (§4.4)
+  public let nonce: String
+  public let observationMessageId: Int64
+  public let toolCallId: String
+  public let reason: ApprovalReason
+  public let promptMessageId: Int64?
+  public let createdTs: Date
+  public let expiresTs: Date
+  public let resolvedTs: Date?
+
+  public init(
+    id: Int64,
+    runId: Int64,
+    sessionId: Int64,
+    state: ApprovalState,
+    tool: String,
+    canonicalArgsJSON: String,
+    canonicalTarget: String,
+    argsHash: String,
+    policyVersion: String,
+    ownerUserId: Int64,
+    nonce: String,
+    observationMessageId: Int64,
+    toolCallId: String,
+    reason: ApprovalReason,
+    promptMessageId: Int64?,
+    createdTs: Date,
+    expiresTs: Date,
+    resolvedTs: Date?
+  ) {
+    self.id = id
+    self.runId = runId
+    self.sessionId = sessionId
+    self.state = state
+    self.tool = tool
+    self.canonicalArgsJSON = canonicalArgsJSON
+    self.canonicalTarget = canonicalTarget
+    self.argsHash = argsHash
+    self.policyVersion = policyVersion
+    self.ownerUserId = ownerUserId
+    self.nonce = nonce
+    self.observationMessageId = observationMessageId
+    self.toolCallId = toolCallId
+    self.reason = reason
+    self.promptMessageId = promptMessageId
+    self.createdTs = createdTs
+    self.expiresTs = expiresTs
+    self.resolvedTs = resolvedTs
+  }
+}
+
+/// The insert payload — id/state/prompt/resolved are store-owned (state always starts PENDING).
+public struct NewApproval: Sendable, Equatable {
+  public let runId: Int64
+  public let sessionId: Int64
+  public let tool: String
+  public let canonicalArgsJSON: String
+  public let canonicalTarget: String
+  public let argsHash: String
+  public let policyVersion: String
+  public let ownerUserId: Int64
+  public let nonce: String
+  public let observationMessageId: Int64
+  public let toolCallId: String
+  public let reason: ApprovalReason
+  public let createdTs: Date
+  public let expiresTs: Date  // createdTs + approval_expiry
+
+  public init(
+    runId: Int64,
+    sessionId: Int64,
+    tool: String,
+    canonicalArgsJSON: String,
+    canonicalTarget: String,
+    argsHash: String,
+    policyVersion: String,
+    ownerUserId: Int64,
+    nonce: String,
+    observationMessageId: Int64,
+    toolCallId: String,
+    reason: ApprovalReason,
+    createdTs: Date,
+    expiresTs: Date
+  ) {
+    self.runId = runId
+    self.sessionId = sessionId
+    self.tool = tool
+    self.canonicalArgsJSON = canonicalArgsJSON
+    self.canonicalTarget = canonicalTarget
+    self.argsHash = argsHash
+    self.policyVersion = policyVersion
+    self.ownerUserId = ownerUserId
+    self.nonce = nonce
+    self.observationMessageId = observationMessageId
+    self.toolCallId = toolCallId
+    self.reason = reason
+    self.createdTs = createdTs
+    self.expiresTs = expiresTs
+  }
+}
+
+/// 16 CSPRNG bytes, base64url without padding (22 chars). `SystemRandomNumberGenerator` is
+/// CSPRNG-backed on Apple platforms and Linux, so no extra entropy dependency is needed.
+public enum ApprovalNonce {
+  public static func generate() -> String {
+    var generator = SystemRandomNumberGenerator()
+    var bytes = Data(capacity: 16)
+    for _ in 0..<2 {
+      withUnsafeBytes(of: generator.next()) { word in
+        bytes.append(contentsOf: word)
+      }
+    }
+    return bytes.base64EncodedString()
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "=", with: "")
+  }
+}
+
+/// The single canonical args digest: computed when an action is recorded and recomputed inside
+/// the approve CAS (spec §6.2 step 5). One helper so the two computations can never diverge.
+public enum ApprovalArgsHash {
+  public static func sha256Hex(_ canonicalArgsJSON: String) -> String {
+    SHA256.hash(data: Data(canonicalArgsJSON.utf8))
+      .map { byte in String(format: "%02x", byte) }
+      .joined()
+  }
+}
+
+/// §6.3 budget carry-over, derived from persisted rows (preamble deviation D4): rounds and tool
+/// calls counted from the run's messages, tokens/USD summed over provider_usage. Defined here so
+/// the `RunStore` seam can name it; produced by Phase 3's `resumeUsage`.
+public struct ResumeUsage: Sendable, Equatable {
+  public let rounds: Int
+  public let toolCalls: Int
+  public let tokens: Int
+  public let costUSD: Double
+
+  public init(rounds: Int, toolCalls: Int, tokens: Int, costUSD: Double) {
+    self.rounds = rounds
+    self.toolCalls = toolCalls
+    self.tokens = tokens
+    self.costUSD = costUSD
+  }
+}

--- a/Sources/ClawCore/Domain/Approval/ApprovalFSM.swift
+++ b/Sources/ClawCore/Domain/Approval/ApprovalFSM.swift
@@ -1,0 +1,30 @@
+/// The four durable approval states (ARCHITECTURE §7.1) — never a fifth: a `/stop`//`new`
+/// resolution lands in REJECTED and the audit `decision` records why (spec §4.2, preamble).
+public enum ApprovalState: String, Sendable, Equatable {
+  case pending = "PENDING"
+  case approved = "APPROVED"
+  case rejected = "REJECTED"
+  case expired = "EXPIRED"
+}
+
+public enum ApprovalEvent: Sendable, Equatable {
+  /// A valid callback: auth + nonce + args-hash + policy_version all OK (§19.1 approve guard).
+  case approve
+  /// Owner deny, stale-policy deny, or run cancel/supersede — the audit decision says why.
+  case reject
+  /// The expiry ticker or boot sweep aged the row out.
+  case expire
+}
+
+/// ARCHITECTURE §19.1's ApprovalState table. Exhaustive switch, no default arm; nil = illegal
+/// (a resolved row never moves again — that is the single-use guarantee's substrate).
+public enum ApprovalFSM {
+  public static func reduce(state: ApprovalState, on event: ApprovalEvent) -> ApprovalState? {
+    switch (state, event) {
+    case (.pending, .approve): .approved
+    case (.pending, .reject): .rejected
+    case (.pending, .expire): .expired
+    case (.approved, _), (.rejected, _), (.expired, _): nil
+    }
+  }
+}

--- a/Sources/ClawCore/Domain/Context/ContextContracts.swift
+++ b/Sources/ClawCore/Domain/Context/ContextContracts.swift
@@ -118,11 +118,20 @@ public struct BuildResult: Sendable, Equatable {
   public let messages: [ChatMessage]
   public let ownerNotices: [String]
   public let hasPrivateDataAccess: Bool
+  /// The per-run prompt/workspace fingerprint (spec §3.2); "" only for test doubles that do not
+  /// exercise the approval fabric — `ContextBuilder.assemble` always sets the real value.
+  public let policyVersion: String
 
-  public init(messages: [ChatMessage], ownerNotices: [String], hasPrivateDataAccess: Bool) {
+  public init(
+    messages: [ChatMessage],
+    ownerNotices: [String],
+    hasPrivateDataAccess: Bool,
+    policyVersion: String = ""
+  ) {
     self.messages = messages
     self.ownerNotices = ownerNotices
     self.hasPrivateDataAccess = hasPrivateDataAccess
+    self.policyVersion = policyVersion
   }
 }
 

--- a/Sources/ClawCore/Domain/Policy/PolicyFingerprint.swift
+++ b/Sources/ClawCore/Domain/Policy/PolicyFingerprint.swift
@@ -1,0 +1,75 @@
+import Crypto
+import Foundation
+
+/// The per-run prompt/workspace fingerprint approvals bind to (spec §3.2). `policy_version` =
+/// `combined(...)` = first 16 hex of SHA-256 over an order-pinned, length-prefixed concatenation of
+/// the policy-relevant inputs at run start. Each part is length-prefixed so boundaries cannot be
+/// confused ("ab"+"c" ≠ "a"+"bc"). Secret values are NEVER hashed — only surface/config identity.
+/// A strict-inequality voider: any change to prompt files, tool surface, or egress config between
+/// an approval's request and its resolution voids the approval with `stale_policy`.
+public enum PolicyFingerprint {
+  /// SHA-256 over length-prefixed parts (each part: 8-byte big-endian UInt64 UTF-8 byte count, then
+  /// the UTF-8 bytes), rendered as the full 64-char lowercase hex digest.
+  public static func hash(parts: [String]) -> String {
+    var hasher = SHA256()
+    for part in parts {
+      let bytes = Array(part.utf8)
+      withUnsafeBytes(of: UInt64(bytes.count).bigEndian) { lengthBytes in
+        hasher.update(data: Data(lengthBytes))
+      }
+      hasher.update(data: Data(bytes))
+    }
+    return hasher.finalize().map { byte in String(format: "%02x", byte) }.joined()
+  }
+
+  /// Input classes 2–3 (§3.2): the tool-registry surface (sorted by name — each tool contributes
+  /// name, canonical `.sortedKeys` parameter JSON, `riskLevel.rawValue`, and the egress label),
+  /// then the llm base URL, the search-endpoint presence, and the canonical workspace root. Computed
+  /// once at the composition root and injected into `ContextBuilder`.
+  public static func staticSubhash(
+    tools: [ToolDefinition],
+    llmBaseURL: String,
+    searchEndpointPresent: Bool,
+    workspaceRoot: String
+  ) -> String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+
+    var parts: [String] = []
+    for tool in tools.sorted(by: { lhs, rhs in lhs.name < rhs.name }) {
+      let canonicalParameters =
+        (try? encoder.encode(tool.parameters))
+        .map { data in String(decoding: data, as: UTF8.self) } ?? ""
+      parts.append(tool.name)
+      parts.append(canonicalParameters)
+      parts.append(tool.riskLevel.rawValue)
+      parts.append(egressLabel(tool.egressClass))
+    }
+    parts.append(llmBaseURL)
+    parts.append(searchEndpointPresent ? "search:present" : "search:absent")
+    parts.append(workspaceRoot)
+
+    return hash(parts: parts)
+  }
+
+  /// The combined fingerprint stored as `policy_version`: first 16 hex of the digest over the
+  /// static sub-hash followed by the class-1 prompt materials in the pinned order
+  /// [systemPrompt, soulText, agentsText, toolsText]. A missing/unreadable file folds in as "".
+  public static func combined(staticSubhash: String, promptMaterials: [String]) -> String {
+    String(hash(parts: [staticSubhash] + promptMaterials).prefix(16))
+  }
+}
+
+// MARK: - Egress Label
+
+private extension PolicyFingerprint {
+  /// `ToolEgressClass` is not `String`-backed, so a stable label pins its contribution to the hash
+  /// (a rename here voids every outstanding approval, which is the intended strictness).
+  static func egressLabel(_ egressClass: ToolEgressClass) -> String {
+    switch egressClass {
+    case .none: "none"
+    case .fixedEndpoint: "fixed_endpoint"
+    case .arbitraryDestination: "arbitrary_destination"
+    }
+  }
+}

--- a/Sources/ClawCore/Domain/Policy/PolicyFingerprint.swift
+++ b/Sources/ClawCore/Domain/Policy/PolicyFingerprint.swift
@@ -37,6 +37,7 @@ public enum PolicyFingerprint {
 
     var parts: [String] = []
     for tool in tools.sorted(by: { lhs, rhs in lhs.name < rhs.name }) {
+      // JSONValue encoding cannot realistically fail for the finite case set; tool name still distinguishes entries.
       let canonicalParameters =
         (try? encoder.encode(tool.parameters))
         .map { data in String(decoding: data, as: UTF8.self) } ?? ""

--- a/Sources/ClawCore/Domain/Policy/PolicyFingerprint.swift
+++ b/Sources/ClawCore/Domain/Policy/PolicyFingerprint.swift
@@ -12,6 +12,7 @@ public enum PolicyFingerprint {
   /// the UTF-8 bytes), rendered as the full 64-char lowercase hex digest.
   public static func hash(parts: [String]) -> String {
     var hasher = SHA256()
+
     for part in parts {
       let bytes = Array(part.utf8)
       withUnsafeBytes(of: UInt64(bytes.count).bigEndian) { lengthBytes in
@@ -19,7 +20,10 @@ public enum PolicyFingerprint {
       }
       hasher.update(data: Data(bytes))
     }
-    return hasher.finalize().map { byte in String(format: "%02x", byte) }.joined()
+
+    return hasher.finalize().map { byte in
+      String(format: "%02x", byte)
+    }.joined()
   }
 
   /// Input classes 2–3 (§3.2): the tool-registry surface (sorted by name — each tool contributes

--- a/Sources/ClawCore/Domain/Run/RunFSM.swift
+++ b/Sources/ClawCore/Domain/Run/RunFSM.swift
@@ -11,36 +11,48 @@ public enum RunEvent: Sendable, Equatable {
   case cancel
   /// `/new` terminates the running turn and any queued turns from the old conversation window.
   case supersede
+  /// The gate demanded an approval mid-turn (§5.3 suspend commit).
+  case suspendForApproval
+  /// A valid owner approval resolved the row; the waiter resumes the turn (§6.3).
+  case resumeApproved
+  /// Reject/expiry resolved the row against the run (§6.4).
+  case resolveDenied
 }
 
 /// The run lifecycle reducer: the single source of truth for legal state changes.
 public enum RunFSM {
+  // The exhaustive no-default state×event switch is deliberate — a `default` arm would defeat the
+  // compiler-enforced exhaustiveness — so `reduce`'s branch count (and thus its cyclomatic
+  // complexity) is intrinsic to the design rather than incidental. The block form keeps the doc
+  // comment attached to the declaration (a `disable:next` line between them would orphan it).
+  // swiftlint:disable cyclomatic_complexity
   /// Returns the next state for a legal transition, or `nil` when the store must perform no write.
   ///
   /// Every state/event pair is explicit so adding a future state or event produces a compiler
   /// reminder to revisit the lifecycle rules.
   public static func reduce(state: RunState, on event: RunEvent) -> RunState? {
     switch (state, event) {
-    case (.pending, .pickUp):
-      .running
-    case (.pending, .fail):
-      .failed
-    case (.pending, .cancel):
-      .cancelled
-    case (.pending, .supersede):
-      .superseded
-    case (.running, .complete):
-      .done
-    case (.running, .fail):
-      .failed
-    case (.running, .cancel):
-      .cancelled
-    case (.running, .supersede):
-      .superseded
-    case (.pending, .complete), (.running, .pickUp):
+    case (.pending, .pickUp): .running
+    case (.pending, .fail): .failed
+    case (.pending, .cancel): .cancelled
+    case (.pending, .supersede): .superseded
+    case (.running, .complete): .done
+    case (.running, .fail): .failed
+    case (.running, .cancel): .cancelled
+    case (.running, .supersede): .superseded
+    case (.running, .suspendForApproval): .awaitingApproval
+    case (.awaitingApproval, .resumeApproved): .running
+    case (.awaitingApproval, .resolveDenied): .failed
+    case (.awaitingApproval, .fail): .failed
+    case (.awaitingApproval, .cancel): .cancelled
+    case (.awaitingApproval, .supersede): .superseded
+    case (.pending, .complete), (.pending, .suspendForApproval), (.pending, .resumeApproved),
+      (.pending, .resolveDenied), (.running, .pickUp), (.running, .resumeApproved),
+      (.running, .resolveDenied), (.awaitingApproval, .pickUp), (.awaitingApproval, .complete),
+      (.awaitingApproval, .suspendForApproval):
       nil
-    case (.done, _), (.failed, _), (.cancelled, _), (.superseded, _):
-      nil
+    case (.done, _), (.failed, _), (.cancelled, _), (.superseded, _): nil
     }
   }
+  // swiftlint:enable cyclomatic_complexity
 }

--- a/Sources/ClawCore/Domain/Tools/ToolApproval.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolApproval.swift
@@ -20,6 +20,7 @@ public struct ToolAction: Sendable, Equatable {
 /// never reuses one, because the prompt copy is keyed on the reason alone.
 public enum ApprovalReason: String, Sendable, Equatable {
   case exfilTrifecta = "exfil_trifecta"
+  case askTier = "ask_tier"
 }
 
 /// A gate trip awaiting the owner's ephemeral text approval (§9.2). Carries the action identity

--- a/Sources/ClawCore/Domain/Tools/ToolContracts.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolContracts.swift
@@ -143,6 +143,16 @@ public enum CanonicalTargetResolution: Sendable, Equatable {
   case refused(reason: String)
 }
 
+/// The declared risk tier the gate enforces (ARCHITECTURE §10.2): `safe` executes untapped,
+/// `ask` requires a per-action durable approval (Inc 5a), `dangerous` is refused unless
+/// explicitly config-enabled (vacuous until Inc 5b). No default anywhere — a new tool cannot
+/// compile without classifying itself, mirroring `ToolEgressClass`.
+public enum RiskLevel: String, Sendable, Equatable {
+  case safe
+  case ask
+  case dangerous
+}
+
 /// What the registry advertises to the provider (wire `tools` entry).
 public struct ToolDefinition: Sendable, Equatable {
   public let name: String
@@ -150,17 +160,21 @@ public struct ToolDefinition: Sendable, Equatable {
   public let parameters: JSONValue  // JSON-Schema object
   /// The declared policy class the gate enforces. NOT advertised on the wire.
   public let egressClass: ToolEgressClass
+  /// The declared risk tier (orthogonal to egress). NOT advertised on the wire.
+  public let riskLevel: RiskLevel
 
   public init(
     name: String,
     description: String,
     parameters: JSONValue,
-    egressClass: ToolEgressClass
+    egressClass: ToolEgressClass,
+    riskLevel: RiskLevel
   ) {
     self.name = name
     self.description = description
     self.parameters = parameters
     self.egressClass = egressClass
+    self.riskLevel = riskLevel
   }
 }
 

--- a/Sources/ClawCore/Persistence/Persistence.swift
+++ b/Sources/ClawCore/Persistence/Persistence.swift
@@ -347,6 +347,9 @@ public enum AuditAction: String, Sendable, Equatable {
   case heartbeatFired = "heartbeat_fired"
   case heartbeatSuppressed = "heartbeat_suppressed"
   case heartbeatSkipped = "heartbeat_skipped"
+  case approvalRequested = "approval_requested"
+  case approvalGranted = "approval_granted"
+  case approvalDenied = "approval_denied"
 }
 
 public struct AuditEvent: Sendable, Equatable {

--- a/Sources/ClawCore/Persistence/Persistence.swift
+++ b/Sources/ClawCore/Persistence/Persistence.swift
@@ -411,6 +411,19 @@ public struct RunsHealth: Sendable, Equatable {
   }
 }
 
+/// Doctor snapshot of the approvals table (spec §4.6): how many owner decisions are outstanding
+/// and how long the oldest one has waited. `oldestPendingAgeSeconds` is nil when nothing is
+/// pending. The ClawGateway renderer (Task 07) compares the age against `approval_expiry`.
+public struct ApprovalsHealth: Sendable, Equatable {
+  public let pendingCount: Int
+  public let oldestPendingAgeSeconds: Int?
+
+  public init(pendingCount: Int, oldestPendingAgeSeconds: Int?) {
+    self.pendingCount = pendingCount
+    self.oldestPendingAgeSeconds = oldestPendingAgeSeconds
+  }
+}
+
 public struct DegradationReply: Sendable, Equatable {
   public let chatId: Int64
   public let runId: Int64

--- a/Sources/ClawCore/Persistence/Persistence.swift
+++ b/Sources/ClawCore/Persistence/Persistence.swift
@@ -13,6 +13,9 @@ public enum RunState: String, Sendable, Equatable {
   case cancelled = "CANCELLED"
   /// Terminal cancellation requested by `/new`; queued turns are superseded too.
   case superseded = "SUPERSEDED"
+  /// Suspended to a durable checkpoint: an `approvals` row is the one source of truth for
+  /// "blocked on approval" (ARCHITECTURE §7.1); resolved by callback, ticker, boot, or command.
+  case awaitingApproval = "AWAITING_APPROVAL"
 }
 
 /// The two command-owned reasons for terminating a live run.

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -168,6 +168,40 @@ public protocol RunStore: Sendable {
   func runsHealth(now: Date) throws -> RunsHealth
 }
 
+/// The four outcomes of the §6.2 step-5 approve CAS. Only `.approved`/`.stalePolicy` mutate the
+/// row (each with its own same-txn audit); `.notPending`/`.expiredRow` leave it untouched for the
+/// caller to route (duplicate-tap toast, or the deny path for an aged-out row).
+public enum ApprovalApproveOutcome: Sendable, Equatable {
+  case approved(Approval)
+  case stalePolicy(Approval)
+  case notPending
+  case expiredRow
+}
+
+public protocol ApprovalStore: Sendable {
+  /// Lookup by nonce ONLY (the callback's single-use credential), never by id.
+  func approval(nonce: String) throws -> Approval?
+  func approval(id: Int64) throws -> Approval?
+  /// §6.2 step 5, one transaction: still PENDING, unexpired, stored argsHash ==
+  /// `ApprovalArgsHash.sha256Hex(canonicalArgsJSON)`, and storedPolicyVersion ==
+  /// `currentPolicyVersion`. All satisfied → APPROVED + `approvalGranted`. Hash/version mismatch
+  /// → REJECTED + decision `stale_policy` + `approvalDenied`, returns `.stalePolicy`.
+  func approve(id: Int64, currentPolicyVersion: String, now: Date) throws -> ApprovalApproveOutcome
+  /// CAS PENDING→(EXPIRED when decision is `.expired`, else REJECTED) + `approvalDenied` audit in
+  /// the same txn. false when the row is no longer PENDING (a racing resolver won).
+  func deny(id: Int64, decision: ApprovalDecision, now: Date) throws -> Bool
+  /// Ticker/boot sweep: CAS every PENDING row with `expires_ts <= now` → EXPIRED (+ `approvalDenied`
+  /// audit, decision `expired`) and return the swept rows for the waiter signals.
+  func sweepExpired(now: Date) throws -> [Approval]
+  /// Boot: PENDING rows (any expiry) and APPROVED rows whose run is AWAITING_APPROVAL (§6.5).
+  func unresolvedAtBoot() throws -> [Approval]
+  /// Boot hygiene: a terminal run holding a PENDING approval → REJECTED + `approvalDenied`
+  /// (decision `cancelled`). Returns the count cleaned.
+  func resolveOrphans(now: Date) throws -> Int
+  /// Doctor: outstanding PENDING count + the oldest pending row's age.
+  func approvalsHealth(now: Date) throws -> ApprovalsHealth
+}
+
 public protocol UsageStore: Sendable {
   func recordUsage(_ usage: ProviderUsage) throws
   /// Running totals over `provider_usage` for the calendar-day-UTC window containing `now` (D4).

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -188,7 +188,8 @@ public protocol OutboxStore: Sendable {
     payload: String,
     payloadHash: String
   ) throws -> Bool
-  /// Claims a degradation reply only while the owning run is still RUNNING.
+  /// Claims a reply only while the owning run is still active (RUNNING or AWAITING_APPROVAL —
+  /// a suspended run's own approval prompt must be deliverable, preamble D7).
   func claimOutboundIfRunActive(
     runId: Int64,
     stepIndex: Int,

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -139,8 +139,9 @@ public protocol SessionMessageStore: Sendable {
 public protocol RunStore: Sendable {
   /// PENDING → RUNNING through `RunFSM`, returning the run's origin in the same write; nil means
   /// the run is absent or no longer pending — the guard semantics are unchanged (spec §10,
-  /// preamble deviation 3: one query, no separate origin read).
-  func pickUp(runId: Int64, now: Date) throws -> RunOrigin?
+  /// preamble deviation 3: one query, no separate origin read). `policyVersion` (spec §3.2) is
+  /// stamped onto `runs.policy_version` in the SAME UPDATE as the flip; nil records no fingerprint.
+  func pickUp(runId: Int64, policyVersion: String?, now: Date) throws -> RunOrigin?
   /// F6 atomicity: assistant message + run→DONE + provider_usage + outbox chunk(s) in ONE txn,
   /// committed before any send. If cancellation/supersede already won, records usage only.
   func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws -> RunCommitResult
@@ -166,6 +167,14 @@ public protocol RunStore: Sendable {
   /// Snapshot of run-table health: in-flight count, age of oldest running run, last
   /// success/failure timestamps, and count of consecutive failures at the head of the table.
   func runsHealth(now: Date) throws -> RunsHealth
+}
+
+public extension RunStore {
+  /// The no-stamp pick-up (the resume path, which never re-stamps, and every non-interactive
+  /// caller): PENDING → RUNNING without touching `runs.policy_version`.
+  func pickUp(runId: Int64, now: Date) throws -> RunOrigin? {
+    try pickUp(runId: runId, policyVersion: nil, now: now)
+  }
 }
 
 /// The four outcomes of the §6.2 step-5 approve CAS. Only `.approved`/`.stalePolicy` mutate the

--- a/Sources/ClawData/Database/ClawDatabase.swift
+++ b/Sources/ClawData/Database/ClawDatabase.swift
@@ -62,7 +62,7 @@ public enum ClawDatabase {
           .references("sessions", onDelete: .cascade)
         table.column("state", .text).notNull()
         table.column("created_ts", .datetime).notNull()
-        table.column("updated_ts", .datetime).notNull()  // lease for the boot sweep
+        table.column("updated_ts", .datetime).notNull()
         table.column("input_tokens", .integer)
         table.column("output_tokens", .integer)
         table.column("cost_usd", .double)
@@ -96,9 +96,7 @@ public enum ClawDatabase {
         table.column("run_id", .integer).notNull().references("runs", onDelete: .cascade)
         table.column("step_index", .integer).notNull()
         table.column("chat_id", .integer).notNull()
-        // Deterministic dedup key = "run_id:step_index" (NOT a UUID/wall-clock).
         table.column("dedup_key", .text).notNull().unique()
-        // the markdown to (re-)send
         table.column("payload", .text).notNull()
         table.column("payload_hash", .text).notNull()
         table.column("telegram_message_id", .integer)
@@ -111,7 +109,7 @@ public enum ClawDatabase {
         table.column("ts", .datetime).notNull()
         table.column("actor", .text).notNull()
         table.column("action", .text).notNull()
-        table.column("tool", .text)  // nullable now → no Inc-3 migration (F9)
+        table.column("tool", .text)
         table.column("args_redacted", .text).notNull()
         table.column("result_size", .integer).notNull()
         table.column("decision", .text).notNull()
@@ -145,9 +143,6 @@ public enum ClawDatabase {
         columns: ["created_at"]
       )
       try db.create(index: "index_memory_items_kind", on: "memory_items", columns: ["kind"])
-      // messages FTS5 index. GRDB's FTS5 builder - never raw SQL.
-      // `synchronize` wires external content (content_rowid = messages.id), the ordered
-      // AFTER INSERT/UPDATE/DELETE sync triggers, and the initial backfill of existing rows.
       try db.create(virtualTable: "messages_fts", using: FTS5()) { table in
         table.synchronize(withTable: "messages")
         table.tokenizer = .unicode61(diacritics: .remove)
@@ -161,14 +156,11 @@ public enum ClawDatabase {
       }
     }
     migrator.registerMigration("v6") { db in
-      // Spec §4.1. Occurrence/timestamp columns are UTC epoch-second INTEGERs so the fused
-      // claim's compare-and-advance (§5.2) is exact integer equality, never a string compare.
       try db.create(table: "scheduled_jobs") { table in
         table.autoIncrementedPrimaryKey("id")
         table.column("owner_chat_id", .integer).notNull()
         table.column("label", .text).notNull()
         table.column("prompt", .text).notNull()
-        // {"schema_version":1,"rule":<RecurrenceRule JSON>}; NULL ⇔ one-shot (D2)
         table.column("recurrence", .text)
         table.column("timezone", .text).notNull()
         table.column("next_occurrence", .integer)
@@ -178,7 +170,6 @@ public enum ClawDatabase {
         table.column("created_ts", .integer).notNull()
         table.column("updated_ts", .integer).notNull()
       }
-      // Partial: terminal rows keep next_occurrence NULL, so the ticker scan never sees them.
       try db.create(
         index: "index_scheduled_jobs_status_next_occurrence",
         on: "scheduled_jobs",
@@ -186,12 +177,9 @@ public enum ClawDatabase {
         condition: Column("next_occurrence") != nil
       )
       try db.alter(table: "runs") { table in
-        // 'interactive' | 'scheduled' | 'heartbeat' — backfill is the default, no data rewrite.
         table.add(column: "origin", .text).notNull().defaults(to: "interactive")
         table.add(column: "job_id", .integer).references("scheduled_jobs")
       }
-      // Spec §4.3: one row, updated inside tick/claim transactions; doctor reads it from its
-      // separate process. due_count is deliberately NOT stored (computed by query).
       try db.create(table: "scheduler_state") { table in
         table.primaryKey("id", .integer).check { id in id == 1 }
         table.column("last_tick_at", .integer)
@@ -221,30 +209,27 @@ public enum ClawDatabase {
       try db.rename(table: "provider_usage_new", to: "provider_usage")
     }
     migrator.registerMigration("v8") { db in
-      // Spec §4.1. Timestamps are UTC epoch-second INTEGERs (the v6 idiom) so the expiry
-      // sweep's `expires_ts <= now` compare is exact integer arithmetic.
       try db.create(table: "approvals") { table in
-        table.autoIncrementedPrimaryKey("id")  // never exposed in callback data (§4.1)
+        table.autoIncrementedPrimaryKey("id")
         table.column("run_id", .integer).notNull().references("runs", onDelete: .cascade)
         table.column("session_id", .integer).notNull()
           .references("sessions", onDelete: .cascade)
-        table.column("state", .text).notNull()  // PENDING | APPROVED | REJECTED | EXPIRED
+        table.column("state", .text).notNull()
         table.column("tool", .text).notNull()
-        table.column("canonical_args", .text).notNull()  // the exact recorded args that execute
+        table.column("canonical_args", .text).notNull()
         table.column("canonical_target", .text).notNull()
         table.column("args_hash", .text).notNull()
-        table.column("policy_version", .text).notNull()  // copied from the run row (§3.2)
+        table.column("policy_version", .text).notNull()
         table.column("owner_user_id", .integer).notNull()
         table.column("nonce", .text).notNull().unique()
         table.column("observation_message_id", .integer).notNull()
         table.column("tool_call_id", .text).notNull()
-        table.column("reason", .text).notNull()  // ask_tier | exfil_trifecta
+        table.column("reason", .text).notNull()
         table.column("prompt_message_id", .integer)
         table.column("created_ts", .integer).notNull()
         table.column("expires_ts", .integer).notNull()
         table.column("resolved_ts", .integer)
       }
-      // At most one live approval per run, enforced by the schema, not by convention (§4.1).
       try db.create(
         index: "index_approvals_pending_run",
         on: "approvals",
@@ -258,8 +243,6 @@ public enum ClawDatabase {
       try db.alter(table: "sessions") { table in
         table.add(column: "has_private_data", .boolean).notNull().defaults(to: false)
       }
-      // Additive nullable columns: pre-upgrade PENDING deliveries stay valid; the button
-      // envelope is not smuggled into `payload` (§4.1).
       try db.alter(table: "outbound_deliveries") { table in
         table.add(column: "approval_id", .integer).references("approvals")
         table.add(column: "reply_markup", .text)

--- a/Sources/ClawData/Database/ClawDatabase.swift
+++ b/Sources/ClawData/Database/ClawDatabase.swift
@@ -220,6 +220,51 @@ public enum ClawDatabase {
       try db.drop(table: "provider_usage")
       try db.rename(table: "provider_usage_new", to: "provider_usage")
     }
+    migrator.registerMigration("v8") { db in
+      // Spec §4.1. Timestamps are UTC epoch-second INTEGERs (the v6 idiom) so the expiry
+      // sweep's `expires_ts <= now` compare is exact integer arithmetic.
+      try db.create(table: "approvals") { table in
+        table.autoIncrementedPrimaryKey("id")  // never exposed in callback data (§4.1)
+        table.column("run_id", .integer).notNull().references("runs", onDelete: .cascade)
+        table.column("session_id", .integer).notNull()
+          .references("sessions", onDelete: .cascade)
+        table.column("state", .text).notNull()  // PENDING | APPROVED | REJECTED | EXPIRED
+        table.column("tool", .text).notNull()
+        table.column("canonical_args", .text).notNull()  // the exact recorded args that execute
+        table.column("canonical_target", .text).notNull()
+        table.column("args_hash", .text).notNull()
+        table.column("policy_version", .text).notNull()  // copied from the run row (§3.2)
+        table.column("owner_user_id", .integer).notNull()
+        table.column("nonce", .text).notNull().unique()
+        table.column("observation_message_id", .integer).notNull()
+        table.column("tool_call_id", .text).notNull()
+        table.column("reason", .text).notNull()  // ask_tier | exfil_trifecta
+        table.column("prompt_message_id", .integer)
+        table.column("created_ts", .integer).notNull()
+        table.column("expires_ts", .integer).notNull()
+        table.column("resolved_ts", .integer)
+      }
+      // At most one live approval per run, enforced by the schema, not by convention (§4.1).
+      try db.create(
+        index: "index_approvals_pending_run",
+        on: "approvals",
+        columns: ["run_id"],
+        options: [.unique],
+        condition: Column("state") == "PENDING"
+      )
+      try db.alter(table: "runs") { table in
+        table.add(column: "policy_version", .text)
+      }
+      try db.alter(table: "sessions") { table in
+        table.add(column: "has_private_data", .boolean).notNull().defaults(to: false)
+      }
+      // Additive nullable columns: pre-upgrade PENDING deliveries stay valid; the button
+      // envelope is not smuggled into `payload` (§4.1).
+      try db.alter(table: "outbound_deliveries") { table in
+        table.add(column: "approval_id", .integer).references("approvals")
+        table.add(column: "reply_markup", .text)
+      }
+    }
     return migrator
   }
 

--- a/Sources/ClawData/Database/ClawStores.swift
+++ b/Sources/ClawData/Database/ClawStores.swift
@@ -17,6 +17,7 @@ public struct ClawStores: Sendable {
   public let retriever: any Retriever
   public let scheduledJobs: any ScheduledJobStore
   public let scheduleCommands: any ScheduleCommandStore
+  public let approvals: any ApprovalStore
 
   public init(
     allowlist: any AllowlistStore,
@@ -32,7 +33,8 @@ public struct ClawStores: Sendable {
     memoryCommands: any MemoryCommandStore,
     retriever: any Retriever,
     scheduledJobs: any ScheduledJobStore,
-    scheduleCommands: any ScheduleCommandStore
+    scheduleCommands: any ScheduleCommandStore,
+    approvals: any ApprovalStore
   ) {
     self.allowlist = allowlist
     self.processed = processed
@@ -48,6 +50,7 @@ public struct ClawStores: Sendable {
     self.retriever = retriever
     self.scheduledJobs = scheduledJobs
     self.scheduleCommands = scheduleCommands
+    self.approvals = approvals
   }
 }
 
@@ -70,7 +73,8 @@ extension ClawDatabase {
       memoryCommands: MemoryCommandStoreGRDB(writer: pool),
       retriever: RetrieverGRDB(writer: pool),
       scheduledJobs: ScheduledJobStoreGRDB(writer: pool),
-      scheduleCommands: ScheduleCommandStoreGRDB(writer: pool)
+      scheduleCommands: ScheduleCommandStoreGRDB(writer: pool),
+      approvals: ApprovalStoreGRDB(writer: pool)
     )
   }
 }

--- a/Sources/ClawData/Stores/Approval/ApprovalStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Approval/ApprovalStoreGRDB.swift
@@ -1,0 +1,414 @@
+import ClawCore
+import Foundation
+import GRDB
+
+/// GRDB implementation of `ApprovalStore` (spec §4.2 / §6.2 / §6.4). Mirrors `RunStoreGRDB`:
+/// every write rides `database.writeMapping`, every state change funnels through the single
+/// `transitionApproval` static (built like `RunStoreGRDB.transitionRun` but calling
+/// `ApprovalFSM.reduce`), and every resolution appends its `approvalGranted`/`approvalDenied`
+/// audit inside the same transaction (spec §3.1, preamble D3). The `approvals` timestamp columns
+/// are `.integer` UTC epoch seconds (v8 migration), so they travel through the epoch codec below —
+/// never a raw `Date` bind, which GRDB would serialize as a string and break `expires_ts <= now`.
+public struct ApprovalStoreGRDB: ApprovalStore {
+  private let database: MappedDatabase
+
+  public init(writer: any DatabaseWriter) {
+    database = MappedDatabase(writer: writer)
+  }
+
+  public func approval(nonce: String) throws -> Approval? {
+    try database.readMapping { db in
+      try Self.fetchApproval(db, whereClause: "nonce = ?", arguments: [nonce])
+    }
+  }
+
+  public func approval(id: Int64) throws -> Approval? {
+    try database.readMapping { db in
+      try Self.fetchApproval(db, id: id)
+    }
+  }
+
+  public func approve(
+    id: Int64,
+    currentPolicyVersion: String,
+    now: Date
+  ) throws -> ApprovalApproveOutcome {
+    try database.writeMapping { db in
+      guard let approval = try Self.fetchApproval(db, id: id), approval.state == .pending else {
+        return .notPending
+      }
+      guard approval.expiresTs > now else {
+        return .expiredRow
+      }
+
+      let hashMatches = approval.argsHash == ApprovalArgsHash.sha256Hex(approval.canonicalArgsJSON)
+      let policyMatches = approval.policyVersion == currentPolicyVersion
+      guard hashMatches, policyMatches else {
+        // §6.2 step 5 mismatch: the recorded action no longer matches its fingerprint — reject.
+        guard try Self.transitionApproval(db, id: id, on: .reject, now: now) != nil else {
+          return .notPending
+        }
+        try Self.insertApprovalAudit(
+          db,
+          approval: approval,
+          actor: .owner,
+          action: .approvalDenied,
+          decision: .stalePolicy,
+          now: now
+        )
+        guard let rejected = try Self.fetchApproval(db, id: id) else {
+          return .notPending
+        }
+        return .stalePolicy(rejected)
+      }
+
+      guard try Self.transitionApproval(db, id: id, on: .approve, now: now) != nil else {
+        return .notPending
+      }
+      try Self.insertApprovalAudit(
+        db,
+        approval: approval,
+        actor: .owner,
+        action: .approvalGranted,
+        decision: nil,
+        now: now
+      )
+      guard let approved = try Self.fetchApproval(db, id: id) else {
+        return .notPending
+      }
+      return .approved(approved)
+    }
+  }
+
+  public func deny(id: Int64, decision: ApprovalDecision, now: Date) throws -> Bool {
+    try database.writeMapping { db in
+      guard let approval = try Self.fetchApproval(db, id: id), approval.state == .pending else {
+        return false
+      }
+      // Only expiry lands in EXPIRED; every other decision (owner reject, cancel, supersede,
+      // stale policy) resolves to REJECTED — the four-state rule (preamble Global Constraints).
+      let event: ApprovalEvent = decision == .expired ? .expire : .reject
+      guard try Self.transitionApproval(db, id: id, on: event, now: now) != nil else {
+        return false
+      }
+      // Attribute by who initiated the resolution (preamble actor rule). `.rejected` is the only
+      // owner-initiated deny (the owner tapped Deny → `.owner`); every other decision reaching deny
+      // is system-determined — `.expired` is the clock (a stale-button tap or the boot sweep) and,
+      // defensively, `.cancelled`/`.superseded` — so it audits `.system`. Without this the boot-sweep
+      // expiry path (Phase 3 Task 19) would mis-record a system action as `.owner`.
+      let auditActor: AuditActor = decision == .rejected ? .owner : .system
+      try Self.insertApprovalAudit(
+        db,
+        approval: approval,
+        actor: auditActor,
+        action: .approvalDenied,
+        decision: decision,
+        now: now
+      )
+      return true
+    }
+  }
+
+  public func sweepExpired(now: Date) throws -> [Approval] {
+    try database.writeMapping { db in
+      let expired = try Self.fetchApprovals(
+        db,
+        whereClause: "state = ? AND expires_ts <= ?",
+        arguments: [ApprovalState.pending.rawValue, Self.epoch(now)]
+      )
+
+      var swept: [Approval] = []
+      for approval in expired {
+        guard try Self.transitionApproval(db, id: approval.id, on: .expire, now: now) != nil else {
+          continue
+        }
+        try Self.insertApprovalAudit(
+          db,
+          approval: approval,
+          actor: .system,
+          action: .approvalDenied,
+          decision: .expired,
+          now: now
+        )
+        if let resolved = try Self.fetchApproval(db, id: approval.id) {
+          swept.append(resolved)
+        }
+      }
+      return swept
+    }
+  }
+
+  public func unresolvedAtBoot() throws -> [Approval] {
+    try database.readMapping { db in
+      try Self.fetchApprovals(
+        db,
+        whereClause: """
+          state = ?
+          OR (state = ? AND EXISTS (
+            SELECT 1 FROM runs WHERE runs.id = approvals.run_id AND runs.state = ?
+          ))
+          """,
+        arguments: [
+          ApprovalState.pending.rawValue,
+          ApprovalState.approved.rawValue,
+          RunState.awaitingApproval.rawValue,
+        ]
+      )
+    }
+  }
+
+  public func resolveOrphans(now: Date) throws -> Int {
+    try database.writeMapping { db in
+      let orphans = try Self.fetchApprovals(
+        db,
+        whereClause: """
+          state = ?
+          AND EXISTS (
+            SELECT 1 FROM runs WHERE runs.id = approvals.run_id AND runs.state IN (?, ?, ?, ?)
+          )
+          """,
+        arguments: [
+          ApprovalState.pending.rawValue,
+          RunState.done.rawValue,
+          RunState.failed.rawValue,
+          RunState.cancelled.rawValue,
+          RunState.superseded.rawValue,
+        ]
+      )
+
+      var cleaned = 0
+      for approval in orphans {
+        guard try Self.transitionApproval(db, id: approval.id, on: .reject, now: now) != nil else {
+          continue
+        }
+        try Self.insertApprovalAudit(
+          db,
+          approval: approval,
+          actor: .system,
+          action: .approvalDenied,
+          decision: .cancelled,
+          now: now
+        )
+        cleaned += 1
+      }
+      return cleaned
+    }
+  }
+
+  public func approvalsHealth(now: Date) throws -> ApprovalsHealth {
+    try database.readMapping { db in
+      let pendingCount =
+        try Int.fetchOne(
+          db,
+          sql: "SELECT COUNT(*) FROM approvals WHERE state = ?",
+          arguments: [ApprovalState.pending.rawValue]
+        ) ?? 0
+
+      let oldestPendingAgeSeconds =
+        try Int64.fetchOne(
+          db,
+          sql: "SELECT MIN(created_ts) FROM approvals WHERE state = ?",
+          arguments: [ApprovalState.pending.rawValue]
+        ).map { oldestEpoch in Int(Self.epoch(now) - oldestEpoch) }
+
+      return ApprovalsHealth(
+        pendingCount: pendingCount,
+        oldestPendingAgeSeconds: oldestPendingAgeSeconds
+      )
+    }
+  }
+}
+
+// MARK: - Insert + Transition Seam (reused cross-store by commitSuspendedTurn, Task 14)
+
+extension ApprovalStoreGRDB {
+  /// The insert every approval starts from — a PENDING row (state is store-owned, never carried on
+  /// `NewApproval`). Called inside `commitSuspendedTurn`'s single transaction (Task 14).
+  static func insertApproval(_ db: Database, _ approval: NewApproval) throws -> Int64 {
+    try db.execute(
+      sql: """
+        INSERT INTO approvals(run_id, session_id, state, tool, canonical_args, canonical_target,
+          args_hash, policy_version, owner_user_id, nonce, observation_message_id, tool_call_id,
+          reason, created_ts, expires_ts)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+      arguments: [
+        approval.runId,
+        approval.sessionId,
+        ApprovalState.pending.rawValue,
+        approval.tool,
+        approval.canonicalArgsJSON,
+        approval.canonicalTarget,
+        approval.argsHash,
+        approval.policyVersion,
+        approval.ownerUserId,
+        approval.nonce,
+        approval.observationMessageId,
+        approval.toolCallId,
+        approval.reason.rawValue,
+        epoch(approval.createdTs),
+        epoch(approval.expiresTs),
+      ]
+    )
+    return db.lastInsertedRowID
+  }
+
+  /// The single state-change seam — mirrors `RunStoreGRDB.transitionRun`, but every legal event
+  /// resolves a PENDING row to a terminal state, so `resolved_ts` is always stamped here.
+  static func transitionApproval(
+    _ db: Database,
+    id: Int64,
+    on event: ApprovalEvent,
+    now: Date
+  ) throws -> ApprovalState? {
+    guard
+      let state = try currentApprovalState(db, id: id),
+      let nextState = ApprovalFSM.reduce(state: state, on: event)
+    else {
+      return nil
+    }
+
+    try db.execute(
+      sql: "UPDATE approvals SET state = ?, resolved_ts = ? WHERE id = ?",
+      arguments: [nextState.rawValue, epoch(now), id]
+    )
+
+    return nextState
+  }
+}
+
+// MARK: - Row Mapping + Reads
+
+private extension ApprovalStoreGRDB {
+  static let selectColumns = """
+    id, run_id, session_id, state, tool, canonical_args, canonical_target, args_hash,
+    policy_version, owner_user_id, nonce, observation_message_id, tool_call_id, reason,
+    prompt_message_id, created_ts, expires_ts, resolved_ts
+    """
+
+  static func currentApprovalState(_ db: Database, id: Int64) throws -> ApprovalState? {
+    guard
+      let rawState = try String.fetchOne(
+        db,
+        sql: "SELECT state FROM approvals WHERE id = ?",
+        arguments: [id]
+      )
+    else {
+      return nil
+    }
+    return ApprovalState(rawValue: rawState)
+  }
+
+  static func fetchApproval(_ db: Database, id: Int64) throws -> Approval? {
+    try fetchApproval(db, whereClause: "id = ?", arguments: [id])
+  }
+
+  static func fetchApproval(
+    _ db: Database,
+    whereClause: String,
+    arguments: StatementArguments
+  ) throws -> Approval? {
+    guard
+      let row = try Row.fetchOne(
+        db,
+        sql: "SELECT \(selectColumns) FROM approvals WHERE \(whereClause)",
+        arguments: arguments
+      )
+    else {
+      return nil
+    }
+    return try mapApproval(row)
+  }
+
+  static func fetchApprovals(
+    _ db: Database,
+    whereClause: String,
+    arguments: StatementArguments
+  ) throws -> [Approval] {
+    try Row.fetchAll(
+      db,
+      sql: "SELECT \(selectColumns) FROM approvals WHERE \(whereClause) ORDER BY id ASC",
+      arguments: arguments
+    )
+    .map(mapApproval)
+  }
+
+  /// Fail closed on a corrupted enum column or missing epoch (same rule as `decodeItem`): a
+  /// mislabeled state must never silently re-route the resolution logic.
+  static func mapApproval(_ row: Row) throws -> Approval {
+    guard let state = ApprovalState(rawValue: row["state"]) else {
+      throw StoreError.unexpected("approvals row has an unrecognized state")
+    }
+    guard let reason = ApprovalReason(rawValue: row["reason"]) else {
+      throw StoreError.unexpected("approvals row has an unrecognized reason")
+    }
+    guard
+      let createdTs = date(fromEpoch: row["created_ts"]),
+      let expiresTs = date(fromEpoch: row["expires_ts"])
+    else {
+      throw StoreError.unexpected("approvals row is missing a required timestamp")
+    }
+
+    return Approval(
+      id: row["id"],
+      runId: row["run_id"],
+      sessionId: row["session_id"],
+      state: state,
+      tool: row["tool"],
+      canonicalArgsJSON: row["canonical_args"],
+      canonicalTarget: row["canonical_target"],
+      argsHash: row["args_hash"],
+      policyVersion: row["policy_version"],
+      ownerUserId: row["owner_user_id"],
+      nonce: row["nonce"],
+      observationMessageId: row["observation_message_id"],
+      toolCallId: row["tool_call_id"],
+      reason: reason,
+      promptMessageId: row["prompt_message_id"],
+      createdTs: createdTs,
+      expiresTs: expiresTs,
+      resolvedTs: date(fromEpoch: row["resolved_ts"])
+    )
+  }
+}
+
+// MARK: - Same-Transaction Audit
+
+private extension ApprovalStoreGRDB {
+  /// Appends the resolution audit inside the caller's `writeMapping` transaction (spec §3.1, D3):
+  /// the approval-state CAS is the recorded transition, so its audit rides the same commit. The
+  /// decision rawValue is the `ApprovalDecision` vocabulary; a grant carries the default "ok".
+  static func insertApprovalAudit(  // swiftlint:disable:this function_parameter_count
+    _ db: Database,
+    approval: Approval,
+    actor: AuditActor,
+    action: AuditAction,
+    decision: ApprovalDecision?,
+    now: Date
+  ) throws {
+    try AuditLogGRDB.insertAudit(
+      db,
+      AuditEvent(
+        actor: actor,
+        action: action,
+        tool: approval.tool,
+        decision: decision?.rawValue ?? "ok",
+        runId: approval.runId,
+        sessionId: approval.sessionId,
+        ts: now
+      )
+    )
+  }
+}
+
+// MARK: - Epoch-Second Column Codec
+
+private extension ApprovalStoreGRDB {
+  static func epoch(_ instant: Date) -> Int64 {
+    Int64(instant.timeIntervalSince1970.rounded())
+  }
+
+  static func date(fromEpoch value: Int64?) -> Date? {
+    value.map { seconds in Date(timeIntervalSince1970: TimeInterval(seconds)) }
+  }
+}

--- a/Sources/ClawData/Stores/Approval/ApprovalStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Approval/ApprovalStoreGRDB.swift
@@ -48,6 +48,7 @@ public struct ApprovalStoreGRDB: ApprovalStore {
         guard try Self.transitionApproval(db, id: id, on: .reject, now: now) != nil else {
           return .notPending
         }
+
         try Self.insertApprovalAudit(
           db,
           approval: approval,
@@ -56,15 +57,18 @@ public struct ApprovalStoreGRDB: ApprovalStore {
           decision: .stalePolicy,
           now: now
         )
+
         guard let rejected = try Self.fetchApproval(db, id: id) else {
           return .notPending
         }
+
         return .stalePolicy(rejected)
       }
 
       guard try Self.transitionApproval(db, id: id, on: .approve, now: now) != nil else {
         return .notPending
       }
+
       try Self.insertApprovalAudit(
         db,
         approval: approval,
@@ -73,9 +77,11 @@ public struct ApprovalStoreGRDB: ApprovalStore {
         decision: nil,
         now: now
       )
+
       guard let approved = try Self.fetchApproval(db, id: id) else {
         return .notPending
       }
+
       return .approved(approved)
     }
   }
@@ -105,6 +111,7 @@ public struct ApprovalStoreGRDB: ApprovalStore {
         decision: decision,
         now: now
       )
+
       return true
     }
   }
@@ -122,6 +129,7 @@ public struct ApprovalStoreGRDB: ApprovalStore {
         guard try Self.transitionApproval(db, id: approval.id, on: .expire, now: now) != nil else {
           continue
         }
+
         try Self.insertApprovalAudit(
           db,
           approval: approval,
@@ -130,10 +138,12 @@ public struct ApprovalStoreGRDB: ApprovalStore {
           decision: .expired,
           now: now
         )
+
         if let resolved = try Self.fetchApproval(db, id: approval.id) {
           swept.append(resolved)
         }
       }
+
       return swept
     }
   }
@@ -181,6 +191,7 @@ public struct ApprovalStoreGRDB: ApprovalStore {
         guard try Self.transitionApproval(db, id: approval.id, on: .reject, now: now) != nil else {
           continue
         }
+
         try Self.insertApprovalAudit(
           db,
           approval: approval,
@@ -189,8 +200,10 @@ public struct ApprovalStoreGRDB: ApprovalStore {
           decision: .cancelled,
           now: now
         )
+
         cleaned += 1
       }
+
       return cleaned
     }
   }
@@ -209,7 +222,9 @@ public struct ApprovalStoreGRDB: ApprovalStore {
           db,
           sql: "SELECT MIN(created_ts) FROM approvals WHERE state = ?",
           arguments: [ApprovalState.pending.rawValue]
-        ).map { oldestEpoch in Int(Self.epoch(now) - oldestEpoch) }
+        ).map { oldestEpoch in
+          Int(Self.epoch(now) - oldestEpoch)
+        }
 
       return ApprovalsHealth(
         pendingCount: pendingCount,
@@ -287,16 +302,14 @@ private extension ApprovalStoreGRDB {
     """
 
   static func currentApprovalState(_ db: Database, id: Int64) throws -> ApprovalState? {
-    guard
-      let rawState = try String.fetchOne(
-        db,
-        sql: "SELECT state FROM approvals WHERE id = ?",
-        arguments: [id]
-      )
-    else {
-      return nil
+    if let rawState = try String.fetchOne(
+      db,
+      sql: "SELECT state FROM approvals WHERE id = ?",
+      arguments: [id]
+    ) {
+      return ApprovalState(rawValue: rawState)
     }
-    return ApprovalState(rawValue: rawState)
+    return nil
   }
 
   static func fetchApproval(_ db: Database, id: Int64) throws -> Approval? {
@@ -308,16 +321,14 @@ private extension ApprovalStoreGRDB {
     whereClause: String,
     arguments: StatementArguments
   ) throws -> Approval? {
-    guard
-      let row = try Row.fetchOne(
-        db,
-        sql: "SELECT \(selectColumns) FROM approvals WHERE \(whereClause)",
-        arguments: arguments
-      )
-    else {
-      return nil
+    if let row = try Row.fetchOne(
+      db,
+      sql: "SELECT \(selectColumns) FROM approvals WHERE \(whereClause)",
+      arguments: arguments
+    ) {
+      return try mapApproval(row)
     }
-    return try mapApproval(row)
+    return nil
   }
 
   static func fetchApprovals(
@@ -339,9 +350,11 @@ private extension ApprovalStoreGRDB {
     guard let state = ApprovalState(rawValue: row["state"]) else {
       throw StoreError.unexpected("approvals row has an unrecognized state")
     }
+
     guard let reason = ApprovalReason(rawValue: row["reason"]) else {
       throw StoreError.unexpected("approvals row has an unrecognized reason")
     }
+
     guard
       let createdTs = date(fromEpoch: row["created_ts"]),
       let expiresTs = date(fromEpoch: row["expires_ts"])
@@ -409,6 +422,8 @@ private extension ApprovalStoreGRDB {
   }
 
   static func date(fromEpoch value: Int64?) -> Date? {
-    value.map { seconds in Date(timeIntervalSince1970: TimeInterval(seconds)) }
+    value.map { seconds in
+      Date(timeIntervalSince1970: TimeInterval(seconds))
+    }
   }
 }

--- a/Sources/ClawData/Stores/Delivery/OutboxStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Delivery/OutboxStoreGRDB.swift
@@ -46,7 +46,7 @@ public struct OutboxStoreGRDB: OutboxStore {
           )
           SELECT ?, ?, ?, ?, ?, ?, 'PENDING', ?
           WHERE EXISTS (
-            SELECT 1 FROM runs WHERE id = ? AND state = ?
+            SELECT 1 FROM runs WHERE id = ? AND state IN (?, ?)
           )
           """,
         arguments: [
@@ -59,6 +59,7 @@ public struct OutboxStoreGRDB: OutboxStore {
           Date(),
           runId,
           RunState.running.rawValue,
+          RunState.awaitingApproval.rawValue,
         ]
       )
       return db.changesCount > 0

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -9,9 +9,17 @@ public struct RunStoreGRDB: RunStore {
     database = MappedDatabase(writer: writer)
   }
 
-  public func pickUp(runId: Int64, now: Date) throws -> RunOrigin? {
+  public func pickUp(runId: Int64, policyVersion: String?, now: Date) throws -> RunOrigin? {
     try database.writeMapping { db in
-      guard try Self.transitionRun(db, runId: runId, event: .pickUp, now: now) != nil else {
+      guard
+        try Self.transitionRun(
+          db,
+          runId: runId,
+          event: .pickUp,
+          now: now,
+          policyVersion: policyVersion
+        ) != nil
+      else {
         return nil
       }
 
@@ -423,7 +431,8 @@ extension RunStoreGRDB {
     _ db: Database,
     runId: Int64,
     event: RunEvent,
-    now: Date
+    now: Date,
+    policyVersion: String? = nil
   ) throws -> RunState? {
     guard
       let state = try currentRunState(db, runId: runId),
@@ -432,10 +441,19 @@ extension RunStoreGRDB {
       return nil
     }
 
-    try db.execute(
-      sql: "UPDATE runs SET state = ?, updated_ts = ? WHERE id = ?",
-      arguments: [nextState.rawValue, now, runId]
-    )
+    // The fingerprint rides the state flip in one UPDATE (spec §3.2); a nil leaves the column
+    // untouched so resolution/deny transitions never disturb the stamped value.
+    if let policyVersion {
+      try db.execute(
+        sql: "UPDATE runs SET state = ?, updated_ts = ?, policy_version = ? WHERE id = ?",
+        arguments: [nextState.rawValue, now, policyVersion, runId]
+      )
+    } else {
+      try db.execute(
+        sql: "UPDATE runs SET state = ?, updated_ts = ? WHERE id = ?",
+        arguments: [nextState.rawValue, now, runId]
+      )
+    }
 
     return nextState
   }

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -275,18 +275,22 @@ public struct RunStoreGRDB: RunStore {
 
   public func runsHealth(now: Date) throws -> RunsHealth {
     try database.readMapping { db in
-      let activeStates = [RunState.pending.rawValue, RunState.running.rawValue]
+      let activeStates = [
+        RunState.pending.rawValue,
+        RunState.running.rawValue,
+        RunState.awaitingApproval.rawValue,
+      ]
       let inFlight =
         try Int.fetchOne(
           db,
-          sql: "SELECT COUNT(*) FROM runs WHERE state IN (?, ?)",
+          sql: "SELECT COUNT(*) FROM runs WHERE state IN (?, ?, ?)",
           arguments: StatementArguments(activeStates)
         ) ?? 0
 
       let oldestRunAgeSeconds: Double? =
         try Date.fetchOne(
           db,
-          sql: "SELECT MIN(created_ts) FROM runs WHERE state IN (?, ?)",
+          sql: "SELECT MIN(created_ts) FROM runs WHERE state IN (?, ?, ?)",
           arguments: StatementArguments(activeStates)
         ).map { now.timeIntervalSince($0) }
 
@@ -361,11 +365,15 @@ extension RunStoreGRDB {
       db,
       sql: """
         SELECT id FROM runs
-        WHERE session_id = ? AND state = ?
+        WHERE session_id = ? AND state IN (?, ?)
         ORDER BY id DESC
         LIMIT 1
         """,
-      arguments: [sessionId, RunState.running.rawValue]
+      arguments: [
+        sessionId,
+        RunState.running.rawValue,
+        RunState.awaitingApproval.rawValue,
+      ]
     )
   }
 
@@ -389,10 +397,15 @@ extension RunStoreGRDB {
       db,
       sql: """
         SELECT id FROM runs
-        WHERE session_id = ? AND state IN (?, ?)
+        WHERE session_id = ? AND state IN (?, ?, ?)
         ORDER BY id ASC
         """,
-      arguments: [sessionId, RunState.pending.rawValue, RunState.running.rawValue]
+      arguments: [
+        sessionId,
+        RunState.pending.rawValue,
+        RunState.running.rawValue,
+        RunState.awaitingApproval.rawValue,
+      ]
     )
 
     var affected: [Int64] = []

--- a/Sources/ClawGateway/Response/ApprovalsHealth.swift
+++ b/Sources/ClawGateway/Response/ApprovalsHealth.swift
@@ -2,7 +2,7 @@ import ClawCore
 
 /// Renders doctor's approvals health rows from the persisted `approvals` table (spec §4.6). Pure
 /// so the rendering is unit-testable; doctor is a separate process, so only persisted state is
-/// visible to it (D8) — the count/age arrive from `ApprovalStore.approvalsHealth` at call time.
+/// visible to it — the count/age arrive from `ApprovalStore.approvalsHealth` at call time.
 ///
 /// Named `ApprovalsHealthRows` (not `ApprovalsHealth`) so it never collides with the ClawCore
 /// `ApprovalsHealth` data struct it renders — ClawGateway imports both.

--- a/Sources/ClawGateway/Response/ApprovalsHealth.swift
+++ b/Sources/ClawGateway/Response/ApprovalsHealth.swift
@@ -1,0 +1,32 @@
+import ClawCore
+
+/// Renders doctor's approvals health rows from the persisted `approvals` table (spec §4.6). Pure
+/// so the rendering is unit-testable; doctor is a separate process, so only persisted state is
+/// visible to it (D8) — the count/age arrive from `ApprovalStore.approvalsHealth` at call time.
+///
+/// Named `ApprovalsHealthRows` (not `ApprovalsHealth`) so it never collides with the ClawCore
+/// `ApprovalsHealth` data struct it renders — ClawGateway imports both.
+public enum ApprovalsHealthRows {
+  public struct Row: Sendable, Equatable {
+    public let key: String
+    public let value: String
+
+    public init(key: String, value: String) {
+      self.key = key
+      self.value = value
+    }
+  }
+
+  public static func rows(health: ApprovalsHealth, approvalExpirySeconds: Int) -> [Row] {
+    // Oldest pending age shown against the expiry window (age/expiry), mirroring the
+    // heartbeat.today "count/cap" idiom — a row nearing the cap flags a stuck approval before the
+    // ticker sweeps it (spec §4.6).
+    let oldestAge =
+      health.oldestPendingAgeSeconds.map { age in "\(age)/\(approvalExpirySeconds)" } ?? "none"
+
+    return [
+      Row(key: "approvals.pending", value: "\(health.pendingCount)"),
+      Row(key: "approvals.oldest_age_s", value: oldestAge),
+    ]
+  }
+}

--- a/Sources/ClawGateway/Response/ToolApprovalPrompt.swift
+++ b/Sources/ClawGateway/Response/ToolApprovalPrompt.swift
@@ -15,6 +15,12 @@ public enum ToolApprovalPrompt {
       This session has read external content and holds private data.
       Reply yes to allow this one fetch; anything else cancels.
       """
+    case .askTier:
+      """
+      ⚠ I want to run \(request.action.tool) on
+      \(request.action.target)
+      This action changes state and needs your explicit approval.
+      """
     }
   }
 }

--- a/Sources/ClawGateway/Routing/TurnRunner.swift
+++ b/Sources/ClawGateway/Routing/TurnRunner.swift
@@ -85,7 +85,11 @@ public struct TurnRunner: TurnDispatching {
     }
 
     let now = now()
-    guard let origin = try runs.pickUp(runId: runId, now: now) else {
+    // §3.2: the fingerprint is computed from the same builder inputs `assemble` will use and
+    // stamped in the same UPDATE that flips PENDING→RUNNING, so an approval this run creates binds
+    // to the exact prompt/tool/config surface in force at run start.
+    let policyVersion = contextBuilder.currentPolicyVersion()
+    guard let origin = try runs.pickUp(runId: runId, policyVersion: policyVersion, now: now) else {
       logger.debug("run \(runId) was not pending at pickup; skipping turn")
       return
     }

--- a/Sources/ClawTools/Tools/FileReadTool.swift
+++ b/Sources/ClawTools/Tools/FileReadTool.swift
@@ -40,7 +40,8 @@ public struct FileReadTool: Tool {
         ]),
         "required": .array([.string("path")]),
       ]),
-      egressClass: .none
+      egressClass: .none,
+      riskLevel: .safe
     )
   }
 

--- a/Sources/ClawTools/Tools/WebFetchTool.swift
+++ b/Sources/ClawTools/Tools/WebFetchTool.swift
@@ -48,7 +48,8 @@ public struct WebFetchTool: Tool {
         ]),
         "required": .array([.string("url")]),
       ]),
-      egressClass: .arbitraryDestination
+      egressClass: .arbitraryDestination,
+      riskLevel: .safe
     )
   }
 

--- a/Sources/ClawTools/Tools/WebSearchTool.swift
+++ b/Sources/ClawTools/Tools/WebSearchTool.swift
@@ -33,7 +33,8 @@ public struct WebSearchTool: Tool {
         ]),
         "required": .array([.string("query")]),
       ]),
-      egressClass: .fixedEndpoint
+      egressClass: .fixedEndpoint,
+      riskLevel: .safe
     )
   }
 

--- a/Sources/clawd/Subcommands/DoctorCommand.swift
+++ b/Sources/clawd/Subcommands/DoctorCommand.swift
@@ -54,6 +54,7 @@ struct DoctorCommand: AsyncParsableCommand {
       report.add(key: "heartbeat.interval_min", value: "\(config.heartbeatIntervalMinutes)")
       report.add(key: "heartbeat.quiet_hours", value: config.heartbeatQuietHours.rendered)
       report.add(key: "heartbeat.max_per_day", value: "\(config.heartbeatMaxPerDay)")
+      report.add(key: "approval.expiry_s", value: "\(config.approvalExpirySeconds)")
     }
 
     let secretsRow = SecretStoreResolver.doctorRow(
@@ -211,6 +212,16 @@ struct DoctorCommand: AsyncParsableCommand {
       heartbeatMaxPerDay: config.heartbeatMaxPerDay,
       timezone: config.timezone,
       now: now
+    ) {
+      report.add(key: row.key, value: row.value)
+    }
+
+    let approvalsHealth =
+      (try? stores.approvals.approvalsHealth(now: now))
+      ?? ApprovalsHealth(pendingCount: 0, oldestPendingAgeSeconds: nil)
+    for row in ApprovalsHealthRows.rows(
+      health: approvalsHealth,
+      approvalExpirySeconds: config.approvalExpirySeconds
     ) {
       report.add(key: row.key, value: row.value)
     }

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -198,6 +198,12 @@ private extension RunCommand {
       workspace: workspace,
       toolExecutor: toolExecutor
     )
+    let policyStaticSubhash = policyStaticSubhash(
+      toolDispatcher: toolDispatcher,
+      config: config,
+      secrets: secrets,
+      workspace: workspace
+    )
     let agent = makeAgent(
       config: config,
       secrets: secrets,
@@ -209,25 +215,12 @@ private extension RunCommand {
       logger: logger
     )
 
-    let contextBudget = ContextBudget(
-      inputCapGraphemes: TokenEstimator.graphemeBudget(
-        forInputTokens: config.budget.maxInputTokens
-      ),
-      userFileCap: ContextBudget.default.userFileCap,
-      memoryFileCap: ContextBudget.default.memoryFileCap,
-      itemsCap: ContextBudget.default.itemsCap,
-      historyCap: ContextBudget.default.historyCap,
-      recallCap: ContextBudget.default.recallCap,
-      skillsCap: ContextBudget.default.skillsCap,
-      recallHitCap: ContextBudget.default.recallHitCap
-    )
-    let contextBuilder = ContextBuilder(
-      systemPrompt: SystemPrompt.minimal,
+    let contextBuilder = makeContextBuilder(
+      config: config,
       workspace: workspace,
-      memoryStore: stores.memory,
-      retriever: stores.retriever,
-      budget: contextBudget,
-      warn: { warning in logger.warning("\(warning)") }
+      stores: stores,
+      policyStaticSubhash: policyStaticSubhash,
+      logger: logger
     )
 
     let turnRunner = TurnRunner(
@@ -415,6 +408,57 @@ private extension RunCommand {
         argGuard: ExfilArgGuard(secretValues: secretValues),
         privateFileLoader: privateFileLoader
       )
+    )
+  }
+
+  /// §3.2 static sub-hash (classes 2–3): the same tool surface the gate enforces, plus the pinned
+  /// egress/policy config. Secret values are never hashed — only the base URL, search presence,
+  /// and workspace root identity. Injected into `ContextBuilder`, which folds in the class-1 prompt
+  /// materials and returns the combined `policy_version`.
+  func policyStaticSubhash(
+    toolDispatcher: GatedToolDispatcher,
+    config: AppConfig,
+    secrets: Secrets,
+    workspace: FileSystemWorkspace
+  ) -> String {
+    PolicyFingerprint.staticSubhash(
+      tools: toolDispatcher.definitions,
+      llmBaseURL: config.llm.baseURL,
+      searchEndpointPresent: secrets.searchApiKey != nil,
+      workspaceRoot: workspace.root.path
+    )
+  }
+
+  /// Builds the grapheme-budgeted context assembler, injected with the composition root's static
+  /// policy sub-hash (§3.2) so `contextBuilder.currentPolicyVersion()` reflects the real tool/config
+  /// surface, not a test default.
+  func makeContextBuilder(
+    config: AppConfig,
+    workspace: FileSystemWorkspace,
+    stores: ClawStores,
+    policyStaticSubhash: String,
+    logger: Logger
+  ) -> ContextBuilder {
+    let contextBudget = ContextBudget(
+      inputCapGraphemes: TokenEstimator.graphemeBudget(
+        forInputTokens: config.budget.maxInputTokens
+      ),
+      userFileCap: ContextBudget.default.userFileCap,
+      memoryFileCap: ContextBudget.default.memoryFileCap,
+      itemsCap: ContextBudget.default.itemsCap,
+      historyCap: ContextBudget.default.historyCap,
+      recallCap: ContextBudget.default.recallCap,
+      skillsCap: ContextBudget.default.skillsCap,
+      recallHitCap: ContextBudget.default.recallHitCap
+    )
+    return ContextBuilder(
+      systemPrompt: SystemPrompt.minimal,
+      workspace: workspace,
+      memoryStore: stores.memory,
+      retriever: stores.retriever,
+      budget: contextBudget,
+      policyStaticSubhash: policyStaticSubhash,
+      warn: { warning in logger.warning("\(warning)") }
     )
   }
 

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -198,7 +198,7 @@ private extension RunCommand {
       workspace: workspace,
       toolExecutor: toolExecutor
     )
-    let policyStaticSubhash = policyStaticSubhash(
+    let staticSubhash = policyStaticSubhash(
       toolDispatcher: toolDispatcher,
       config: config,
       secrets: secrets,
@@ -219,7 +219,7 @@ private extension RunCommand {
       config: config,
       workspace: workspace,
       stores: stores,
-      policyStaticSubhash: policyStaticSubhash,
+      policyStaticSubhash: staticSubhash,
       logger: logger
     )
 

--- a/Tests/ClawAgentTests/Context/ContextBuilderTests.swift
+++ b/Tests/ClawAgentTests/Context/ContextBuilderTests.swift
@@ -54,6 +54,92 @@ struct ContextBuilderTests {
     #expect(result.ownerNotices.isEmpty)
   }
 
+  @Test func policyVersionFoldsTheStaticSubhashWithTheRawPromptMaterials() throws {
+    // given — the RAW file texts (pre "## path" wrapping) fold into the injected static sub-hash
+    let builder = makeBuilder(
+      policyStaticSubhash: "static-sub-hash",
+      workspace: FakeWorkspace(
+        files: [
+          .soul: .present("soul text"),
+          .agents: .present("agent rules"),
+          .tools: .present("tool policy"),
+        ]
+      )
+    )
+    let snapshot = SessionContextSnapshot(
+      history: [],
+      historyMessageIds: [],
+      windowStartMessageId: 0,
+      isTainted: false
+    )
+
+    // when
+    let result = try builder.assemble(snapshot: snapshot, sessionId: 1)
+
+    // then — combined = first 16 hex over [staticSubhash, systemPrompt, soul, agents, tools]
+    let expected = PolicyFingerprint.combined(
+      staticSubhash: "static-sub-hash",
+      promptMaterials: ["system policy", "soul text", "agent rules", "tool policy"]
+    )
+    #expect(result.policyVersion == expected)
+    #expect(result.policyVersion.count == 16)
+  }
+
+  @Test func currentPolicyVersionMatchesTheAssembledFingerprint() throws {
+    // given — the recompute seam (§6.3) must equal the value `assemble` produces, by construction
+    let builder = makeBuilder(
+      policyStaticSubhash: "sub",
+      workspace: FakeWorkspace(
+        files: [.soul: .present("s"), .agents: .present("a"), .tools: .present("t")]
+      )
+    )
+    let snapshot = SessionContextSnapshot(
+      history: [],
+      historyMessageIds: [],
+      windowStartMessageId: 0,
+      isTainted: false
+    )
+
+    // when
+    let standalone = builder.currentPolicyVersion()
+    let assembled = try builder.assemble(snapshot: snapshot, sessionId: 1).policyVersion
+
+    // then
+    #expect(standalone == assembled)
+  }
+
+  @Test func missingPromptFilesFoldInAsEmpty() {
+    // given — no workspace files; only the systemPrompt contributes to class 1
+    let builder = makeBuilder(policyStaticSubhash: "sub", workspace: FakeWorkspace(files: [:]))
+
+    // when
+    let version = builder.currentPolicyVersion()
+
+    // then — missing/unreadable files hash as "" (spec §3.2)
+    #expect(
+      version
+        == PolicyFingerprint.combined(
+          staticSubhash: "sub",
+          promptMaterials: ["system policy", "", "", ""]
+        )
+    )
+  }
+
+  @Test func editingAPromptFileChangesThePolicyVersion() {
+    // given / when — a strict-inequality voider (§3.2)
+    let before = makeBuilder(
+      policyStaticSubhash: "sub",
+      workspace: FakeWorkspace(files: [.soul: .present("v1")])
+    ).currentPolicyVersion()
+    let after = makeBuilder(
+      policyStaticSubhash: "sub",
+      workspace: FakeWorkspace(files: [.soul: .present("v2")])
+    ).currentPolicyVersion()
+
+    // then
+    #expect(before != after)
+  }
+
   @Test func hardCapOverflowOmitsFileAndProducesOwnerNotice() throws {
     // given
     let builder = makeBuilder(
@@ -278,6 +364,7 @@ struct ContextBuilderTests {
 }
 
 private func makeBuilder(
+  policyStaticSubhash: String = "",
   workspace: FakeWorkspace = FakeWorkspace(),
   memoryStore: FakeMemoryStore = FakeMemoryStore(),
   retriever: FakeRetriever = FakeRetriever(),
@@ -290,6 +377,7 @@ private func makeBuilder(
     retriever: retriever,
     recallCutoff: CandidateCapRecallCutoff(),
     budget: budget,
+    policyStaticSubhash: policyStaticSubhash,
     now: { Date(timeIntervalSince1970: 0) }
   )
 }

--- a/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
@@ -107,7 +107,8 @@ import Testing
       name: "web_fetch",
       description: "d",
       parameters: .object(["type": .string("object")]),
-      egressClass: .none
+      egressClass: .none,
+      riskLevel: .safe
     )
     let provider = SequenceProvider([okResponse()])
     let dispatcher = ScriptedDispatcher(definitions: [definition], respond: okOutcome())

--- a/Tests/ClawCoreTests/Config/AppConfigTests.swift
+++ b/Tests/ClawCoreTests/Config/AppConfigTests.swift
@@ -379,4 +379,60 @@ import Testing
     #expect(config.budget.proactivePerDayUSD == 1.25)
     #expect(config.proactivePerDayUSD == 1.25)
   }
+
+  @Test func approvalExpiryDefaultsTo3600() throws {
+    // given — the key unset
+    let env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+
+    // when
+    let config = try AppConfig.load(environment: env)
+
+    // then — spec §4.6 default
+    #expect(config.approvalExpirySeconds == 3600)
+  }
+
+  @Test func approvalExpiryOverrideParses() throws {
+    // given
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[EnvKey.approvalExpiry] = "1800"
+
+    // when
+    let config = try AppConfig.load(environment: env)
+
+    // then
+    #expect(config.approvalExpirySeconds == 1800)
+  }
+
+  @Test func approvalExpiryFloorAndCeilingAreInclusive() throws {
+    // given — the exact bounds are legal (spec §4.6: floor 60, ceiling 86400)
+    var floorEnv = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    floorEnv[EnvKey.approvalExpiry] = "60"
+    var ceilingEnv = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    ceilingEnv[EnvKey.approvalExpiry] = "86400"
+
+    // when
+    let floorConfig = try AppConfig.load(environment: floorEnv)
+    let ceilingConfig = try AppConfig.load(environment: ceilingEnv)
+
+    // then
+    #expect(floorConfig.approvalExpirySeconds == 60)
+    #expect(ceilingConfig.approvalExpirySeconds == 86400)
+  }
+
+  @Test(arguments: [
+    "59",  // below the 60s floor
+    "86401",  // above the 86400s ceiling
+    "soon",  // non-numeric
+    "0",  // zero
+  ])
+  func outOfRangeApprovalExpiryFailsClosed(_ rawValue: String) {
+    // given
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[EnvKey.approvalExpiry] = rawValue
+
+    // when / then — a dedicated ConfigError case (spec §4.6), never the scheduling vocabulary
+    #expect(throws: ConfigError.invalidApprovalExpiry(rawValue)) {
+      try AppConfig.load(environment: env)
+    }
+  }
 }

--- a/Tests/ClawCoreTests/Config/ErrorTests.swift
+++ b/Tests/ClawCoreTests/Config/ErrorTests.swift
@@ -28,5 +28,8 @@ import Testing
     // then
     #expect(ConfigError.invalidAllowlist("bad").exitCode == ClawExitCode.configInvalid.rawValue)
     #expect(ConfigError.unwritableStateRoot("/x").exitCode == ClawExitCode.configInvalid.rawValue)
+    #expect(
+      ConfigError.invalidApprovalExpiry("999999").exitCode == ClawExitCode.configInvalid.rawValue
+    )
   }
 }

--- a/Tests/ClawCoreTests/Domain/Approval/ApprovalDomainTests.swift
+++ b/Tests/ClawCoreTests/Domain/Approval/ApprovalDomainTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+@testable import ClawCore
+
+@Suite struct ApprovalDomainTests {
+  @Test func stateRawValuesMatchTheDBVocabulary() {
+    // given / when / then — exactly four states, per ARCHITECTURE §7.1/§19.1
+    #expect(ApprovalState.pending.rawValue == "PENDING")
+    #expect(ApprovalState.approved.rawValue == "APPROVED")
+    #expect(ApprovalState.rejected.rawValue == "REJECTED")
+    #expect(ApprovalState.expired.rawValue == "EXPIRED")
+  }
+
+  @Test func decisionRawValuesMatchTheAuditVocabulary() {
+    // given / when / then — the audit `decision` column vocabulary (spec §3.1, preamble D9)
+    #expect(ApprovalDecision.rejected.rawValue == "rejected")
+    #expect(ApprovalDecision.expired.rawValue == "expired")
+    #expect(ApprovalDecision.cancelled.rawValue == "cancelled")
+    #expect(ApprovalDecision.superseded.rawValue == "superseded")
+    #expect(ApprovalDecision.stalePolicy.rawValue == "stale_policy")
+  }
+
+  @Test func nonceIsTwentyTwoURLSafeCharacters() {
+    // given
+    let urlSafeAlphabet = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+
+    // when
+    let nonce = ApprovalNonce.generate()
+
+    // then — 16 bytes → base64url unpadded is exactly 22 chars, ≤ Telegram's 64-byte cap
+    // with the "apr:<nonce>:y" framing
+    #expect(nonce.count == 22)
+    #expect(nonce.allSatisfy { character in urlSafeAlphabet.contains(character) })
+  }
+
+  @Test func noncesDoNotRepeat() {
+    // given / when — 128 bits of CSPRNG output cannot collide over a small sample
+    let nonces = Set((0..<100).map { _ in ApprovalNonce.generate() })
+
+    // then
+    #expect(nonces.count == 100)
+  }
+
+  @Test func argsHashMatchesTheKnownSHA256Vectors() {
+    // given / when / then — pins the digest algorithm + hex rendering the approve CAS
+    // recomputes against (spec §6.2 step 5)
+    #expect(
+      ApprovalArgsHash.sha256Hex("")
+        == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    )
+    #expect(
+      ApprovalArgsHash.sha256Hex("abc")
+        == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    )
+  }
+}

--- a/Tests/ClawCoreTests/Domain/Approval/ApprovalFSMTests.swift
+++ b/Tests/ClawCoreTests/Domain/Approval/ApprovalFSMTests.swift
@@ -1,0 +1,51 @@
+import Testing
+
+@testable import ClawCore
+
+@Suite struct ApprovalFSMTests {
+  private struct Transition {
+    let state: ApprovalState
+    let event: ApprovalEvent
+    let expected: ApprovalState
+  }
+
+  @Test func legalTransitions() {
+    // given — the full legal set of ARCHITECTURE §19.1's ApprovalState table
+    let legal = [
+      Transition(state: .pending, event: .approve, expected: .approved),
+      Transition(state: .pending, event: .reject, expected: .rejected),
+      Transition(state: .pending, event: .expire, expected: .expired),
+    ]
+
+    for transition in legal {
+      // when
+      let next = ApprovalFSM.reduce(state: transition.state, on: transition.event)
+
+      // then
+      #expect(next == transition.expected)
+    }
+  }
+
+  @Test func illegalTransitionsHaveNoDefaultArm() {
+    // given — every remaining state×event cell: resolved rows never move again
+    let illegal: [(state: ApprovalState, event: ApprovalEvent)] = [
+      (.approved, .approve),
+      (.approved, .reject),
+      (.approved, .expire),
+      (.rejected, .approve),
+      (.rejected, .reject),
+      (.rejected, .expire),
+      (.expired, .approve),
+      (.expired, .reject),
+      (.expired, .expire),
+    ]
+
+    for transition in illegal {
+      // when
+      let next = ApprovalFSM.reduce(state: transition.state, on: transition.event)
+
+      // then
+      #expect(next == nil)
+    }
+  }
+}

--- a/Tests/ClawCoreTests/Domain/Policy/PolicyFingerprintTests.swift
+++ b/Tests/ClawCoreTests/Domain/Policy/PolicyFingerprintTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Testing
+
+@testable import ClawCore
+
+@Suite struct PolicyFingerprintTests {
+  // MARK: - hash(parts:)
+
+  @Test func hashIsDeterministicAcrossCalls() {
+    // given / when / then — same inputs, same digest (the recompute-at-resolution seam relies on it)
+    let parts = ["alpha", "beta", "gamma"]
+    #expect(PolicyFingerprint.hash(parts: parts) == PolicyFingerprint.hash(parts: parts))
+  }
+
+  @Test func hashRendersTheFullSHA256Hex() {
+    // given / when / then — 32 digest bytes → 64 lowercase hex chars
+    let digest = PolicyFingerprint.hash(parts: ["x"])
+    #expect(digest.count == 64)
+    #expect(digest.allSatisfy { character in "0123456789abcdef".contains(character) })
+  }
+
+  @Test func lengthPrefixDefeatsBoundaryConfusion() {
+    // given / when / then — "ab"+"c" and "a"+"bc" share the byte stream, but the 8-byte length
+    // prefixes differ, so the digests must differ (spec §3.2)
+    #expect(
+      PolicyFingerprint.hash(parts: ["ab", "c"]) != PolicyFingerprint.hash(parts: ["a", "bc"])
+    )
+  }
+
+  @Test func emptyPartCountsAsAField() {
+    // given / when / then — a present-but-empty file (missing → "") is distinct from an absent one
+    #expect(PolicyFingerprint.hash(parts: ["", ""]) != PolicyFingerprint.hash(parts: [""]))
+  }
+
+  // MARK: - staticSubhash
+
+  private func tool(
+    name: String,
+    params: JSONValue = .object(["type": .string("object")]),
+    risk: RiskLevel = .safe,
+    egress: ToolEgressClass = .none
+  ) -> ToolDefinition {
+    ToolDefinition(
+      name: name,
+      description: "d",
+      parameters: params,
+      egressClass: egress,
+      riskLevel: risk
+    )
+  }
+
+  private func subhash(
+    tools: [ToolDefinition]? = nil,
+    llm: String = "https://llm.example",
+    search: Bool = false,
+    root: String = "/workspace"
+  ) -> String {
+    PolicyFingerprint.staticSubhash(
+      tools: tools ?? [tool(name: "file_read")],
+      llmBaseURL: llm,
+      searchEndpointPresent: search,
+      workspaceRoot: root
+    )
+  }
+
+  @Test func staticSubhashIsIndependentOfToolInputOrder() {
+    // given
+    let first = tool(name: "a")
+    let second = tool(name: "b")
+
+    // when — sorted-by-name, so array order cannot move the hash
+    let forward = subhash(tools: [first, second])
+    let reversed = subhash(tools: [second, first])
+
+    // then
+    #expect(forward == reversed)
+  }
+
+  @Test func staticSubhashIsDeterministicForMultiKeySchemas() {
+    // given — a multi-key parameter schema; `.sortedKeys` canonicalization makes the encoding
+    // (and thus the hash) stable across calls
+    let schema: JSONValue = .object([
+      "type": .string("object"),
+      "properties": .object(["path": .string("string"), "content": .string("string")]),
+    ])
+
+    // when / then
+    #expect(
+      subhash(tools: [tool(name: "t", params: schema)])
+        == subhash(tools: [tool(name: "t", params: schema)])
+    )
+  }
+
+  @Test func toolNameIsAnInputClass() {
+    // given / when / then — the sorted tool name is a hashed surface class (§3.2)
+    #expect(subhash(tools: [tool(name: "a")]) != subhash(tools: [tool(name: "b")]))
+  }
+
+  @Test func toolParametersAreAnInputClass() {
+    // given / when / then — the canonical parameter JSON is a hashed surface class (§3.2)
+    #expect(
+      subhash(tools: [tool(name: "t", params: .object(["type": .string("object")]))])
+        != subhash(tools: [tool(name: "t", params: .object(["type": .string("string")]))])
+    )
+  }
+
+  @Test func riskLevelIsAnInputClass() {
+    // given / when / then — the declared riskLevel is a hashed surface class (§3.2)
+    #expect(
+      subhash(tools: [tool(name: "t", risk: .safe)])
+        != subhash(tools: [tool(name: "t", risk: .ask)])
+    )
+  }
+
+  @Test func egressClassIsAnInputClass() {
+    // given / when / then — the egress label is a hashed surface class (§3.2)
+    #expect(
+      subhash(tools: [tool(name: "t", egress: .none)])
+        != subhash(tools: [tool(name: "t", egress: .arbitraryDestination)])
+    )
+  }
+
+  @Test func llmBaseURLIsAnInputClass() {
+    // given / when / then — the pinned llm base URL is a hashed config class (§3.2)
+    #expect(subhash(llm: "https://a") != subhash(llm: "https://b"))
+  }
+
+  @Test func searchEndpointPresenceIsAnInputClass() {
+    // given / when / then — the search-endpoint presence sentinel is a hashed config class (§3.2)
+    #expect(subhash(search: true) != subhash(search: false))
+  }
+
+  @Test func workspaceRootIsAnInputClass() {
+    // given / when / then — the canonical workspace root is a hashed config class (§3.2)
+    #expect(subhash(root: "/a") != subhash(root: "/b"))
+  }
+
+  // MARK: - combined
+
+  @Test func combinedIsFirst16HexOfTheDigest() {
+    // given / when
+    let combined = PolicyFingerprint.combined(
+      staticSubhash: "sub",
+      promptMaterials: ["sys", "soul", "agents", "tools"]
+    )
+
+    // then — the persisted `policy_version` form (spec §3.2)
+    #expect(combined.count == 16)
+    #expect(
+      combined
+        == String(
+          PolicyFingerprint.hash(parts: ["sub", "sys", "soul", "agents", "tools"]).prefix(16)
+        )
+    )
+  }
+
+  @Test func combinedIsSensitiveToTheStaticSubhash() {
+    // given / when / then — a different classes 2–3 sub-hash flips the persisted fingerprint (§3.2)
+    #expect(
+      PolicyFingerprint.combined(staticSubhash: "s1", promptMaterials: ["a", "b", "c", "d"])
+        != PolicyFingerprint.combined(staticSubhash: "s2", promptMaterials: ["a", "b", "c", "d"])
+    )
+  }
+
+  @Test(arguments: 0..<4)
+  func combinedIsSensitiveToEachPromptMaterial(_ index: Int) {
+    // given
+    var mutated = ["sys", "soul", "agents", "tools"]
+    mutated[index] += "-changed"
+
+    // when / then — a strict-inequality voider: any prompt-file edit flips the fingerprint (§3.2)
+    #expect(
+      PolicyFingerprint.combined(
+        staticSubhash: "s",
+        promptMaterials: ["sys", "soul", "agents", "tools"]
+      )
+        != PolicyFingerprint.combined(staticSubhash: "s", promptMaterials: mutated)
+    )
+  }
+}

--- a/Tests/ClawCoreTests/Domain/Run/RunFSMTests.swift
+++ b/Tests/ClawCoreTests/Domain/Run/RunFSMTests.swift
@@ -20,6 +20,12 @@ import Testing
       Transition(state: .running, event: .fail, expected: .failed),
       Transition(state: .running, event: .cancel, expected: .cancelled),
       Transition(state: .running, event: .supersede, expected: .superseded),
+      Transition(state: .running, event: .suspendForApproval, expected: .awaitingApproval),
+      Transition(state: .awaitingApproval, event: .resumeApproved, expected: .running),
+      Transition(state: .awaitingApproval, event: .resolveDenied, expected: .failed),
+      Transition(state: .awaitingApproval, event: .fail, expected: .failed),
+      Transition(state: .awaitingApproval, event: .cancel, expected: .cancelled),
+      Transition(state: .awaitingApproval, event: .supersede, expected: .superseded),
     ]
 
     for transition in legal {
@@ -40,6 +46,18 @@ import Testing
       (.superseded, .fail),
       (.pending, .complete),
       (.running, .pickUp),
+      (.pending, .suspendForApproval),
+      (.pending, .resumeApproved),
+      (.pending, .resolveDenied),
+      (.running, .resumeApproved),
+      (.running, .resolveDenied),
+      (.awaitingApproval, .pickUp),
+      (.awaitingApproval, .complete),
+      (.awaitingApproval, .suspendForApproval),
+      (.done, .suspendForApproval),
+      (.failed, .resumeApproved),
+      (.cancelled, .resolveDenied),
+      (.superseded, .suspendForApproval),
     ]
 
     for transition in illegal {

--- a/Tests/ClawCoreTests/Domain/Tools/RiskLevelTests.swift
+++ b/Tests/ClawCoreTests/Domain/Tools/RiskLevelTests.swift
@@ -1,0 +1,33 @@
+import Testing
+
+@testable import ClawCore
+
+@Suite struct RiskLevelTests {
+  @Test func rawValuesMatchTheFingerprintVocabulary() {
+    // given / when / then — rawValues feed the §3.2 static sub-hash; renames void every
+    // outstanding approval, so they are pinned here
+    #expect(RiskLevel.safe.rawValue == "safe")
+    #expect(RiskLevel.ask.rawValue == "ask")
+    #expect(RiskLevel.dangerous.rawValue == "dangerous")
+  }
+
+  @Test func toolDefinitionCarriesItsDeclaredRiskLevel() {
+    // given
+    let definition = ToolDefinition(
+      name: "file_write",
+      description: "stub",
+      parameters: .object(["type": .string("object")]),
+      egressClass: .none,
+      riskLevel: .ask
+    )
+
+    // when / then
+    #expect(definition.riskLevel == .ask)
+  }
+
+  @Test func askTierReasonHasTheStableRawValue() {
+    // given / when / then — the approvals.reason column vocabulary (spec §4.1)
+    #expect(ApprovalReason.askTier.rawValue == "ask_tier")
+    #expect(ApprovalReason.exfilTrifecta.rawValue == "exfil_trifecta")
+  }
+}

--- a/Tests/ClawCoreTests/Persistence/AuditActionTests.swift
+++ b/Tests/ClawCoreTests/Persistence/AuditActionTests.swift
@@ -44,4 +44,16 @@ import Testing
     // given / when / then — rawValues are the durable audit vocabulary (preamble)
     #expect(fixture.action.rawValue == fixture.rawValue)
   }
+
+  private static let approvalActions: [(action: AuditAction, rawValue: String)] = [
+    (.approvalRequested, "approval_requested"),
+    (.approvalGranted, "approval_granted"),
+    (.approvalDenied, "approval_denied"),
+  ]
+
+  @Test(arguments: approvalActions)
+  func approvalActionsHaveStableRawValues(_ fixture: (action: AuditAction, rawValue: String)) {
+    // given / when / then — rawValues are the durable audit vocabulary (spec §3.1, preamble)
+    #expect(fixture.action.rawValue == fixture.rawValue)
+  }
 }

--- a/Tests/ClawDataTests/Database/V8MigrationTests.swift
+++ b/Tests/ClawDataTests/Database/V8MigrationTests.swift
@@ -1,0 +1,189 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct V8MigrationTests {
+  private func columnNames(_ queue: DatabaseQueue, table: String) throws -> [String] {
+    try queue.read { db in
+      try Row.fetchAll(db, sql: "PRAGMA table_info(\(table))").map { row in
+        row["name"] as String
+      }
+    }
+  }
+
+  /// Seeds one session + one run via raw SQL so approvals rows have valid FK targets.
+  private func seedSessionAndRun(_ queue: DatabaseQueue, state: String = "RUNNING") throws {
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO sessions(session_key, created_ts, updated_ts, tainted)
+          VALUES ('tg:dm:7', ?, ?, 0)
+          """,
+        arguments: [Date(), Date()]
+      )
+      try db.execute(
+        sql: "INSERT INTO runs(session_id, state, created_ts, updated_ts) VALUES (1, ?, ?, ?)",
+        arguments: [state, Date(), Date()]
+      )
+    }
+  }
+
+  private func insertApproval(
+    _ db: Database,
+    runId: Int64,
+    nonce: String,
+    state: String = "PENDING"
+  ) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO approvals(run_id, session_id, state, tool, canonical_args, canonical_target,
+          args_hash, policy_version, owner_user_id, nonce, observation_message_id, tool_call_id,
+          reason, created_ts, expires_ts)
+        VALUES (?, 1, ?, 'file_write', '{}', '/w/plan.md', 'h16', 'pv16', 7, ?, 1, 'c1',
+          'ask_tier', 1782000000, 1782003600)
+        """,
+      arguments: [runId, state, nonce]
+    )
+  }
+
+  @Test func vEightCreatesTheApprovalsTableAndLinkageColumns() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+
+    // when
+    try ClawDatabase.migrate(queue)
+
+    // then — the required spec §4.1 columns (superset; order and extras not pinned)
+    let approvalColumns = Set(try columnNames(queue, table: "approvals"))
+    #expect(
+      approvalColumns.isSuperset(of: [
+        "id", "run_id", "session_id", "state", "tool", "canonical_args", "canonical_target",
+        "args_hash", "policy_version", "owner_user_id", "nonce", "observation_message_id",
+        "tool_call_id", "reason", "prompt_message_id", "created_ts", "expires_ts", "resolved_ts",
+      ])
+    )
+    #expect(try columnNames(queue, table: "runs").contains("policy_version"))
+    #expect(try columnNames(queue, table: "sessions").contains("has_private_data"))
+    let outboundColumns = Set(try columnNames(queue, table: "outbound_deliveries"))
+    #expect(outboundColumns.isSuperset(of: ["approval_id", "reply_markup"]))
+  }
+
+  @Test func pendingPerRunIndexIsUniqueAndPartial() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+
+    // when
+    try ClawDatabase.migrate(queue)
+
+    // then — UNIQUE + WHERE in sqlite_master (the V6 partial-index idiom)
+    let indexSQL = try queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: """
+          SELECT sql FROM sqlite_master
+          WHERE type = 'index' AND name = 'index_approvals_pending_run'
+          """
+      )
+    }
+    #expect(indexSQL?.localizedCaseInsensitiveContains("unique") == true)
+    #expect(indexSQL?.localizedCaseInsensitiveContains("where") == true)
+    #expect(indexSQL?.contains("run_id") == true)
+  }
+
+  @Test func atMostOneLivePendingApprovalPerRun() throws {
+    // given — one run already holding a PENDING approval
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    try seedSessionAndRun(queue)
+    try queue.write { db in
+      try self.insertApproval(db, runId: 1, nonce: "nonce-a")
+    }
+
+    // when / then — a second PENDING row for the same run violates the partial UNIQUE index
+    #expect(throws: (any Error).self) {
+      try queue.write { db in
+        try self.insertApproval(db, runId: 1, nonce: "nonce-b")
+      }
+    }
+
+    // and a RESOLVED row does not block a fresh PENDING one (the index is partial)
+    try queue.write { db in
+      try db.execute(sql: "UPDATE approvals SET state = 'REJECTED' WHERE nonce = 'nonce-a'")
+      try self.insertApproval(db, runId: 1, nonce: "nonce-c")
+    }
+    let pendingCount = try queue.read { db in
+      try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM approvals WHERE state = 'PENDING'")
+    }
+    #expect(pendingCount == 1)
+  }
+
+  @Test func nonceIsGloballyUnique() throws {
+    // given — a resolved row already holds the nonce (single-use = never reused, spec §6.2)
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    try seedSessionAndRun(queue)
+    try queue.write { db in
+      try self.insertApproval(db, runId: 1, nonce: "nonce-a", state: "REJECTED")
+    }
+
+    // when / then
+    #expect(throws: (any Error).self) {
+      try queue.write { db in
+        try self.insertApproval(db, runId: 1, nonce: "nonce-a")
+      }
+    }
+  }
+
+  @Test func vEightUpgradesAPopulatedVSevenDatabase() throws {
+    // given — a v7 database holding a session, a run, and a PENDING outbox row
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrator.migrate(queue, upTo: "v7")
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO sessions(session_key, created_ts, updated_ts, tainted)
+          VALUES ('tg:dm:1', ?, ?, 0)
+          """,
+        arguments: [Date(), Date()]
+      )
+      try db.execute(
+        sql: "INSERT INTO runs(session_id, state, created_ts, updated_ts) VALUES (1, 'DONE', ?, ?)",
+        arguments: [Date(), Date()]
+      )
+      try db.execute(
+        sql: """
+          INSERT INTO outbound_deliveries(run_id, step_index, chat_id, dedup_key, payload,
+            payload_hash, status, created_ts)
+          VALUES (1, 0, 7, '1:0', 'hello', 'h', 'PENDING', ?)
+          """,
+        arguments: [Date()]
+      )
+    }
+
+    // when
+    try ClawDatabase.migrate(queue)
+
+    // then — additive nullable columns: the old rows stay valid with NULL/default backfill
+    let sessionFlag = try queue.read { db in
+      try Bool.fetchOne(db, sql: "SELECT has_private_data FROM sessions WHERE id = 1")
+    }
+    #expect(sessionFlag == false)
+    let runPolicy = try queue.read { db in
+      try String.fetchOne(db, sql: "SELECT policy_version FROM runs WHERE id = 1")
+    }
+    #expect(runPolicy == nil)
+    let outboundRow = try queue.read { db in
+      try Row.fetchOne(
+        db,
+        sql:
+          "SELECT status, approval_id, reply_markup FROM outbound_deliveries WHERE dedup_key = '1:0'"
+      )
+    }
+    #expect(outboundRow?["status"] == "PENDING")
+    #expect((outboundRow?["approval_id"] as Int64?) == nil)
+    #expect((outboundRow?["reply_markup"] as String?) == nil)
+  }
+}

--- a/Tests/ClawDataTests/Stores/Approval/ApprovalStoreGRDBTests.swift
+++ b/Tests/ClawDataTests/Stores/Approval/ApprovalStoreGRDBTests.swift
@@ -1,0 +1,527 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct ApprovalStoreGRDBTests {
+  private struct Fixture {
+    let queue: DatabaseQueue
+    let store: ApprovalStoreGRDB
+  }
+
+  /// Fresh in-memory DB with one session (id 1). Runs are seeded per-test so their state is
+  /// exactly what each boot/orphan scenario needs.
+  private func makeFixture() throws -> Fixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO sessions(session_key, created_ts, updated_ts, tainted)
+          VALUES ('tg:dm:7', ?, ?, 0)
+          """,
+        arguments: [Date(), Date()]
+      )
+    }
+    return Fixture(queue: queue, store: ApprovalStoreGRDB(writer: queue))
+  }
+
+  /// Inserts a run in the given state and returns its id (approvals.run_id has an FK to runs).
+  private func seedRun(_ queue: DatabaseQueue, state: RunState = .running) throws -> Int64 {
+    try queue.write { db in
+      try db.execute(
+        sql: "INSERT INTO runs(session_id, state, created_ts, updated_ts) VALUES (1, ?, ?, ?)",
+        arguments: [state.rawValue, Date(), Date()]
+      )
+      return db.lastInsertedRowID
+    }
+  }
+
+  private func makeNewApproval(
+    runId: Int64,
+    nonce: String = "nonce-a",
+    canonicalArgsJSON: String = #"{"path":"/w/plan.md"}"#,
+    policyVersion: String = "pv16",
+    createdTs: Date,
+    expiresTs: Date
+  ) -> NewApproval {
+    NewApproval(
+      runId: runId,
+      sessionId: 1,
+      tool: "file_write",
+      canonicalArgsJSON: canonicalArgsJSON,
+      canonicalTarget: "/w/plan.md",
+      argsHash: ApprovalArgsHash.sha256Hex(canonicalArgsJSON),
+      policyVersion: policyVersion,
+      ownerUserId: 7,
+      nonce: nonce,
+      observationMessageId: 1,
+      toolCallId: "c1",
+      reason: .askTier,
+      createdTs: createdTs,
+      expiresTs: expiresTs
+    )
+  }
+
+  @discardableResult
+  private func insert(_ queue: DatabaseQueue, _ newApproval: NewApproval) throws -> Int64 {
+    try queue.write { db in try ApprovalStoreGRDB.insertApproval(db, newApproval) }
+  }
+
+  private struct AuditLine: Equatable {
+    let actor: String
+    let action: String
+    let decision: String
+  }
+
+  private func audits(_ queue: DatabaseQueue) throws -> [AuditLine] {
+    try queue.read { db in
+      try Row.fetchAll(db, sql: "SELECT actor, action, decision FROM audit_events ORDER BY id")
+        .map { row in
+          AuditLine(actor: row["actor"], action: row["action"], decision: row["decision"])
+        }
+    }
+  }
+
+  @Test func insertStartsPendingAndRoundTripsEveryColumn() throws {
+    // given
+    let env = try makeFixture()
+    let runId = try seedRun(env.queue)
+    let created = Date(timeIntervalSince1970: 1_782_000_000)
+    let expires = Date(timeIntervalSince1970: 1_782_003_600)
+
+    // when
+    let id = try insert(
+      env.queue,
+      makeNewApproval(runId: runId, createdTs: created, expiresTs: expires)
+    )
+
+    // then — the state is store-owned (always PENDING) and the epoch columns decode back exactly
+    let approval = try #require(try env.store.approval(id: id))
+    #expect(approval.state == .pending)
+    #expect(approval.tool == "file_write")
+    #expect(approval.reason == .askTier)
+    #expect(approval.canonicalArgsJSON == #"{"path":"/w/plan.md"}"#)
+    #expect(approval.argsHash == ApprovalArgsHash.sha256Hex(#"{"path":"/w/plan.md"}"#))
+    #expect(approval.createdTs == created)
+    #expect(approval.expiresTs == expires)
+    #expect(approval.resolvedTs == nil)
+    #expect(approval.promptMessageId == nil)
+  }
+
+  @Test func approvalByNonceFindsTheRowAndMissesUnknown() throws {
+    // given
+    let env = try makeFixture()
+    let runId = try seedRun(env.queue)
+    let now = Date()
+    try insert(
+      env.queue,
+      makeNewApproval(
+        runId: runId,
+        nonce: "n-77",
+        createdTs: now,
+        expiresTs: now.addingTimeInterval(60)
+      )
+    )
+
+    // when / then — lookup is by nonce ONLY (never by id)
+    #expect(try env.store.approval(nonce: "n-77")?.nonce == "n-77")
+    #expect(try env.store.approval(nonce: "does-not-exist") == nil)
+  }
+
+  @Test func approveCommitsWhenHashAndPolicyMatch() throws {
+    // given
+    let env = try makeFixture()
+    let runId = try seedRun(env.queue)
+    let now = Date()
+    let id = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: runId,
+        policyVersion: "pv16",
+        createdTs: now,
+        expiresTs: now.addingTimeInterval(3600)
+      )
+    )
+
+    // when
+    let outcome = try env.store.approve(id: id, currentPolicyVersion: "pv16", now: now)
+
+    // then — PENDING→APPROVED, resolved_ts stamped, approvalGranted audited in the same txn
+    guard case .approved(let approved) = outcome else {
+      Issue.record("expected .approved, got \(outcome)")
+      return
+    }
+    #expect(approved.state == .approved)
+    #expect(approved.resolvedTs != nil)  // resolved_ts stamped (epoch codec rounds to the second)
+    #expect(try env.store.approval(id: id)?.state == .approved)
+    #expect(
+      try audits(env.queue) == [
+        AuditLine(
+          actor: AuditActor.owner.rawValue,
+          action: AuditAction.approvalGranted.rawValue,
+          decision: "ok"
+        )
+      ]
+    )
+  }
+
+  @Test func approveRejectsOnArgsHashMismatch() throws {
+    // given — the stored args_hash no longer matches SHA-256(canonical_args): tampered row
+    let env = try makeFixture()
+    let runId = try seedRun(env.queue)
+    let now = Date()
+    let id = try insert(
+      env.queue,
+      makeNewApproval(runId: runId, createdTs: now, expiresTs: now.addingTimeInterval(3600))
+    )
+    try env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE approvals SET args_hash = 'tampered' WHERE id = ?",
+        arguments: [id]
+      )
+    }
+
+    // when
+    let outcome = try env.store.approve(id: id, currentPolicyVersion: "pv16", now: now)
+
+    // then — PENDING→REJECTED, decision stale_policy, approvalDenied audited
+    guard case .stalePolicy(let rejected) = outcome else {
+      Issue.record("expected .stalePolicy, got \(outcome)")
+      return
+    }
+    #expect(rejected.state == .rejected)
+    #expect(try env.store.approval(id: id)?.state == .rejected)
+    #expect(
+      try audits(env.queue) == [
+        AuditLine(
+          actor: AuditActor.owner.rawValue,
+          action: AuditAction.approvalDenied.rawValue,
+          decision: ApprovalDecision.stalePolicy.rawValue
+        )
+      ]
+    )
+  }
+
+  @Test func approveRejectsOnPolicyVersionMismatch() throws {
+    // given — args match, but the recomputed policy_version drifted
+    let env = try makeFixture()
+    let runId = try seedRun(env.queue)
+    let now = Date()
+    let id = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: runId,
+        policyVersion: "pv16",
+        createdTs: now,
+        expiresTs: now.addingTimeInterval(3600)
+      )
+    )
+
+    // when
+    let outcome = try env.store.approve(id: id, currentPolicyVersion: "pv99", now: now)
+
+    // then
+    guard case .stalePolicy = outcome else {
+      Issue.record("expected .stalePolicy, got \(outcome)")
+      return
+    }
+    #expect(try env.store.approval(id: id)?.state == .rejected)
+  }
+
+  @Test func approveOfAnAlreadyResolvedRowIsNotPending() throws {
+    // given — a row already denied (duplicate-tap scenario)
+    let env = try makeFixture()
+    let runId = try seedRun(env.queue)
+    let now = Date()
+    let id = try insert(
+      env.queue,
+      makeNewApproval(runId: runId, createdTs: now, expiresTs: now.addingTimeInterval(3600))
+    )
+    #expect(try env.store.deny(id: id, decision: .rejected, now: now))
+
+    // when
+    let outcome = try env.store.approve(id: id, currentPolicyVersion: "pv16", now: now)
+
+    // then — the second tap is a no-op the caller answers "already handled"
+    #expect(outcome == .notPending)
+    #expect(try env.store.approval(id: id)?.state == .rejected)
+  }
+
+  @Test func approveOfAnExpiredPendingRowReturnsExpiredRowUntouched() throws {
+    // given — expires_ts already passed while still PENDING
+    let env = try makeFixture()
+    let runId = try seedRun(env.queue)
+    let now = Date()
+    let id = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: runId,
+        createdTs: now.addingTimeInterval(-7200),
+        expiresTs: now.addingTimeInterval(-3600)
+      )
+    )
+
+    // when
+    let outcome = try env.store.approve(id: id, currentPolicyVersion: "pv16", now: now)
+
+    // then — the caller routes to the deny path; the row stays PENDING and nothing is audited
+    #expect(outcome == .expiredRow)
+    #expect(try env.store.approval(id: id)?.state == .pending)
+    #expect(try audits(env.queue).isEmpty)
+  }
+
+  @Test func denyCommitsRejectedAndAudits() throws {
+    // given
+    let env = try makeFixture()
+    let runId = try seedRun(env.queue)
+    let now = Date()
+    let id = try insert(
+      env.queue,
+      makeNewApproval(runId: runId, createdTs: now, expiresTs: now.addingTimeInterval(3600))
+    )
+
+    // when
+    let resolved = try env.store.deny(id: id, decision: .cancelled, now: now)
+
+    // then — PENDING→REJECTED (cancel/supersede resolve to REJECTED; decision records why)
+    #expect(resolved)
+    #expect(try env.store.approval(id: id)?.state == .rejected)
+    #expect(
+      try audits(env.queue) == [
+        AuditLine(
+          actor: AuditActor.system.rawValue,
+          action: AuditAction.approvalDenied.rawValue,
+          decision: ApprovalDecision.cancelled.rawValue
+        )
+      ]
+    )
+  }
+
+  @Test func denyWithExpiredDecisionMovesToExpired() throws {
+    // given
+    let env = try makeFixture()
+    let runId = try seedRun(env.queue)
+    let now = Date()
+    let id = try insert(
+      env.queue,
+      makeNewApproval(runId: runId, createdTs: now, expiresTs: now.addingTimeInterval(3600))
+    )
+
+    // when — the .expired decision alone routes PENDING→EXPIRED (all others → REJECTED)
+    #expect(try env.store.deny(id: id, decision: .expired, now: now))
+
+    // then
+    #expect(try env.store.approval(id: id)?.state == .expired)
+  }
+
+  @Test func denyLosesTheRaceWhenAlreadyResolved() throws {
+    // given — a racing resolver already moved the row
+    let env = try makeFixture()
+    let runId = try seedRun(env.queue)
+    let now = Date()
+    let id = try insert(
+      env.queue,
+      makeNewApproval(runId: runId, createdTs: now, expiresTs: now.addingTimeInterval(3600))
+    )
+    #expect(try env.store.deny(id: id, decision: .rejected, now: now))
+
+    // when / then — the second deny observes a non-PENDING row and reports the loss
+    #expect(try env.store.deny(id: id, decision: .cancelled, now: now) == false)
+  }
+
+  @Test func sweepExpiredMovesOnlyThePastDuePendingRows() throws {
+    // given — two runs: one approval already expired, one still live (distinct runs so the
+    // partial UNIQUE-PENDING index permits both)
+    let env = try makeFixture()
+    let expiredRun = try seedRun(env.queue)
+    let liveRun = try seedRun(env.queue)
+    let now = Date()
+    let expiredId = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: expiredRun,
+        nonce: "n-expired",
+        createdTs: now.addingTimeInterval(-7200),
+        expiresTs: now.addingTimeInterval(-60)
+      )
+    )
+    let liveId = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: liveRun,
+        nonce: "n-live",
+        createdTs: now,
+        expiresTs: now.addingTimeInterval(3600)
+      )
+    )
+
+    // when
+    let swept = try env.store.sweepExpired(now: now)
+
+    // then — only the past-due row sweeps; each swept row is EXPIRED + audited decision expired
+    #expect(swept.map(\.id) == [expiredId])
+    #expect(swept.allSatisfy { row in row.state == .expired })
+    #expect(try env.store.approval(id: expiredId)?.state == .expired)
+    #expect(try env.store.approval(id: liveId)?.state == .pending)
+    #expect(
+      try audits(env.queue) == [
+        AuditLine(
+          actor: AuditActor.system.rawValue,
+          action: AuditAction.approvalDenied.rawValue,
+          decision: ApprovalDecision.expired.rawValue
+        )
+      ]
+    )
+  }
+
+  @Test func unresolvedAtBootReturnsPendingAndAwaitingApprovedRows() throws {
+    // given — a PENDING row, an APPROVED row whose run is AWAITING_APPROVAL (§6.5 crash window),
+    // and an APPROVED row whose run already reached DONE (settled — must be excluded)
+    let env = try makeFixture()
+    let pendingRun = try seedRun(env.queue, state: .awaitingApproval)
+    let crashRun = try seedRun(env.queue, state: .awaitingApproval)
+    let settledRun = try seedRun(env.queue, state: .done)
+    let now = Date()
+    let pendingId = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: pendingRun,
+        nonce: "n-pending",
+        createdTs: now,
+        expiresTs: now.addingTimeInterval(3600)
+      )
+    )
+    let crashId = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: crashRun,
+        nonce: "n-crash",
+        createdTs: now,
+        expiresTs: now.addingTimeInterval(3600)
+      )
+    )
+    let settledId = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: settledRun,
+        nonce: "n-settled",
+        createdTs: now,
+        expiresTs: now.addingTimeInterval(3600)
+      )
+    )
+    try env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE approvals SET state = 'APPROVED' WHERE id IN (?, ?)",
+        arguments: [crashId, settledId]
+      )
+    }
+
+    // when
+    let unresolved = try env.store.unresolvedAtBoot()
+
+    // then
+    #expect(Set(unresolved.map(\.id)) == Set([pendingId, crashId]))
+  }
+
+  @Test func resolveOrphansRejectsPendingRowsOfTerminalRuns() throws {
+    // given — a PENDING approval whose run FAILED (orphan) and one whose run is still parked
+    let env = try makeFixture()
+    let terminalRun = try seedRun(env.queue, state: .failed)
+    let parkedRun = try seedRun(env.queue, state: .awaitingApproval)
+    let now = Date()
+    let orphanId = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: terminalRun,
+        nonce: "n-orphan",
+        createdTs: now,
+        expiresTs: now.addingTimeInterval(3600)
+      )
+    )
+    let keptId = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: parkedRun,
+        nonce: "n-kept",
+        createdTs: now,
+        expiresTs: now.addingTimeInterval(3600)
+      )
+    )
+
+    // when
+    let cleaned = try env.store.resolveOrphans(now: now)
+
+    // then — only the terminal-run orphan is rejected; the parked one is left for the re-park
+    #expect(cleaned == 1)
+    #expect(try env.store.approval(id: orphanId)?.state == .rejected)
+    #expect(try env.store.approval(id: keptId)?.state == .pending)
+    #expect(
+      try audits(env.queue) == [
+        AuditLine(
+          actor: AuditActor.system.rawValue,
+          action: AuditAction.approvalDenied.rawValue,
+          decision: ApprovalDecision.cancelled.rawValue
+        )
+      ]
+    )
+  }
+
+  @Test func approvalsHealthCountsPendingAndOldestAge() throws {
+    // given — two PENDING rows on distinct runs; the older created 300 s before now
+    let env = try makeFixture()
+    let firstRun = try seedRun(env.queue)
+    let secondRun = try seedRun(env.queue)
+    let now = Date(timeIntervalSince1970: 1_782_000_300)
+    try insert(
+      env.queue,
+      makeNewApproval(
+        runId: firstRun,
+        nonce: "n-old",
+        createdTs: Date(timeIntervalSince1970: 1_782_000_000),
+        expiresTs: Date(timeIntervalSince1970: 1_782_003_600)
+      )
+    )
+    try insert(
+      env.queue,
+      makeNewApproval(
+        runId: secondRun,
+        nonce: "n-new",
+        createdTs: Date(timeIntervalSince1970: 1_782_000_200),
+        expiresTs: Date(timeIntervalSince1970: 1_782_003_600)
+      )
+    )
+
+    // when
+    let health = try env.store.approvalsHealth(now: now)
+
+    // then
+    #expect(health.pendingCount == 2)
+    #expect(health.oldestPendingAgeSeconds == 300)
+  }
+
+  @Test func approvalsHealthIsZeroWhenNothingPending() throws {
+    // given
+    let env = try makeFixture()
+
+    // when
+    let health = try env.store.approvalsHealth(now: Date())
+
+    // then
+    #expect(health.pendingCount == 0)
+    #expect(health.oldestPendingAgeSeconds == nil)
+  }
+
+  @Test func openStoresExposesTheApprovalStore() throws {
+    // given — the composed store bundle, wired through openStores on a real file DB
+    let path = FileManager.default.temporaryDirectory
+      .appendingPathComponent("claw-approvals-\(UUID().uuidString).sqlite").path
+    defer { try? FileManager.default.removeItem(atPath: path) }
+    let stores = try ClawDatabase.openStores(path: path)
+
+    // when / then — the protocol-typed store is reachable and functional
+    #expect(try stores.approvals.approvalsHealth(now: Date()).pendingCount == 0)
+  }
+}

--- a/Tests/ClawDataTests/Stores/Run/AwaitingApprovalSeamTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/AwaitingApprovalSeamTests.swift
@@ -1,0 +1,170 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct AwaitingApprovalSeamTests {
+  private struct Fixture {
+    let queue: DatabaseQueue
+    let runs: RunStoreGRDB
+    let outbox: OutboxStoreGRDB
+    let sessionId: Int64
+    let runId: Int64
+  }
+
+  /// One run suspended to AWAITING_APPROVAL through the real reducer (pickUp → suspend).
+  private func makeSuspendedFixture() throws -> Fixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: 7),
+        chatId: 7,
+        userId: 7,
+        text: "write the plan",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let sessionId = try #require(claim.sessionId)
+    let runId = try #require(claim.runId)
+    let runs = RunStoreGRDB(writer: queue)
+    _ = try #require(try runs.pickUp(runId: runId, now: Date()))
+    try queue.write { db in
+      _ = try RunStoreGRDB.transitionRun(db, runId: runId, event: .suspendForApproval, now: Date())
+    }
+    return Fixture(
+      queue: queue,
+      runs: runs,
+      outbox: OutboxStoreGRDB(writer: queue),
+      sessionId: sessionId,
+      runId: runId
+    )
+  }
+
+  private func runState(_ queue: DatabaseQueue, runId: Int64) throws -> String? {
+    try queue.read { db in
+      try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [runId])
+    }
+  }
+
+  @Test func stopCancelsASuspendedRun() throws {
+    // given
+    let env = try makeSuspendedFixture()
+
+    // when — /stop's single-run path (cancelActiveRun → fetchActiveRunId)
+    let cancelled = try env.runs.cancelActiveRun(
+      sessionId: env.sessionId,
+      reason: .cancelled,
+      now: Date()
+    )
+
+    // then — without the widened predicate, /stop silently skips the suspended run (§4.2)
+    #expect(cancelled == env.runId)
+    #expect(try runState(env.queue, runId: env.runId) == RunState.cancelled.rawValue)
+  }
+
+  @Test func newSupersedesASuspendedRun() throws {
+    // given
+    let env = try makeSuspendedFixture()
+
+    // when — /new's plural path (supersedeSessionRuns → terminateActiveRuns)
+    let superseded = try env.runs.supersedeSessionRuns(sessionId: env.sessionId, now: Date())
+
+    // then
+    #expect(superseded == [env.runId])
+    #expect(try runState(env.queue, runId: env.runId) == RunState.superseded.rawValue)
+  }
+
+  @Test func runsHealthCountsASuspendedRunAsInFlight() throws {
+    // given
+    let env = try makeSuspendedFixture()
+
+    // when
+    let health = try env.runs.runsHealth(now: Date())
+
+    // then — a parked lane is live capacity; doctor must see it (spec §4.2)
+    #expect(health.inFlight == 1)
+    #expect(health.oldestRunAgeSeconds != nil)
+  }
+
+  @Test func outboxClaimTreatsASuspendedRunAsActive() throws {
+    // given
+    let env = try makeSuspendedFixture()
+
+    // when — the suspended run's own approval prompt rides this claim (preamble D7)
+    let claimed = try env.outbox.claimOutboundIfRunActive(
+      runId: env.runId,
+      stepIndex: 0,
+      chatId: 7,
+      payload: "approve?",
+      payloadHash: "h"
+    )
+
+    // then
+    #expect(claimed)
+    #expect(try env.outbox.pendingOutbound().count == 1)
+  }
+
+  @Test func assistantCommitOnASuspendedRunLosesArbitration() throws {
+    // given
+    let env = try makeSuspendedFixture()
+    let turn = AssistantTurn(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: 7,
+      content: "late reply",
+      usage: ProviderUsage(
+        runId: env.runId,
+        sessionId: env.sessionId,
+        model: "m",
+        promptTokens: 1,
+        completionTokens: 1,
+        costUSD: 0,
+        costSource: .heuristic,
+        isEstimated: true,
+        ts: Date()
+      ),
+      chunks: []
+    )
+
+    // when
+    let result = try env.runs.commitAssistantTurn(turn, now: Date())
+
+    // then — same as terminal states: the suspended run owns no commit (spec §4.2); no
+    // assistant row lands and the state is untouched
+    #expect(result == .ignored)
+    #expect(try runState(env.queue, runId: env.runId) == RunState.awaitingApproval.rawValue)
+    let assistantRows = try env.queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM messages WHERE run_id = ? AND role = 'assistant'",
+        arguments: [env.runId]
+      )
+    }
+    #expect(assistantRows == 0)
+  }
+
+  @Test func degradedCommitOnASuspendedRunLosesArbitration() throws {
+    // given
+    let env = try makeSuspendedFixture()
+    let turn = DegradedTurn(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: 7,
+      usage: nil,
+      chunk: OutboxChunk(stepIndex: 0, chatId: 7, payload: "degraded", payloadHash: "h")
+    )
+
+    // when
+    let result = try env.runs.commitDegradedTurn(turn, now: Date())
+
+    // then
+    #expect(result == .ignored)
+    #expect(try runState(env.queue, runId: env.runId) == RunState.awaitingApproval.rawValue)
+  }
+}

--- a/Tests/ClawDataTests/Stores/Run/PickUpPolicyVersionTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/PickUpPolicyVersionTests.swift
@@ -1,0 +1,78 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct PickUpPolicyVersionTests {
+  private struct Fixture {
+    let queue: DatabaseQueue
+    let runs: RunStoreGRDB
+    let runId: Int64
+  }
+
+  private func fixture() throws -> Fixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: 7),
+        chatId: 7,
+        userId: 7,
+        text: "write the plan",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let runId = try #require(claim.runId)
+    return Fixture(queue: queue, runs: RunStoreGRDB(writer: queue), runId: runId)
+  }
+
+  private func persistedPolicyVersion(_ queue: DatabaseQueue, runId: Int64) throws -> String? {
+    try queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT policy_version FROM runs WHERE id = ?",
+        arguments: [runId]
+      )
+    }
+  }
+
+  private func runState(_ queue: DatabaseQueue, runId: Int64) throws -> String? {
+    try queue.read { db in
+      try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [runId])
+    }
+  }
+
+  @Test func pickUpStampsPolicyVersionInTheSameFlipToRunning() throws {
+    // given
+    let env = try fixture()
+
+    // when
+    let origin = try env.runs.pickUp(
+      runId: env.runId,
+      policyVersion: "abc0123456789def",
+      now: Date()
+    )
+
+    // then — the RUNNING flip and the stamp are one UPDATE (§3.2)
+    #expect(origin == .interactive)
+    #expect(try runState(env.queue, runId: env.runId) == RunState.running.rawValue)
+    #expect(try persistedPolicyVersion(env.queue, runId: env.runId) == "abc0123456789def")
+  }
+
+  @Test func theResumeConvenienceNeverStampsAPolicyVersion() throws {
+    // given — the two-arg convenience models the resume path (which never re-stamps, preamble §3.2)
+    let env = try fixture()
+
+    // when
+    _ = try #require(try env.runs.pickUp(runId: env.runId, now: Date()))
+
+    // then
+    #expect(try runState(env.queue, runId: env.runId) == RunState.running.rawValue)
+    #expect(try persistedPolicyVersion(env.queue, runId: env.runId) == nil)
+  }
+}

--- a/Tests/ClawGatewayTests/Response/ApprovalsHealthTests.swift
+++ b/Tests/ClawGatewayTests/Response/ApprovalsHealthTests.swift
@@ -1,0 +1,34 @@
+import ClawCore
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct ApprovalsHealthTests {
+  private func value(_ rows: [ApprovalsHealthRows.Row], _ key: String) -> String? {
+    rows.first { row in row.key == key }?.value
+  }
+
+  @Test func noPendingApprovalsRendersZeroAndNone() {
+    // given — a freshly-migrated approvals table: nothing pending
+    let health = ApprovalsHealth(pendingCount: 0, oldestPendingAgeSeconds: nil)
+
+    // when
+    let rows = ApprovalsHealthRows.rows(health: health, approvalExpirySeconds: 3600)
+
+    // then
+    #expect(value(rows, "approvals.pending") == "0")
+    #expect(value(rows, "approvals.oldest_age_s") == "none")
+  }
+
+  @Test func pendingApprovalsRenderCountAndOldestAgeAgainstTheExpiry() {
+    // given — two pending approvals, the oldest 900s into its 3600s window
+    let health = ApprovalsHealth(pendingCount: 2, oldestPendingAgeSeconds: 900)
+
+    // when
+    let rows = ApprovalsHealthRows.rows(health: health, approvalExpirySeconds: 3600)
+
+    // then — age/expiry mirrors the heartbeat.today count/cap idiom (spec §4.6)
+    #expect(value(rows, "approvals.pending") == "2")
+    #expect(value(rows, "approvals.oldest_age_s") == "900/3600")
+  }
+}

--- a/Tests/ClawGatewayTests/Response/ToolApprovalPromptTests.swift
+++ b/Tests/ClawGatewayTests/Response/ToolApprovalPromptTests.swift
@@ -20,4 +20,19 @@ import Testing
     #expect(text.contains("This session has read external content and holds private data."))
     #expect(text.contains("Reply yes to allow this one fetch"))
   }
+
+  @Test func askTierPromptCarriesTheToolAndTheFullTarget() {
+    // given — the minimal Phase 1 arm; the full §5.4 contract lands in Task 13
+    let request = ToolApprovalRequest(
+      action: ToolAction(tool: "file_write", target: "/workspace/notes/plan.md"),
+      reason: .askTier
+    )
+
+    // when
+    let text = ToolApprovalPrompt.text(for: request)
+
+    // then — structural fields only, not full copy (TESTING §7.2)
+    #expect(text.contains("file_write"))
+    #expect(text.contains("/workspace/notes/plan.md"))
+  }
 }

--- a/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
+++ b/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
@@ -42,8 +42,8 @@ struct CancellingBeforeAssistantCommitRuns: RunStore {
   let base: RunStoreGRDB
   let sessionId: Int64
 
-  func pickUp(runId: Int64, now: Date) throws -> RunOrigin? {
-    try base.pickUp(runId: runId, now: now)
+  func pickUp(runId: Int64, policyVersion: String?, now: Date) throws -> RunOrigin? {
+    try base.pickUp(runId: runId, policyVersion: policyVersion, now: now)
   }
 
   func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws -> RunCommitResult {
@@ -90,8 +90,8 @@ struct CancellingBeforeDegradedCommitRuns: RunStore {
   let base: RunStoreGRDB
   let sessionId: Int64
 
-  func pickUp(runId: Int64, now: Date) throws -> RunOrigin? {
-    try base.pickUp(runId: runId, now: now)
+  func pickUp(runId: Int64, policyVersion: String?, now: Date) throws -> RunOrigin? {
+    try base.pickUp(runId: runId, policyVersion: policyVersion, now: now)
   }
 
   func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws -> RunCommitResult {
@@ -134,7 +134,9 @@ struct CancellingBeforeDegradedCommitRuns: RunStore {
 
 /// A `RunStore` whose first write reports a full disk, to exercise the storage-full rethrow.
 struct DiskFullRuns: RunStore {
-  func pickUp(runId: Int64, now: Date) throws -> RunOrigin? { throw StoreError.diskFull }
+  func pickUp(runId: Int64, policyVersion: String?, now: Date) throws -> RunOrigin? {
+    throw StoreError.diskFull
+  }
   func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws -> RunCommitResult { .ignored }
   func commitDegradedTurn(_ turn: DegradedTurn, now: Date) throws -> RunCommitResult { .ignored }
   func failRun(runId: Int64, now: Date) throws {}

--- a/Tests/ClawLLMTests/Provider/ToolWireCodingTests.swift
+++ b/Tests/ClawLLMTests/Provider/ToolWireCodingTests.swift
@@ -67,7 +67,8 @@ import Testing
         "properties": .object(["url": .object(["type": .string("string")])]),
         "required": .array([.string("url")]),
       ]),
-      egressClass: .none
+      egressClass: .none,
+      riskLevel: .safe
     )
     let request = ChatRequest(
       model: "m",

--- a/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
+++ b/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
@@ -15,7 +15,8 @@ struct FetchLikeTool: Tool {
       name: name,
       description: "stub",
       parameters: .object(["type": .string("object")]),
-      egressClass: .arbitraryDestination
+      egressClass: .arbitraryDestination,
+      riskLevel: .safe
     )
   }
 
@@ -43,7 +44,8 @@ struct SearchLikeTool: Tool {
     name: "web_search",
     description: "stub",
     parameters: .object(["type": .string("object")]),
-    egressClass: .fixedEndpoint
+    egressClass: .fixedEndpoint,
+    riskLevel: .safe
   )
   let timeout: Duration = .seconds(1)
 
@@ -532,7 +534,8 @@ struct SearchLikeTool: Tool {
         name: "web_fetch",
         description: "stub",
         parameters: .object(["type": .string("object")]),
-        egressClass: .arbitraryDestination
+        egressClass: .arbitraryDestination,
+        riskLevel: .safe
       )
       let timeout: Duration = .seconds(1)
 
@@ -575,7 +578,8 @@ struct SearchLikeTool: Tool {
         name: "slow",
         description: "slow",
         parameters: .object(["type": .string("object")]),
-        egressClass: .none
+        egressClass: .none,
+        riskLevel: .safe
       )
       let timeout: Duration = .milliseconds(20)
 
@@ -649,7 +653,8 @@ struct WedgedTool: Tool {
     name: "wedged",
     description: "wedged",
     parameters: .object(["type": .string("object")]),
-    egressClass: .none
+    egressClass: .none,
+    riskLevel: .safe
   )
   let timeout: Duration = .seconds(30)
 

--- a/Tests/ClawToolsTests/Tools/ToolRegistryTests.swift
+++ b/Tests/ClawToolsTests/Tools/ToolRegistryTests.swift
@@ -20,7 +20,8 @@ struct StubTool: Tool {
       name: name,
       description: "stub",
       parameters: .object(["type": .string("object")]),
-      egressClass: egressClass
+      egressClass: egressClass,
+      riskLevel: .safe
     )
     self.timeout = timeout
     self.payload = payload


### PR DESCRIPTION
## What this is

The dormant substrate for the durable tool-approval fabric (Increment 5a, Phase 1). It lays the persistence, domain, and policy-fingerprint groundwork that later phases turn on. At runtime the daemon behaves as before: nothing constructs an approval yet, and `policy_version` is computed and persisted but not yet validated. Validation arrives in Phases 2–4.

## What landed

- **Migration v8**: the `approvals` table (unique `nonce`, a partial-unique index enforcing one pending approval per run), plus additive nullable linkage columns on `runs.policy_version`, `sessions.has_private_data`, and `outbound_deliveries.approval_id`/`reply_markup`. It stays additive: a populated v7 database upgrades with pre-existing rows intact.
- **Approval domain + FSMs**: `ApprovalState`/`ApprovalFSM` (four states, an exhaustive reducer with no default arm) and a widened `RunFSM` carrying `AWAITING_APPROVAL` and its suspend/resume/deny events. Adds `ApprovalNonce` (128-bit CSPRNG, base64url), `ApprovalArgsHash`, and `ApprovalDecision`.
- **`ApprovalStoreGRDB`**, the CAS resolution engine: approve, deny, expiry sweep, boot reconciliation, and orphan cleanup. Every state change goes through one FSM-backed transition seam, every resolution's audit rides the same transaction (house rule), timestamps travel as epoch integers through a dedicated codec, and row mapping fails closed on a corrupt column.
- **`RiskLevel` on `ToolDefinition`**: every existing tool declares `.safe`, with no default, so a new tool cannot compile without classifying itself.
- **Run-state seam widenings**: `/stop`, `/new`, doctor health, and the outbox claim now treat a suspended run as active, so a parked run's own approval prompt stays deliverable.
- **`PolicyFingerprint`**: a length-prefixed SHA-256 over the tool surface, egress/policy config, and system-tier prompt materials. It computes at the composition root, folds into `ContextBuilder`, and stamps onto `runs.policy_version` in the same write that starts the run. It never hashes secret values.
- **Config + observability**: `CLAW_APPROVAL_EXPIRY` (bounded, with a dedicated config error) and two approvals rows in `doctor`.

## Verification

`swift build` clean, **871/871 tests pass**, lint gate passes (warning count unchanged vs `main`). I built every task test-first and reviewed each for spec compliance and quality; the whole branch then passed a final review that returned a ready-to-merge verdict with no blocking findings.

One caveat: a single transient test failure showed up on one early full-suite run and did not reproduce across ten subsequent runs. Phase 1 adds only deterministic code (state machines, injected-clock stores, hashing; no concurrency or sleeps), and the review found nothing in the branch that could cause it, so it reads as a pre-existing wider-suite flake rather than a regression here.

## Notes for the reviewer

- The intentional deviations from the spec live in `docs/superpowers/plans/inc5a/00-preamble.md` (D1–D10). Two examples: `RiskLevel` lands in this phase, and budget carry-over is derived rather than stored.
- A forward note for Phase 3: `ApprovalStoreGRDB.deny()` attributes non-rejection decisions to the system actor, which is right for the boot sweep. When `/stop`//`new` resolution gets wired (Task 17), route owner-initiated cancel/supersede through `applyStop`/`applyNew`, not `deny()`.
