### PR TITLE
Durable tool-approval callback resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,11 @@ jobs:
         run: swift test
 
   # docs/TESTING.md single-core convention: cooperative-scheduler races and deadlocks in the
-  # approval suites only discriminate when the runtime has one lane. A one-thread cooperative pool
-  # (SWIFT_MAX_CONCURRENCY_THREADS=1) reproduces that deterministically without pinning the build
-  # itself to one core the way a docker --cpuset-cpus=0 run would.
+  # approval suites only discriminate when the runtime has one lane. LIBDISPATCH_COOPERATIVE_POOL_STRICT=1
+  # forces the Swift default executor's cooperative pool to a single worker regardless of core count,
+  # reproducing that deterministically without pinning the build itself to one core the way a docker
+  # --cpuset-cpus=0 run would (SWIFT_MAX_CONCURRENCY_THREADS is not honored by the runtime — it caps
+  # at core count, not one, so it gives no single-lane discrimination).
   test-linux-single-core:
     runs-on: ubuntu-24.04-arm
     container: swift:6.3-noble
@@ -56,7 +58,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ runner.arch }}-spm-
       - name: Run the concurrency-sensitive suites on one cooperative thread
         env:
-          SWIFT_MAX_CONCURRENCY_THREADS: "1"
+          LIBDISPATCH_COOPERATIVE_POOL_STRICT: "1"
         run: swift test --filter 'CommandApprovalCancelSignalRaceTests|ApprovalExpiryServiceTests|ApprovalWaiterTests|ApprovalBootReconcilerTests'
 
   test-macos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,6 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ runner.arch }}-spm-
       - name: Build and run tests
         run: swift test
-      # docs/TESTING.md single-core convention: cooperative-scheduler races and deadlocks in the
-      # approval suites only discriminate when the runtime has one lane. LIBDISPATCH_COOPERATIVE_POOL_STRICT=1
-      # forces the Swift default executor's cooperative pool to a single worker regardless of core count,
-      # reproducing that deterministically without pinning the build to one core the way a docker
-      # --cpuset-cpus=0 run would (SWIFT_MAX_CONCURRENCY_THREADS is not honored by the runtime — it caps
-      # at core count, not one, so it gives no single-lane discrimination). Runs after the full suite so
-      # it reuses the warm .build with no rebuild.
       - name: Re-run the concurrency-sensitive suites on one cooperative thread
         env:
           LIBDISPATCH_COOPERATIVE_POOL_STRICT: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,32 @@ jobs:
       - name: Build and run tests
         run: swift test
 
+  # docs/TESTING.md single-core convention: cooperative-scheduler races and deadlocks in the
+  # approval suites only discriminate when the runtime has one lane. A one-thread cooperative pool
+  # (SWIFT_MAX_CONCURRENCY_THREADS=1) reproduces that deterministically without pinning the build
+  # itself to one core the way a docker --cpuset-cpus=0 run would.
+  test-linux-single-core:
+    runs-on: ubuntu-24.04-arm
+    container: swift:6.3-noble
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Install system dependencies
+        run: apt-get update && apt-get install -y --no-install-recommends libsqlite3-dev ca-certificates tzdata
+      - name: Show toolchain
+        run: swift --version
+      - uses: actions/cache@v6
+        with:
+          path: .build
+          key: ${{ runner.os }}-${{ runner.arch }}-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-spm-
+      - name: Run the concurrency-sensitive suites on one cooperative thread
+        env:
+          SWIFT_MAX_CONCURRENCY_THREADS: "1"
+        run: swift test --filter 'CommandApprovalCancelSignalRaceTests|ApprovalExpiryServiceTests|ApprovalWaiterTests|ApprovalBootReconcilerTests'
+
   test-macos:
     runs-on: macos-26
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,31 +32,14 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ runner.arch }}-spm-
       - name: Build and run tests
         run: swift test
-
-  # docs/TESTING.md single-core convention: cooperative-scheduler races and deadlocks in the
-  # approval suites only discriminate when the runtime has one lane. LIBDISPATCH_COOPERATIVE_POOL_STRICT=1
-  # forces the Swift default executor's cooperative pool to a single worker regardless of core count,
-  # reproducing that deterministically without pinning the build itself to one core the way a docker
-  # --cpuset-cpus=0 run would (SWIFT_MAX_CONCURRENCY_THREADS is not honored by the runtime — it caps
-  # at core count, not one, so it gives no single-lane discrimination).
-  test-linux-single-core:
-    runs-on: ubuntu-24.04-arm
-    container: swift:6.3-noble
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - name: Install system dependencies
-        run: apt-get update && apt-get install -y --no-install-recommends libsqlite3-dev ca-certificates tzdata
-      - name: Show toolchain
-        run: swift --version
-      - uses: actions/cache@v6
-        with:
-          path: .build
-          key: ${{ runner.os }}-${{ runner.arch }}-spm-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-${{ runner.arch }}-spm-
-      - name: Run the concurrency-sensitive suites on one cooperative thread
+      # docs/TESTING.md single-core convention: cooperative-scheduler races and deadlocks in the
+      # approval suites only discriminate when the runtime has one lane. LIBDISPATCH_COOPERATIVE_POOL_STRICT=1
+      # forces the Swift default executor's cooperative pool to a single worker regardless of core count,
+      # reproducing that deterministically without pinning the build to one core the way a docker
+      # --cpuset-cpus=0 run would (SWIFT_MAX_CONCURRENCY_THREADS is not honored by the runtime — it caps
+      # at core count, not one, so it gives no single-lane discrimination). Runs after the full suite so
+      # it reuses the warm .build with no rebuild.
+      - name: Re-run the concurrency-sensitive suites on one cooperative thread
         env:
           LIBDISPATCH_COOPERATIVE_POOL_STRICT: "1"
         run: swift test --filter 'CommandApprovalCancelSignalRaceTests|ApprovalExpiryServiceTests|ApprovalWaiterTests|ApprovalBootReconcilerTests'

--- a/Sources/ClawAgent/Runtime/AgentRuntime.swift
+++ b/Sources/ClawAgent/Runtime/AgentRuntime.swift
@@ -125,7 +125,8 @@ public struct AgentRuntime: Sendable {
     todayTokens: Int,
     todayUSD: Double,
     origin: RunOrigin = .interactive,
-    proactiveTodayUSD: Double = 0
+    proactiveTodayUSD: Double = 0,
+    carryOver: ResumeUsage? = nil
   ) async throws -> TurnOutcome {
     let deadline = ContinuousClock.now + .seconds(budget.wallClockDeadlineSeconds)
     let definitions = toolDispatcher?.definitions ?? []
@@ -152,9 +153,11 @@ public struct AgentRuntime: Sendable {
     var pendingSuspension: PendingToolAction?
     var remainingGrant = grant
 
-    var proposedToolCalls = 0
-    var recordedRunTokens = 0
-    var recordedRunUSD = 0.0
+    // Seeded from the carried-over usage (nil = a fresh run; §6.3 continuation carries the run's
+    // persisted totals so the tool-call / token / USD caps keep counting across the suspension).
+    var proposedToolCalls = carryOver?.toolCalls ?? 0
+    var recordedRunTokens = carryOver?.tokens ?? 0
+    var recordedRunUSD = carryOver?.costUSD ?? 0.0
 
     // Terminal choke-point for the RESULT paths: every `return outcome(...)` flows through here, so a
     // turn that produces a `TurnOutcome` emits exactly one finished line (see `logFinish`). The
@@ -170,7 +173,10 @@ public struct AgentRuntime: Sendable {
       )
     }
 
-    for roundTripIndex in 1...max(1, budget.maxTurns) {
+    // The wall-clock deadline is left per-segment by construction — it is recomputed at each
+    // `runTurn` entry above; only the round count needs to account for rounds already consumed.
+    let priorRounds = carryOver?.rounds ?? 0
+    for roundTripIndex in 1...max(1, budget.maxTurns - priorRounds) {
       // Per-round-trip preflight (§6.2): day totals at run start + everything this run recorded.
       let inputTokens = TokenEstimator.estimateInputTokens(wire)
       // The loop is the one component that grows provider input (proposals + fenced

--- a/Sources/ClawCore/Domain/Bot/IncomingMessage.swift
+++ b/Sources/ClawCore/Domain/Bot/IncomingMessage.swift
@@ -3,11 +3,43 @@ public struct RawUpdate: Sendable, Equatable {
   public let updateId: Int64
   public let message: RawMessage?
   public let editedMessage: RawMessage?
+  public let callback: RawCallback?
 
-  public init(updateId: Int64, message: RawMessage?, editedMessage: RawMessage?) {
+  public init(
+    updateId: Int64,
+    message: RawMessage?,
+    editedMessage: RawMessage?,
+    callback: RawCallback? = nil
+  ) {
     self.updateId = updateId
     self.message = message
     self.editedMessage = editedMessage
+    self.callback = callback
+  }
+}
+
+/// A tapped inline button, wire-agnostic like `RawUpdate` (ClawCore never imports the Telegram JSON
+/// model). `chatId`/`messageId` come from the prompt message (`callback.message`) and drive the
+/// keyboard-disarm edit; `data` is the raw `callback_data` parsed by `ApprovalKeyboard`.
+public struct RawCallback: Sendable, Equatable {
+  public let callbackId: String
+  public let fromUserId: Int64
+  public let chatId: Int64?
+  public let messageId: Int64?
+  public let data: String?
+
+  public init(
+    callbackId: String,
+    fromUserId: Int64,
+    chatId: Int64?,
+    messageId: Int64?,
+    data: String?
+  ) {
+    self.callbackId = callbackId
+    self.fromUserId = fromUserId
+    self.chatId = chatId
+    self.messageId = messageId
+    self.data = data
   }
 }
 

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -23,11 +23,21 @@ public struct StopCommandResult: Sendable, Equatable {
   /// Every run `/stop` terminated — the RUNNING turn AND any queued PENDING turns (spec FSM:
   /// PENDING + /stop → CANCELLED). Empty when there was nothing to stop.
   public let cancelledRunIds: [Int64]
+  /// PENDING approvals of the terminated runs, CAS'd to REJECTED (decision `cancelled`) in the same
+  /// command transaction (§6.4). The handler signals the coordinator per id so a held/boot-parked
+  /// lane releases. Defaulted so the `newlyClaimed: false` early return needs no change.
+  public let resolvedApprovalIds: [Int64]
 
-  public init(newlyClaimed: Bool, sessionId: Int64?, cancelledRunIds: [Int64]) {
+  public init(
+    newlyClaimed: Bool,
+    sessionId: Int64?,
+    cancelledRunIds: [Int64],
+    resolvedApprovalIds: [Int64] = []
+  ) {
     self.newlyClaimed = newlyClaimed
     self.sessionId = sessionId
     self.cancelledRunIds = cancelledRunIds
+    self.resolvedApprovalIds = resolvedApprovalIds
   }
 }
 
@@ -35,11 +45,21 @@ public struct NewCommandResult: Sendable, Equatable {
   public let newlyClaimed: Bool
   public let sessionId: Int64?
   public let supersededRunIds: [Int64]
+  /// PENDING approvals of the superseded runs, CAS'd to REJECTED (decision `superseded`) in the
+  /// same command transaction (§6.4). The handler signals the coordinator per id. Defaulted so the
+  /// `newlyClaimed: false` early return needs no change.
+  public let resolvedApprovalIds: [Int64]
 
-  public init(newlyClaimed: Bool, sessionId: Int64?, supersededRunIds: [Int64]) {
+  public init(
+    newlyClaimed: Bool,
+    sessionId: Int64?,
+    supersededRunIds: [Int64],
+    resolvedApprovalIds: [Int64] = []
+  ) {
     self.newlyClaimed = newlyClaimed
     self.sessionId = sessionId
     self.supersededRunIds = supersededRunIds
+    self.resolvedApprovalIds = resolvedApprovalIds
   }
 }
 
@@ -275,6 +295,20 @@ public protocol RunStore: Sendable {
   /// `approvalDenied`/`stale_policy` audit in ONE txn, while the approval row stays APPROVED — the
   /// one documented granted-then-denied pair. Returns false when the run was not AWAITING.
   func failRunStalePolicy(runId: Int64, sessionId: Int64, now: Date) throws -> Bool
+  /// §6.4 deny/cancel resolution: fill the placeholder observation row in place with the synthetic
+  /// denial `content` so persisted history never holds a dangling tool_call, then drive the run to
+  /// its terminal state. `cancel == nil` is the owner-deny / expiry path
+  /// (AWAITING_APPROVAL → FAILED via `resolveDenied`, returns `.committed`); `cancel != nil` is the
+  /// `/stop`//`new` path whose command transaction already flipped the run to CANCELLED/SUPERSEDED,
+  /// so the FSM no-ops the transition and the method returns `.ignored` after fixing the
+  /// observation. One transaction.
+  func resolveDeniedObservation(
+    runId: Int64,
+    observationMessageId: Int64,
+    content: String,
+    cancel: CancelReason?,
+    now: Date
+  ) throws -> RunCommitResult
 }
 
 public extension RunStore {

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -247,6 +247,34 @@ public protocol RunStore: Sendable {
     commit: SuspendedTurnCommit,
     now: Date
   ) throws -> SuspendedCommitReceipt
+  /// Task 16 approve resume (file_write / web_fetch): one txn, guarded on the AWAITING_APPROVAL →
+  /// RUNNING flip (which is exactly-once — a duplicate signal finds the run already RUNNING and
+  /// no-ops). UPDATEs the placeholder observation in place with the tool's real result.
+  func completeApprovedObservation(
+    runId: Int64,
+    observationMessageId: Int64,
+    content: String,
+    now: Date
+  ) throws -> RunCommitResult
+  /// Task 16 memory_write fused path (§6.3 exactly-once): the SAME txn additionally inserts the
+  /// memory item (via `MemoryStoreGRDB.insertItem`) BEFORE the observation UPDATE, both gated by
+  /// the AWAITING_APPROVAL → RUNNING flip.
+  func applyApprovedMemoryWrite(
+    runId: Int64,
+    observationMessageId: Int64,
+    item: NewMemoryItem,
+    observationContent: String,
+    now: Date
+  ) throws -> RunCommitResult
+  /// Task 16 §6.3 budget carry-over inputs (D4): rounds = COUNT(role='assistant'),
+  /// toolCalls = COUNT(role='tool') for the run; tokens/costUSD summed over `provider_usage`.
+  func resumeUsage(runId: Int64) throws -> ResumeUsage
+  /// Task 16: the run's origin, read WITHOUT a re-pick-up (the resume path never re-flips PENDING).
+  func runOrigin(runId: Int64) throws -> RunOrigin?
+  /// Task 16 §6.5 crash-window belt: fail the run (AWAITING_APPROVAL → FAILED) and append the
+  /// `approvalDenied`/`stale_policy` audit in ONE txn, while the approval row stays APPROVED — the
+  /// one documented granted-then-denied pair. Returns false when the run was not AWAITING.
+  func failRunStalePolicy(runId: Int64, sessionId: Int64, now: Date) throws -> Bool
 }
 
 public extension RunStore {

--- a/Sources/ClawCore/Persistence/Stores.swift
+++ b/Sources/ClawCore/Persistence/Stores.swift
@@ -344,7 +344,9 @@ public protocol ApprovalStore: Sendable {
   /// Ticker/boot sweep: CAS every PENDING row with `expires_ts <= now` → EXPIRED (+ `approvalDenied`
   /// audit, decision `expired`) and return the swept rows for the waiter signals.
   func sweepExpired(now: Date) throws -> [Approval]
-  /// Boot: PENDING rows (any expiry) and APPROVED rows whose run is AWAITING_APPROVAL (§6.5).
+  /// Boot: PENDING rows (any expiry), plus resolved rows whose run is still AWAITING_APPROVAL —
+  /// APPROVED (§6.5 grant crash window) and REJECTED/EXPIRED (the deny-side twin: the deny CAS +
+  /// audit committed but the waiter's run-fail commit did not). Terminal-run rows never return.
   func unresolvedAtBoot() throws -> [Approval]
   /// Boot hygiene: a terminal run holding a PENDING approval → REJECTED + `approvalDenied`
   /// (decision `cancelled`). Returns the count cleaned.

--- a/Sources/ClawData/Stores/Approval/ApprovalStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Approval/ApprovalStoreGRDB.swift
@@ -290,6 +290,48 @@ extension ApprovalStoreGRDB {
 
     return nextState
   }
+
+  /// §6.4 command-path resolution: CAS every PENDING approval of `runIds` → REJECTED (cancel and
+  /// supersede both land in REJECTED — the four-state rule; the audit `decision` records why) and
+  /// append its `approvalDenied` audit inside the CALLER's transaction (D3 — the CAS is the
+  /// recorded transition). Returns the resolved ids for the coordinator signals. Reused by
+  /// `CommandStoreGRDB.applyStop`/`applyNew` so the run flip and the approval CAS share one commit.
+  static func resolvePendingApprovals(
+    _ db: Database,
+    runIds: [Int64],
+    decision: ApprovalDecision,
+    now: Date
+  ) throws -> [Int64] {
+    guard runIds.isEmpty == false else {
+      return []
+    }
+
+    let placeholders = runIds.map { _ in "?" }.joined(separator: ", ")
+    var arguments: [any DatabaseValueConvertible] = [ApprovalState.pending.rawValue]
+    arguments.append(contentsOf: runIds)
+    let pending = try fetchApprovals(
+      db,
+      whereClause: "state = ? AND run_id IN (\(placeholders))",
+      arguments: StatementArguments(arguments)
+    )
+
+    var resolved: [Int64] = []
+    for approval in pending {
+      guard try transitionApproval(db, id: approval.id, on: .reject, now: now) != nil else {
+        continue
+      }
+      try insertApprovalAudit(
+        db,
+        approval: approval,
+        actor: .owner,
+        action: .approvalDenied,
+        decision: decision,
+        now: now
+      )
+      resolved.append(approval.id)
+    }
+    return resolved
+  }
 }
 
 // MARK: - Row Mapping + Reads

--- a/Sources/ClawData/Stores/Approval/ApprovalStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Approval/ApprovalStoreGRDB.swift
@@ -154,13 +154,15 @@ public struct ApprovalStoreGRDB: ApprovalStore {
         db,
         whereClause: """
           state = ?
-          OR (state = ? AND EXISTS (
+          OR (state IN (?, ?, ?) AND EXISTS (
             SELECT 1 FROM runs WHERE runs.id = approvals.run_id AND runs.state = ?
           ))
           """,
         arguments: [
           ApprovalState.pending.rawValue,
           ApprovalState.approved.rawValue,
+          ApprovalState.rejected.rawValue,
+          ApprovalState.expired.rawValue,
           RunState.awaitingApproval.rawValue,
         ]
       )

--- a/Sources/ClawData/Stores/Bot/CommandStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Bot/CommandStoreGRDB.swift
@@ -41,12 +41,19 @@ public struct CommandStoreGRDB: CommandStore {
         now: now
       )
       let cancelledRunIds = try RunStoreGRDB.cancelRuns(db, sessionId: sessionId, now: now)
+      let resolvedApprovalIds = try ApprovalStoreGRDB.resolvePendingApprovals(
+        db,
+        runIds: cancelledRunIds,
+        decision: .cancelled,
+        now: now
+      )
       try Self.insertStopAudits(db, sessionId: sessionId, runIds: cancelledRunIds, now: now)
 
       return StopCommandResult(
         newlyClaimed: true,
         sessionId: sessionId,
-        cancelledRunIds: cancelledRunIds
+        cancelledRunIds: cancelledRunIds,
+        resolvedApprovalIds: resolvedApprovalIds
       )
     }
   }
@@ -111,6 +118,12 @@ public struct CommandStoreGRDB: CommandStore {
         now: now
       )
       let supersededRunIds = try RunStoreGRDB.supersedeRuns(db, sessionId: sessionId, now: now)
+      let resolvedApprovalIds = try ApprovalStoreGRDB.resolvePendingApprovals(
+        db,
+        runIds: supersededRunIds,
+        decision: .superseded,
+        now: now
+      )
 
       try SessionMessageStoreGRDB.resetWindowAndDetaint(db, sessionId: sessionId, now: now)
       try Self.insertNewAudits(db, sessionId: sessionId, runIds: supersededRunIds, now: now)
@@ -118,7 +131,8 @@ public struct CommandStoreGRDB: CommandStore {
       return NewCommandResult(
         newlyClaimed: true,
         sessionId: sessionId,
-        supersededRunIds: supersededRunIds
+        supersededRunIds: supersededRunIds,
+        resolvedApprovalIds: resolvedApprovalIds
       )
     }
   }

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -219,6 +219,42 @@ public struct RunStoreGRDB: RunStore {
     }
   }
 
+  public func resolveDeniedObservation(
+    runId: Int64,
+    observationMessageId: Int64,
+    content: String,
+    cancel: CancelReason?,
+    now: Date
+  ) throws -> RunCommitResult {
+    try database.writeMapping { db in
+      // Fill the placeholder observation in place (§6.4): both `ContextBuilder.historyGroups` and
+      // `HistoryHygiene` require every anchor's tool rows to be answered, so a dangling
+      // "awaiting owner approval" row would drop the whole exchange from the next assembly. The
+      // UPDATE is by message id — idempotent on a boot re-park, and correct for the /stop//new
+      // path where the command transaction moved the run but never touched this row.
+      try db.execute(
+        sql: "UPDATE messages SET content = ? WHERE id = ?",
+        arguments: [content, observationMessageId]
+      )
+
+      let event: RunEvent =
+        switch cancel {
+        case .none: .resolveDenied
+        case .cancelled: .cancel
+        case .superseded: .supersede
+        }
+      // For the command path the run is already CANCELLED/SUPERSEDED, so the FSM returns nil and we
+      // report `.ignored`: the observation fix above was the only remaining work.
+      guard let nextState = try Self.transitionRun(db, runId: runId, event: event, now: now) else {
+        return .ignored
+      }
+      if nextState == .failed {
+        try Self.appendJobFailedIfJobRun(db, runId: runId, now: now)
+      }
+      return .committed
+    }
+  }
+
   public func commitSuspendedTurn(
     runId: Int64,
     sessionId: Int64,

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -464,6 +464,133 @@ public struct RunStoreGRDB: RunStore {
   }
 }
 
+// MARK: - Approved Resume (Task 16)
+
+extension RunStoreGRDB {
+  public func completeApprovedObservation(
+    runId: Int64,
+    observationMessageId: Int64,
+    content: String,
+    now: Date
+  ) throws -> RunCommitResult {
+    try database.writeMapping { db in
+      // Exactly-once (§6.3): the run flips AWAITING_APPROVAL → RUNNING through the reducer. A
+      // duplicate resume finds the run already RUNNING (or terminal) and no-ops — the observation
+      // (and, for memory_write, the fused insert) never double-apply. This is equivalent to the
+      // spec's "observation still placeholder" guard because the placeholder is only ever filled
+      // inside this same transaction.
+      guard try Self.transitionRun(db, runId: runId, event: .resumeApproved, now: now) != nil else {
+        return .ignored
+      }
+      try Self.fillApprovedObservation(
+        db,
+        runId: runId,
+        messageId: observationMessageId,
+        content: content
+      )
+      return .committed
+    }
+  }
+
+  public func applyApprovedMemoryWrite(
+    runId: Int64,
+    observationMessageId: Int64,
+    item: NewMemoryItem,
+    observationContent: String,
+    now: Date
+  ) throws -> RunCommitResult {
+    try database.writeMapping { db in
+      guard try Self.transitionRun(db, runId: runId, event: .resumeApproved, now: now) != nil else {
+        return .ignored
+      }
+      // §6.3 exactly-once: the item insert shares this transaction with the observation fill, both
+      // gated by the AWAITING_APPROVAL → RUNNING flip above (D10 — the same db-scoped static
+      // `applyRemember` uses; MemoryStore.append would open its own txn and could not fuse).
+      _ = try MemoryStoreGRDB.insertItem(db, item: item, now: now)
+      try Self.fillApprovedObservation(
+        db,
+        runId: runId,
+        messageId: observationMessageId,
+        content: observationContent
+      )
+      return .committed
+    }
+  }
+
+  public func resumeUsage(runId: Int64) throws -> ResumeUsage {
+    try database.readMapping { db in
+      let rounds =
+        try Int.fetchOne(
+          db,
+          sql: "SELECT COUNT(*) FROM messages WHERE run_id = ? AND role = 'assistant'",
+          arguments: [runId]
+        ) ?? 0
+      let toolCalls =
+        try Int.fetchOne(
+          db,
+          sql: "SELECT COUNT(*) FROM messages WHERE run_id = ? AND role = 'tool'",
+          arguments: [runId]
+        ) ?? 0
+      let tokens =
+        try Int.fetchOne(
+          db,
+          sql: """
+            SELECT COALESCE(SUM(prompt_tokens + completion_tokens), 0)
+            FROM provider_usage WHERE run_id = ?
+            """,
+          arguments: [runId]
+        ) ?? 0
+      let costUSD =
+        try Double.fetchOne(
+          db,
+          sql: "SELECT COALESCE(SUM(cost_usd), 0) FROM provider_usage WHERE run_id = ?",
+          arguments: [runId]
+        ) ?? 0
+      return ResumeUsage(rounds: rounds, toolCalls: toolCalls, tokens: tokens, costUSD: costUSD)
+    }
+  }
+
+  public func runOrigin(runId: Int64) throws -> RunOrigin? {
+    try database.readMapping { db in
+      let rawOrigin = try String.fetchOne(
+        db,
+        sql: "SELECT origin FROM runs WHERE id = ?",
+        arguments: [runId]
+      )
+      guard let rawOrigin else {
+        return nil
+      }
+      // Fail closed on a corrupted origin, same rule as `pickUp`: a mislabeled origin would
+      // misroute the continuation's budget pool.
+      guard let origin = RunOrigin(rawValue: rawOrigin) else {
+        throw StoreError.unexpected("runs row \(runId) has an unrecognized origin")
+      }
+      return origin
+    }
+  }
+
+  public func failRunStalePolicy(runId: Int64, sessionId: Int64, now: Date) throws -> Bool {
+    try database.writeMapping { db in
+      guard try Self.transitionRun(db, runId: runId, event: .fail, now: now) != nil else {
+        return false
+      }
+      try Self.appendJobFailedIfJobRun(db, runId: runId, now: now)
+      try AuditLogGRDB.insertAudit(
+        db,
+        AuditEvent(
+          actor: .system,
+          action: .approvalDenied,
+          decision: ApprovalDecision.stalePolicy.rawValue,
+          runId: runId,
+          sessionId: sessionId,
+          ts: now
+        )
+      )
+      return true
+    }
+  }
+}
+
 // MARK: - Cross-Store Run Helpers
 
 extension RunStoreGRDB {
@@ -635,6 +762,21 @@ extension RunStoreGRDB {
       ]
     )
     return db.changesCount > 0
+  }
+
+  /// UPDATEs the reserved placeholder observation row in place with the resolved result. Scoped to
+  /// the run + `role = 'tool'` so a stray id can never rewrite an unrelated row. The v4 FTS5
+  /// synchronize triggers cover the UPDATE — no extra index work.
+  static func fillApprovedObservation(
+    _ db: Database,
+    runId: Int64,
+    messageId: Int64,
+    content: String
+  ) throws {
+    try db.execute(
+      sql: "UPDATE messages SET content = ? WHERE id = ? AND run_id = ? AND role = 'tool'",
+      arguments: [content, messageId, runId]
+    )
   }
 }
 

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -380,6 +380,11 @@ public struct RunStoreGRDB: RunStore {
     heartbeatNoticeChatId: Int64?
   ) throws -> [DegradationReply] {
     try database.writeMapping { db in
+      // AWAITING_APPROVAL is deliberately excluded, not merely omitted: a suspended run is a live
+      // durable checkpoint, not a crash orphan. The approval boot reconciliation
+      // (ApprovalBootReconciler, spec §7) owns those runs — re-parking the unexpired ones and running
+      // the per-row expiry check on the rest. Only true PENDING/RUNNING orphans fail here.
+      let orphanFailStates = [RunState.pending.rawValue, RunState.running.rawValue]
       let stale = try Row.fetchAll(
         db,
         sql: """
@@ -388,7 +393,7 @@ public struct RunStoreGRDB: RunStore {
           WHERE r.state IN (?, ?)
           ORDER BY r.id ASC
           """,
-        arguments: [RunState.pending.rawValue, RunState.running.rawValue]
+        arguments: StatementArguments(orphanFailStates)
       )
 
       var replies: [DegradationReply] = []

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -685,7 +685,9 @@ extension RunStoreGRDB {
   /// The parked-observation body (§5.3). A resolution overwrites it in place with the real result.
   static let placeholderObservationContent = "awaiting owner approval"
 
-  static func transitionRun(
+  // `public`: Task 16 test fixtures outside this module (ClawGatewayTests, via plain `import
+  // ClawData`) drive suspended-run fixtures through the real reducer instead of hand-rolling state.
+  public static func transitionRun(
     _ db: Database,
     runId: Int64,
     event: RunEvent,

--- a/Sources/ClawGateway/Routing/ApprovalCallbackHandler.swift
+++ b/Sources/ClawGateway/Routing/ApprovalCallbackHandler.swift
@@ -1,0 +1,254 @@
+import ClawCore
+import Foundation
+import Logging
+
+/// §6.2 fail-closed callback auth chain. Every failure is audited (`messageIn`/`forbidden`, D8) and
+/// answered with a neutral toast, and the approval row is left untouched. A valid owner tap CASes the
+/// durable row and signals the coordinator — the waiter (Tasks 16/17) performs the resume/deny. The
+/// handler itself only claims, authorizes, CASes, signals, and toasts; it never touches the
+/// observation row, the run state, or the button keyboard.
+public struct ApprovalCallbackHandler: Sendable {
+  private let replies: ReplySender
+  private let accessControl: AccessControl
+  private let approvals: any ApprovalStore
+  private let audit: any AuditLog
+  private let coordinator: ApprovalCoordinator
+  private let callbacks: any CallbackResponding
+  private let currentPolicyVersion: @Sendable () throws -> String
+  private let now: @Sendable () -> Date
+  private let logger: Logger
+
+  // Module-internal init: `ReplySender`/`RoutingHalt` are internal to `ClawGateway`, so a `public`
+  // init would not compile ("parameter uses an internal type"). The daemon composes the handler
+  // through the public `make(...)` factory below — Task 16's `makeDaemon` injects the result into the
+  // production `MessageRouter` via `approvalCallbacks`; tests reach the init directly through
+  // `@testable import ClawGateway`. The `handle(_:updateId:)` surface stays public.
+  init(
+    replies: ReplySender,
+    accessControl: AccessControl,
+    approvals: any ApprovalStore,
+    audit: any AuditLog,
+    coordinator: ApprovalCoordinator,
+    callbacks: any CallbackResponding,
+    currentPolicyVersion: @escaping @Sendable () throws -> String,
+    now: @escaping @Sendable () -> Date,
+    logger: Logger
+  ) {
+    self.replies = replies
+    self.accessControl = accessControl
+    self.approvals = approvals
+    self.audit = audit
+    self.coordinator = coordinator
+    self.callbacks = callbacks
+    self.currentPolicyVersion = currentPolicyVersion
+    self.now = now
+    self.logger = logger
+  }
+
+  /// Composition factory for the `clawd` module. `ReplySender` and the init are `ClawGateway`-internal,
+  /// so the daemon cannot call the init directly; this builds the internal `ReplySender` from public
+  /// ingredients and returns the composed handler. Task 16's `makeDaemon` calls it and injects the
+  /// result into the production `MessageRouter` via `approvalCallbacks`.
+  // swiftlint:disable:next function_parameter_count
+  public static func make(
+    processed: any ProcessedUpdateStore,
+    delivery: any MessageDelivery,
+    accessControl: AccessControl,
+    approvals: any ApprovalStore,
+    audit: any AuditLog,
+    coordinator: ApprovalCoordinator,
+    callbacks: any CallbackResponding,
+    currentPolicyVersion: @escaping @Sendable () throws -> String,
+    now: @escaping @Sendable () -> Date,
+    logger: Logger
+  ) -> ApprovalCallbackHandler {
+    ApprovalCallbackHandler(
+      replies: ReplySender(processed: processed, delivery: delivery, logger: logger),
+      accessControl: accessControl,
+      approvals: approvals,
+      audit: audit,
+      coordinator: coordinator,
+      callbacks: callbacks,
+      currentPolicyVersion: currentPolicyVersion,
+      now: now,
+      logger: logger
+    )
+  }
+
+  /// §6.2 step 1 (claim) then the auth chain. Returns a `HandleOutcome` so the poller's
+  /// cursor-advance semantics are identical to the message path: a redelivered update is deduped by
+  /// the shared `processed_updates` claim and skipped.
+  public func handle(_ callback: RawCallback, updateId: Int64) async -> HandleOutcome {
+    let noticeChatId = callback.chatId ?? callback.fromUserId
+    do throws(RoutingHalt) {
+      try await replies.claimUpdate(updateId: updateId, chatId: noticeChatId)
+    } catch {
+      return error.outcome
+    }
+    return await resolve(callback)
+  }
+}
+
+// MARK: - Auth chain
+
+private extension ApprovalCallbackHandler {
+  func resolve(_ callback: RawCallback) async -> HandleOutcome {
+    // Step 2: allowlist default-deny, before any parsing.
+    guard accessControl.isAllowed(userId: callback.fromUserId) else {
+      return await denyAuth(callback, approval: nil)
+    }
+    // Step 3: parse callback_data strictly (apr:<nonce>:<verdict>).
+    guard let parsed = callback.data.flatMap(ApprovalKeyboard.parse) else {
+      return await denyAuth(callback, approval: nil)
+    }
+    // Step 4: look up by nonce ONLY (unique index) — never by a guessable id.
+    let found: Approval?
+    do {
+      found = try approvals.approval(nonce: parsed.nonce)
+    } catch {
+      return await storeFailure(callback, error)
+    }
+    guard let approval = found else {
+      return await denyAuth(callback, approval: nil)
+    }
+    // Step 5: owner binding.
+    guard callback.fromUserId == approval.ownerUserId else {
+      return await denyAuth(callback, approval: approval)
+    }
+    return await commitResolution(callback, approval: approval, approve: parsed.approve)
+  }
+}
+
+// MARK: - Resolution CAS
+
+private extension ApprovalCallbackHandler {
+  func commitResolution(
+    _ callback: RawCallback,
+    approval: Approval,
+    approve: Bool
+  ) async -> HandleOutcome {
+    guard approve else {
+      return await commitDeny(callback, approval: approval)
+    }
+    return await commitApprove(callback, approval: approval)
+  }
+
+  func commitApprove(_ callback: RawCallback, approval: Approval) async -> HandleOutcome {
+    let policyVersion: String
+    do {
+      policyVersion = try currentPolicyVersion()
+    } catch {
+      return await storeFailure(callback, error)
+    }
+    let outcome: ApprovalApproveOutcome
+    do {
+      outcome = try approvals.approve(
+        id: approval.id,
+        currentPolicyVersion: policyVersion,
+        now: now()
+      )
+    } catch {
+      return await storeFailure(callback, error)
+    }
+    switch outcome {
+    case .approved:
+      await coordinator.signal(approvalId: approval.id, .approved)
+      return await finish(callback, toast: Self.approvedToast)
+    case .stalePolicy:
+      await coordinator.signal(approvalId: approval.id, .denied(.stalePolicy))
+      return await finish(callback, toast: Self.stalePolicyToast)
+    case .notPending:
+      return await finish(callback, toast: Self.alreadyHandledToast)
+    case .expiredRow:
+      return await commitExpiry(callback, approval: approval)
+    }
+  }
+
+  /// The approve CAS found the row already past its deadline: route it through the deny path so the
+  /// waiter fails the run exactly as the ticker would (spec §6.2 step 5 / §6.4).
+  func commitExpiry(_ callback: RawCallback, approval: Approval) async -> HandleOutcome {
+    let denied: Bool
+    do {
+      denied = try approvals.deny(id: approval.id, decision: .expired, now: now())
+    } catch {
+      return await storeFailure(callback, error)
+    }
+    if denied {
+      await coordinator.signal(approvalId: approval.id, .denied(.expired))
+    }
+    return await finish(callback, toast: Self.expiredToast)
+  }
+
+  func commitDeny(_ callback: RawCallback, approval: Approval) async -> HandleOutcome {
+    let denied: Bool
+    do {
+      denied = try approvals.deny(id: approval.id, decision: .rejected, now: now())
+    } catch {
+      return await storeFailure(callback, error)
+    }
+    guard denied else {
+      // A racing resolver (ticker/duplicate) already won; nothing to signal, answer neutrally.
+      return await finish(callback, toast: Self.alreadyHandledToast)
+    }
+    await coordinator.signal(approvalId: approval.id, .denied(.rejected))
+    return await finish(callback, toast: Self.deniedToast)
+  }
+}
+
+// MARK: - Fail-closed helpers
+
+private extension ApprovalCallbackHandler {
+  /// An auth failure is an access event, not an approval decision (D8): audit `messageIn`/
+  /// `forbidden` (actor `owner` only when the sender IS the owner, else `system`), answer a neutral
+  /// toast, leave the row untouched.
+  func denyAuth(_ callback: RawCallback, approval: Approval?) async -> HandleOutcome {
+    let auditActor: AuditActor = approval?.ownerUserId == callback.fromUserId ? .owner : .system
+    let event = AuditEvent(
+      actor: auditActor,
+      action: .messageIn,
+      decision: Self.forbiddenDecision,
+      runId: approval?.runId,
+      sessionId: approval?.sessionId,
+      ts: now()
+    )
+    do {
+      try audit.appendAudit(event)
+    } catch {
+      logger.error("failed to audit forbidden callback: \(error)")
+    }
+    return await finish(callback, toast: Self.neutralToast)
+  }
+
+  /// A transient store failure after the claim: the update is already consumed, so a re-poll would
+  /// only hit the duplicate claim. Fail closed — no CAS means no execution — and leave the PENDING
+  /// row for the expiry ticker or a fresh owner tap. Because the row is still tappable, §9 answers
+  /// "try again" (not the neutral "no longer available" copy). The spinner is still stopped.
+  func storeFailure(_ callback: RawCallback, _ error: any Error) async -> HandleOutcome {
+    logger.error("callback resolution store failure: \(error)")
+    return await finish(callback, toast: Self.retryToast)
+  }
+
+  /// Answer the callback (stop the client spinner) and report the update durably handled. The answer
+  /// is best-effort: a lost toast must not re-run the resolution.
+  func finish(_ callback: RawCallback, toast: String) async -> HandleOutcome {
+    do {
+      try await callbacks.answerCallbackQuery(id: callback.callbackId, text: toast)
+    } catch {
+      logger.warning("failed to answer callback \(callback.callbackId): \(error)")
+    }
+    return .processed
+  }
+}
+
+// MARK: - Toasts
+
+private extension ApprovalCallbackHandler {
+  static let forbiddenDecision = "forbidden"
+  static let neutralToast = "This action is no longer available."
+  static let retryToast = "Something went wrong — please try again."
+  static let approvedToast = "Approved."
+  static let deniedToast = "Denied."
+  static let alreadyHandledToast = "Already handled."
+  static let stalePolicyToast = "This approval is no longer valid."
+  static let expiredToast = "This approval has expired."
+}

--- a/Sources/ClawGateway/Routing/ApprovalCallbackHandler.swift
+++ b/Sources/ClawGateway/Routing/ApprovalCallbackHandler.swift
@@ -80,11 +80,13 @@ public struct ApprovalCallbackHandler: Sendable {
   /// the shared `processed_updates` claim and skipped.
   public func handle(_ callback: RawCallback, updateId: Int64) async -> HandleOutcome {
     let noticeChatId = callback.chatId ?? callback.fromUserId
+
     do throws(RoutingHalt) {
       try await replies.claimUpdate(updateId: updateId, chatId: noticeChatId)
     } catch {
       return error.outcome
     }
+
     return await resolve(callback)
   }
 }
@@ -115,6 +117,7 @@ private extension ApprovalCallbackHandler {
     guard callback.fromUserId == approval.ownerUserId else {
       return await denyAuth(callback, approval: approval)
     }
+
     return await commitResolution(callback, approval: approval, approve: parsed.approve)
   }
 }
@@ -127,10 +130,10 @@ private extension ApprovalCallbackHandler {
     approval: Approval,
     approve: Bool
   ) async -> HandleOutcome {
-    guard approve else {
-      return await commitDeny(callback, approval: approval)
+    if approve {
+      return await commitApprove(callback, approval: approval)
     }
-    return await commitApprove(callback, approval: approval)
+    return await commitDeny(callback, approval: approval)
   }
 
   func commitApprove(_ callback: RawCallback, approval: Approval) async -> HandleOutcome {
@@ -140,6 +143,7 @@ private extension ApprovalCallbackHandler {
     } catch {
       return await storeFailure(callback, error)
     }
+
     let outcome: ApprovalApproveOutcome
     do {
       outcome = try approvals.approve(
@@ -150,6 +154,7 @@ private extension ApprovalCallbackHandler {
     } catch {
       return await storeFailure(callback, error)
     }
+
     switch outcome {
     case .approved:
       await coordinator.signal(approvalId: approval.id, .approved)
@@ -173,9 +178,11 @@ private extension ApprovalCallbackHandler {
     } catch {
       return await storeFailure(callback, error)
     }
+
     if denied {
       await coordinator.signal(approvalId: approval.id, .denied(.expired))
     }
+
     return await finish(callback, toast: Self.expiredToast)
   }
 
@@ -186,11 +193,13 @@ private extension ApprovalCallbackHandler {
     } catch {
       return await storeFailure(callback, error)
     }
+
     guard denied else {
       // A racing resolver (ticker/duplicate) already won; nothing to signal, answer neutrally.
       return await finish(callback, toast: Self.alreadyHandledToast)
     }
     await coordinator.signal(approvalId: approval.id, .denied(.rejected))
+
     return await finish(callback, toast: Self.deniedToast)
   }
 }
@@ -211,11 +220,13 @@ private extension ApprovalCallbackHandler {
       sessionId: approval?.sessionId,
       ts: now()
     )
+
     do {
       try audit.appendAudit(event)
     } catch {
       logger.error("failed to audit forbidden callback: \(error)")
     }
+
     return await finish(callback, toast: Self.neutralToast)
   }
 

--- a/Sources/ClawGateway/Routing/ApprovalCoordinator.swift
+++ b/Sources/ClawGateway/Routing/ApprovalCoordinator.swift
@@ -93,6 +93,8 @@ public struct InertApprovalParker: ApprovalParking {
     revalidatePolicyOnApprove: Bool
   ) async {
     let signal = await coordinator.awaitResolution(approvalId: approvalId)
-    logger.debug("approval \(approvalId) resolved as \(signal); Phase 3 waiter completes the run")
+    logger.debug(
+      "approval \(approvalId) resolved as \(String(describing: signal)); Phase 3 waiter completes the run"
+    )
   }
 }

--- a/Sources/ClawGateway/Routing/ApprovalCoordinator.swift
+++ b/Sources/ClawGateway/Routing/ApprovalCoordinator.swift
@@ -13,18 +13,29 @@ public enum ApprovalSignal: Sendable, Equatable {
 /// the suspend commit and the waiter's registration (§5.5): a signal with no waiter is retained and
 /// delivered on the next `awaitResolution`.
 public actor ApprovalCoordinator {
-  private var waiters: [Int64: CheckedContinuation<ApprovalSignal, Never>] = [:]
+  private var waiters: [Int64: CheckedContinuation<ApprovalSignal?, Never>] = [:]
   private var buffered: [Int64: ApprovalSignal] = [:]
 
   public init() {}
 
   /// One waiter per approval id. A buffered signal (resolver won the race) returns immediately.
-  public func awaitResolution(approvalId: Int64) async -> ApprovalSignal {
+  /// Returns `nil` when the awaiting task is cancelled before a signal arrives (graceful shutdown /
+  /// lane cancel): the continuation is resumed and its slot cleared so nothing leaks, and the
+  /// durable row is left untouched for Task 19 boot re-park to rebuild.
+  public func awaitResolution(approvalId: Int64) async -> ApprovalSignal? {
     if let signal = buffered.removeValue(forKey: approvalId) {
       return signal
     }
-    return await withCheckedContinuation { continuation in
-      waiters[approvalId] = continuation
+    return await withTaskCancellationHandler {
+      await withCheckedContinuation { (continuation: CheckedContinuation<ApprovalSignal?, Never>) in
+        if Task.isCancelled {
+          continuation.resume(returning: nil)
+        } else {
+          waiters[approvalId] = continuation
+        }
+      }
+    } onCancel: {
+      Task { await self.cancelWaiter(approvalId) }
     }
   }
 
@@ -34,6 +45,15 @@ public actor ApprovalCoordinator {
       continuation.resume(returning: signal)
     } else {
       buffered[approvalId] = signal
+    }
+  }
+
+  /// Resumes a still-parked waiter with `nil` on cancellation. A no-op if a `signal` already removed
+  /// it (the resolver won the race), so a resolution is never dropped. Actor isolation guarantees
+  /// the `waiters[id] = continuation` registration completes before this can observe the slot.
+  private func cancelWaiter(_ approvalId: Int64) {
+    if let continuation = waiters.removeValue(forKey: approvalId) {
+      continuation.resume(returning: nil)
     }
   }
 }

--- a/Sources/ClawGateway/Routing/ApprovalWaiter.swift
+++ b/Sources/ClawGateway/Routing/ApprovalWaiter.swift
@@ -71,12 +71,13 @@ public struct ApprovalWaiter: ApprovalParking {
         revalidatePolicyOnApprove: revalidatePolicyOnApprove
       )
     case .denied(let decision):
-      await resolveDenied(
-        approvalId: approvalId,
-        runId: runId,
-        chatId: chatId,
-        decision: decision
-      )
+      guard let approval = loadApproval(approvalId) else {
+        // The nonce is never consumed, so a nil row means a resolver already drove the run
+        // terminal; the durable state is settled and the lane is free.
+        logger.debug("approval \(approvalId) absent at deny resume; nothing to finalize")
+        return
+      }
+      await resolveDenied(approval: approval, decision: decision, chatId: chatId)
     }
   }
 }
@@ -142,40 +143,79 @@ private extension ApprovalWaiter {
   }
 }
 
-// MARK: - Deny Finalization (Task 17 replaces the body)
+// MARK: - Deny Half (§6.4)
+
+extension ApprovalWaiter {
+  /// The §6.4 deny/cancel/expiry half: the resolver (callback handler, ticker, `/stop`//`new`, or
+  /// boot sweep) has ALREADY CAS'd the row and signalled the coordinator (D3 — the audit rode that
+  /// CAS). The waiter — the single execution locus (§5.5) — now (1) fills the placeholder
+  /// observation in place so history never holds a dangling tool_call, (2) drives the run to its
+  /// terminal state, (3) sends the plain-language owner notice for a reject/expiry (the `/stop`//
+  /// `new` command already acked the owner), and (4) disarms the buttons. Steps 3–4 are best-effort
+  /// transport over already-committed durable state — a transport failure must not strand the lane.
+  func resolveDenied(
+    approval: Approval,
+    decision: ApprovalDecision,
+    chatId: Int64
+  ) async {
+    let cancel: CancelReason? =
+      switch decision {
+      case .cancelled: .cancelled
+      case .superseded: .superseded
+      case .rejected, .expired, .stalePolicy: nil
+      }
+
+    do {
+      _ = try runs.resolveDeniedObservation(
+        runId: approval.runId,
+        observationMessageId: approval.observationMessageId,
+        content: Self.deniedObservationContent(for: decision),
+        cancel: cancel,
+        now: now()
+      )
+    } catch {
+      logger.error("approval \(approval.id) deny-observation commit failed: \(error)")
+    }
+
+    if cancel == nil {
+      _ = try? await delivery.sendMessage(
+        chatId: chatId,
+        text: Self.ownerNotice(for: decision)
+      )
+    }
+
+    if let promptMessageId = approval.promptMessageId {
+      try? await callbacks.editMessageReplyMarkup(
+        chatId: chatId,
+        messageId: promptMessageId,
+        replyMarkup: nil
+      )
+    }
+  }
+}
+
+// MARK: - Deny Copy
 
 private extension ApprovalWaiter {
-  /// Task 17 owns the deny half: it replaces this body with `resolveDeniedObservation` (the
-  /// synthetic in-place observation + cancel/supersede run states + decision-specific copy). This
-  /// increment guarantees only the lane-freeing contract: the run fails, the owner is told, the
-  /// keyboard is disarmed — so a `.denied` signal never leaves the lane hung.
-  func resolveDenied(
-    approvalId: Int64,
-    runId: Int64,
-    chatId: Int64,
-    decision: ApprovalDecision
-  ) async {
-    guard let approval = loadApproval(approvalId) else {
-      return
+  /// The synthetic tool-observation content (§6.4) — what the model sees for the un-run call, so
+  /// the next assembly explains the missing result instead of exposing a dangling proposal.
+  static func deniedObservationContent(for decision: ApprovalDecision) -> String {
+    switch decision {
+    case .rejected: "The owner declined this action."
+    case .expired: "The approval expired before the owner responded."
+    case .cancelled: "Cancelled by /stop."
+    case .superseded: "Superseded by /new."
+    case .stalePolicy: "The approval was voided because the policy changed before it ran."
     }
-    do {
-      // No-op when the run is already CANCELLED/SUPERSEDED (the command path won first); fails an
-      // AWAITING_APPROVAL run for reject/expiry.
-      try runs.failRun(runId: runId, now: now())
-    } catch {
-      logger.error("failRun after denial failed for run \(runId): \(error)")
-    }
-    await notifyOwner(chatId: chatId, text: Self.denialNotice(for: decision))
-    await disarm(approval, chatId: chatId)
   }
 
-  static func denialNotice(for decision: ApprovalDecision) -> String {
+  /// The plain-language owner DM for a reject/expiry (§6.4). Cancel/supersede are covered by the
+  /// `/stop`//`new` command ack, so no notice is sent for those.
+  static func ownerNotice(for decision: ApprovalDecision) -> String {
     switch decision {
-    case .rejected: "Okay — I won't do that."
-    case .expired: "That approval expired, so I didn't do it."
-    case .cancelled: "Cancelled."
-    case .superseded: "Starting fresh — I dropped the pending action."
-    case .stalePolicy: "My instructions or tools changed, so I didn't run that."
+    case .expired: "That approval expired, so I didn't run the action."
+    case .stalePolicy: "I didn't run that action — the configuration changed after I asked."
+    case .rejected, .cancelled, .superseded: "Understood — I won't run that action."
     }
   }
 }

--- a/Sources/ClawGateway/Routing/ApprovalWaiter.swift
+++ b/Sources/ClawGateway/Routing/ApprovalWaiter.swift
@@ -1,0 +1,212 @@
+import ClawCore
+import Foundation
+import Logging
+
+/// The single execution locus (§5.5): the parked task that turns a coordinator resolution signal
+/// into the §6.3 approve resume or the §6.4 deny finalization. Resolvers (callback handler, ticker,
+/// command path) only CAS the durable row and `signal` the coordinator; the waiter — always running
+/// on the session lane via `SessionActor.enqueue`, at suspend time (Task 14) and boot re-park
+/// (Task 19) — performs the observation update, run transition, owner notice, and button disarm.
+///
+/// Conforms to the Task-14 `ApprovalParking` seam (which refines `Sendable`) so `TurnRunner` can
+/// hold it as `parker`; the `park` signature is exactly the protocol requirement.
+public struct ApprovalWaiter: ApprovalParking {
+  private let approvals: any ApprovalStore
+  private let runs: any RunStore
+  private let coordinator: ApprovalCoordinator
+  private let executor: any ApprovedActionExecuting
+  private let turns: any TurnDispatching
+  private let delivery: any MessageDelivery
+  private let callbacks: any CallbackResponding
+  private let currentPolicyVersion: @Sendable () throws -> String
+  private let now: @Sendable () -> Date
+  private let logger: Logger
+
+  public init(
+    approvals: any ApprovalStore,
+    runs: any RunStore,
+    coordinator: ApprovalCoordinator,
+    executor: any ApprovedActionExecuting,
+    turns: any TurnDispatching,
+    delivery: any MessageDelivery,
+    callbacks: any CallbackResponding,
+    currentPolicyVersion: @escaping @Sendable () throws -> String,
+    now: @escaping @Sendable () -> Date,
+    logger: Logger
+  ) {
+    self.approvals = approvals
+    self.runs = runs
+    self.coordinator = coordinator
+    self.executor = executor
+    self.turns = turns
+    self.delivery = delivery
+    self.callbacks = callbacks
+    self.currentPolicyVersion = currentPolicyVersion
+    self.now = now
+    self.logger = logger
+  }
+
+  /// Awaits the coordinator resolution (buffered if it already landed), then runs the resume/deny
+  /// steps. `revalidatePolicyOnApprove` is true ONLY for the §6.5 boot crash-window re-park.
+  public func park(
+    approvalId: Int64,
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    revalidatePolicyOnApprove: Bool
+  ) async {
+    guard let signal = await coordinator.awaitResolution(approvalId: approvalId) else {
+      // Cancelled while parked (graceful shutdown / lane cancel) with no resolution: exit cleanly.
+      // The durable approval row is untouched; Task 19 boot re-park rebuilds the hold on restart.
+      logger.debug("approval \(approvalId) park cancelled before resolution; exiting cleanly")
+      return
+    }
+    switch signal {
+    case .approved:
+      await resolveApproved(
+        approvalId: approvalId,
+        runId: runId,
+        sessionId: sessionId,
+        chatId: chatId,
+        revalidatePolicyOnApprove: revalidatePolicyOnApprove
+      )
+    case .denied(let decision):
+      await resolveDenied(
+        approvalId: approvalId,
+        runId: runId,
+        chatId: chatId,
+        decision: decision
+      )
+    }
+  }
+}
+
+// MARK: - Approve Resume
+
+private extension ApprovalWaiter {
+  func resolveApproved(
+    approvalId: Int64,
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    revalidatePolicyOnApprove: Bool
+  ) async {
+    guard let approval = loadApproval(approvalId), approval.state == .approved else {
+      logger.warning("approval \(approvalId) was not APPROVED at resume; skipping")
+      return
+    }
+
+    if revalidatePolicyOnApprove, policyStillMatches(approval) == false {
+      await failOnStalePolicy(approval, chatId: chatId)
+      return
+    }
+
+    let outcome = await executor.executeApproved(approval)
+    guard outcome.commit == .committed else {
+      // A duplicate signal already resumed the run; do not run the continuation twice.
+      logger.debug("approved resume for run \(runId) was a no-op (\(outcome.commit))")
+      await disarm(approval, chatId: chatId)
+      return
+    }
+
+    await turns.resume(
+      runId: runId,
+      sessionId: sessionId,
+      chatId: chatId,
+      contextBoundMessageId: approval.observationMessageId
+    )
+    await disarm(approval, chatId: chatId)
+  }
+
+  func policyStillMatches(_ approval: Approval) -> Bool {
+    do {
+      return try currentPolicyVersion() == approval.policyVersion
+    } catch {
+      logger.error("policy recompute failed at resume for run \(approval.runId): \(error)")
+      return false  // fail closed
+    }
+  }
+
+  func failOnStalePolicy(_ approval: Approval, chatId: Int64) async {
+    do {
+      _ = try runs.failRunStalePolicy(
+        runId: approval.runId,
+        sessionId: approval.sessionId,
+        now: now()
+      )
+    } catch {
+      logger.error("failRunStalePolicy failed for run \(approval.runId): \(error)")
+    }
+    await notifyOwner(chatId: chatId, text: Self.stalePolicyNotice)
+    await disarm(approval, chatId: chatId)
+  }
+}
+
+// MARK: - Deny Finalization (Task 17 replaces the body)
+
+private extension ApprovalWaiter {
+  /// Task 17 owns the deny half: it replaces this body with `resolveDeniedObservation` (the
+  /// synthetic in-place observation + cancel/supersede run states + decision-specific copy). This
+  /// increment guarantees only the lane-freeing contract: the run fails, the owner is told, the
+  /// keyboard is disarmed — so a `.denied` signal never leaves the lane hung.
+  func resolveDenied(
+    approvalId: Int64,
+    runId: Int64,
+    chatId: Int64,
+    decision: ApprovalDecision
+  ) async {
+    guard let approval = loadApproval(approvalId) else {
+      return
+    }
+    do {
+      // No-op when the run is already CANCELLED/SUPERSEDED (the command path won first); fails an
+      // AWAITING_APPROVAL run for reject/expiry.
+      try runs.failRun(runId: runId, now: now())
+    } catch {
+      logger.error("failRun after denial failed for run \(runId): \(error)")
+    }
+    await notifyOwner(chatId: chatId, text: Self.denialNotice(for: decision))
+    await disarm(approval, chatId: chatId)
+  }
+
+  static func denialNotice(for decision: ApprovalDecision) -> String {
+    switch decision {
+    case .rejected: "Okay — I won't do that."
+    case .expired: "That approval expired, so I didn't do it."
+    case .cancelled: "Cancelled."
+    case .superseded: "Starting fresh — I dropped the pending action."
+    case .stalePolicy: "My instructions or tools changed, so I didn't run that."
+    }
+  }
+}
+
+// MARK: - Shared Side Effects
+
+private extension ApprovalWaiter {
+  static let stalePolicyNotice =
+    "My instructions or tools changed since you were asked, so I can't run that now — please re-run."
+
+  func loadApproval(_ id: Int64) -> Approval? {
+    do {
+      return try approvals.approval(id: id)
+    } catch {
+      logger.error("approval \(id) load failed: \(error)")
+      return nil
+    }
+  }
+
+  func notifyOwner(chatId: Int64, text: String) async {
+    _ = try? await delivery.sendMessage(chatId: chatId, text: text)
+  }
+
+  func disarm(_ approval: Approval, chatId: Int64) async {
+    guard let promptMessageId = approval.promptMessageId else {
+      return
+    }
+    try? await callbacks.editMessageReplyMarkup(
+      chatId: chatId,
+      messageId: promptMessageId,
+      replyMarkup: nil
+    )
+  }
+}

--- a/Sources/ClawGateway/Routing/ApprovedActionExecutor.swift
+++ b/Sources/ClawGateway/Routing/ApprovedActionExecutor.swift
@@ -1,0 +1,155 @@
+import ClawCore
+import Foundation
+import Logging
+
+/// Executes an APPROVED action from its recorded canonical args and commits the observation/run
+/// transition (§6.3/§6.6). No gate re-trip, no model turn — grant semantics are gone; this is
+/// recorded-args execution. Tools are held by name as ClawCore `Tool`s: the executor never imports
+/// `ClawTools`; the composition root injects the same instances the dispatcher uses.
+public protocol ApprovedActionExecuting: Sendable {
+  func executeApproved(_ approval: Approval) async -> ApprovedExecutionOutcome
+}
+
+public struct ApprovedExecutionOutcome: Sendable, Equatable {
+  /// What the placeholder observation now says (the waiter forwards nothing — the executor already
+  /// committed it; this is returned for logging/assertions).
+  public let observationContent: String
+  /// `.committed` when this call performed the resume; `.ignored` when a duplicate already did.
+  public let commit: RunCommitResult
+
+  public init(observationContent: String, commit: RunCommitResult) {
+    self.observationContent = observationContent
+    self.commit = commit
+  }
+}
+
+public struct ApprovedActionExecutor: ApprovedActionExecuting {
+  /// `memory_write`'s side effect is a DB insert that must FUSE with the observation update for
+  /// exactly-once (D10), so it never runs the tool's `execute`; every other write tool executes
+  /// its recorded args, then commits the observation generically.
+  private static let memoryWriteToolName = "memory_write"
+
+  private let tools: [String: any Tool]
+  private let runs: any RunStore
+  private let now: @Sendable () -> Date
+  private let logger: Logger
+
+  public init(
+    tools: [String: any Tool],
+    runs: any RunStore,
+    now: @escaping @Sendable () -> Date = { Date() },
+    logger: Logger
+  ) {
+    self.tools = tools
+    self.runs = runs
+    self.now = now
+    self.logger = logger
+  }
+
+  public func executeApproved(_ approval: Approval) async -> ApprovedExecutionOutcome {
+    if approval.tool == Self.memoryWriteToolName {
+      return applyMemoryWrite(approval)
+    }
+    return await executeGenericWrite(approval)
+  }
+}
+
+// MARK: - Generic Write Execution
+
+private extension ApprovedActionExecutor {
+  func executeGenericWrite(_ approval: Approval) async -> ApprovedExecutionOutcome {
+    guard
+      let tool = tools[approval.tool],
+      let arguments = JSONValue.parse(approval.canonicalArgsJSON)
+    else {
+      logger.error("approved action \(approval.tool) has no registered tool or unparsable args")
+      let content = "That action could not run because its tool is no longer available."
+      return ApprovedExecutionOutcome(
+        observationContent: content,
+        commit: commitObservation(approval, content: content)
+      )
+    }
+
+    // §6.6: run to completion on the waiter task — direct await, NEVER `executeWithTimeout`'s
+    // abandon-on-timeout race, so the observation is always truthful (file_write is atomic).
+    let payload = await tool.execute(
+      arguments: arguments,
+      canonicalTarget: approval.canonicalTarget
+    )
+    return ApprovedExecutionOutcome(
+      observationContent: payload.content,
+      commit: commitObservation(approval, content: payload.content)
+    )
+  }
+
+  func commitObservation(_ approval: Approval, content: String) -> RunCommitResult {
+    do {
+      return try runs.completeApprovedObservation(
+        runId: approval.runId,
+        observationMessageId: approval.observationMessageId,
+        content: content,
+        now: now()
+      )
+    } catch {
+      logger.error("completeApprovedObservation failed for run \(approval.runId): \(error)")
+      return .ignored
+    }
+  }
+}
+
+// MARK: - Memory Write (Fused, Exactly-Once)
+
+private extension ApprovedActionExecutor {
+  func applyMemoryWrite(_ approval: Approval) -> ApprovedExecutionOutcome {
+    guard let item = Self.rebuildMemoryItem(from: approval) else {
+      logger.error("memory_write approval \(approval.id) has unreadable recorded args")
+      let content = "That memory could not be saved because its details were unreadable."
+      return ApprovedExecutionOutcome(
+        observationContent: content,
+        commit: commitObservation(approval, content: content)
+      )
+    }
+
+    let content = "Saved to memory as \(item.kind.rawValue)."
+    do {
+      let commit = try runs.applyApprovedMemoryWrite(
+        runId: approval.runId,
+        observationMessageId: approval.observationMessageId,
+        item: item,
+        observationContent: content,
+        now: now()
+      )
+      return ApprovedExecutionOutcome(observationContent: content, commit: commit)
+    } catch {
+      logger.error("applyApprovedMemoryWrite failed for run \(approval.runId): \(error)")
+      return ApprovedExecutionOutcome(observationContent: content, commit: .ignored)
+    }
+  }
+
+  /// Rebuilds the `NewMemoryItem` from the recorded canonical args. The args were already
+  /// normalized + scanned at gate time (Task 22), so no re-normalization here.
+  static func rebuildMemoryItem(from approval: Approval) -> NewMemoryItem? {
+    guard
+      let object = JSONValue.parse(approval.canonicalArgsJSON)?.objectValue,
+      let text = object["text"]?.stringValue,
+      let kindRaw = object["kind"]?.stringValue,
+      let kind = MemoryKind(rawValue: kindRaw)
+    else {
+      return nil
+    }
+    let importance =
+      object["importance"]?.numberValue.flatMap { Importance(rawValue: Int($0)) } ?? .normal
+    let sensitivity =
+      object["sensitivity"]?.stringValue.flatMap(Sensitivity.init(rawValue:)) ?? .normal
+    // Task 22 flips `source` to `.assistant` (the case does not exist yet in Phase 3) and unifies
+    // this decode with the shared `MemoryWriteArguments` decoder (Task 22 owns that unification).
+    return NewMemoryItem(
+      text: text,
+      kind: kind,
+      sensitivity: sensitivity,
+      importance: importance,
+      source: .owner,
+      sessionId: approval.sessionId
+    )
+  }
+}

--- a/Sources/ClawGateway/Routing/CommandHandlers.swift
+++ b/Sources/ClawGateway/Routing/CommandHandlers.swift
@@ -14,6 +14,7 @@ struct CommandHandlers: Sendable {
   let replies: ReplySender
   let now: @Sendable () -> Date
   let logger: Logger
+  let coordinator: ApprovalCoordinator
 
   func stop(
     rawUpdate: RawUpdate,
@@ -40,6 +41,10 @@ struct CommandHandlers: Sendable {
       for runId in result.cancelledRunIds {
         await lane.cancel(runId: runId)
       }
+    }
+
+    for approvalId in result.resolvedApprovalIds {
+      await coordinator.signal(approvalId: approvalId, .denied(.cancelled))
     }
 
     let reply =
@@ -75,6 +80,10 @@ struct CommandHandlers: Sendable {
       let lane = await lanes.actor(for: sessionId)
       await lane.cancelAll()
       await pendingConfirmations.clear(sessionId: sessionId)
+    }
+
+    for approvalId in result.resolvedApprovalIds {
+      await coordinator.signal(approvalId: approvalId, .denied(.superseded))
     }
 
     return await replies.sendCommandAck(

--- a/Sources/ClawGateway/Routing/CommandHandlers.swift
+++ b/Sources/ClawGateway/Routing/CommandHandlers.swift
@@ -36,15 +36,23 @@ struct CommandHandlers: Sendable {
       return replies.skipDuplicate(updateId: rawUpdate.updateId)
     }
 
+    // Signal the coordinator BEFORE cancelling the lane. Cancelling first would race the parked
+    // waiter: `lane.cancel` cancels the very Task suspended in `ApprovalWaiter.park`, whose
+    // `awaitResolution` cancellation path resumes the waiter with `nil` — if that wins the race
+    // against this signal, `park` returns early and never fills the synthetic observation, leaving
+    // a dangling tool_call on the now-terminal run. Signalling first delivers a real `.denied` to
+    // the still-registered waiter, and there is no suspension point between its resume and the
+    // synchronous observation-fill write, so the subsequent cancel can only no-op an already
+    // resumed task. (Deliberate deviation from the plan's literal Step 13 ordering.)
+    for approvalId in result.resolvedApprovalIds {
+      await coordinator.signal(approvalId: approvalId, .denied(.cancelled))
+    }
+
     if let sessionId = result.sessionId, result.cancelledRunIds.isEmpty == false {
       let lane = await lanes.actor(for: sessionId)
       for runId in result.cancelledRunIds {
         await lane.cancel(runId: runId)
       }
-    }
-
-    for approvalId in result.resolvedApprovalIds {
-      await coordinator.signal(approvalId: approvalId, .denied(.cancelled))
     }
 
     let reply =
@@ -76,14 +84,19 @@ struct CommandHandlers: Sendable {
       return replies.skipDuplicate(updateId: rawUpdate.updateId)
     }
 
+    // Signal the coordinator BEFORE cancelling the lane — same race as `/stop` (see `stop`):
+    // cancelling first can let the parked waiter's `nil`-resume win over this signal, so `park`
+    // exits without filling the synthetic observation. Signalling first delivers a real
+    // `.superseded` to the still-registered waiter, whose observation-fill write then runs before
+    // the cancel can interrupt it. (Deliberate deviation from the plan's literal Step 13 ordering.)
+    for approvalId in result.resolvedApprovalIds {
+      await coordinator.signal(approvalId: approvalId, .denied(.superseded))
+    }
+
     if let sessionId = result.sessionId {
       let lane = await lanes.actor(for: sessionId)
       await lane.cancelAll()
       await pendingConfirmations.clear(sessionId: sessionId)
-    }
-
-    for approvalId in result.resolvedApprovalIds {
-      await coordinator.signal(approvalId: approvalId, .denied(.superseded))
     }
 
     return await replies.sendCommandAck(

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -26,6 +26,7 @@ public struct MessageRouter: Sendable {
   private let scheduleHandlers: ScheduleHandlers
   private let confirmations: ConfirmationResolver
   private let turnDispatch: TurnDispatch
+  private let approvalCallbacks: ApprovalCallbackHandler?
   private let logger: Logger
 
   public init(
@@ -41,11 +42,13 @@ public struct MessageRouter: Sendable {
     turnRunner: any TurnDispatching,
     lanes: SessionLaneRegistry,
     schedule: ScheduleSurface,
+    approvalCallbacks: ApprovalCallbackHandler? = nil,
     now: @escaping @Sendable () -> Date = { Date() },
     logger: Logger
   ) {
     self.botUsername = botUsername
     self.accessControl = accessControl
+    self.approvalCallbacks = approvalCallbacks
     self.logger = logger
 
     let replies = ReplySender(processed: processed, delivery: delivery, logger: logger)
@@ -111,6 +114,17 @@ public struct MessageRouter: Sendable {
 
 private extension MessageRouter {
   func route(rawUpdate: RawUpdate) async throws(RoutingHalt) -> HandleOutcome {
+    // A callback-only update normalizes to nil (no message/edited_message); without this branch it
+    // would .skipped and the cursor would advance past it (spec §6.1). The handler runs the §6.2
+    // chain and returns a real HandleOutcome, so cursor semantics are unchanged.
+    if let callback = rawUpdate.callback {
+      guard let approvalCallbacks else {
+        logger.debug("callback update \(rawUpdate.updateId) with no approval handler, skipping")
+        return .skipped
+      }
+      return await approvalCallbacks.handle(callback, updateId: rawUpdate.updateId)
+    }
+
     guard let message = IncomingMessage.normalize(from: rawUpdate) else {
       logger.debug("update \(rawUpdate.updateId) has nothing actionable, skipping")
       return .skipped

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -43,6 +43,7 @@ public struct MessageRouter: Sendable {
     lanes: SessionLaneRegistry,
     schedule: ScheduleSurface,
     approvalCallbacks: ApprovalCallbackHandler? = nil,
+    coordinator: ApprovalCoordinator = ApprovalCoordinator(),
     now: @escaping @Sendable () -> Date = { Date() },
     logger: Logger
   ) {
@@ -70,7 +71,8 @@ public struct MessageRouter: Sendable {
       lanes: lanes,
       replies: replies,
       now: now,
-      logger: logger
+      logger: logger,
+      coordinator: coordinator
     )
     self.scheduleHandlers = ScheduleHandlers(
       schedule: schedule,

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -43,7 +43,7 @@ public struct MessageRouter: Sendable {
     lanes: SessionLaneRegistry,
     schedule: ScheduleSurface,
     approvalCallbacks: ApprovalCallbackHandler? = nil,
-    coordinator: ApprovalCoordinator = ApprovalCoordinator(),
+    coordinator: ApprovalCoordinator,
     now: @escaping @Sendable () -> Date = { Date() },
     logger: Logger
   ) {

--- a/Sources/ClawGateway/Routing/TurnRunner.swift
+++ b/Sources/ClawGateway/Routing/TurnRunner.swift
@@ -13,6 +13,18 @@ public protocol TurnDispatching: Sendable {
     triggerMessageId: Int64,
     grant: OneTurnGrant?
   ) async throws
+  /// Continues a run the approval waiter already flipped AWAITING_APPROVAL → RUNNING: no pick-up,
+  /// context bound to the filled observation row, budget counters carried over (§6.3).
+  func resume(runId: Int64, sessionId: Int64, chatId: Int64, contextBoundMessageId: Int64) async
+}
+
+extension TurnDispatching {
+  public func resume(
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    contextBoundMessageId: Int64
+  ) async {}
 }
 
 /// Picks up a durable PENDING run, assembles its trigger-bounded context, executes the agent, and
@@ -179,6 +191,99 @@ public struct TurnRunner: TurnDispatching {
       ownerNotices: buildResult.ownerNotices,
       origin: origin
     )
+  }
+
+  /// The §6.3 continuation, identical to `run` except: no `pickUp` (the waiter already flipped
+  /// AWAITING_APPROVAL → RUNNING via the executor), the context bound is the FILLED observation
+  /// row's message id (the trigger id would exclude the partial exchange), and `runTurn` is seeded
+  /// with the run's carried-over budget counters. Non-throwing: it runs on the session lane inside
+  /// the waiter's `park`, so every failure resolves in-band (a build/turn failure fails the run so
+  /// the lane frees).
+  public func resume(
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    contextBoundMessageId: Int64
+  ) async {
+    guard !Task.isCancelled else {
+      return
+    }
+
+    let origin: RunOrigin
+    do {
+      guard let resolvedOrigin = try runs.runOrigin(runId: runId) else {
+        logger.debug("run \(runId) has no origin at resume; skipping")
+        return
+      }
+      origin = resolvedOrigin
+    } catch {
+      logger.error("resume origin read failed for run \(runId): \(error)")
+      return
+    }
+
+    let clock = now()
+    let snapshot: SessionContextSnapshot
+    let buildResult: BuildResult
+    let todayTokens: Int
+    let todayUSD: Double
+    let proactiveTodayUSD: Double
+    let carryOver: ResumeUsage
+    do {
+      snapshot = try sessionMessages.loadContextSnapshot(
+        sessionId: sessionId,
+        throughMessageId: contextBoundMessageId,
+        limit: Self.historyLimit
+      )
+      let totals = try usageStore.todayTokensAndCost(now: clock)
+      todayTokens = totals.tokens
+      todayUSD = totals.costUSD
+      if origin == .interactive {
+        proactiveTodayUSD = 0
+      } else {
+        proactiveTodayUSD =
+          try usageStore.todayTokensAndCost(origins: [.scheduled, .heartbeat], now: clock).costUSD
+      }
+      carryOver = try runs.resumeUsage(runId: runId)
+      buildResult = try contextBuilder.assemble(snapshot: snapshot, sessionId: sessionId)
+    } catch {
+      logger.error("resume context build failed for run \(runId): \(error)")
+      try? runs.failRun(runId: runId, now: Date())
+      return
+    }
+
+    let outcome: TurnOutcome
+    do {
+      outcome = try await agent.runTurn(
+        runId: runId,
+        sessionId: sessionId,
+        chatId: chatId,
+        buildResult: buildResult,
+        sessionTainted: snapshot.isTainted,
+        grant: nil,
+        todayTokens: todayTokens,
+        todayUSD: todayUSD,
+        origin: origin,
+        proactiveTodayUSD: proactiveTodayUSD,
+        carryOver: carryOver
+      )
+    } catch {
+      logger.error("resume turn failed for run \(runId): \(error)")
+      try? runs.failRun(runId: runId, now: Date())
+      return
+    }
+
+    do {
+      try await commit(
+        outcome,
+        runId: runId,
+        sessionId: sessionId,
+        chatId: chatId,
+        ownerNotices: buildResult.ownerNotices,
+        origin: origin
+      )
+    } catch {
+      logger.error("resume commit failed for run \(runId): \(error)")
+    }
   }
 }
 

--- a/Sources/ClawGateway/Routing/TurnRunner.swift
+++ b/Sources/ClawGateway/Routing/TurnRunner.swift
@@ -247,7 +247,7 @@ public struct TurnRunner: TurnDispatching {
       buildResult = try contextBuilder.assemble(snapshot: snapshot, sessionId: sessionId)
     } catch {
       logger.error("resume context build failed for run \(runId): \(error)")
-      try? runs.failRun(runId: runId, now: Date())
+      try? runs.failRun(runId: runId, now: now())
       return
     }
 
@@ -268,7 +268,7 @@ public struct TurnRunner: TurnDispatching {
       )
     } catch {
       logger.error("resume turn failed for run \(runId): \(error)")
-      try? runs.failRun(runId: runId, now: Date())
+      try? runs.failRun(runId: runId, now: now())
       return
     }
 

--- a/Sources/ClawGateway/Services/ApprovalBootReconciler.swift
+++ b/Sources/ClawGateway/Services/ApprovalBootReconciler.swift
@@ -1,0 +1,120 @@
+import ClawAgent
+import ClawCore
+import Foundation
+import Logging
+
+// `ApprovalParking` is already declared in `ApprovalCoordinator.swift` (Task 14) and `ApprovalWaiter`
+// already conforms to it (Task 16, Step 20) — both in this same `ClawGateway` module. Do NOT
+// redeclare the protocol or re-add the conformance here: a second `public protocol ApprovalParking`
+// is an "invalid redeclaration" build error, and a second `extension ApprovalWaiter: ApprovalParking`
+// is a redundant conformance. The reconciler just USES the existing protocol as its `waiter`
+// dependency type — it is already the single `park` method the boot path needs, so no narrowing is
+// required. In tests the boot spy conforms to that same existing protocol.
+
+/// §7 boot reconciliation for the approval fabric — the restart entry point of the §5.5 single
+/// execution locus. It never transitions a run row directly: it cleans terminal-run orphans, then
+/// per unresolved approval either re-parks a waiter on the session lane (unexpired PENDING),
+/// CAS-expires + signals a denial for the parked waiter to consume (expired PENDING), or re-parks
+/// under the §6.5 crash-window belt (APPROVED row on an AWAITING_APPROVAL run). The parked waiter
+/// performs every run transition, owner notice, and button disarm; the reconciler only orchestrates.
+public struct ApprovalBootReconciler: Sendable {
+  private let approvals: any ApprovalStore
+  private let lanes: SessionLaneRegistry
+  private let coordinator: ApprovalCoordinator
+  private let waiter: any ApprovalParking
+  private let now: @Sendable () -> Date
+  private let logger: Logger
+
+  public init(
+    approvals: any ApprovalStore,
+    lanes: SessionLaneRegistry,
+    coordinator: ApprovalCoordinator,
+    waiter: any ApprovalParking,
+    now: @escaping @Sendable () -> Date,
+    logger: Logger
+  ) {
+    self.approvals = approvals
+    self.lanes = lanes
+    self.coordinator = coordinator
+    self.waiter = waiter
+    self.now = now
+    self.logger = logger
+  }
+
+  /// Best-effort and ordered: orphan cleanup runs first so `unresolvedAtBoot`'s PENDING rows all
+  /// belong to still-parked (AWAITING_APPROVAL) runs (a suspend commit flips the run and inserts the
+  /// row in one txn, so a PENDING approval's run is only ever AWAITING_APPROVAL or terminal). A
+  /// failure on one row is logged and never strands the others.
+  public func reconcile() async {
+    let instant = now()
+
+    do {
+      let cleaned = try approvals.resolveOrphans(now: instant)
+      if cleaned > 0 {
+        logger.warning("boot approvals: resolved \(cleaned) orphaned pending approval(s)")
+      }
+    } catch {
+      logger.error("boot approvals: resolveOrphans failed: \(error)")
+    }
+
+    let unresolved: [Approval]
+    do {
+      unresolved = try approvals.unresolvedAtBoot()
+    } catch {
+      logger.error("boot approvals: unresolvedAtBoot failed: \(error)")
+      return
+    }
+
+    for approval in unresolved {
+      await reparkOne(approval, now: instant)
+    }
+  }
+}
+
+// MARK: - Per-Row Re-Park
+
+private extension ApprovalBootReconciler {
+  func reparkOne(_ approval: Approval, now instant: Date) async {
+    let revalidate: Bool
+    switch approval.state {
+    case .approved:
+      // §6.5 crash window: granted before the crash. Buffer the approval signal and re-park under
+      // re-validation so the waiter rechecks policy_version before executing the recorded action.
+      await coordinator.signal(approvalId: approval.id, .approved)
+      revalidate = true
+    case .pending where approval.expiresTs <= instant:
+      // §6.4 expiry: CAS PENDING→EXPIRED (+ approvalDenied/expired audit) here, then let the parked
+      // waiter consume the buffered denial and drive the run AWAITING_APPROVAL→FAILED.
+      do {
+        _ = try approvals.deny(id: approval.id, decision: .expired, now: instant)
+      } catch {
+        logger.error("boot approvals: expiry deny failed for approval \(approval.id): \(error)")
+        return
+      }
+      await coordinator.signal(approvalId: approval.id, .denied(.expired))
+      revalidate = false
+    case .pending:
+      // Unexpired: re-park so buttons and the FIFO queue-behind contract survive restart (§5.5).
+      revalidate = false
+    case .rejected, .expired:
+      // `unresolvedAtBoot` never returns a resolved row; ignore defensively.
+      return
+    }
+
+    let park = waiter
+    let approvalId = approval.id
+    let runId = approval.runId
+    let sessionId = approval.sessionId
+    let chatId = approval.ownerUserId
+    let lane = await lanes.actor(for: sessionId)
+    await lane.enqueue(runId: runId) {
+      await park.park(
+        approvalId: approvalId,
+        runId: runId,
+        sessionId: sessionId,
+        chatId: chatId,
+        revalidatePolicyOnApprove: revalidate
+      )
+    }
+  }
+}

--- a/Sources/ClawGateway/Services/ApprovalBootReconciler.swift
+++ b/Sources/ClawGateway/Services/ApprovalBootReconciler.swift
@@ -14,9 +14,11 @@ import Logging
 /// §7 boot reconciliation for the approval fabric — the restart entry point of the §5.5 single
 /// execution locus. It never transitions a run row directly: it cleans terminal-run orphans, then
 /// per unresolved approval either re-parks a waiter on the session lane (unexpired PENDING),
-/// CAS-expires + signals a denial for the parked waiter to consume (expired PENDING), or re-parks
-/// under the §6.5 crash-window belt (APPROVED row on an AWAITING_APPROVAL run). The parked waiter
-/// performs every run transition, owner notice, and button disarm; the reconciler only orchestrates.
+/// CAS-expires + signals a denial for the parked waiter to consume (expired PENDING), re-parks
+/// under the §6.5 crash-window belt (APPROVED row on an AWAITING_APPROVAL run), or re-buffers the
+/// already-committed denial (REJECTED/EXPIRED row on an AWAITING_APPROVAL run — the deny-side
+/// crash window). The parked waiter performs every run transition, owner notice, and button
+/// disarm; the reconciler only orchestrates.
 public struct ApprovalBootReconciler: Sendable {
   private let approvals: any ApprovalStore
   private let lanes: SessionLaneRegistry
@@ -86,7 +88,11 @@ private extension ApprovalBootReconciler {
       // §6.4 expiry: CAS PENDING→EXPIRED (+ approvalDenied/expired audit) here, then let the parked
       // waiter consume the buffered denial and drive the run AWAITING_APPROVAL→FAILED.
       do {
-        _ = try approvals.deny(id: approval.id, decision: .expired, now: instant)
+        // Nothing races the boot sweep, so a lost CAS should be impossible; still signal so the
+        // parked waiter frees the lane, but leave a trace instead of silently dropping the miss.
+        if try approvals.deny(id: approval.id, decision: .expired, now: instant) == false {
+          logger.warning("boot approvals: expiry CAS found approval \(approval.id) not PENDING")
+        }
       } catch {
         logger.error("boot approvals: expiry deny failed for approval \(approval.id): \(error)")
         return
@@ -96,9 +102,20 @@ private extension ApprovalBootReconciler {
     case .pending:
       // Unexpired: re-park so buttons and the FIFO queue-behind contract survive restart (§5.5).
       revalidate = false
-    case .rejected, .expired:
-      // `unresolvedAtBoot` never returns a resolved row; ignore defensively.
-      return
+    case .rejected:
+      // Deny-side twin of the §6.5 crash window: the deny CAS (+ its audit) committed but the
+      // process died before the waiter's observation-fill/run-fail commit. Never re-CAS or
+      // re-audit — just re-buffer the denial so the re-parked waiter finalizes the run
+      // AWAITING_APPROVAL→FAILED. The original decision (owner reject vs stale policy) is not
+      // recoverable from the row; both map to run→FAILED with no cancel, so the generic
+      // `.rejected` differs only in owner-notice copy. (Cancel/supersede denials can never land
+      // here — the command txn moves the run off AWAITING_APPROVAL atomically with the CAS.)
+      await coordinator.signal(approvalId: approval.id, .denied(.rejected))
+      revalidate = false
+    case .expired:
+      // The same deny-side belt for a row the expiry CAS resolved before the crash.
+      await coordinator.signal(approvalId: approval.id, .denied(.expired))
+      revalidate = false
     }
 
     let park = waiter

--- a/Sources/ClawGateway/Services/ApprovalBootReconciler.swift
+++ b/Sources/ClawGateway/Services/ApprovalBootReconciler.swift
@@ -78,6 +78,7 @@ public struct ApprovalBootReconciler: Sendable {
 private extension ApprovalBootReconciler {
   func reparkOne(_ approval: Approval, now instant: Date) async {
     let revalidate: Bool
+
     switch approval.state {
     case .approved:
       // §6.5 crash window: granted before the crash. Buffer the approval signal and re-park under
@@ -124,6 +125,7 @@ private extension ApprovalBootReconciler {
     let sessionId = approval.sessionId
     let chatId = approval.ownerUserId
     let lane = await lanes.actor(for: sessionId)
+
     await lane.enqueue(runId: runId) {
       await park.park(
         approvalId: approvalId,

--- a/Sources/ClawGateway/Services/ApprovalExpiryService.swift
+++ b/Sources/ClawGateway/Services/ApprovalExpiryService.swift
@@ -1,0 +1,75 @@
+import ClawCore
+import Foundation
+import Logging
+import ServiceLifecycle
+
+/// The 60 s wall-clock expiry ticker (spec §7). Each tick sweeps every `PENDING` approval whose
+/// `expires_ts <= now` to `EXPIRED` — the CAS and its `approvalDenied`/`expired` audit ride the
+/// store's single transaction (Task 06 `sweepExpired`, preamble D3) — then signals the coordinator
+/// so the parked waiter runs the exact §6.4 Deny path (synthetic observation, run→FAILED, owner
+/// notice, button disarm). This service owns NONE of that; it sweeps then signals. Wall-clock
+/// comparison only (never tick-counting): the durable `expires_ts` is the real deadline, so a
+/// late-landing tick still resolves the row correctly. Tick-level mutual exclusion is structural —
+/// one instance, one sequential loop; cross-process exclusion is the startup flock.
+public struct ApprovalExpiryService: Service {
+  /// The tick grain — pinned 60 s, NOT config (spec §7/§11). Expiry is a liveness / bounded-state
+  /// control (an unresolved approval must not pin a session lane indefinitely), not an attacker
+  /// defense, so sub-minute precision buys nothing: the row's `expires_ts` is authoritative and the
+  /// sweep compare is exact regardless of when the tick fires.
+  public static let tickInterval: Duration = .seconds(60)
+
+  private let approvals: any ApprovalStore
+  private let coordinator: ApprovalCoordinator
+  private let now: @Sendable () -> Date
+  private let sleep: @Sendable (Duration) async throws -> Void
+  private let logger: Logger
+
+  public init(
+    approvals: any ApprovalStore,
+    coordinator: ApprovalCoordinator,
+    now: @escaping @Sendable () -> Date,
+    sleep: @escaping @Sendable (Duration) async throws -> Void,
+    logger: Logger
+  ) {
+    self.approvals = approvals
+    self.coordinator = coordinator
+    self.now = now
+    self.sleep = sleep
+    self.logger = logger
+  }
+
+  public func run() async throws {
+    logger.info("approval-expiry starting")
+    await cancelWhenGracefulShutdown {
+      // Immediate first tick (restart recovery — a row that aged out while the daemon was down
+      // sweeps at once), then sleep between ticks; a thrown sleep is graceful shutdown, so break.
+      while !Task.isCancelled {
+        await tick()
+        do {
+          try await sleep(Self.tickInterval)
+        } catch {
+          break
+        }
+      }
+    }
+    logger.info("approval-expiry stopped")
+  }
+
+  /// One sweep pass. Non-throwing by contract: the ticker must survive every store failure (the
+  /// next tick retries) rather than crash the service group. The CAS + audit live in the store;
+  /// this service only sweeps then signals — the waiter owns the observation, run transition,
+  /// owner notice, and button disarm (spec §7).
+  func tick() async {
+    let sweepTime = now()
+    let expired: [Approval]
+    do {
+      expired = try approvals.sweepExpired(now: sweepTime)
+    } catch {
+      logger.error("approval-expiry sweep failed: \(error)")
+      return
+    }
+    for approval in expired {
+      await coordinator.signal(approvalId: approval.id, .denied(.expired))
+    }
+  }
+}

--- a/Sources/ClawGateway/Services/TelegramPollerService.swift
+++ b/Sources/ClawGateway/Services/TelegramPollerService.swift
@@ -12,9 +12,10 @@ public struct TelegramPollerService: Service {
   private let pollTimeout: Int
   private let logger: Logger
 
-  /// Re-sent on every call: omitting it would reuse the previous server-side setting. Only
-  /// direct messages and edits are requested (no callback_query — no approvals yet).
-  private static let allowedUpdates = ["message", "edited_message"]
+  /// Re-sent on every call: omitting it would reuse the previous server-side setting. Approval
+  /// inline buttons are delivered as `callback_query`, so it joins direct messages and edits — the
+  /// callback branch in `MessageRouter` (spec §6.1/§6.2) handles them ahead of `normalize`.
+  private static let allowedUpdates = ["message", "edited_message", "callback_query"]
 
   /// Back-off windows that stop a persistent fault from becoming a tight re-poll loop.
   private enum Backoff {

--- a/Sources/ClawTelegram/Wire/WireModels.swift
+++ b/Sources/ClawTelegram/Wire/WireModels.swift
@@ -110,14 +110,23 @@ struct TUpdate: Decodable {
   let edited_message: TMessage?
   let callback_query: TCallbackQuery?
 
-  // The button tap is decoded here so the client + tests have the wire surface; it is mapped into
-  // the wire-agnostic RawUpdate once that type gains its callback field (the intake half lands
-  // with the router's callback branch).
+  // The button tap decodes here and maps into the wire-agnostic RawUpdate.callback; chat/message
+  // ids come from the prompt message (callback_query.message), which Telegram always includes for
+  // an inline-keyboard tap.
   func toRawUpdate() -> RawUpdate {
     RawUpdate(
       updateId: update_id,
       message: message?.toRawMessage(),
-      editedMessage: edited_message?.toRawMessage()
+      editedMessage: edited_message?.toRawMessage(),
+      callback: callback_query.map { query in
+        RawCallback(
+          callbackId: query.id,
+          fromUserId: query.from.id,
+          chatId: query.message?.chat.id,
+          messageId: query.message?.message_id,
+          data: query.data
+        )
+      }
     )
   }
 }

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -321,6 +321,12 @@ public struct GatedToolDispatcher: ToolDispatching {
     registry.definitions
   }
 
+  /// The same name-keyed catalog `dispatch` gates through, surfaced so Task 16's composition root
+  /// can build `ApprovedActionExecutor` against the identical tool instances.
+  public var toolsByName: [String: any Tool] {
+    registry.toolsByName
+  }
+
   public func dispatch(call: ToolCall, context: ToolDispatchContext) async -> ToolDispatchOutcome {
     // (0) unknown tool → error observation, never a crash
     guard let tool = registry.tool(named: call.name) else {

--- a/Sources/ClawTools/Tools/ToolRegistry.swift
+++ b/Sources/ClawTools/Tools/ToolRegistry.swift
@@ -5,7 +5,10 @@ import Foundation
 /// membership (an unkeyed `web_search` is simply never constructed — unconfigured ⇒ absent, §7.3).
 public struct ToolRegistry: Sendable {
   private let orderedTools: [any Tool]
-  private let toolsByName: [String: any Tool]
+  /// `public`: Task 16's composition root builds `ApprovedActionExecutor`'s name-keyed tool table
+  /// from this same catalog, so the approve-resume path executes the identical tool instances the
+  /// gated dispatcher does.
+  public let toolsByName: [String: any Tool]
 
   public init(tools: [any Tool]) {
     orderedTools = tools

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -12,6 +12,33 @@ import ClawWorkspace
 import Foundation
 import Logging
 
+/// Breaks the `turnRunner` ⇄ `approvalWaiter` construction cycle: `TurnRunner` needs a `parker`,
+/// and the real parker (the waiter) needs `turnRunner` as its dispatcher. Adopted once during
+/// composition, before the service group starts.
+actor DeferredApprovalParker: ApprovalParking {
+  private var wrapped: (any ApprovalParking)?
+
+  func adopt(_ parker: any ApprovalParking) {
+    wrapped = parker
+  }
+
+  func park(
+    approvalId: Int64,
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    revalidatePolicyOnApprove: Bool
+  ) async {
+    await wrapped?.park(
+      approvalId: approvalId,
+      runId: runId,
+      sessionId: sessionId,
+      chatId: chatId,
+      revalidatePolicyOnApprove: revalidatePolicyOnApprove
+    )
+  }
+}
+
 struct RunCommand: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "run",
@@ -74,7 +101,7 @@ struct RunCommand: AsyncParsableCommand {
     let transport = TelegramClient(token: secrets.telegramBotToken, http: executor)
     let botUsername = await fetchBotUsername(transport: transport, logger: logger)
 
-    let daemon = makeDaemon(
+    let daemon = await makeDaemon(
       config: config,
       secrets: secrets,
       stores: stores,
@@ -166,7 +193,7 @@ private extension RunCommand {
     transport: TelegramClient,
     botUsername: String?,
     logger: Logger
-  ) -> Daemon {
+  ) async -> Daemon {
     // Created before the TurnRunner so its notifyOutbox closure can capture it: each commit pokes
     // the dispatcher to drain the rows it just enqueued.
     let outboxSignal = OutboxSignal()
@@ -194,36 +221,19 @@ private extension RunCommand {
     let workspace = FileSystemWorkspace(
       root: config.stateRoot.appendingPathComponent("workspace", isDirectory: true)
     )
-    let toolDispatcher = makeToolDispatcher(
-      secrets: secrets,
-      workspace: workspace,
-      toolExecutor: toolExecutor
-    )
-    let staticSubhash = policyStaticSubhash(
-      toolDispatcher: toolDispatcher,
-      config: config,
-      secrets: secrets,
-      workspace: workspace
-    )
-    let agent = makeAgent(
+    let (toolDispatcher, agent, contextBuilder) = makeAgentStack(
       config: config,
       secrets: secrets,
       provider: provider,
       transport: transport,
       stores: stores,
-      toolDispatcher: toolDispatcher,
+      workspace: workspace,
+      toolExecutor: toolExecutor,
       costResolver: costResolver,
       logger: logger
     )
 
-    let contextBuilder = makeContextBuilder(
-      config: config,
-      workspace: workspace,
-      stores: stores,
-      policyStaticSubhash: staticSubhash,
-      logger: logger
-    )
-
+    let deferredParker = DeferredApprovalParker()
     let turnRunner = TurnRunner(
       sessionMessages: stores.sessionMessages,
       runs: stores.runs,
@@ -236,10 +246,22 @@ private extension RunCommand {
       notifyOutbox: { outboxSignal.poke() },
       breaker: breaker,
       delivery: transport,
-      parker: InertApprovalParker(coordinator: approvalCoordinator, logger: logger),
+      parker: deferredParker,
       approvalExpirySeconds: config.approvalExpirySeconds,
       logger: logger
     )
+
+    let approvalCallbackHandler = await makeApprovalFabric(
+      stores: stores,
+      transport: transport,
+      toolDispatcher: toolDispatcher,
+      turnRunner: turnRunner,
+      approvalCoordinator: approvalCoordinator,
+      deferredParker: deferredParker,
+      contextBuilder: contextBuilder,
+      logger: logger
+    )
+
     let scheduleSurface = makeScheduleSurface(
       config: config,
       stores: stores,
@@ -260,6 +282,7 @@ private extension RunCommand {
       turnRunner: turnRunner,
       lanes: lanes,
       schedule: scheduleSurface,
+      approvalCallbacks: approvalCallbackHandler,
       logger: logger
     )
     let poller = TelegramPollerService(
@@ -294,6 +317,102 @@ private extension RunCommand {
         heartbeatOwner: heartbeatOwner,
         logger: logger
       ),
+      logger: logger
+    )
+  }
+
+  /// Assembles the tool-gated agent stack: the policy-gated dispatcher, its static sub-hash, the
+  /// `AgentRuntime`, and the context builder that folds the sub-hash into `policy_version`.
+  /// Extracted from `makeDaemon` purely to keep its body short.
+  // swiftlint:disable:next function_parameter_count
+  func makeAgentStack(
+    config: AppConfig,
+    secrets: Secrets,
+    provider: OpenAICompatibleProvider,
+    transport: TelegramClient,
+    stores: ClawStores,
+    workspace: FileSystemWorkspace,
+    toolExecutor: AsyncHTTPExecutor,
+    costResolver: CostResolver,
+    logger: Logger
+  ) -> (toolDispatcher: GatedToolDispatcher, agent: AgentRuntime, contextBuilder: ContextBuilder) {
+    let toolDispatcher = makeToolDispatcher(
+      secrets: secrets,
+      workspace: workspace,
+      toolExecutor: toolExecutor
+    )
+    let staticSubhash = policyStaticSubhash(
+      toolDispatcher: toolDispatcher,
+      config: config,
+      secrets: secrets,
+      workspace: workspace
+    )
+    let agent = makeAgent(
+      config: config,
+      secrets: secrets,
+      provider: provider,
+      transport: transport,
+      stores: stores,
+      toolDispatcher: toolDispatcher,
+      costResolver: costResolver,
+      logger: logger
+    )
+    let contextBuilder = makeContextBuilder(
+      config: config,
+      workspace: workspace,
+      stores: stores,
+      policyStaticSubhash: staticSubhash,
+      logger: logger
+    )
+    return (toolDispatcher, agent, contextBuilder)
+  }
+
+  /// Builds the Task-16 approve-resume fabric — the executor (recorded-args execution) and the
+  /// waiter (the single execution locus, §5.5), adopted into `deferredParker` to close the
+  /// `turnRunner` ⇄ `approvalWaiter` construction cycle — and the Task-15 callback handler that
+  /// answers an owner's tap into it. Extracted from `makeDaemon` purely to keep its body short;
+  /// every argument here is already in scope at the call site.
+  // swiftlint:disable:next function_parameter_count
+  func makeApprovalFabric(
+    stores: ClawStores,
+    transport: TelegramClient,
+    toolDispatcher: GatedToolDispatcher,
+    turnRunner: TurnRunner,
+    approvalCoordinator: ApprovalCoordinator,
+    deferredParker: DeferredApprovalParker,
+    contextBuilder: ContextBuilder,
+    logger: Logger
+  ) async -> ApprovalCallbackHandler {
+    let approvedExecutor = ApprovedActionExecutor(
+      tools: toolDispatcher.toolsByName,
+      runs: stores.runs,
+      now: { Date() },
+      logger: logger
+    )
+    let approvalWaiter = ApprovalWaiter(
+      approvals: stores.approvals,
+      runs: stores.runs,
+      coordinator: approvalCoordinator,
+      executor: approvedExecutor,
+      turns: turnRunner,
+      delivery: transport,
+      callbacks: transport,
+      currentPolicyVersion: { contextBuilder.currentPolicyVersion() },
+      now: { Date() },
+      logger: logger
+    )
+    await deferredParker.adopt(approvalWaiter)
+
+    return ApprovalCallbackHandler.make(
+      processed: stores.processed,
+      delivery: transport,
+      accessControl: AccessControl(allowlist: stores.allowlist),
+      approvals: stores.approvals,
+      audit: stores.audit,
+      coordinator: approvalCoordinator,
+      callbacks: transport,
+      currentPolicyVersion: { contextBuilder.currentPolicyVersion() },
+      now: { Date() },
       logger: logger
     )
   }

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -310,8 +310,16 @@ private extension RunCommand {
       logger: logger
     )
 
+    let approvalExpiry = ApprovalExpiryService(
+      approvals: stores.approvals,
+      coordinator: approvalCoordinator,
+      now: { Date() },
+      sleep: { try await Task.sleep(for: $0) },
+      logger: logger
+    )
+
     return Daemon(
-      services: [poller, dispatcher, scheduler],
+      services: [poller, dispatcher, scheduler, approvalExpiry],
       boot: bootSequence(
         transport: transport,
         stores: stores,

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -634,9 +634,11 @@ private extension RunCommand {
 // MARK: - Boot Sequence
 
 private extension RunCommand {
-  /// Composes the daemon's one-shot boot reconciliation: register the command menu with Telegram,
-  /// then sweep crash-orphaned runs (F22). The steps are independent and best-effort, so the order
-  /// is cosmetic; both run before any update is served.
+  /// Composes the daemon's one-shot boot reconciliation: register the command menu with Telegram
+  /// (`registerMenu`), sweep crash-orphaned runs (`reconcileRuns`, F22), then re-park unresolved
+  /// approvals (`reconcileApprovals`, §7). Each step is best-effort, but `reconcileApprovals` is
+  /// deliberately last: the run sweep must fail its orphans first so the approval sweep only sees
+  /// runs that are genuinely still parked. All three run before any update is served.
   func bootSequence(
     transport: any TelegramTransport,
     stores: ClawStores,

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -283,6 +283,7 @@ private extension RunCommand {
       lanes: lanes,
       schedule: scheduleSurface,
       approvalCallbacks: approvalCallbackHandler,
+      coordinator: approvalCoordinator,
       logger: logger
     )
     let poller = TelegramPollerService(

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -251,7 +251,7 @@ private extension RunCommand {
       logger: logger
     )
 
-    let approvalCallbackHandler = await makeApprovalFabric(
+    let (approvalCallbackHandler, approvalWaiter, approvalExpiry) = await makeApprovalFabric(
       stores: stores,
       transport: transport,
       toolDispatcher: toolDispatcher,
@@ -310,19 +310,14 @@ private extension RunCommand {
       logger: logger
     )
 
-    let approvalExpiry = ApprovalExpiryService(
-      approvals: stores.approvals,
-      coordinator: approvalCoordinator,
-      now: { Date() },
-      sleep: { try await Task.sleep(for: $0) },
-      logger: logger
-    )
-
     return Daemon(
       services: [poller, dispatcher, scheduler, approvalExpiry],
       boot: bootSequence(
         transport: transport,
         stores: stores,
+        lanes: lanes,
+        coordinator: approvalCoordinator,
+        waiter: approvalWaiter,
         heartbeatOwner: heartbeatOwner,
         logger: logger
       ),
@@ -391,7 +386,9 @@ private extension RunCommand {
     deferredParker: DeferredApprovalParker,
     contextBuilder: ContextBuilder,
     logger: Logger
-  ) async -> ApprovalCallbackHandler {
+  ) async -> (
+    handler: ApprovalCallbackHandler, waiter: ApprovalWaiter, expiry: ApprovalExpiryService
+  ) {
     let approvedExecutor = ApprovedActionExecutor(
       tools: toolDispatcher.toolsByName,
       runs: stores.runs,
@@ -412,7 +409,7 @@ private extension RunCommand {
     )
     await deferredParker.adopt(approvalWaiter)
 
-    return ApprovalCallbackHandler.make(
+    let handler = ApprovalCallbackHandler.make(
       processed: stores.processed,
       delivery: transport,
       accessControl: AccessControl(allowlist: stores.allowlist),
@@ -424,6 +421,16 @@ private extension RunCommand {
       now: { Date() },
       logger: logger
     )
+    let expiry = ApprovalExpiryService(
+      approvals: stores.approvals,
+      coordinator: approvalCoordinator,
+      now: { Date() },
+      sleep: { try await Task.sleep(for: $0) },
+      logger: logger
+    )
+    // The real waiter is returned so boot re-park (spec §7) parks the SAME instance the callback
+    // path resumes — one execution locus across suspend, callback, and restart.
+    return (handler: handler, waiter: approvalWaiter, expiry: expiry)
   }
 
   /// Builds the `/schedule` surface: the budget-gated, deadline-bounded draft parser (sharing the
@@ -633,6 +640,9 @@ private extension RunCommand {
   func bootSequence(
     transport: any TelegramTransport,
     stores: ClawStores,
+    lanes: SessionLaneRegistry,
+    coordinator: ApprovalCoordinator,
+    waiter: ApprovalWaiter,
     heartbeatOwner: Int64?,
     logger: Logger
   ) -> @Sendable () async -> Void {
@@ -642,9 +652,17 @@ private extension RunCommand {
       heartbeatOwner: heartbeatOwner,
       logger: logger
     )
+    let reconcileApprovals = bootReconcileApprovals(
+      stores: stores,
+      lanes: lanes,
+      coordinator: coordinator,
+      waiter: waiter,
+      logger: logger
+    )
     return {
       await registerMenu()
       await reconcileRuns()
+      await reconcileApprovals()
     }
   }
 
@@ -702,6 +720,32 @@ private extension RunCommand {
       } catch {
         logger.error("boot reconcile failed: \(error)")
       }
+    }
+  }
+
+  /// The boot step that re-establishes the approval fabric after a restart (spec §7): terminal-run
+  /// PENDING rows are cleaned, unexpired parked approvals are re-parked on their lanes so buttons and
+  /// the FIFO queue-behind contract survive restart (§5.5), expired ones are swept to DENY→FAILED
+  /// (§6.4), and an APPROVED row left by a crash between grant and execution is resumed under the
+  /// §6.5 re-validation belt. Runs before the services serve, so the re-parked lanes are live before
+  /// the first callback arrives.
+  func bootReconcileApprovals(
+    stores: ClawStores,
+    lanes: SessionLaneRegistry,
+    coordinator: ApprovalCoordinator,
+    waiter: ApprovalWaiter,
+    logger: Logger
+  ) -> @Sendable () async -> Void {
+    let reconciler = ApprovalBootReconciler(
+      approvals: stores.approvals,
+      lanes: lanes,
+      coordinator: coordinator,
+      waiter: waiter,
+      now: { Date() },
+      logger: logger
+    )
+    return {
+      await reconciler.reconcile()
     }
   }
 }

--- a/Tests/ClawAgentTests/Runtime/AgentRuntimeCarryOverTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentRuntimeCarryOverTests.swift
@@ -1,0 +1,59 @@
+import ClawCore
+import Testing
+
+@testable import ClawAgent
+
+@Suite struct AgentRuntimeCarryOverTests {
+  @Test func carriedOverSpendStopsBeforeAnyProviderCall() async throws {
+    // given — a run that already spent its entire per-run USD budget before it suspended; the
+    // resume must inherit that spend so a suspend cycle can't reset the cap (§6.3 no cap evasion)
+    let provider = StubProvider(.respond(okResponse(content: "should never send")))
+    let runtime = makeRuntime(provider: provider)
+    let carryOver = ResumeUsage(
+      rounds: 1,
+      toolCalls: 0,
+      tokens: 0,
+      costUSD: RunBudget.default.perRunUSD + 1
+    )
+
+    // when
+    let outcome = try await runtime.runTurn(
+      runId: 1,
+      sessionId: 1,
+      chatId: 7,
+      buildResult: makeBuildResult(),
+      sessionTainted: false,
+      grant: nil,
+      todayTokens: 0,
+      todayUSD: 0,
+      carryOver: carryOver
+    )
+
+    // then — the per-run spend cap trips on the carried total; the provider is never reached
+    #expect(outcome.result == .budgetStopped(cap: "per-run spend"))
+    #expect(await provider.calls == 0)
+  }
+
+  @Test func nilCarryOverLeavesTheRunFreeToComplete() async throws {
+    // given — the identical setup WITHOUT carry-over completes, proving the stop above came from
+    // the seeded counter and not the base budget
+    let provider = StubProvider(.respond(okResponse(content: "hi")))
+    let runtime = makeRuntime(provider: provider)
+
+    // when
+    let outcome = try await runtime.runTurn(
+      runId: 1,
+      sessionId: 1,
+      chatId: 7,
+      buildResult: makeBuildResult(),
+      sessionTainted: false,
+      grant: nil,
+      todayTokens: 0,
+      todayUSD: 0
+    )
+
+    // then
+    let completed = try requireCompleted(outcome.result)
+    #expect(completed.content == "hi")
+  }
+}

--- a/Tests/ClawDataTests/Stores/Approval/ApprovalStoreGRDBTests.swift
+++ b/Tests/ClawDataTests/Stores/Approval/ApprovalStoreGRDBTests.swift
@@ -376,7 +376,11 @@ import Testing
       ]
     )
   }
+}
 
+// MARK: - Boot Reconciliation
+
+extension ApprovalStoreGRDBTests {
   @Test func unresolvedAtBootReturnsPendingAndAwaitingApprovedRows() throws {
     // given — a PENDING row, an APPROVED row whose run is AWAITING_APPROVAL (§6.5 crash window),
     // and an APPROVED row whose run already reached DONE (settled — must be excluded)
@@ -426,6 +430,70 @@ import Testing
     #expect(Set(unresolved.map(\.id)) == Set([pendingId, crashId]))
   }
 
+  @Test func unresolvedAtBootReturnsDeniedRowsOnlyOnAwaitingRuns() throws {
+    // given — the deny-side crash window: REJECTED and EXPIRED rows whose run is still
+    // AWAITING_APPROVAL (the deny CAS committed, the waiter's run-fail commit did not), plus the
+    // same denied states on terminal runs (settled — must be excluded)
+    let env = try makeFixture()
+    let rejectedAwaitingRun = try seedRun(env.queue, state: .awaitingApproval)
+    let expiredAwaitingRun = try seedRun(env.queue, state: .awaitingApproval)
+    let rejectedFailedRun = try seedRun(env.queue, state: .failed)
+    let expiredCancelledRun = try seedRun(env.queue, state: .cancelled)
+    let now = Date()
+    let rejectedAwaitingId = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: rejectedAwaitingRun,
+        nonce: "n-rej-awaiting",
+        createdTs: now,
+        expiresTs: now.addingTimeInterval(3600)
+      )
+    )
+    let expiredAwaitingId = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: expiredAwaitingRun,
+        nonce: "n-exp-awaiting",
+        createdTs: now.addingTimeInterval(-7200),
+        expiresTs: now.addingTimeInterval(-60)
+      )
+    )
+    let rejectedFailedId = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: rejectedFailedRun,
+        nonce: "n-rej-failed",
+        createdTs: now,
+        expiresTs: now.addingTimeInterval(3600)
+      )
+    )
+    let expiredCancelledId = try insert(
+      env.queue,
+      makeNewApproval(
+        runId: expiredCancelledRun,
+        nonce: "n-exp-cancelled",
+        createdTs: now.addingTimeInterval(-7200),
+        expiresTs: now.addingTimeInterval(-60)
+      )
+    )
+    try env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE approvals SET state = 'REJECTED' WHERE id IN (?, ?)",
+        arguments: [rejectedAwaitingId, rejectedFailedId]
+      )
+      try db.execute(
+        sql: "UPDATE approvals SET state = 'EXPIRED' WHERE id IN (?, ?)",
+        arguments: [expiredAwaitingId, expiredCancelledId]
+      )
+    }
+
+    // when
+    let unresolved = try env.store.unresolvedAtBoot()
+
+    // then — only the AWAITING_APPROVAL-run rows come back; terminal-run denials stay settled
+    #expect(Set(unresolved.map(\.id)) == Set([rejectedAwaitingId, expiredAwaitingId]))
+  }
+
   @Test func resolveOrphansRejectsPendingRowsOfTerminalRuns() throws {
     // given — a PENDING approval whose run FAILED (orphan) and one whose run is still parked
     let env = try makeFixture()
@@ -468,7 +536,11 @@ import Testing
       ]
     )
   }
+}
 
+// MARK: - Health + Store Wiring
+
+extension ApprovalStoreGRDBTests {
   @Test func approvalsHealthCountsPendingAndOldestAge() throws {
     // given — two PENDING rows on distinct runs; the older created 300 s before now
     let env = try makeFixture()

--- a/Tests/ClawDataTests/Stores/Bot/CommandApprovalResolutionTests.swift
+++ b/Tests/ClawDataTests/Stores/Bot/CommandApprovalResolutionTests.swift
@@ -1,0 +1,150 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct CommandApprovalResolutionTests {
+  private struct Fixture {
+    let queue: DatabaseQueue
+    let commands: CommandStoreGRDB
+    let approvals: ApprovalStoreGRDB
+    let sessionId: Int64
+    let runId: Int64
+    let approvalId: Int64
+  }
+
+  /// One session, one run parked at AWAITING_APPROVAL through the real reducer, and one PENDING
+  /// approval inserted through the store's own seam — the exact shape `/stop`//`new` must resolve.
+  private func makeParkedFixture() throws -> Fixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: 7),
+        chatId: 7,
+        userId: 7,
+        text: "write the plan",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let sessionId = try #require(claim.sessionId)
+    let runId = try #require(claim.runId)
+    let runs = RunStoreGRDB(writer: queue)
+    _ = try #require(try runs.pickUp(runId: runId, now: Date()))
+
+    let now = Date()
+    let approvalId = try queue.write { db -> Int64 in
+      _ = try RunStoreGRDB.transitionRun(db, runId: runId, event: .suspendForApproval, now: now)
+      let canonicalArgs = #"{"path":"/w/plan.md"}"#
+      return try ApprovalStoreGRDB.insertApproval(
+        db,
+        NewApproval(
+          runId: runId,
+          sessionId: sessionId,
+          tool: "file_write",
+          canonicalArgsJSON: canonicalArgs,
+          canonicalTarget: "/w/plan.md",
+          argsHash: ApprovalArgsHash.sha256Hex(canonicalArgs),
+          policyVersion: "pv16",
+          ownerUserId: 7,
+          nonce: "nonce-a",
+          observationMessageId: 1,
+          toolCallId: "c1",
+          reason: .askTier,
+          createdTs: now,
+          expiresTs: now.addingTimeInterval(3600)
+        )
+      )
+    }
+
+    return Fixture(
+      queue: queue,
+      commands: CommandStoreGRDB(writer: queue),
+      approvals: ApprovalStoreGRDB(writer: queue),
+      sessionId: sessionId,
+      runId: runId,
+      approvalId: approvalId
+    )
+  }
+
+  private func audits(_ queue: DatabaseQueue) throws -> [(action: String, decision: String)] {
+    try queue.read { db in
+      try Row.fetchAll(db, sql: "SELECT action, decision FROM audit_events ORDER BY id")
+        .map { row in (action: row["action"], decision: row["decision"]) }
+    }
+  }
+
+  @Test func stopResolvesTheParkedApprovalToRejectedCancelled() throws {
+    // given
+    let env = try makeParkedFixture()
+
+    // when
+    let result = try env.commands.applyStop(
+      updateId: 2,
+      sessionKey: SessionKey.telegramDM(chatId: 7),
+      now: Date()
+    )
+
+    // then — the suspended run is CANCELLED and its approval is REJECTED (decision cancelled),
+    // reported for the coordinator signal — no second PENDING row, no orphan (§6.4)
+    #expect(result.cancelledRunIds == [env.runId])
+    #expect(result.resolvedApprovalIds == [env.approvalId])
+    #expect(try env.approvals.approval(id: env.approvalId)?.state == .rejected)
+    let pending = try env.queue.read { db in
+      try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM approvals WHERE state = 'PENDING'")
+    }
+    #expect(pending == 0)
+    #expect(
+      try audits(env.queue).contains { row in
+        row.action == AuditAction.approvalDenied.rawValue
+          && row.decision == ApprovalDecision.cancelled.rawValue
+      }
+    )
+  }
+
+  @Test func newResolvesTheParkedApprovalToRejectedSuperseded() throws {
+    // given
+    let env = try makeParkedFixture()
+
+    // when
+    let result = try env.commands.applyNew(
+      updateId: 2,
+      sessionKey: SessionKey.telegramDM(chatId: 7),
+      now: Date()
+    )
+
+    // then
+    #expect(result.supersededRunIds == [env.runId])
+    #expect(result.resolvedApprovalIds == [env.approvalId])
+    #expect(try env.approvals.approval(id: env.approvalId)?.state == .rejected)
+    #expect(
+      try audits(env.queue).contains { row in
+        row.action == AuditAction.approvalDenied.rawValue
+          && row.decision == ApprovalDecision.superseded.rawValue
+      }
+    )
+  }
+
+  @Test func stopWithNoParkedApprovalResolvesNothing() throws {
+    // given — a session with no runs at all
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let commands = CommandStoreGRDB(writer: queue)
+
+    // when
+    let result = try commands.applyStop(
+      updateId: 1,
+      sessionKey: SessionKey.telegramDM(chatId: 7),
+      now: Date()
+    )
+
+    // then — nothing to resolve; the field is present and empty
+    #expect(result.cancelledRunIds.isEmpty)
+    #expect(result.resolvedApprovalIds.isEmpty)
+  }
+}

--- a/Tests/ClawDataTests/Stores/Run/ApprovedResumeStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/ApprovedResumeStoreTests.swift
@@ -1,0 +1,264 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct ApprovedResumeStoreTests {
+  private struct Fixture {
+    let queue: DatabaseQueue
+    let runs: RunStoreGRDB
+    let sessionId: Int64
+    let runId: Int64
+    let observationMessageId: Int64
+  }
+
+  private static let placeholder = "awaiting owner approval"
+
+  /// A run suspended to AWAITING_APPROVAL through the real reducer, with an assistant anchor and a
+  /// placeholder observation row persisted (the shape Task 14's `commitSuspendedTurn` leaves).
+  private func makeSuspendedFixture() throws -> Fixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: 7),
+        chatId: 7,
+        userId: 7,
+        text: "remember the plan",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let sessionId = try #require(claim.sessionId)
+    let runId = try #require(claim.runId)
+    let runs = RunStoreGRDB(writer: queue)
+    _ = try #require(try runs.pickUp(runId: runId, now: Date()))
+
+    let observationMessageId = try queue.write { db -> Int64 in
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_calls)
+          VALUES (?, ?, 'assistant', '', 'trusted', ?, '[{"id":"c1","name":"file_write","arguments":"{}"}]')
+          """,
+        arguments: [sessionId, runId, Date()]
+      )
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_call_id)
+          VALUES (?, ?, 'tool', ?, 'untrusted', ?, 'c1')
+          """,
+        arguments: [sessionId, runId, Self.placeholder, Date()]
+      )
+      let messageId = db.lastInsertedRowID
+      _ = try RunStoreGRDB.transitionRun(db, runId: runId, event: .suspendForApproval, now: Date())
+      return messageId
+    }
+
+    return Fixture(
+      queue: queue,
+      runs: runs,
+      sessionId: sessionId,
+      runId: runId,
+      observationMessageId: observationMessageId
+    )
+  }
+
+  private func runState(_ queue: DatabaseQueue, _ runId: Int64) throws -> String? {
+    try queue.read { db in
+      try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [runId])
+    }
+  }
+
+  private func messageContent(_ queue: DatabaseQueue, _ messageId: Int64) throws -> String? {
+    try queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT content FROM messages WHERE id = ?",
+        arguments: [messageId]
+      )
+    }
+  }
+
+  @Test func completeApprovedObservationFillsInPlaceAndResumesTheRun() throws {
+    // given
+    let env = try makeSuspendedFixture()
+
+    // when
+    let result = try env.runs.completeApprovedObservation(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      content: "Wrote 12 B to /w/plan.md (created).",
+      now: Date()
+    )
+
+    // then — the placeholder is updated in place (same row id) and the run is RUNNING again
+    #expect(result == .committed)
+    #expect(
+      try messageContent(env.queue, env.observationMessageId)
+        == "Wrote 12 B to /w/plan.md (created)."
+    )
+    #expect(try runState(env.queue, env.runId) == RunState.running.rawValue)
+  }
+
+  @Test func completeApprovedObservationIsExactlyOnce() throws {
+    // given — a first resume already flipped the run to RUNNING
+    let env = try makeSuspendedFixture()
+    _ = try env.runs.completeApprovedObservation(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      content: "first",
+      now: Date()
+    )
+
+    // when — a duplicate signal re-runs the same method
+    let second = try env.runs.completeApprovedObservation(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      content: "second",
+      now: Date()
+    )
+
+    // then — the run is no longer AWAITING, so the reducer no-ops and the content is unchanged
+    #expect(second == .ignored)
+    #expect(try messageContent(env.queue, env.observationMessageId) == "first")
+  }
+
+  @Test func applyApprovedMemoryWriteFusesTheInsertWithTheObservationFill() throws {
+    // given
+    let env = try makeSuspendedFixture()
+    let item = NewMemoryItem(text: "the plan is ready", kind: .project, sessionId: env.sessionId)
+
+    // when
+    let result = try env.runs.applyApprovedMemoryWrite(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      item: item,
+      observationContent: "Saved to memory as project.",
+      now: Date()
+    )
+
+    // then — one fused transaction: memory row inserted, observation filled, run RUNNING
+    #expect(result == .committed)
+    let memoryCount = try env.queue.read { db in
+      try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM memory_items")
+    }
+    #expect(memoryCount == 1)
+    #expect(
+      try messageContent(env.queue, env.observationMessageId) == "Saved to memory as project."
+    )
+    #expect(try runState(env.queue, env.runId) == RunState.running.rawValue)
+  }
+
+  @Test func applyApprovedMemoryWriteIsExactlyOnce() throws {
+    // given — the fused write already committed once
+    let env = try makeSuspendedFixture()
+    let item = NewMemoryItem(text: "remember me once", kind: .user, sessionId: env.sessionId)
+    _ = try env.runs.applyApprovedMemoryWrite(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      item: item,
+      observationContent: "Saved.",
+      now: Date()
+    )
+
+    // when — re-running the fused method after the observation is filled
+    let second = try env.runs.applyApprovedMemoryWrite(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      item: item,
+      observationContent: "Saved again.",
+      now: Date()
+    )
+
+    // then — the guard on the AWAITING→RUNNING flip means NO second memory row (§6.3 exactly-once)
+    #expect(second == .ignored)
+    let memoryCount = try env.queue.read { db in
+      try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM memory_items")
+    }
+    #expect(memoryCount == 1)
+  }
+
+  @Test func resumeUsageDerivesCountersFromPersistedRows() throws {
+    // given — the fixture already has one assistant row and one tool row; add usage + a second
+    // assistant/tool pair so the counts and sums are unambiguous (D4)
+    let env = try makeSuspendedFixture()
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_calls)
+          VALUES (?, ?, 'assistant', '', 'trusted', ?, '[]')
+          """,
+        arguments: [env.sessionId, env.runId, Date()]
+      )
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_call_id)
+          VALUES (?, ?, 'tool', 'obs', 'untrusted', ?, 'c2')
+          """,
+        arguments: [env.sessionId, env.runId, Date()]
+      )
+      try db.execute(
+        sql: """
+          INSERT INTO provider_usage(run_id, session_id, model, prompt_tokens, completion_tokens,
+            cost_usd, cost_source, is_estimated, ts)
+          VALUES (?, ?, 'm', 100, 20, 0.03, 'price_file', 0, ?)
+          """,
+        arguments: [env.runId, env.sessionId, Date()]
+      )
+      try db.execute(
+        sql: """
+          INSERT INTO provider_usage(run_id, session_id, model, prompt_tokens, completion_tokens,
+            cost_usd, cost_source, is_estimated, ts)
+          VALUES (?, ?, 'm', 50, 10, 0.01, 'price_file', 0, ?)
+          """,
+        arguments: [env.runId, env.sessionId, Date()]
+      )
+    }
+
+    // when
+    let usage = try env.runs.resumeUsage(runId: env.runId)
+
+    // then — 2 assistant rounds, 2 tool calls, 180 tokens, $0.04
+    #expect(usage.rounds == 2)
+    #expect(usage.toolCalls == 2)
+    #expect(usage.tokens == 180)
+    #expect(usage.costUSD == 0.04)
+  }
+
+  @Test func runOriginReadsTheRunsColumn() throws {
+    // given
+    let env = try makeSuspendedFixture()
+
+    // when / then — resume reads origin without re-picking-up the run
+    #expect(try env.runs.runOrigin(runId: env.runId) == .interactive)
+    #expect(try env.runs.runOrigin(runId: 9999) == nil)
+  }
+
+  @Test func failRunStalePolicyFailsTheRunAndAuditsTheDenial() throws {
+    // given
+    let env = try makeSuspendedFixture()
+
+    // when
+    let failed = try env.runs.failRunStalePolicy(
+      runId: env.runId,
+      sessionId: env.sessionId,
+      now: Date()
+    )
+
+    // then — run FAILED, and an approvalDenied/stale_policy audit rode the same transaction (§6.5)
+    #expect(failed)
+    #expect(try runState(env.queue, env.runId) == RunState.failed.rawValue)
+    let auditDecision = try env.queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT decision FROM audit_events WHERE action = ? AND run_id = ?",
+        arguments: [AuditAction.approvalDenied.rawValue, env.runId]
+      )
+    }
+    #expect(auditDecision == ApprovalDecision.stalePolicy.rawValue)
+  }
+}

--- a/Tests/ClawDataTests/Stores/Run/ReconcileBootApprovalExemptionTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/ReconcileBootApprovalExemptionTests.swift
@@ -1,0 +1,48 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct ReconcileBootApprovalExemptionTests {
+  @Test func reconcileFailsRunningOrphansButLeavesSuspendedRunsParked() throws {
+    // given — a crashed RUNNING run and a suspended AWAITING_APPROVAL run in the reopened DB
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO sessions(session_key, created_ts, updated_ts, tainted)
+          VALUES ('tg:dm:7', ?, ?, 0)
+          """,
+        arguments: [Date(), Date()]
+      )
+      try db.execute(
+        sql: "INSERT INTO runs(session_id, state, created_ts, updated_ts) VALUES (1, ?, ?, ?)",
+        arguments: [RunState.running.rawValue, Date(), Date()]
+      )
+      try db.execute(
+        sql: "INSERT INTO runs(session_id, state, created_ts, updated_ts) VALUES (1, ?, ?, ?)",
+        arguments: [RunState.awaitingApproval.rawValue, Date(), Date()]
+      )
+    }
+    let runs = RunStoreGRDB(writer: queue)
+
+    // when
+    _ = try runs.reconcileRunsAtBoot(
+      now: Date(),
+      degradationText: "unfinished",
+      heartbeatNoticeChatId: nil
+    )
+
+    // then — the RUNNING orphan is failed; the suspended run is DELIBERATELY exempt (§7), left for
+    // the approval boot reconciliation to re-park
+    let states = try queue.read { db in
+      try Row.fetchAll(db, sql: "SELECT state FROM runs ORDER BY id").map { row in
+        row["state"] as String
+      }
+    }
+    #expect(states == [RunState.failed.rawValue, RunState.awaitingApproval.rawValue])
+  }
+}

--- a/Tests/ClawDataTests/Stores/Run/ResolveDeniedObservationTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/ResolveDeniedObservationTests.swift
@@ -1,0 +1,166 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct ResolveDeniedObservationTests {
+  private struct Fixture {
+    let queue: DatabaseQueue
+    let runs: RunStoreGRDB
+    let sessionId: Int64
+    let runId: Int64
+    let observationMessageId: Int64
+  }
+
+  /// A run suspended to AWAITING_APPROVAL through the real reducer, with the assistant anchor and
+  /// its placeholder tool observation persisted exactly as `commitSuspendedTurn` (Task 14) leaves
+  /// them: adjacent rows, the observation carrying the pending `tool_call_id` and the sentinel
+  /// "awaiting owner approval" content.
+  private func makeSuspendedFixture() throws -> Fixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: 7),
+        chatId: 7,
+        userId: 7,
+        text: "write the plan",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let sessionId = try #require(claim.sessionId)
+    let runId = try #require(claim.runId)
+    let runs = RunStoreGRDB(writer: queue)
+    _ = try #require(try runs.pickUp(runId: runId, now: Date()))
+
+    let observationMessageId = try queue.write { db -> Int64 in
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_calls)
+          VALUES (?, ?, 'assistant', 'I will write the plan.', 'trusted', ?, '[{"id":"c1"}]')
+          """,
+        arguments: [sessionId, runId, Date()]
+      )
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_call_id)
+          VALUES (?, ?, 'tool', 'awaiting owner approval', 'untrusted', ?, 'c1')
+          """,
+        arguments: [sessionId, runId, Date()]
+      )
+      let placeholderId = db.lastInsertedRowID
+      _ = try RunStoreGRDB.transitionRun(
+        db,
+        runId: runId,
+        event: .suspendForApproval,
+        now: Date()
+      )
+      return placeholderId
+    }
+
+    return Fixture(
+      queue: queue,
+      runs: runs,
+      sessionId: sessionId,
+      runId: runId,
+      observationMessageId: observationMessageId
+    )
+  }
+
+  private func runState(_ queue: DatabaseQueue, runId: Int64) throws -> String? {
+    try queue.read { db in
+      try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [runId])
+    }
+  }
+
+  private func observationContent(_ queue: DatabaseQueue, id: Int64) throws -> String? {
+    try queue.read { db in
+      try String.fetchOne(db, sql: "SELECT content FROM messages WHERE id = ?", arguments: [id])
+    }
+  }
+
+  @Test func rejectFillsThePlaceholderAndFailsTheRun() throws {
+    // given
+    let env = try makeSuspendedFixture()
+
+    // when — the owner-deny path: cancel is nil → resolveDenied → FAILED
+    let result = try env.runs.resolveDeniedObservation(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      content: "The owner declined this action.",
+      cancel: nil,
+      now: Date()
+    )
+
+    // then — the placeholder is filled in place (no dangling tool_call) and the run is FAILED
+    #expect(result == .committed)
+    #expect(try runState(env.queue, runId: env.runId) == RunState.failed.rawValue)
+    #expect(
+      try observationContent(env.queue, id: env.observationMessageId)
+        == "The owner declined this action."
+    )
+  }
+
+  @Test func nextTurnAssemblyStaysWellFormedAfterDeny() throws {
+    // given
+    let env = try makeSuspendedFixture()
+
+    // when
+    _ = try env.runs.resolveDeniedObservation(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      content: "The approval expired before the owner responded.",
+      cancel: nil,
+      now: Date()
+    )
+
+    // then — the anchor and its observation are contiguous and every tool_call_id is answered
+    // (the placeholder no longer reads "awaiting owner approval"): no orphan proposal row survives
+    let rows = try env.queue.read { db in
+      try Row.fetchAll(
+        db,
+        sql: """
+          SELECT role, content, tool_call_id FROM messages
+          WHERE run_id = ? AND role IN ('assistant', 'tool')
+          ORDER BY id ASC
+          """,
+        arguments: [env.runId]
+      )
+    }
+    #expect(rows.count == 2)
+    #expect((rows[0]["role"] as String) == "assistant")
+    #expect((rows[1]["role"] as String) == "tool")
+    #expect((rows[1]["tool_call_id"] as String?) == "c1")
+    #expect((rows[1]["content"] as String) != "awaiting owner approval")
+  }
+
+  @Test func cancelFixesTheObservationOnAnAlreadyTerminatedRun() throws {
+    // given — /stop has already moved the run to CANCELLED in its command transaction; the waiter
+    // now fixes the observation the command left as a placeholder
+    let env = try makeSuspendedFixture()
+    _ = try env.runs.cancelActiveRun(sessionId: env.sessionId, reason: .cancelled, now: Date())
+    #expect(try runState(env.queue, runId: env.runId) == RunState.cancelled.rawValue)
+
+    // when — cancel is non-nil; the FSM refuses the already-terminal run, but the observation
+    // still gets its synthetic content
+    let result = try env.runs.resolveDeniedObservation(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      content: "Cancelled by /stop.",
+      cancel: .cancelled,
+      now: Date()
+    )
+
+    // then — the run stays CANCELLED (no illegal re-transition) and history is well-formed
+    #expect(result == .ignored)
+    #expect(try runState(env.queue, runId: env.runId) == RunState.cancelled.rawValue)
+    #expect(
+      try observationContent(env.queue, id: env.observationMessageId) == "Cancelled by /stop."
+    )
+  }
+}

--- a/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
+++ b/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
@@ -237,6 +237,7 @@ func makeSC3Harness(
       jobs: stores.scheduledJobs,
       commands: stores.scheduleCommands
     ),
+    coordinator: coordinator,
     logger: logger
   )
 

--- a/Tests/ClawGatewayTests/Acceptance/SC7Harness.swift
+++ b/Tests/ClawGatewayTests/Acceptance/SC7Harness.swift
@@ -268,6 +268,7 @@ func makeSC7Harness(
       jobs: stores.scheduledJobs,
       commands: stores.scheduleCommands
     ),
+    coordinator: ApprovalCoordinator(),
     now: { clock.now },
     logger: logger
   )

--- a/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
+++ b/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
@@ -376,6 +376,7 @@ func makeStack(
     turnRunner: turnRunner,
     lanes: lanes,
     schedule: makeIdleScheduleSurface(writer: writer),
+    coordinator: ApprovalCoordinator(),
     logger: logger
   )
 
@@ -464,6 +465,7 @@ func makeStreamingStack(
     turnRunner: turnRunner,
     lanes: lanes,
     schedule: makeIdleScheduleSurface(writer: writer),
+    coordinator: ApprovalCoordinator(),
     logger: logger
   )
   let dispatcher = OutboxDispatcher(
@@ -548,6 +550,7 @@ func makeStopNewStack(
     turnRunner: turnRunner,
     lanes: lanes,
     schedule: makeIdleScheduleSurface(writer: writer),
+    coordinator: ApprovalCoordinator(),
     logger: logger
   )
 

--- a/Tests/ClawGatewayTests/Routing/ApprovalCallbackHandlerTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ApprovalCallbackHandlerTests.swift
@@ -208,6 +208,7 @@ final class ScriptedApprovals: ApprovalStore, @unchecked Sendable {
       lanes: SessionLaneRegistry(),
       schedule: makeIdleScheduleSurface(writer: queue),
       approvalCallbacks: wireHandler ? handler : nil,
+      coordinator: coordinator,
       logger: TestLog.silent
     )
     return Harness(

--- a/Tests/ClawGatewayTests/Routing/ApprovalCallbackHandlerTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ApprovalCallbackHandlerTests.swift
@@ -1,0 +1,467 @@
+import ClawAgent
+import ClawCore
+import ClawData
+import Foundation
+import GRDB
+import Logging
+import Testing
+
+@testable import ClawGateway
+
+/// A callback update carrying only a tapped inline button (no message/edited_message).
+func callbackUpdate(
+  id: Int64,
+  from: Int64,
+  chat: Int64? = nil,
+  messageId: Int64 = 1,
+  data: String?
+) -> RawUpdate {
+  RawUpdate(
+    updateId: id,
+    message: nil,
+    editedMessage: nil,
+    callback: RawCallback(
+      callbackId: "cb\(id)",
+      fromUserId: from,
+      chatId: chat ?? from,
+      messageId: messageId,
+      data: data
+    )
+  )
+}
+
+/// Records `answerCallbackQuery`; the handler never disarms buttons (that is the waiter's job).
+actor RecordingCallbacks: CallbackResponding {
+  private(set) var answers: [(id: String, text: String?)] = []
+
+  func answerCallbackQuery(id: String, text: String?) async throws {
+    answers.append((id, text))
+  }
+
+  func editMessageReplyMarkup(chatId: Int64, messageId: Int64, replyMarkup: String?) async throws {}
+}
+
+/// A scripted `ApprovalStore`: `approval(nonce:)` returns a seeded row; `approve`/`deny` return a
+/// scripted outcome and RECORD the call so tests can assert the row was (or was not) CAS-ed. All
+/// other protocol members are unused by the handler and fail loudly if reached.
+final class ScriptedApprovals: ApprovalStore, @unchecked Sendable {
+  private let lock = NSLock()
+  private let byNonce: [String: Approval]
+  private let approveOutcome: ApprovalApproveOutcome
+  private let denyResult: Bool
+  private let throwOnResolve: Bool
+  private var recordedApproveCalls: [(id: Int64, policyVersion: String)] = []
+  private var recordedDenyCalls: [(id: Int64, decision: ApprovalDecision)] = []
+
+  init(
+    byNonce: [String: Approval],
+    approveOutcome: ApprovalApproveOutcome,
+    denyResult: Bool,
+    throwOnResolve: Bool = false
+  ) {
+    self.byNonce = byNonce
+    self.approveOutcome = approveOutcome
+    self.denyResult = denyResult
+    self.throwOnResolve = throwOnResolve
+  }
+
+  var approveCalls: [(id: Int64, policyVersion: String)] {
+    lock.lock()
+    defer { lock.unlock() }
+    return recordedApproveCalls
+  }
+
+  var denyCalls: [(id: Int64, decision: ApprovalDecision)] {
+    lock.lock()
+    defer { lock.unlock() }
+    return recordedDenyCalls
+  }
+
+  func approval(nonce: String) throws -> Approval? { byNonce[nonce] }
+  func approval(id: Int64) throws -> Approval? { nil }
+
+  func approve(
+    id: Int64,
+    currentPolicyVersion: String,
+    now: Date
+  ) throws -> ApprovalApproveOutcome {
+    if throwOnResolve { throw StoreError.unexpected("scripted store failure") }
+    lock.lock()
+    defer { lock.unlock() }
+    recordedApproveCalls.append((id, currentPolicyVersion))
+    return approveOutcome
+  }
+
+  func deny(id: Int64, decision: ApprovalDecision, now: Date) throws -> Bool {
+    if throwOnResolve { throw StoreError.unexpected("scripted store failure") }
+    lock.lock()
+    defer { lock.unlock() }
+    recordedDenyCalls.append((id, decision))
+    return denyResult
+  }
+
+  func sweepExpired(now: Date) throws -> [Approval] { [] }
+  func unresolvedAtBoot() throws -> [Approval] { [] }
+  func resolveOrphans(now: Date) throws -> Int { 0 }
+  func approvalsHealth(now: Date) throws -> ApprovalsHealth {
+    throw StoreError.unexpected("approvalsHealth is not used by the callback handler")
+  }
+}
+
+@Suite struct ApprovalCallbackHandlerTests {
+  private struct Harness {
+    let handler: ApprovalCallbackHandler
+    let router: MessageRouter
+    let approvals: ScriptedApprovals
+    let audit: RecordingAuditLog
+    let callbacks: RecordingCallbacks
+    let coordinator: ApprovalCoordinator
+    let approval: Approval
+  }
+
+  private static let ownerId: Int64 = 42
+  private static let nonce = "NONCE22CHARSEXAMPLE00"
+  private static let fixedNow = Date(timeIntervalSince1970: 1_000_000)
+
+  private static func makeApproval(id: Int64, nonce: String, ownerUserId: Int64) -> Approval {
+    Approval(
+      id: id,
+      runId: 100,
+      sessionId: 200,
+      state: .pending,
+      tool: "file_write",
+      canonicalArgsJSON: "{\"path\":\"notes.md\"}",
+      canonicalTarget: "/ws/notes.md",
+      argsHash: "abc123",
+      policyVersion: "POLICYV1",
+      ownerUserId: ownerUserId,
+      nonce: nonce,
+      observationMessageId: 300,
+      toolCallId: "call-1",
+      reason: .askTier,
+      promptMessageId: nil,
+      createdTs: Date(timeIntervalSince1970: 999_000),
+      expiresTs: Date(timeIntervalSince1970: 1_003_600),
+      resolvedTs: nil
+    )
+  }
+
+  private func approveData() -> String {
+    ApprovalKeyboard.callbackData(nonce: Self.nonce, verdict: ApprovalKeyboard.approveVerdict)
+  }
+
+  private func denyData() -> String {
+    ApprovalKeyboard.callbackData(nonce: Self.nonce, verdict: ApprovalKeyboard.denyVerdict)
+  }
+
+  private func makeHarness(
+    allowed: [Int64] = [ownerId],
+    approveOutcome: ApprovalApproveOutcome? = nil,
+    denyResult: Bool = true,
+    knownNonce: Bool = true,
+    wireHandler: Bool = true,
+    resolveThrows: Bool = false
+  ) throws -> Harness {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let allowlist = AllowlistStoreGRDB(writer: queue)
+    try allowlist.seedAllowlist(userIds: allowed)
+
+    let approval = Self.makeApproval(id: 7, nonce: Self.nonce, ownerUserId: Self.ownerId)
+    let approvals = ScriptedApprovals(
+      byNonce: knownNonce ? [Self.nonce: approval] : [:],
+      approveOutcome: approveOutcome ?? .approved(approval),
+      denyResult: denyResult,
+      throwOnResolve: resolveThrows
+    )
+    let audit = RecordingAuditLog()
+    let callbacks = RecordingCallbacks()
+    let coordinator = ApprovalCoordinator()
+    let accessControl = AccessControl(allowlist: allowlist)
+    let replies = ReplySender(
+      processed: ProcessedUpdateStoreGRDB(writer: queue),
+      delivery: RecordingTransport(),
+      logger: TestLog.silent
+    )
+    let handler = ApprovalCallbackHandler(
+      replies: replies,
+      accessControl: accessControl,
+      approvals: approvals,
+      audit: audit,
+      coordinator: coordinator,
+      callbacks: callbacks,
+      currentPolicyVersion: { "POLICYV1" },
+      now: { Self.fixedNow },
+      logger: TestLog.silent
+    )
+    let router = MessageRouter(
+      processed: ProcessedUpdateStoreGRDB(writer: queue),
+      sessionMessages: SessionMessageStoreGRDB(writer: queue),
+      commands: CommandStoreGRDB(writer: queue),
+      memory: MemoryStoreGRDB(writer: queue),
+      memoryCommands: MemoryCommandStoreGRDB(writer: queue),
+      pendingConfirmations: PendingConfirmationRegistry(),
+      botUsername: "claw_bot",
+      accessControl: accessControl,
+      delivery: RecordingTransport(),
+      turnRunner: FakeTurnRunner(),
+      lanes: SessionLaneRegistry(),
+      schedule: makeIdleScheduleSurface(writer: queue),
+      approvalCallbacks: wireHandler ? handler : nil,
+      logger: TestLog.silent
+    )
+    return Harness(
+      handler: handler,
+      router: router,
+      approvals: approvals,
+      audit: audit,
+      callbacks: callbacks,
+      coordinator: coordinator,
+      approval: approval
+    )
+  }
+
+  // MARK: - Auth failures (row untouched, audited forbidden, neutral toast)
+
+  @Test func nonAllowlistedSenderIsDeniedAndAudited() async throws {
+    // given — a stranger taps a well-formed approve button
+    let harness = try makeHarness()
+    let update = callbackUpdate(id: 1, from: 9999, data: approveData())
+
+    // when
+    let callback = try #require(update.callback)
+    let outcome = await harness.handler.handle(callback, updateId: update.updateId)
+
+    // then — no CAS, one forbidden access audit (system actor), one neutral toast, update consumed
+    #expect(outcome == .processed)
+    #expect(harness.approvals.approveCalls.isEmpty)
+    #expect(harness.approvals.denyCalls.isEmpty)
+    let events = harness.audit.events
+    #expect(events.count == 1)
+    #expect(events.first?.action == .messageIn)
+    #expect(events.first?.decision == "forbidden")
+    #expect(events.first?.actor == .system)
+    #expect(await harness.callbacks.answers.count == 1)
+  }
+
+  @Test func allowlistedNonOwnerFailsOwnerBinding() async throws {
+    // given — an allowlisted user who is NOT the approval's owner taps approve
+    let harness = try makeHarness(allowed: [Self.ownerId, 43])
+    let update = callbackUpdate(id: 2, from: 43, data: approveData())
+
+    // when
+    let callback = try #require(update.callback)
+    let outcome = await harness.handler.handle(callback, updateId: update.updateId)
+
+    // then — owner binding fails: no CAS, forbidden audit linked to the run, one toast
+    #expect(outcome == .processed)
+    #expect(harness.approvals.approveCalls.isEmpty)
+    let events = harness.audit.events
+    #expect(events.count == 1)
+    #expect(events.first?.decision == "forbidden")
+    #expect(events.first?.actor == .system)
+    #expect(events.first?.runId == 100)
+    #expect(await harness.callbacks.answers.count == 1)
+  }
+
+  @Test func unknownNonceIsDenied() async throws {
+    // given — the nonce resolves to no row
+    let harness = try makeHarness(knownNonce: false)
+    let update = callbackUpdate(id: 3, from: Self.ownerId, data: approveData())
+
+    // when
+    let callback = try #require(update.callback)
+    let outcome = await harness.handler.handle(callback, updateId: update.updateId)
+
+    // then
+    #expect(outcome == .processed)
+    #expect(harness.approvals.approveCalls.isEmpty)
+    #expect(harness.audit.events.first?.decision == "forbidden")
+    #expect(await harness.callbacks.answers.count == 1)
+  }
+
+  @Test func unparseableCallbackDataIsDenied() async throws {
+    // given — the owner taps but the callback_data is malformed
+    let harness = try makeHarness()
+    let update = callbackUpdate(id: 4, from: Self.ownerId, data: "not-a-verdict")
+
+    // when
+    let callback = try #require(update.callback)
+    let outcome = await harness.handler.handle(callback, updateId: update.updateId)
+
+    // then — never reaches the store; audited forbidden; toasted
+    #expect(outcome == .processed)
+    #expect(harness.approvals.approveCalls.isEmpty)
+    #expect(harness.audit.events.first?.decision == "forbidden")
+    #expect(await harness.callbacks.answers.count == 1)
+  }
+
+  // MARK: - Valid resolutions (CAS + coordinator signal + toast)
+
+  @Test func validApproveCASesAndSignalsApproved() async throws {
+    // given — the owner taps approve on a still-PENDING row
+    let harness = try makeHarness(
+      approveOutcome: .approved(
+        Self.makeApproval(
+          id: 7,
+          nonce: Self.nonce,
+          ownerUserId: Self.ownerId
+        )
+      )
+    )
+    let update = callbackUpdate(id: 5, from: Self.ownerId, data: approveData())
+
+    // when
+    let callback = try #require(update.callback)
+    let outcome = await harness.handler.handle(callback, updateId: update.updateId)
+
+    // then — approve CAS carries the recomputed policy_version; coordinator signaled .approved; no
+    // handler-side audit (approvalGranted rides the store CAS, D3)
+    #expect(outcome == .processed)
+    #expect(harness.approvals.approveCalls.count == 1)
+    #expect(harness.approvals.approveCalls.first?.id == 7)
+    #expect(harness.approvals.approveCalls.first?.policyVersion == "POLICYV1")
+    #expect(harness.audit.events.isEmpty)
+    #expect(await harness.coordinator.awaitResolution(approvalId: 7) == .approved)
+    #expect(await harness.callbacks.answers.count == 1)
+  }
+
+  @Test func validDenyCASesAndSignalsRejected() async throws {
+    // given — the owner taps deny
+    let harness = try makeHarness()
+    let update = callbackUpdate(id: 6, from: Self.ownerId, data: denyData())
+
+    // when
+    let callback = try #require(update.callback)
+    let outcome = await harness.handler.handle(callback, updateId: update.updateId)
+
+    // then
+    #expect(outcome == .processed)
+    #expect(harness.approvals.approveCalls.isEmpty)
+    #expect(harness.approvals.denyCalls.count == 1)
+    #expect(harness.approvals.denyCalls.first?.id == 7)
+    #expect(harness.approvals.denyCalls.first?.decision == .rejected)
+    #expect(await harness.coordinator.awaitResolution(approvalId: 7) == .denied(.rejected))
+    #expect(await harness.callbacks.answers.count == 1)
+  }
+
+  @Test func stalePolicyApproveSignalsDeniedStalePolicy() async throws {
+    // given — the approve CAS finds a hash/policy mismatch
+    let harness = try makeHarness(
+      approveOutcome: .stalePolicy(
+        Self.makeApproval(
+          id: 7,
+          nonce: Self.nonce,
+          ownerUserId: Self.ownerId
+        )
+      )
+    )
+    let update = callbackUpdate(id: 7, from: Self.ownerId, data: approveData())
+
+    // when
+    let callback = try #require(update.callback)
+    let outcome = await harness.handler.handle(callback, updateId: update.updateId)
+
+    // then — coordinator signaled a denial with the stale_policy decision
+    #expect(outcome == .processed)
+    #expect(harness.approvals.approveCalls.count == 1)
+    #expect(await harness.coordinator.awaitResolution(approvalId: 7) == .denied(.stalePolicy))
+    #expect(await harness.callbacks.answers.count == 1)
+  }
+
+  @Test func expiredRowApproveRoutesToDenyExpired() async throws {
+    // given — the approve CAS finds the row already past its deadline
+    let harness = try makeHarness(approveOutcome: .expiredRow)
+    let update = callbackUpdate(id: 8, from: Self.ownerId, data: approveData())
+
+    // when
+    let callback = try #require(update.callback)
+    let outcome = await harness.handler.handle(callback, updateId: update.updateId)
+
+    // then — the handler routes to deny(.expired) and signals .denied(.expired)
+    #expect(outcome == .processed)
+    #expect(harness.approvals.denyCalls.count == 1)
+    #expect(harness.approvals.denyCalls.first?.decision == .expired)
+    #expect(await harness.coordinator.awaitResolution(approvalId: 7) == .denied(.expired))
+    #expect(await harness.callbacks.answers.count == 1)
+  }
+
+  @Test func alreadyResolvedApproveDoesNotSignal() async throws {
+    // given — a duplicate tap lands after the row is already resolved
+    let harness = try makeHarness(approveOutcome: .notPending)
+    let update = callbackUpdate(id: 9, from: Self.ownerId, data: approveData())
+
+    // when
+    let callback = try #require(update.callback)
+    let outcome = await harness.handler.handle(callback, updateId: update.updateId)
+
+    // then — CAS attempted, no coordinator signal (nothing to resume), still answered
+    #expect(outcome == .processed)
+    #expect(harness.approvals.approveCalls.count == 1)
+    #expect(harness.audit.events.isEmpty)
+    #expect(await harness.callbacks.answers.count == 1)
+  }
+
+  // MARK: - Dedup + router branch
+
+  @Test func duplicateUpdateIdIsClaimedOnce() async throws {
+    // given — the same update is redelivered (same update_id)
+    let harness = try makeHarness()
+    let update = callbackUpdate(id: 10, from: Self.ownerId, data: approveData())
+    let callback = try #require(update.callback)
+
+    // when
+    let first = await harness.handler.handle(callback, updateId: update.updateId)
+    let second = await harness.handler.handle(callback, updateId: update.updateId)
+
+    // then — the processed_updates claim dedups the redelivery; the CAS ran exactly once
+    #expect(first == .processed)
+    #expect(second == .skipped)
+    #expect(harness.approvals.approveCalls.count == 1)
+  }
+
+  @Test func routerRoutesCallbackToHandlerAheadOfNormalize() async throws {
+    // given — a router wired with the handler
+    let harness = try makeHarness()
+    let update = callbackUpdate(id: 11, from: Self.ownerId, data: approveData())
+
+    // when — routed through the full MessageRouter (not the handler directly)
+    let outcome = await harness.router.handle(rawUpdate: update)
+
+    // then — the callback branch fired before IncomingMessage.normalize would have skipped it
+    #expect(outcome == .processed)
+    #expect(harness.approvals.approveCalls.count == 1)
+  }
+
+  @Test func routerWithoutHandlerSkipsCallback() async throws {
+    // given — a router with no approval handler configured (dormant composition)
+    let harness = try makeHarness(wireHandler: false)
+    let update = callbackUpdate(id: 12, from: Self.ownerId, data: approveData())
+
+    // when
+    let outcome = await harness.router.handle(rawUpdate: update)
+
+    // then — no handler, no CAS, safely skipped (cursor advances)
+    #expect(outcome == .skipped)
+    #expect(harness.approvals.approveCalls.isEmpty)
+  }
+
+  // MARK: - Store-failure retry (§9)
+
+  @Test func storeFailureAnswersRetryAndLeavesRowUnresolved() async throws {
+    // given — the approve CAS throws a transient store failure after the update is claimed
+    let harness = try makeHarness(resolveThrows: true)
+    let update = callbackUpdate(id: 13, from: Self.ownerId, data: approveData())
+
+    // when
+    let callback = try #require(update.callback)
+    let outcome = await harness.handler.handle(callback, updateId: update.updateId)
+
+    // then — §9: the owner is told to try again (the row is still PENDING and tappable, so the
+    // neutral "no longer available" copy would mislead); no coordinator signal, no terminal audit
+    #expect(outcome == .processed)
+    let answer = try #require(await harness.callbacks.answers.first)
+    #expect(answer.text == "Something went wrong — please try again.")
+    #expect(harness.audit.events.isEmpty)
+  }
+}

--- a/Tests/ClawGatewayTests/Routing/ApprovalWaiterTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ApprovalWaiterTests.swift
@@ -1,0 +1,365 @@
+import ClawCore
+import ClawData
+import Foundation
+import GRDB
+import Logging
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct ApprovalWaiterTests {
+  // MARK: - Doubles
+
+  /// A `Tool` double the executor runs on the approve path.
+  private struct StubTool: Tool {
+    let toolName: String
+    let result: String
+    var definition: ToolDefinition {
+      ToolDefinition(
+        name: toolName,
+        description: "stub",
+        parameters: .object(["type": .string("object")]),
+        egressClass: .none,
+        riskLevel: .ask
+      )
+    }
+    var timeout: Duration { .seconds(1) }
+    func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? { nil }
+    func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+      ToolPayload(content: result, status: .ok, ingestedUntrusted: false)
+    }
+  }
+
+  /// Records `resume` calls; `run` is unused on the waiter path.
+  private actor ResumeRecorder: TurnDispatching {
+    struct ResumeCall: Sendable, Equatable {
+      let runId: Int64
+      let contextBoundMessageId: Int64
+    }
+    private(set) var resumeCalls: [ResumeCall] = []
+
+    func run(
+      runId: Int64,
+      sessionId: Int64,
+      chatId: Int64,
+      triggerMessageId: Int64,
+      grant: OneTurnGrant?
+    ) async throws {}
+
+    func resume(
+      runId: Int64,
+      sessionId: Int64,
+      chatId: Int64,
+      contextBoundMessageId: Int64
+    ) async {
+      resumeCalls.append(ResumeCall(runId: runId, contextBoundMessageId: contextBoundMessageId))
+    }
+  }
+
+  private actor RecordingDelivery: MessageDelivery {
+    private(set) var texts: [String] = []
+    func sendMessage(chatId: Int64, text: String) async throws -> Int64 {
+      texts.append(text)
+      return 1
+    }
+    func sendRichMessage(chatId: Int64, markdown: String) async throws -> Int64 { 1 }
+  }
+
+  private actor RecordingCallbacks: CallbackResponding {
+    private(set) var disarmed: [Int64] = []
+    func answerCallbackQuery(id: String, text: String?) async throws {}
+    func editMessageReplyMarkup(
+      chatId: Int64,
+      messageId: Int64,
+      replyMarkup: String?
+    ) async throws {
+      if replyMarkup == nil {
+        disarmed.append(messageId)
+      }
+    }
+  }
+
+  // MARK: - Fixture
+
+  private struct Fixture {
+    let queue: DatabaseQueue
+    let runs: RunStoreGRDB
+    let approvals: ApprovalStoreGRDB
+    let sessionId: Int64
+    let runId: Int64
+    let approvalId: Int64
+    let observationMessageId: Int64
+    let promptMessageId: Int64
+  }
+
+  /// A suspended run with a placeholder observation and an APPROVED approvals row (seeded raw so
+  /// the test does not depend on the Task-06 CAS internals; the waiter reads it via the real store).
+  private func makeApprovedFixture(policyVersion: String = "pv") throws -> Fixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: 7),
+        chatId: 7,
+        userId: 7,
+        text: "write",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let sessionId = try #require(claim.sessionId)
+    let runId = try #require(claim.runId)
+    let runs = RunStoreGRDB(writer: queue)
+    _ = try #require(try runs.pickUp(runId: runId, now: Date()))
+
+    let promptMessageId: Int64 = 900
+    let argsJSON = #"{"path":"plan.md"}"#
+    let observationMessageId = try queue.write { db -> Int64 in
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_call_id)
+          VALUES (?, ?, 'tool', 'awaiting owner approval', 'untrusted', ?, 'c1')
+          """,
+        arguments: [sessionId, runId, Date()]
+      )
+      let messageId = db.lastInsertedRowID
+      _ = try RunStoreGRDB.transitionRun(db, runId: runId, event: .suspendForApproval, now: Date())
+      try db.execute(
+        sql: """
+          INSERT INTO approvals(run_id, session_id, state, tool, canonical_args, canonical_target,
+            args_hash, policy_version, owner_user_id, nonce, observation_message_id, tool_call_id,
+            reason, prompt_message_id, created_ts, expires_ts)
+          VALUES (?, ?, 'APPROVED', 'file_write', ?, '/w/plan.md', ?, ?, 7, 'nonce-a', ?, 'c1',
+            'ask_tier', ?, 1782000000, 1782003600)
+          """,
+        arguments: [
+          runId, sessionId, argsJSON, ApprovalArgsHash.sha256Hex(argsJSON), policyVersion,
+          messageId, promptMessageId,
+        ]
+      )
+      return messageId
+    }
+    let approvalId = try queue.read { db in
+      try #require(try Int64.fetchOne(db, sql: "SELECT id FROM approvals WHERE nonce = 'nonce-a'"))
+    }
+
+    return Fixture(
+      queue: queue,
+      runs: runs,
+      approvals: ApprovalStoreGRDB(writer: queue),
+      sessionId: sessionId,
+      runId: runId,
+      approvalId: approvalId,
+      observationMessageId: observationMessageId,
+      promptMessageId: promptMessageId
+    )
+  }
+
+  private func makeWaiter(
+    _ env: Fixture,
+    coordinator: ApprovalCoordinator,
+    turns: ResumeRecorder,
+    delivery: RecordingDelivery,
+    callbacks: RecordingCallbacks,
+    currentPolicyVersion: @escaping @Sendable () throws -> String = { "pv" }
+  ) -> ApprovalWaiter {
+    ApprovalWaiter(
+      approvals: env.approvals,
+      runs: env.runs,
+      coordinator: coordinator,
+      executor: ApprovedActionExecutor(
+        tools: ["file_write": StubTool(toolName: "file_write", result: "Wrote 12 B.")],
+        runs: env.runs,
+        now: { Date() },
+        logger: Logger(label: "test")
+      ),
+      turns: turns,
+      delivery: delivery,
+      callbacks: callbacks,
+      currentPolicyVersion: currentPolicyVersion,
+      now: { Date() },
+      logger: Logger(label: "test")
+    )
+  }
+
+  private func runState(_ env: Fixture) throws -> String? {
+    try env.queue.read { db in
+      try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [env.runId])
+    }
+  }
+
+  private func approvalState(_ env: Fixture) throws -> String? {
+    try env.queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT state FROM approvals WHERE id = ?",
+        arguments: [env.approvalId]
+      )
+    }
+  }
+
+  // MARK: - Tests
+
+  @Test func approveExecutesFillsResumesAndDisarms() async throws {
+    // given
+    let env = try makeApprovedFixture()
+    let coordinator = ApprovalCoordinator()
+    let turns = ResumeRecorder()
+    let delivery = RecordingDelivery()
+    let callbacks = RecordingCallbacks()
+    let waiter = makeWaiter(
+      env,
+      coordinator: coordinator,
+      turns: turns,
+      delivery: delivery,
+      callbacks: callbacks
+    )
+
+    // when — the coordinator buffers the signal, so park consumes it immediately (no polling)
+    await coordinator.signal(approvalId: env.approvalId, .approved)
+    await waiter.park(
+      approvalId: env.approvalId,
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: 7,
+      revalidatePolicyOnApprove: false
+    )
+
+    // then — recorded args executed into the placeholder, run RUNNING, continuation bound to the
+    // observation row, keyboard disarmed
+    #expect(try runState(env) == RunState.running.rawValue)
+    let observation = try await env.queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT content FROM messages WHERE id = ?",
+        arguments: [env.observationMessageId]
+      )
+    }
+    #expect(observation == "Wrote 12 B.")
+    #expect(
+      await turns.resumeCalls == [
+        .init(runId: env.runId, contextBoundMessageId: env.observationMessageId)
+      ]
+    )
+    #expect(await callbacks.disarmed == [env.promptMessageId])
+  }
+
+  @Test func bootRevalidationOnPolicyMismatchFailsTheRunAndLeavesTheRowApproved() async throws {
+    // given — the recorded policy_version no longer matches the current one (§6.5 crash window)
+    let env = try makeApprovedFixture(policyVersion: "pv-old")
+    let coordinator = ApprovalCoordinator()
+    let turns = ResumeRecorder()
+    let delivery = RecordingDelivery()
+    let callbacks = RecordingCallbacks()
+    let waiter = makeWaiter(
+      env,
+      coordinator: coordinator,
+      turns: turns,
+      delivery: delivery,
+      callbacks: callbacks,
+      currentPolicyVersion: { "pv-new" }
+    )
+
+    // when
+    await coordinator.signal(approvalId: env.approvalId, .approved)
+    await waiter.park(
+      approvalId: env.approvalId,
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: 7,
+      revalidatePolicyOnApprove: true
+    )
+
+    // then — the RUN fails, the row stays APPROVED (the one granted-then-denied pair), no resume,
+    // and the owner gets a plain-language notice
+    #expect(try runState(env) == RunState.failed.rawValue)
+    #expect(try approvalState(env) == ApprovalState.approved.rawValue)
+    #expect(await turns.resumeCalls.isEmpty)
+    #expect(await delivery.texts.isEmpty == false)
+    let auditDecision = try await env.queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT decision FROM audit_events WHERE action = ? AND run_id = ?",
+        arguments: [AuditAction.approvalDenied.rawValue, env.runId]
+      )
+    }
+    #expect(auditDecision == ApprovalDecision.stalePolicy.rawValue)
+  }
+
+  @Test func denyFailsTheRunAndNotifiesTheOwner() async throws {
+    // given — the deny half is a working stub here; Task 17 replaces the body with the synthetic
+    // observation resolution. This asserts only the lane-freeing contract Task 16 must guarantee.
+    let env = try makeApprovedFixture()
+    let coordinator = ApprovalCoordinator()
+    let turns = ResumeRecorder()
+    let delivery = RecordingDelivery()
+    let callbacks = RecordingCallbacks()
+    let waiter = makeWaiter(
+      env,
+      coordinator: coordinator,
+      turns: turns,
+      delivery: delivery,
+      callbacks: callbacks
+    )
+
+    // when
+    await coordinator.signal(approvalId: env.approvalId, .denied(.rejected))
+    await waiter.park(
+      approvalId: env.approvalId,
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: 7,
+      revalidatePolicyOnApprove: false
+    )
+
+    // then — the lane is freed (run FAILED), the owner is told, and no continuation runs
+    #expect(try runState(env) == RunState.failed.rawValue)
+    #expect(await turns.resumeCalls.isEmpty)
+    #expect(await delivery.texts.isEmpty == false)
+    #expect(await callbacks.disarmed == [env.promptMessageId])
+  }
+
+  // MARK: - Cancellation (carried-in liveness note #2)
+
+  @Test(.timeLimit(.minutes(1)))
+  func parkExitsCleanlyWhenCancelledWithoutResolution() async throws {
+    // given — a genuinely parked waiter: no buffered signal, so park suspends on the coordinator
+    let env = try makeApprovedFixture()
+    let coordinator = ApprovalCoordinator()
+    let turns = ResumeRecorder()
+    let delivery = RecordingDelivery()
+    let callbacks = RecordingCallbacks()
+    let waiter = makeWaiter(
+      env,
+      coordinator: coordinator,
+      turns: turns,
+      delivery: delivery,
+      callbacks: callbacks
+    )
+
+    // when — the lane task parks, then is cancelled with no resolution (graceful shutdown /
+    // lane cancel). A leaked continuation would hang `await task.value`; the time limit turns that
+    // regression into a failure instead of a wedged suite.
+    let task = Task {
+      await waiter.park(
+        approvalId: env.approvalId,
+        runId: env.runId,
+        sessionId: env.sessionId,
+        chatId: 7,
+        revalidatePolicyOnApprove: false
+      )
+    }
+    task.cancel()
+    await task.value
+
+    // then — park returned without resuming or denying; the durable row and run are untouched, so
+    // Task 19 boot re-park rebuilds the hold on restart
+    #expect(try runState(env) == RunState.awaitingApproval.rawValue)
+    #expect(try approvalState(env) == ApprovalState.approved.rawValue)
+    #expect(await turns.resumeCalls.isEmpty)
+    #expect(await delivery.texts.isEmpty)
+    #expect(await callbacks.disarmed.isEmpty)
+  }
+}

--- a/Tests/ClawGatewayTests/Routing/ApprovalWaiterTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ApprovalWaiterTests.swift
@@ -321,6 +321,47 @@ import Testing
     #expect(await callbacks.disarmed == [env.promptMessageId])
   }
 
+  @Test func denySignalFillsPlaceholderObservationInPlace() async throws {
+    // given — a parked waiter with the real deny half
+    let env = try makeApprovedFixture()
+    let coordinator = ApprovalCoordinator()
+    let turns = ResumeRecorder()
+    let delivery = RecordingDelivery()
+    let callbacks = RecordingCallbacks()
+    let waiter = makeWaiter(
+      env,
+      coordinator: coordinator,
+      turns: turns,
+      delivery: delivery,
+      callbacks: callbacks
+    )
+
+    // when — an owner reject lands and the parked waiter finalizes it
+    await coordinator.signal(approvalId: env.approvalId, .denied(.rejected))
+    await waiter.park(
+      approvalId: env.approvalId,
+      runId: env.runId,
+      sessionId: env.sessionId,
+      chatId: 7,
+      revalidatePolicyOnApprove: false
+    )
+
+    // then — the placeholder is REPLACED in place (no dangling tool_call), the run is FAILED, the
+    // owner is notified, and the buttons are disarmed — via resolveDeniedObservation, not failRun
+    let observation = try await env.queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT content FROM messages WHERE id = ?",
+        arguments: [env.observationMessageId]
+      )
+    }
+    #expect(observation == "The owner declined this action.")
+    #expect(try runState(env) == RunState.failed.rawValue)
+    #expect(await turns.resumeCalls.isEmpty)
+    #expect(await delivery.texts.isEmpty == false)
+    #expect(await callbacks.disarmed == [env.promptMessageId])
+  }
+
   // MARK: - Cancellation (carried-in liveness note #2)
 
   @Test(.timeLimit(.minutes(1)))

--- a/Tests/ClawGatewayTests/Routing/ApprovedActionExecutorTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ApprovedActionExecutorTests.swift
@@ -1,0 +1,239 @@
+import ClawCore
+import ClawData
+import Foundation
+import GRDB
+import Logging
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct ApprovedActionExecutorTests {
+  /// A ClawCore `Tool` double that records execution and can stall past its own declared timeout —
+  /// the executor must still await it to completion (§6.6, never the read-tool abandon race).
+  private struct RecordingWriteTool: Tool {
+    let toolName: String
+    let result: String
+    let status: ToolObservationStatus
+    let stallFor: Duration?
+
+    init(
+      toolName: String,
+      result: String,
+      status: ToolObservationStatus = .ok,
+      stallFor: Duration? = nil
+    ) {
+      self.toolName = toolName
+      self.result = result
+      self.status = status
+      self.stallFor = stallFor
+    }
+
+    var definition: ToolDefinition {
+      ToolDefinition(
+        name: toolName,
+        description: "stub",
+        parameters: .object(["type": .string("object")]),
+        egressClass: .none,
+        riskLevel: .ask
+      )
+    }
+
+    var timeout: Duration { .milliseconds(1) }
+
+    func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? { nil }
+
+    func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+      if let stallFor {
+        try? await Task.sleep(for: stallFor)
+      }
+      return ToolPayload(content: result, status: status, ingestedUntrusted: false)
+    }
+  }
+
+  private struct Fixture {
+    let queue: DatabaseQueue
+    let runs: RunStoreGRDB
+    let sessionId: Int64
+    let runId: Int64
+    let observationMessageId: Int64
+  }
+
+  private func makeSuspendedFixture() throws -> Fixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: 7),
+        chatId: 7,
+        userId: 7,
+        text: "write",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let sessionId = try #require(claim.sessionId)
+    let runId = try #require(claim.runId)
+    let runs = RunStoreGRDB(writer: queue)
+    _ = try #require(try runs.pickUp(runId: runId, now: Date()))
+    let observationMessageId = try queue.write { db -> Int64 in
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_call_id)
+          VALUES (?, ?, 'tool', 'awaiting owner approval', 'untrusted', ?, 'c1')
+          """,
+        arguments: [sessionId, runId, Date()]
+      )
+      let messageId = db.lastInsertedRowID
+      _ = try RunStoreGRDB.transitionRun(db, runId: runId, event: .suspendForApproval, now: Date())
+      return messageId
+    }
+    return Fixture(
+      queue: queue,
+      runs: runs,
+      sessionId: sessionId,
+      runId: runId,
+      observationMessageId: observationMessageId
+    )
+  }
+
+  private func approval(
+    _ env: Fixture,
+    tool: String,
+    argsJSON: String,
+    target: String = "/w/plan.md"
+  ) -> Approval {
+    Approval(
+      id: 1,
+      runId: env.runId,
+      sessionId: env.sessionId,
+      state: .approved,
+      tool: tool,
+      canonicalArgsJSON: argsJSON,
+      canonicalTarget: target,
+      argsHash: ApprovalArgsHash.sha256Hex(argsJSON),
+      policyVersion: "pv",
+      ownerUserId: 7,
+      nonce: "nonce-a",
+      observationMessageId: env.observationMessageId,
+      toolCallId: "c1",
+      reason: .askTier,
+      promptMessageId: 900,
+      createdTs: Date(),
+      expiresTs: Date(),
+      resolvedTs: Date()
+    )
+  }
+
+  private func makeExecutor(_ env: Fixture, tools: [any Tool]) -> ApprovedActionExecutor {
+    ApprovedActionExecutor(
+      tools: Dictionary(uniqueKeysWithValues: tools.map { ($0.definition.name, $0) }),
+      runs: env.runs,
+      now: { Date() },
+      logger: Logger(label: "test")
+    )
+  }
+
+  private func messageContent(_ env: Fixture) throws -> String? {
+    try env.queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT content FROM messages WHERE id = ?",
+        arguments: [env.observationMessageId]
+      )
+    }
+  }
+
+  private func runState(_ env: Fixture) throws -> String? {
+    try env.queue.read { db in
+      try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [env.runId])
+    }
+  }
+
+  @Test func executesRecordedArgsAndFillsTheObservation() async throws {
+    // given
+    let env = try makeSuspendedFixture()
+    let executor = makeExecutor(
+      env,
+      tools: [RecordingWriteTool(toolName: "file_write", result: "Wrote 12 B to /w/plan.md.")]
+    )
+
+    // when
+    let outcome = await executor.executeApproved(
+      approval(env, tool: "file_write", argsJSON: #"{"path":"plan.md"}"#)
+    )
+
+    // then — the tool's real result lands in the placeholder and the run resumes
+    #expect(outcome.commit == .committed)
+    #expect(outcome.observationContent == "Wrote 12 B to /w/plan.md.")
+    #expect(try messageContent(env) == "Wrote 12 B to /w/plan.md.")
+    #expect(try runState(env) == RunState.running.rawValue)
+  }
+
+  @Test func awaitsAStallingToolToCompletionWithoutTheTimeoutAbandonRace() async throws {
+    // given — the tool stalls 20ms past its own 1ms declared timeout; the executor must NOT abandon
+    let env = try makeSuspendedFixture()
+    let executor = makeExecutor(
+      env,
+      tools: [
+        RecordingWriteTool(
+          toolName: "file_write",
+          result: "the slow write finished",
+          stallFor: .milliseconds(20)
+        )
+      ]
+    )
+
+    // when
+    let outcome = await executor.executeApproved(
+      approval(env, tool: "file_write", argsJSON: #"{"path":"plan.md"}"#)
+    )
+
+    // then — the observation is truthful: the completed result, never a "timed out but maybe applied"
+    #expect(outcome.observationContent == "the slow write finished")
+    #expect(try messageContent(env) == "the slow write finished")
+  }
+
+  @Test func memoryWriteFusesTheInsertAndIsExactlyOnce() async throws {
+    // given — no tool is registered for memory_write: the executor rebuilds the item and routes
+    // through the fused store method (D10), never a tool `execute`
+    let env = try makeSuspendedFixture()
+    let executor = makeExecutor(env, tools: [])
+    let memoryApproval = approval(
+      env,
+      tool: "memory_write",
+      argsJSON: #"{"kind":"project","text":"the plan shipped"}"#,
+      target: "memory_item:project:abc123"
+    )
+
+    // when
+    let first = await executor.executeApproved(memoryApproval)
+    let second = await executor.executeApproved(memoryApproval)
+
+    // then — one memory row, observation filled, and the duplicate is a no-op (§6.3)
+    #expect(first.commit == .committed)
+    #expect(second.commit == .ignored)
+    let memoryCount = try await env.queue.read { db in
+      try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM memory_items")
+    }
+    #expect(memoryCount == 1)
+    #expect(try messageContent(env)?.contains("project") == true)
+  }
+
+  @Test func aMissingToolStillResumesWithAnErrorObservation() async throws {
+    // given — a recorded action whose tool is no longer registered
+    let env = try makeSuspendedFixture()
+    let executor = makeExecutor(env, tools: [])
+
+    // when
+    let outcome = await executor.executeApproved(
+      approval(env, tool: "vanished_tool", argsJSON: "{}")
+    )
+
+    // then — the run must not hang: it resumes with a truthful failure observation
+    #expect(outcome.commit == .committed)
+    #expect(try runState(env) == RunState.running.rawValue)
+    #expect(try messageContent(env)?.isEmpty == false)
+  }
+}

--- a/Tests/ClawGatewayTests/Routing/CommandApprovalCancelSignalRaceTests.swift
+++ b/Tests/ClawGatewayTests/Routing/CommandApprovalCancelSignalRaceTests.swift
@@ -1,0 +1,313 @@
+import ClawAgent
+import ClawCore
+import Foundation
+import GRDB
+import Logging
+import Testing
+
+@testable import ClawData
+@testable import ClawGateway
+
+/// Guards the Task-17 follow-up fix: `CommandHandlers.stop`/`new` must signal the
+/// `ApprovalCoordinator` BEFORE cancelling the session lane. A genuinely parked `ApprovalWaiter`
+/// (awaiting the coordinator on the lane, no pre-buffered signal) then always consumes a real
+/// `.denied` and fills its synthetic observation in place; the subsequent lane cancel can only
+/// no-op the already-resumed waiter.
+///
+/// Under the pre-fix ordering (cancel, then signal) the lane cancel resumes the parked waiter with
+/// `nil` via the coordinator's cancellation path (a detached `Task` running `cancelWaiter`), which
+/// races the later signal. When the nil-resume wins, `park` exits early and never fills the
+/// placeholder — a dangling "awaiting owner approval" tool_call is left on the now-terminal run.
+///
+/// To make the nil-resume win the race deterministically, the session carries extra cancellable
+/// runs: the parked run has the lowest id, so `/stop`//`new` cancel it FIRST (spawning its detached
+/// cancel task) while its `signal` is deferred behind every other run's `lane.cancel` hop. Under one
+/// cooperative thread (`SWIFT_MAX_CONCURRENCY_THREADS=1`, the project's nproc=1 convention for
+/// concurrency tests) that head start lets `cancelWaiter` reach the coordinator before the signal, so
+/// the pre-fix code leaves the placeholder dangling. On a multi-threaded scheduler the atomic
+/// `signal` wins, so the pre-fix bug does not surface there. The fixed ordering signals before any
+/// cancel, so the fill lands on every cycle under either scheduler.
+@Suite struct CommandApprovalCancelSignalRaceTests {
+  /// Extra cancellable runs queued ahead of the parked approval's signal in the command's cancel
+  /// loop — they defer the signal enough for the parked run's detached cancel task to win the
+  /// pre-fix race under cooperative FIFO scheduling.
+  private static let paddingRuns = 64
+
+  // MARK: - Doubles
+
+  /// The waiter's approve-path collaborator is unused on the deny/cancel path; a no-op stub keeps
+  /// the fixture focused on the resolution the command triggers.
+  private struct InertExecutor: ApprovedActionExecuting {
+    func executeApproved(_ approval: Approval) async -> ApprovedExecutionOutcome {
+      ApprovedExecutionOutcome(observationContent: "", commit: .ignored)
+    }
+  }
+
+  /// A one-shot rendezvous the trailing lane unit opens once it runs — proving the lane drained.
+  private actor Latch {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func open() {
+      isOpen = true
+      for waiter in waiters {
+        waiter.resume()
+      }
+      waiters.removeAll()
+    }
+
+    func wait() async {
+      guard isOpen == false else {
+        return
+      }
+      await withCheckedContinuation { continuation in
+        waiters.append(continuation)
+      }
+    }
+  }
+
+  // MARK: - Fixture
+
+  private struct Harness {
+    let router: MessageRouter
+    let queue: DatabaseQueue
+    let lanes: SessionLaneRegistry
+    let coordinator: ApprovalCoordinator
+    let sessionId: Int64
+    let runId: Int64
+    let approvalId: Int64
+    let observationMessageId: Int64
+    let chatId: Int64
+  }
+
+  // MARK: - Tests
+
+  @Test(.timeLimit(.minutes(1)))
+  func liveStopFillsTheParkedObservationAndFreesTheLaneEveryCycle() async throws {
+    // The pre-fix (cancel-then-signal) ordering fails this: the parked waiter's nil-resume wins the
+    // race and skips the fill. The fixed ordering fills the observation on every cycle.
+    for cycle in 0..<40 {
+      // given / when
+      let observation = try await runLiveCommandCycle(command: "/stop")
+
+      // then — the placeholder was replaced in place, proving resolveDeniedObservation ran (the
+      // signal was consumed before the cancel); reaching here proves the lane drained.
+      #expect(
+        observation == "Cancelled by /stop.",
+        "cycle \(cycle): the parked approval left a dangling placeholder"
+      )
+    }
+  }
+
+  @Test(.timeLimit(.minutes(1)))
+  func liveNewFillsTheParkedObservationAndFreesTheLaneEveryCycle() async throws {
+    for cycle in 0..<40 {
+      // given / when
+      let observation = try await runLiveCommandCycle(command: "/new")
+
+      // then
+      #expect(
+        observation == "Superseded by /new.",
+        "cycle \(cycle): the parked approval left a dangling placeholder"
+      )
+    }
+  }
+}
+
+// MARK: - Cycle
+
+private extension CommandApprovalCancelSignalRaceTests {
+  /// Parks a real waiter on the session lane (genuinely awaiting the coordinator), queues a plain
+  /// unit behind it, drives one live command through the router, waits for the lane to drain, and
+  /// returns the observation content the resolution left behind.
+  func runLiveCommandCycle(command: String) async throws -> String? {
+    let harness = try makeHarness()
+    let waiter = makeWaiter(harness)
+    let laneFreed = Latch()
+
+    let lane = await harness.lanes.actor(for: harness.sessionId)
+    await lane.enqueue(runId: harness.runId) {
+      await waiter.park(
+        approvalId: harness.approvalId,
+        runId: harness.runId,
+        sessionId: harness.sessionId,
+        chatId: harness.chatId,
+        revalidatePolicyOnApprove: false
+      )
+    }
+    // A plain unit of lane work queued BEHIND the park: FIFO chaining means it can only run once
+    // the parked waiter completes, so its execution proves the lane was freed.
+    let trailingRunId = harness.runId + 1_000_000
+    await lane.enqueue(runId: trailingRunId) {
+      await laneFreed.open()
+    }
+
+    // Let the parked waiter reach its coordinator registration before the command resolves it, so
+    // this exercises the live cancel-vs-signal window rather than a pre-buffered signal. Yields are
+    // cooperative (never block a thread), so this is safe at nproc=1.
+    for _ in 0..<16 {
+      await Task.yield()
+    }
+
+    let outcome = await harness.router.handle(
+      rawUpdate: textUpdate(id: 9_999, from: harness.chatId, text: command)
+    )
+    #expect(outcome == .processed)
+
+    await laneFreed.wait()
+
+    return try await harness.queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT content FROM messages WHERE id = ?",
+        arguments: [harness.observationMessageId]
+      )
+    }
+  }
+}
+
+// MARK: - Builders
+
+private extension CommandApprovalCancelSignalRaceTests {
+  private func makeHarness() throws -> Harness {
+    let chatId: Int64 = 42
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let allowlist = AllowlistStoreGRDB(writer: queue)
+    try allowlist.seedAllowlist(userIds: [chatId])
+
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let runs = RunStoreGRDB(writer: queue)
+
+    // The parked run is seeded FIRST so it holds the lowest run id and is cancelled first (`/stop`
+    // cancels in ascending id order) — its detached cancel task then races ahead of the signal.
+    let claim = try sessions.claimAndPersistInbound(
+      InboundMessage(
+        updateId: 1,
+        sessionKey: SessionKey.telegramDM(chatId: chatId),
+        chatId: chatId,
+        userId: chatId,
+        text: "write the plan",
+        isEdited: false,
+        ts: Date()
+      )
+    )
+    let sessionId = try #require(claim.sessionId)
+    let runId = try #require(claim.runId)
+    _ = try #require(try runs.pickUp(runId: runId, now: Date()))
+    let observationMessageId = try seedParkedApproval(
+      queue: queue,
+      sessionId: sessionId,
+      runId: runId
+    )
+    let approvalId = try queue.read { db in
+      try #require(try Int64.fetchOne(db, sql: "SELECT id FROM approvals WHERE nonce = 'nonce-a'"))
+    }
+
+    try seedPaddingRuns(sessions: sessions, runs: runs, chatId: chatId)
+
+    let coordinator = ApprovalCoordinator()
+    let lanes = SessionLaneRegistry()
+    let router = MessageRouter(
+      processed: ProcessedUpdateStoreGRDB(writer: queue),
+      sessionMessages: sessions,
+      commands: CommandStoreGRDB(writer: queue),
+      memory: MemoryStoreGRDB(writer: queue),
+      memoryCommands: MemoryCommandStoreGRDB(writer: queue),
+      pendingConfirmations: PendingConfirmationRegistry(),
+      botUsername: "claw_bot",
+      accessControl: AccessControl(allowlist: allowlist),
+      delivery: RecordingTransport(),
+      turnRunner: FakeTurnRunner(),
+      lanes: lanes,
+      schedule: makeIdleScheduleSurface(writer: queue),
+      coordinator: coordinator,
+      logger: TestLog.silent
+    )
+
+    return Harness(
+      router: router,
+      queue: queue,
+      lanes: lanes,
+      coordinator: coordinator,
+      sessionId: sessionId,
+      runId: runId,
+      approvalId: approvalId,
+      observationMessageId: observationMessageId,
+      chatId: chatId
+    )
+  }
+
+  /// Extra RUNNING runs in the same session. They carry no approval, so they only pad the command's
+  /// cancel loop, deferring the parked approval's signal behind their `lane.cancel` hops.
+  func seedPaddingRuns(
+    sessions: SessionMessageStoreGRDB,
+    runs: RunStoreGRDB,
+    chatId: Int64
+  ) throws {
+    for index in 0..<Self.paddingRuns {
+      let paddingClaim = try sessions.claimAndPersistInbound(
+        InboundMessage(
+          updateId: Int64(1_000 + index),
+          sessionKey: SessionKey.telegramDM(chatId: chatId),
+          chatId: chatId,
+          userId: chatId,
+          text: "padding \(index)",
+          isEdited: false,
+          ts: Date()
+        )
+      )
+      let paddingRunId = try #require(paddingClaim.runId)
+      _ = try #require(try runs.pickUp(runId: paddingRunId, now: Date()))
+    }
+  }
+
+  /// Suspends the run at AWAITING_APPROVAL behind a placeholder tool observation and a PENDING
+  /// approval — the exact shape `/stop`//`new` must resolve. Returns the observation row id the
+  /// resolution must fill in place. Seeded raw so the fixture does not depend on Task-06 CAS
+  /// internals; the command path and waiter read it through the real stores.
+  func seedParkedApproval(queue: DatabaseQueue, sessionId: Int64, runId: Int64) throws -> Int64 {
+    let now = Date()
+    let argsJSON = #"{"path":"/w/plan.md"}"#
+    return try queue.write { db -> Int64 in
+      try db.execute(
+        sql: """
+          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_call_id)
+          VALUES (?, ?, 'tool', ?, 'untrusted', ?, 'c1')
+          """,
+        arguments: [sessionId, runId, RunStoreGRDB.placeholderObservationContent, now]
+      )
+      let observationMessageId = db.lastInsertedRowID
+      _ = try RunStoreGRDB.transitionRun(db, runId: runId, event: .suspendForApproval, now: now)
+      try db.execute(
+        sql: """
+          INSERT INTO approvals(run_id, session_id, state, tool, canonical_args, canonical_target,
+            args_hash, policy_version, owner_user_id, nonce, observation_message_id, tool_call_id,
+            reason, prompt_message_id, created_ts, expires_ts)
+          VALUES (?, ?, 'PENDING', 'file_write', ?, '/w/plan.md', ?, 'pv', 42, 'nonce-a', ?, 'c1',
+            'ask_tier', 900, 1782000000, 1782003600)
+          """,
+        arguments: [
+          runId, sessionId, argsJSON, ApprovalArgsHash.sha256Hex(argsJSON), observationMessageId,
+        ]
+      )
+      return observationMessageId
+    }
+  }
+
+  private func makeWaiter(_ harness: Harness) -> ApprovalWaiter {
+    let transport = RecordingTransport()
+    return ApprovalWaiter(
+      approvals: ApprovalStoreGRDB(writer: harness.queue),
+      runs: RunStoreGRDB(writer: harness.queue),
+      coordinator: harness.coordinator,
+      executor: InertExecutor(),
+      turns: FakeTurnRunner(),
+      delivery: transport,
+      callbacks: transport,
+      currentPolicyVersion: { "pv" },
+      now: { Date() },
+      logger: TestLog.silent
+    )
+  }
+}

--- a/Tests/ClawGatewayTests/Routing/MessageRouterTests.swift
+++ b/Tests/ClawGatewayTests/Routing/MessageRouterTests.swift
@@ -83,6 +83,7 @@ struct FullSessions: SessionMessageStore {
       turnRunner: dispatcher,
       lanes: SessionLaneRegistry(),
       schedule: makeIdleScheduleSurface(writer: queue),
+      coordinator: ApprovalCoordinator(),
       logger: TestLog.silent
     )
 
@@ -303,6 +304,7 @@ struct FullSessions: SessionMessageStore {
       turnRunner: dispatcher,
       lanes: SessionLaneRegistry(),
       schedule: makeIdleScheduleSurface(writer: queue),
+      coordinator: ApprovalCoordinator(),
       logger: TestLog.silent
     )
 
@@ -364,6 +366,7 @@ struct FullSessions: SessionMessageStore {
       turnRunner: dispatcher,
       lanes: SessionLaneRegistry(),
       schedule: makeIdleScheduleSurface(writer: queue),
+      coordinator: ApprovalCoordinator(),
       logger: TestLog.silent
     )
 
@@ -426,6 +429,7 @@ struct FullSessions: SessionMessageStore {
       turnRunner: FakeTurnRunner(),
       lanes: SessionLaneRegistry(),
       schedule: makeIdleScheduleSurface(writer: queue),
+      coordinator: ApprovalCoordinator(),
       logger: TestLog.silent
     )
 

--- a/Tests/ClawGatewayTests/Routing/ScheduleInteractionTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ScheduleInteractionTests.swift
@@ -60,6 +60,7 @@ import Testing
         jobs: ScheduledJobStoreGRDB(writer: queue),
         commands: ScheduleCommandStoreGRDB(writer: queue)
       ),
+      coordinator: ApprovalCoordinator(),
       now: { Self.fixedNow },
       logger: TestLog.silent
     )

--- a/Tests/ClawGatewayTests/Routing/ScheduleRoutingTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ScheduleRoutingTests.swift
@@ -83,6 +83,7 @@ import Testing
         jobs: ScheduledJobStoreGRDB(writer: queue),
         commands: ScheduleCommandStoreGRDB(writer: queue)
       ),
+      coordinator: ApprovalCoordinator(),
       now: { Self.fixedNow },
       logger: TestLog.silent
     )

--- a/Tests/ClawGatewayTests/Routing/ScheduleVerbRoutingTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ScheduleVerbRoutingTests.swift
@@ -40,6 +40,7 @@ import Testing
       turnRunner: dispatcher,
       lanes: SessionLaneRegistry(),
       schedule: makeIdleScheduleSurface(writer: queue),
+      coordinator: ApprovalCoordinator(),
       now: { Self.fixedNow },
       logger: TestLog.silent
     )

--- a/Tests/ClawGatewayTests/Routing/ToolApprovalRoutingTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ToolApprovalRoutingTests.swift
@@ -39,6 +39,7 @@ import Testing
       turnRunner: runner,
       lanes: SessionLaneRegistry(),
       schedule: makeIdleScheduleSurface(writer: queue),
+      coordinator: ApprovalCoordinator(),
       logger: TestLog.silent
     )
     return Fixture(

--- a/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
+++ b/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
@@ -91,6 +91,48 @@ struct CancellingBeforeAssistantCommitRuns: RunStore {
   func runsHealth(now: Date) throws -> RunsHealth {
     try base.runsHealth(now: now)
   }
+
+  func completeApprovedObservation(
+    runId: Int64,
+    observationMessageId: Int64,
+    content: String,
+    now: Date
+  ) throws -> RunCommitResult {
+    try base.completeApprovedObservation(
+      runId: runId,
+      observationMessageId: observationMessageId,
+      content: content,
+      now: now
+    )
+  }
+
+  func applyApprovedMemoryWrite(
+    runId: Int64,
+    observationMessageId: Int64,
+    item: NewMemoryItem,
+    observationContent: String,
+    now: Date
+  ) throws -> RunCommitResult {
+    try base.applyApprovedMemoryWrite(
+      runId: runId,
+      observationMessageId: observationMessageId,
+      item: item,
+      observationContent: observationContent,
+      now: now
+    )
+  }
+
+  func resumeUsage(runId: Int64) throws -> ResumeUsage {
+    try base.resumeUsage(runId: runId)
+  }
+
+  func runOrigin(runId: Int64) throws -> RunOrigin? {
+    try base.runOrigin(runId: runId)
+  }
+
+  func failRunStalePolicy(runId: Int64, sessionId: Int64, now: Date) throws -> Bool {
+    try base.failRunStalePolicy(runId: runId, sessionId: sessionId, now: now)
+  }
 }
 
 /// Delegates to the real run store but flips the active run to CANCELLED immediately before the
@@ -148,6 +190,48 @@ struct CancellingBeforeDegradedCommitRuns: RunStore {
   func runsHealth(now: Date) throws -> RunsHealth {
     try base.runsHealth(now: now)
   }
+
+  func completeApprovedObservation(
+    runId: Int64,
+    observationMessageId: Int64,
+    content: String,
+    now: Date
+  ) throws -> RunCommitResult {
+    try base.completeApprovedObservation(
+      runId: runId,
+      observationMessageId: observationMessageId,
+      content: content,
+      now: now
+    )
+  }
+
+  func applyApprovedMemoryWrite(
+    runId: Int64,
+    observationMessageId: Int64,
+    item: NewMemoryItem,
+    observationContent: String,
+    now: Date
+  ) throws -> RunCommitResult {
+    try base.applyApprovedMemoryWrite(
+      runId: runId,
+      observationMessageId: observationMessageId,
+      item: item,
+      observationContent: observationContent,
+      now: now
+    )
+  }
+
+  func resumeUsage(runId: Int64) throws -> ResumeUsage {
+    try base.resumeUsage(runId: runId)
+  }
+
+  func runOrigin(runId: Int64) throws -> RunOrigin? {
+    try base.runOrigin(runId: runId)
+  }
+
+  func failRunStalePolicy(runId: Int64, sessionId: Int64, now: Date) throws -> Bool {
+    try base.failRunStalePolicy(runId: runId, sessionId: sessionId, now: now)
+  }
 }
 
 /// A `RunStore` whose first write reports a full disk, to exercise the storage-full rethrow.
@@ -181,6 +265,32 @@ struct DiskFullRuns: RunStore {
       lastSuccessAt: nil,
       consecutiveFailures: 0
     )
+  }
+  func completeApprovedObservation(
+    runId: Int64,
+    observationMessageId: Int64,
+    content: String,
+    now: Date
+  ) throws -> RunCommitResult {
+    throw StoreError.diskFull
+  }
+  func applyApprovedMemoryWrite(
+    runId: Int64,
+    observationMessageId: Int64,
+    item: NewMemoryItem,
+    observationContent: String,
+    now: Date
+  ) throws -> RunCommitResult {
+    throw StoreError.diskFull
+  }
+  func resumeUsage(runId: Int64) throws -> ResumeUsage {
+    throw StoreError.diskFull
+  }
+  func runOrigin(runId: Int64) throws -> RunOrigin? {
+    throw StoreError.diskFull
+  }
+  func failRunStalePolicy(runId: Int64, sessionId: Int64, now: Date) throws -> Bool {
+    throw StoreError.diskFull
   }
 }
 

--- a/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
+++ b/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
@@ -133,6 +133,22 @@ struct CancellingBeforeAssistantCommitRuns: RunStore {
   func failRunStalePolicy(runId: Int64, sessionId: Int64, now: Date) throws -> Bool {
     try base.failRunStalePolicy(runId: runId, sessionId: sessionId, now: now)
   }
+
+  func resolveDeniedObservation(
+    runId: Int64,
+    observationMessageId: Int64,
+    content: String,
+    cancel: CancelReason?,
+    now: Date
+  ) throws -> RunCommitResult {
+    try base.resolveDeniedObservation(
+      runId: runId,
+      observationMessageId: observationMessageId,
+      content: content,
+      cancel: cancel,
+      now: now
+    )
+  }
 }
 
 /// Delegates to the real run store but flips the active run to CANCELLED immediately before the
@@ -232,6 +248,22 @@ struct CancellingBeforeDegradedCommitRuns: RunStore {
   func failRunStalePolicy(runId: Int64, sessionId: Int64, now: Date) throws -> Bool {
     try base.failRunStalePolicy(runId: runId, sessionId: sessionId, now: now)
   }
+
+  func resolveDeniedObservation(
+    runId: Int64,
+    observationMessageId: Int64,
+    content: String,
+    cancel: CancelReason?,
+    now: Date
+  ) throws -> RunCommitResult {
+    try base.resolveDeniedObservation(
+      runId: runId,
+      observationMessageId: observationMessageId,
+      content: content,
+      cancel: cancel,
+      now: now
+    )
+  }
 }
 
 /// A `RunStore` whose first write reports a full disk, to exercise the storage-full rethrow.
@@ -290,6 +322,15 @@ struct DiskFullRuns: RunStore {
     throw StoreError.diskFull
   }
   func failRunStalePolicy(runId: Int64, sessionId: Int64, now: Date) throws -> Bool {
+    throw StoreError.diskFull
+  }
+  func resolveDeniedObservation(
+    runId: Int64,
+    observationMessageId: Int64,
+    content: String,
+    cancel: CancelReason?,
+    now: Date
+  ) throws -> RunCommitResult {
     throw StoreError.diskFull
   }
 }

--- a/Tests/ClawGatewayTests/Services/ApprovalBootReconcilerTests.swift
+++ b/Tests/ClawGatewayTests/Services/ApprovalBootReconcilerTests.swift
@@ -1,0 +1,368 @@
+import ClawAgent
+import ClawCore
+import ClawGateway
+import Foundation
+import GRDB
+import Testing
+
+// `@testable` is required for the seed helper: `ApprovalStoreGRDB.insertApproval` (Task 06) is an
+// internal db-scoped static, not `public`, so a plain `import ClawData` can't reach it.
+@testable import ClawData
+
+@Suite struct ApprovalBootReconcilerTests {
+  /// Records every `park` and models the real waiter: it registers with the coordinator and awaits
+  /// resolution, so the lane stays held until the row resolves. All rendezvous are continuation-based
+  /// (never a sleep or a spin) so the suite is deterministic at nproc=1.
+  private actor ParkingSpy: ApprovalParking {
+    struct Call: Sendable, Equatable {
+      let approvalId: Int64
+      let runId: Int64
+      let sessionId: Int64
+      let chatId: Int64
+      let revalidate: Bool
+    }
+
+    private let coordinator: ApprovalCoordinator
+    private var bufferedCalls: [Call] = []
+    private var callWaiters: [CheckedContinuation<Call, Never>] = []
+    private var resolvedSignals: [Int64: ApprovalSignal] = [:]
+    private var resolutionWaiters: [Int64: [CheckedContinuation<ApprovalSignal, Never>]] = [:]
+
+    init(coordinator: ApprovalCoordinator) {
+      self.coordinator = coordinator
+    }
+
+    func park(
+      approvalId: Int64,
+      runId: Int64,
+      sessionId: Int64,
+      chatId: Int64,
+      revalidatePolicyOnApprove: Bool
+    ) async {
+      let call = Call(
+        approvalId: approvalId,
+        runId: runId,
+        sessionId: sessionId,
+        chatId: chatId,
+        revalidate: revalidatePolicyOnApprove
+      )
+      deliver(call)
+      // `awaitResolution` returns nil only on cancellation (never in these tests); guard mirrors the
+      // real `ApprovalWaiter.park`, which exits cleanly on a nil resolution.
+      guard let signal = await coordinator.awaitResolution(approvalId: approvalId) else {
+        return
+      }
+      recordResolution(signal, for: approvalId)
+    }
+
+    /// Suspends until the next `park` lands — the deterministic "the boot-parked waiter registered
+    /// and is holding the lane" checkpoint the tests synchronize on.
+    func nextParkCall() async -> Call {
+      if !bufferedCalls.isEmpty {
+        return bufferedCalls.removeFirst()
+      }
+      return await withCheckedContinuation { continuation in
+        callWaiters.append(continuation)
+      }
+    }
+
+    /// Suspends until the parked waiter for `approvalId` observes its coordinator resolution.
+    func awaitParkResolution(of approvalId: Int64) async -> ApprovalSignal {
+      if let signal = resolvedSignals[approvalId] {
+        return signal
+      }
+      return await withCheckedContinuation { continuation in
+        resolutionWaiters[approvalId, default: []].append(continuation)
+      }
+    }
+
+    private func deliver(_ call: Call) {
+      if callWaiters.isEmpty {
+        bufferedCalls.append(call)
+      } else {
+        callWaiters.removeFirst().resume(returning: call)
+      }
+    }
+
+    private func recordResolution(_ signal: ApprovalSignal, for approvalId: Int64) {
+      resolvedSignals[approvalId] = signal
+      let waiters = resolutionWaiters[approvalId] ?? []
+      resolutionWaiters[approvalId] = nil
+      for waiter in waiters {
+        waiter.resume(returning: signal)
+      }
+    }
+  }
+
+  /// A plain lane citizen enqueued behind a re-parked waiter — proves the FIFO queue-behind contract.
+  private actor FollowerFlag {
+    private(set) var ran = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func markRan() {
+      ran = true
+      for waiter in waiters {
+        waiter.resume()
+      }
+      waiters = []
+    }
+
+    func awaitRan() async {
+      if ran {
+        return
+      }
+      await withCheckedContinuation { continuation in
+        waiters.append(continuation)
+      }
+    }
+  }
+
+  private struct Fixture {
+    let queue: DatabaseQueue
+    let store: ApprovalStoreGRDB
+    let sessionId: Int64
+    let lanes: SessionLaneRegistry
+    let coordinator: ApprovalCoordinator
+    let spy: ParkingSpy
+
+    func reconciler(now instant: Date) -> ApprovalBootReconciler {
+      ApprovalBootReconciler(
+        approvals: store,
+        lanes: lanes,
+        coordinator: coordinator,
+        waiter: spy,
+        now: { instant },
+        logger: TestLog.silent
+      )
+    }
+
+    func seedRun(state: String) throws -> Int64 {
+      try queue.write { db in
+        try db.execute(
+          sql: "INSERT INTO runs(session_id, state, created_ts, updated_ts) VALUES (1, ?, ?, ?)",
+          arguments: [state, Date(), Date()]
+        )
+        return db.lastInsertedRowID
+      }
+    }
+
+    @discardableResult
+    func insertApproval(
+      runId: Int64,
+      nonce: String,
+      createdTs: Date,
+      expiresTs: Date
+    ) throws -> Int64 {
+      let canonicalArgsJSON = #"{"path":"/w/plan.md"}"#
+      let newApproval = NewApproval(
+        runId: runId,
+        sessionId: 1,
+        tool: "file_write",
+        canonicalArgsJSON: canonicalArgsJSON,
+        canonicalTarget: "/w/plan.md",
+        argsHash: ApprovalArgsHash.sha256Hex(canonicalArgsJSON),
+        policyVersion: "pv16",
+        ownerUserId: 7,
+        nonce: nonce,
+        observationMessageId: 1,
+        toolCallId: "c1",
+        reason: .askTier,
+        createdTs: createdTs,
+        expiresTs: expiresTs
+      )
+      return try queue.write { db in try ApprovalStoreGRDB.insertApproval(db, newApproval) }
+    }
+
+    func audits() throws -> [(action: String, decision: String)] {
+      try queue.read { db in
+        try Row.fetchAll(db, sql: "SELECT action, decision FROM audit_events ORDER BY id")
+          .map { row in (action: row["action"], decision: row["decision"]) }
+      }
+    }
+
+    func approvalState(_ id: Int64) throws -> ApprovalState? {
+      try store.approval(id: id)?.state
+    }
+  }
+
+  private func makeFixture() throws -> Fixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO sessions(session_key, created_ts, updated_ts, tainted)
+          VALUES ('tg:dm:7', ?, ?, 0)
+          """,
+        arguments: [Date(), Date()]
+      )
+    }
+    let coordinator = ApprovalCoordinator()
+    return Fixture(
+      queue: queue,
+      store: ApprovalStoreGRDB(writer: queue),
+      sessionId: 1,
+      lanes: SessionLaneRegistry(),
+      coordinator: coordinator,
+      spy: ParkingSpy(coordinator: coordinator)
+    )
+  }
+
+  @Test func terminalRunPendingApprovalIsResolvedWithNoOrphan() async throws {
+    // given — a PENDING approval whose run already FAILED (a restart orphan) plus one genuinely
+    // parked approval, so we prove only the orphan is cleaned and the parked row is left alone
+    let env = try makeFixture()
+    let failedRun = try env.seedRun(state: RunState.failed.rawValue)
+    let parkedRun = try env.seedRun(state: RunState.awaitingApproval.rawValue)
+    let now = Date(timeIntervalSince1970: 1_782_000_000)
+    let orphanId = try env.insertApproval(
+      runId: failedRun,
+      nonce: "n-orphan",
+      createdTs: now,
+      expiresTs: now.addingTimeInterval(3600)
+    )
+    let keptId = try env.insertApproval(
+      runId: parkedRun,
+      nonce: "n-kept",
+      createdTs: now,
+      expiresTs: now.addingTimeInterval(3600)
+    )
+
+    // when — resolveOrphans runs before unresolvedAtBoot, so the parked row is never mistaken for one
+    await env.reconciler(now: now).reconcile()
+    _ = await env.spy.nextParkCall()
+
+    // then — the terminal-run orphan is REJECTED/cancelled; the parked row stays PENDING for re-park
+    #expect(try env.approvalState(orphanId) == .rejected)
+    #expect(try env.approvalState(keptId) == .pending)
+    #expect(
+      try env.audits()
+        .contains {
+          $0 == (AuditAction.approvalDenied.rawValue, ApprovalDecision.cancelled.rawValue)
+        }
+    )
+  }
+
+  @Test func unexpiredPendingReParksAndResolvesViaTheBootParkedWaiter() async throws {
+    // given — one unexpired PENDING approval on an AWAITING_APPROVAL run (the reopened suspended DB)
+    let env = try makeFixture()
+    let runId = try env.seedRun(state: RunState.awaitingApproval.rawValue)
+    let now = Date(timeIntervalSince1970: 1_782_000_000)
+    let approvalId = try env.insertApproval(
+      runId: runId,
+      nonce: "n-live",
+      createdTs: now,
+      expiresTs: now.addingTimeInterval(3600)
+    )
+
+    // when — boot re-parks the lane
+    await env.reconciler(now: now).reconcile()
+    let call = await env.spy.nextParkCall()
+
+    // then — re-parked on the run's session lane, chatId = the approval's delivery chat (§4.4), and
+    // NOT under crash-window re-validation (the row is still PENDING)
+    #expect(call.approvalId == approvalId)
+    #expect(call.runId == runId)
+    #expect(call.sessionId == env.sessionId)
+    #expect(call.chatId == 7)
+    #expect(call.revalidate == false)
+    #expect(try env.approvalState(approvalId) == .pending)
+
+    // and — a live callback (approve CAS + coordinator signal) still resolves through the
+    // boot-parked waiter after restart: buttons survive the reboot
+    let outcome = try env.store.approve(id: approvalId, currentPolicyVersion: "pv16", now: now)
+    guard case .approved = outcome else {
+      Issue.record("expected the callback approve CAS to commit, got \(outcome)")
+      return
+    }
+    await env.coordinator.signal(approvalId: approvalId, .approved)
+    #expect(await env.spy.awaitParkResolution(of: approvalId) == .approved)
+  }
+
+  @Test func aPlainMessageQueuesBehindTheReParkedLane() async throws {
+    // given — an unexpired parked approval, re-parked at boot; the waiter now holds the session lane
+    let env = try makeFixture()
+    let runId = try env.seedRun(state: RunState.awaitingApproval.rawValue)
+    let now = Date(timeIntervalSince1970: 1_782_000_000)
+    let approvalId = try env.insertApproval(
+      runId: runId,
+      nonce: "n-fifo",
+      createdTs: now,
+      expiresTs: now.addingTimeInterval(3600)
+    )
+    await env.reconciler(now: now).reconcile()
+    _ = await env.spy.nextParkCall()
+
+    // when — a plain message lands on the SAME session lane after the restart
+    let follower = FollowerFlag()
+    let lane = await env.lanes.actor(for: env.sessionId)
+    await lane.enqueue(runId: runId &+ 1_000) { await follower.markRan() }
+
+    // then — it cannot run until the parked approval resolves (FIFO queue-behind survives restart):
+    // the follower's task chains behind the still-suspended waiter task on the lane
+    #expect(await follower.ran == false)
+
+    // and — once the approval resolves, the queued message runs
+    await env.coordinator.signal(approvalId: approvalId, .approved)
+    await follower.awaitRan()
+    #expect(await follower.ran == true)
+  }
+
+  @Test func expiredPendingIsSweptToDenyAndDrivesTheParkedWaiter() async throws {
+    // given — a PENDING approval whose expires_ts already passed while the process was down
+    let env = try makeFixture()
+    let runId = try env.seedRun(state: RunState.awaitingApproval.rawValue)
+    let now = Date(timeIntervalSince1970: 1_782_010_000)
+    let approvalId = try env.insertApproval(
+      runId: runId,
+      nonce: "n-expired",
+      createdTs: now.addingTimeInterval(-7200),
+      expiresTs: now.addingTimeInterval(-60)
+    )
+
+    // when
+    await env.reconciler(now: now).reconcile()
+    let call = await env.spy.nextParkCall()
+
+    // then — the §6.4 expiry path: CAS PENDING→EXPIRED + approvalDenied/expired audited here, and the
+    // parked waiter consumes the buffered denial so it can drive the run AWAITING_APPROVAL→FAILED
+    #expect(call.revalidate == false)
+    #expect(try env.approvalState(approvalId) == .expired)
+    #expect(await env.spy.awaitParkResolution(of: approvalId) == .denied(.expired))
+    #expect(
+      try env.audits()
+        .contains { $0 == (AuditAction.approvalDenied.rawValue, ApprovalDecision.expired.rawValue) }
+    )
+  }
+
+  @Test func approvedAwaitingRunReParksUnderCrashWindowRevalidation() async throws {
+    // given — the §6.5 crash window: the row was granted, the process died before execution, so boot
+    // finds an APPROVED row on an AWAITING_APPROVAL run
+    let env = try makeFixture()
+    let runId = try env.seedRun(state: RunState.awaitingApproval.rawValue)
+    let now = Date(timeIntervalSince1970: 1_782_000_000)
+    let approvalId = try env.insertApproval(
+      runId: runId,
+      nonce: "n-crash",
+      createdTs: now,
+      expiresTs: now.addingTimeInterval(3600)
+    )
+    try await env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE approvals SET state = 'APPROVED' WHERE id = ?",
+        arguments: [approvalId]
+      )
+    }
+
+    // when
+    await env.reconciler(now: now).reconcile()
+    let call = await env.spy.nextParkCall()
+
+    // then — re-parked with revalidatePolicyOnApprove true and the .approved signal buffered, so the
+    // waiter re-validates policy_version before executing (or fails the RUN on mismatch, §6.5). The
+    // row STAYS APPROVED — the boot re-validation is the waiter's job, never the reconciler's
+    #expect(call.revalidate == true)
+    #expect(try env.approvalState(approvalId) == .approved)
+    #expect(await env.spy.awaitParkResolution(of: approvalId) == .approved)
+  }
+}

--- a/Tests/ClawGatewayTests/Services/ApprovalBootReconcilerTests.swift
+++ b/Tests/ClawGatewayTests/Services/ApprovalBootReconcilerTests.swift
@@ -366,3 +366,72 @@ import Testing
     #expect(await env.spy.awaitParkResolution(of: approvalId) == .approved)
   }
 }
+
+// MARK: - Deny-Side Crash Window
+
+extension ApprovalBootReconcilerTests {
+  @Test func rejectedAwaitingRunIsReParkedWithTheBufferedDenial() async throws {
+    // given — the deny-side crash window: the reject CAS (+ its approvalDenied audit) committed,
+    // but the process died before the waiter's observation-fill/run-fail commit, so boot finds a
+    // REJECTED approval on a still-AWAITING_APPROVAL run
+    let env = try makeFixture()
+    let runId = try env.seedRun(state: RunState.awaitingApproval.rawValue)
+    let now = Date(timeIntervalSince1970: 1_782_000_000)
+    let approvalId = try env.insertApproval(
+      runId: runId,
+      nonce: "n-rejected",
+      createdTs: now,
+      expiresTs: now.addingTimeInterval(3600)
+    )
+    try await env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE approvals SET state = 'REJECTED' WHERE id = ?",
+        arguments: [approvalId]
+      )
+    }
+
+    // when
+    await env.reconciler(now: now).reconcile()
+    let call = await env.spy.nextParkCall()
+
+    // then — finalized, not ignored: re-parked without re-validation and the generic denial
+    // buffered so the waiter drives the run AWAITING_APPROVAL→FAILED. The row STAYS REJECTED and
+    // no new audit lands — the pre-crash CAS already recorded both
+    #expect(call.approvalId == approvalId)
+    #expect(call.revalidate == false)
+    #expect(await env.spy.awaitParkResolution(of: approvalId) == .denied(.rejected))
+    #expect(try env.approvalState(approvalId) == .rejected)
+    #expect(try env.audits().isEmpty)
+  }
+
+  @Test func expiredAwaitingRunIsReParkedWithTheBufferedDenial() async throws {
+    // given — the same deny-side crash window for a row the expiry CAS resolved before the crash:
+    // an EXPIRED approval on a still-AWAITING_APPROVAL run
+    let env = try makeFixture()
+    let runId = try env.seedRun(state: RunState.awaitingApproval.rawValue)
+    let now = Date(timeIntervalSince1970: 1_782_010_000)
+    let approvalId = try env.insertApproval(
+      runId: runId,
+      nonce: "n-expired-cas",
+      createdTs: now.addingTimeInterval(-7200),
+      expiresTs: now.addingTimeInterval(-60)
+    )
+    try await env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE approvals SET state = 'EXPIRED' WHERE id = ?",
+        arguments: [approvalId]
+      )
+    }
+
+    // when
+    await env.reconciler(now: now).reconcile()
+    let call = await env.spy.nextParkCall()
+
+    // then — the buffered denial carries .expired; the row stays EXPIRED with no re-CAS/re-audit
+    #expect(call.approvalId == approvalId)
+    #expect(call.revalidate == false)
+    #expect(await env.spy.awaitParkResolution(of: approvalId) == .denied(.expired))
+    #expect(try env.approvalState(approvalId) == .expired)
+    #expect(try env.audits().isEmpty)
+  }
+}

--- a/Tests/ClawGatewayTests/Services/ApprovalExpiryServiceTests.swift
+++ b/Tests/ClawGatewayTests/Services/ApprovalExpiryServiceTests.swift
@@ -1,0 +1,268 @@
+import ClawCore
+import ClawData
+import Foundation
+import GRDB
+import Logging
+import Testing
+
+@testable import ClawGateway
+
+/// A scripted `ApprovalStore` for the run()-loop timing test: counts `sweepExpired` calls and
+/// returns no swept rows (the loop test asserts on tick count + slept duration, not on signals —
+/// those are covered by the real-store tick() tests). Every other method is loud, so the ticker
+/// calling anything but `sweepExpired` fails the test instead of silently passing.
+private final class RecordingApprovalStore: ApprovalStore, @unchecked Sendable {
+  private let lock = NSLock()
+  private var sweepCount = 0
+
+  var sweeps: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return sweepCount
+  }
+
+  func sweepExpired(now: Date) throws -> [Approval] {
+    lock.lock()
+    defer { lock.unlock() }
+    sweepCount += 1
+    return []
+  }
+
+  func approval(nonce: String) throws -> Approval? {
+    throw StoreError.unexpected("unused by ApprovalExpiryService")
+  }
+
+  func approval(id: Int64) throws -> Approval? {
+    throw StoreError.unexpected("unused by ApprovalExpiryService")
+  }
+
+  func approve(
+    id: Int64,
+    currentPolicyVersion: String,
+    now: Date
+  ) throws -> ApprovalApproveOutcome {
+    throw StoreError.unexpected("unused by ApprovalExpiryService")
+  }
+
+  func deny(id: Int64, decision: ApprovalDecision, now: Date) throws -> Bool {
+    throw StoreError.unexpected("unused by ApprovalExpiryService")
+  }
+
+  func unresolvedAtBoot() throws -> [Approval] {
+    throw StoreError.unexpected("unused by ApprovalExpiryService")
+  }
+
+  func resolveOrphans(now: Date) throws -> Int {
+    throw StoreError.unexpected("unused by ApprovalExpiryService")
+  }
+
+  func approvalsHealth(now: Date) throws -> ApprovalsHealth {
+    throw StoreError.unexpected("unused by ApprovalExpiryService")
+  }
+}
+
+/// Records the durations the run() loop sleeps; throwing after a real suspend ends the loop like a
+/// graceful shutdown WITHOUT blocking the cooperative thread (TESTING §8 / preamble nproc=1 rule).
+private final class ExpirySleepRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var recorded: [Duration] = []
+
+  var durations: [Duration] {
+    lock.lock()
+    defer { lock.unlock() }
+    return recorded
+  }
+
+  func append(_ duration: Duration) {
+    lock.lock()
+    defer { lock.unlock() }
+    recorded.append(duration)
+  }
+}
+
+@Suite struct ApprovalExpiryServiceTests {
+  private struct TickFixture {
+    let queue: DatabaseQueue
+    let store: ApprovalStoreGRDB
+    let coordinator: ApprovalCoordinator
+    let service: ApprovalExpiryService
+  }
+
+  /// A fresh in-memory DB with one session (id 1); the service wraps the REAL store + a REAL
+  /// coordinator so the tick() tests assert on persisted rows AND the buffered coordinator signal.
+  /// The sleep double is never reached in a tick() test but still SUSPENDS before throwing.
+  private func makeTickFixture(now: Date) throws -> TickFixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO sessions(session_key, created_ts, updated_ts, tainted)
+          VALUES ('tg:dm:7', ?, ?, 0)
+          """,
+        arguments: [Date(), Date()]
+      )
+    }
+    let store = ApprovalStoreGRDB(writer: queue)
+    let coordinator = ApprovalCoordinator()
+    let service = ApprovalExpiryService(
+      approvals: store,
+      coordinator: coordinator,
+      now: { now },
+      sleep: { _ in
+        try? await Task.sleep(for: .milliseconds(1))
+        throw CancellationError()
+      },
+      logger: TestLog.silent
+    )
+    return TickFixture(queue: queue, store: store, coordinator: coordinator, service: service)
+  }
+
+  /// Seeds a run (approvals.run_id has an FK to runs) and returns its id.
+  private func seedRun(_ queue: DatabaseQueue) throws -> Int64 {
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO runs(session_id, state, created_ts, updated_ts)
+          VALUES (1, ?, ?, ?)
+          """,
+        arguments: [RunState.awaitingApproval.rawValue, Date(), Date()]
+      )
+      return db.lastInsertedRowID
+    }
+  }
+
+  /// Inserts a PENDING approval with explicit epoch-second timestamps (the v8 `approvals` columns
+  /// are INTEGER epochs, so the sweep's `expires_ts <= now` compare is exact integer arithmetic).
+  @discardableResult
+  private func seedApproval(
+    _ queue: DatabaseQueue,
+    runId: Int64,
+    nonce: String,
+    createdEpoch: Int64,
+    expiresEpoch: Int64
+  ) throws -> Int64 {
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO approvals(run_id, session_id, state, tool, canonical_args, canonical_target,
+            args_hash, policy_version, owner_user_id, nonce, observation_message_id, tool_call_id,
+            reason, created_ts, expires_ts)
+          VALUES (?, 1, 'PENDING', 'file_write', '{}', '/w/plan.md', 'h16', 'pv16', 7, ?, 1, 'c1',
+            'ask_tier', ?, ?)
+          """,
+        arguments: [runId, nonce, createdEpoch, expiresEpoch]
+      )
+      return db.lastInsertedRowID
+    }
+  }
+
+  @Test func tickExpiresPastDuePendingRowsAndSignalsTheirWaiters() async throws {
+    // given — two runs: one approval already past its deadline, one still live (distinct runs so
+    // the partial UNIQUE-PENDING index permits both)
+    let now = Date(timeIntervalSince1970: 1_782_003_600)
+    let fixture = try makeTickFixture(now: now)
+    let expiredRun = try seedRun(fixture.queue)
+    let liveRun = try seedRun(fixture.queue)
+    let expiredId = try seedApproval(
+      fixture.queue,
+      runId: expiredRun,
+      nonce: "n-expired",
+      createdEpoch: 1_781_996_400,
+      expiresEpoch: 1_782_000_000
+    )
+    let liveId = try seedApproval(
+      fixture.queue,
+      runId: liveRun,
+      nonce: "n-live",
+      createdEpoch: 1_782_003_000,
+      expiresEpoch: 1_782_007_200
+    )
+
+    // when — one immediate sweep pass
+    await fixture.service.tick()
+
+    // then — the past-due row is EXPIRED in the DB and its waiter received denied(.expired); the
+    // live row is untouched
+    #expect(try fixture.store.approval(id: expiredId)?.state == .expired)
+    #expect(try fixture.store.approval(id: liveId)?.state == .pending)
+    #expect(await fixture.coordinator.awaitResolution(approvalId: expiredId) == .denied(.expired))
+  }
+
+  @Test func tickSignalsEverySweptRow() async throws {
+    // given — two independently past-due approvals on distinct runs
+    let now = Date(timeIntervalSince1970: 1_782_003_600)
+    let fixture = try makeTickFixture(now: now)
+    let firstRun = try seedRun(fixture.queue)
+    let secondRun = try seedRun(fixture.queue)
+    let firstId = try seedApproval(
+      fixture.queue,
+      runId: firstRun,
+      nonce: "n-1",
+      createdEpoch: 1_781_996_400,
+      expiresEpoch: 1_782_000_000
+    )
+    let secondId = try seedApproval(
+      fixture.queue,
+      runId: secondRun,
+      nonce: "n-2",
+      createdEpoch: 1_781_996_400,
+      expiresEpoch: 1_782_000_060
+    )
+
+    // when
+    await fixture.service.tick()
+
+    // then — every swept row got its own denied(.expired) signal and is EXPIRED in the DB
+    #expect(await fixture.coordinator.awaitResolution(approvalId: firstId) == .denied(.expired))
+    #expect(await fixture.coordinator.awaitResolution(approvalId: secondId) == .denied(.expired))
+    #expect(try fixture.store.approval(id: firstId)?.state == .expired)
+    #expect(try fixture.store.approval(id: secondId)?.state == .expired)
+  }
+
+  @Test func tickLeavesLiveRowsPendingAndSignalsNoOne() async throws {
+    // given — a single approval whose deadline is still in the future
+    let now = Date(timeIntervalSince1970: 1_782_003_600)
+    let fixture = try makeTickFixture(now: now)
+    let run = try seedRun(fixture.queue)
+    let liveId = try seedApproval(
+      fixture.queue,
+      runId: run,
+      nonce: "n-live",
+      createdEpoch: 1_782_003_000,
+      expiresEpoch: 1_782_007_200
+    )
+
+    // when
+    await fixture.service.tick()
+
+    // then — nothing swept: the row stays PENDING (a never-signaled id cannot be awaited without
+    // hanging, so the untouched persisted row is the observable proof no waiter was signaled)
+    #expect(try fixture.store.approval(id: liveId)?.state == .pending)
+  }
+
+  @Test func runTicksImmediatelyThenSleepsTheTickInterval() async throws {
+    // given — a recording store and a sleep that SUSPENDS (never blocks the cooperative thread,
+    // TESTING §8) then throws to end the loop like a graceful shutdown
+    let store = RecordingApprovalStore()
+    let recorder = ExpirySleepRecorder()
+    let service = ApprovalExpiryService(
+      approvals: store,
+      coordinator: ApprovalCoordinator(),
+      now: { Date(timeIntervalSince1970: 1_782_003_600) },
+      sleep: { duration in
+        try? await Task.sleep(for: .milliseconds(1))
+        recorder.append(duration)
+        throw CancellationError()
+      },
+      logger: TestLog.silent
+    )
+
+    // when — restart recovery: the first sweep happens BEFORE the first sleep
+    try await service.run()
+
+    // then
+    #expect(store.sweeps == 1)
+    #expect(recorder.durations == [ApprovalExpiryService.tickInterval])
+  }
+}

--- a/Tests/ClawGatewayTests/Services/TelegramPollerServiceTests.swift
+++ b/Tests/ClawGatewayTests/Services/TelegramPollerServiceTests.swift
@@ -125,6 +125,22 @@ private actor BlockingTurnRunner: TurnDispatching {
     try await task.value  // returns promptly, no throw
   }
 
+  @Test func requestsCallbackQueryUpdates() async throws {
+    // given — an idle poller (no batches) so it only long-polls
+    let stack = try makeStack(batches: [], allowed: [42])
+
+    // when
+    let task = Task { try await stack.poller.run() }
+    await stack.transport.waitForPolls(atLeast: 1)
+    task.cancel()
+    try await task.value
+
+    // then — callback_query rides the same allowed_updates as messages/edits (spec §6.1)
+    #expect(
+      await stack.transport.lastAllowedUpdates == ["message", "edited_message", "callback_query"]
+    )
+  }
+
   @Test func cursorAdvancesAfterEnqueueWithoutWaitingForTurnCompletion() async throws {
     // given
     let queue = try ClawDatabase.makeInMemoryQueue()

--- a/Tests/ClawGatewayTests/Services/TelegramPollerServiceTests.swift
+++ b/Tests/ClawGatewayTests/Services/TelegramPollerServiceTests.swift
@@ -79,6 +79,7 @@ private actor BlockingTurnRunner: TurnDispatching {
       turnRunner: dispatcher,
       lanes: SessionLaneRegistry(),
       schedule: makeIdleScheduleSurface(writer: queue),
+      coordinator: ApprovalCoordinator(),
       logger: TestLog.silent
     )
     let cursor = UpdateCursorStoreGRDB(writer: queue)
@@ -162,6 +163,7 @@ private actor BlockingTurnRunner: TurnDispatching {
       turnRunner: runner,
       lanes: SessionLaneRegistry(),
       schedule: makeIdleScheduleSurface(writer: queue),
+      coordinator: ApprovalCoordinator(),
       logger: TestLog.silent
     )
     let cursor = UpdateCursorStoreGRDB(writer: queue)

--- a/Tests/ClawGatewayTests/Support/MemoryRoutingHarness.swift
+++ b/Tests/ClawGatewayTests/Support/MemoryRoutingHarness.swift
@@ -47,6 +47,7 @@ struct MemoryRoutingHarness {
       turnRunner: dispatcher,
       lanes: SessionLaneRegistry(),
       schedule: makeIdleScheduleSurface(writer: queue),
+      coordinator: ApprovalCoordinator(),
       logger: TestLog.silent
     )
 

--- a/Tests/ClawGatewayTests/Support/TestSupport.swift
+++ b/Tests/ClawGatewayTests/Support/TestSupport.swift
@@ -70,6 +70,7 @@ actor RecordingTransport: TelegramTransport {
   private(set) var drafts: [DraftRecord] = []
   private(set) var sendAttempts = 0
   private(set) var pollCount = 0
+  private(set) var lastAllowedUpdates: [String] = []
   private var batches: [[RawUpdate]]
   private let onExhausted: TelegramError?
   private let sendError: TelegramError?
@@ -106,6 +107,7 @@ actor RecordingTransport: TelegramTransport {
     allowedUpdates: [String]
   ) async throws -> [RawUpdate] {
     pollCount += 1
+    lastAllowedUpdates = allowedUpdates
     resumeWaiters(.poll, reached: pollCount)
     if batches.isEmpty {
       if let onExhausted {

--- a/Tests/ClawTelegramTests/Wire/CallbackUpdateMappingTests.swift
+++ b/Tests/ClawTelegramTests/Wire/CallbackUpdateMappingTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+
+@testable import ClawCore
+@testable import ClawTelegram
+
+@Suite struct CallbackUpdateMappingTests {
+  @Test func mapsCallbackQueryIntoRawUpdateCallback() throws {
+    // given — a Bot API update carrying only a callback_query (no message/edited_message)
+    let json = """
+      {"update_id":77,"callback_query":{"id":"cbX","from":{"id":42},
+      "message":{"message_id":9,"chat":{"id":99}},"data":"apr:NONCE:y"}}
+      """
+
+    // when
+    let update = try JSONDecoder().decode(TUpdate.self, from: Data(json.utf8))
+    let raw = update.toRawUpdate()
+
+    // then — the callback rides RawUpdate.callback; message/edited stay nil; chat/message ids come
+    // from the prompt message (callback.message)
+    let callback = try #require(raw.callback)
+    #expect(raw.message == nil)
+    #expect(raw.editedMessage == nil)
+    #expect(callback.callbackId == "cbX")
+    #expect(callback.fromUserId == 42)
+    #expect(callback.chatId == 99)
+    #expect(callback.messageId == 9)
+    #expect(callback.data == "apr:NONCE:y")
+  }
+
+  @Test func plainMessageUpdateHasNilCallback() throws {
+    // given
+    let json = """
+      {"update_id":78,"message":{"message_id":3,"from":{"id":42},"chat":{"id":42},"text":"hi"}}
+      """
+
+    // when
+    let raw = try JSONDecoder().decode(TUpdate.self, from: Data(json.utf8)).toRawUpdate()
+
+    // then
+    #expect(raw.callback == nil)
+    #expect(raw.message != nil)
+  }
+}


### PR DESCRIPTION
## What this does

Makes durable tool-approval **resolution** live end to end. A suspended run (parked at `AWAITING_APPROVAL` with a persisted `approvals` row) can now be resolved three ways: the owner taps an authenticated inline button, the approval expires, or `/stop`//`new` clears it. All three survive a restart. The fabric stays dormant in production because no registered tool declares the `ask` tier yet, so no run can actually suspend until the write tools land in the next increment.

Builds on the suspend-path work in #37.

## The resolution flow

- **Callback intake and auth.** The poller now requests `callback_query`, and `MessageRouter` routes callbacks through a fail-closed §6.2 chain: allowlist, then owner binding, then nonce-only lookup, then a single-use CAS. A failure at any step audits `messageIn`/`forbidden`, answers a neutral toast, and leaves the row untouched.
- **Approve.** A valid tap CASes the row and signals a process-local coordinator. The parked `ApprovalWaiter` then runs the recorded canonical args through the tool directly, with no fresh model turn, no gate re-trip, and no timeout-abandon race. It fills the placeholder observation in place, flips the run back to `RUNNING`, and continues the turn with the run's budget counters carried over.
- **Deny, expiry, cancel.** Owner deny, the 60 s expiry ticker, and `/stop`//`new` each write a synthetic observation in place (so history never holds a dangling `tool_call`) and drive the run terminal. Each approval audit rides the transaction that records the state change. The waiter handles only the observation, the run transition, the owner notice, and the button disarm.
- **Restart survival.** Boot reconciliation cleans terminal-run orphans, re-parks unexpired approvals on their session lanes so buttons and the FIFO queue-behind contract survive a reboot, sweeps expired ones to a denial, and resumes the crash-window case (`APPROVED` before execution) behind a `policy_version` re-validation belt.

## Review hardening folded in

- **Cancel-vs-signal race** on live `/stop`//`new`: the handler now signals the coordinator before it cancels the lane, so the parked waiter fills the observation instead of exiting on the cancel. A deterministic single-lane test covers it.
- **Deny-side crash-window belt.** A crash between a deny/expiry CAS and the waiter's fill used to strand the run in `AWAITING_APPROVAL` (the mirror image of the existing `APPROVED` belt). Boot reconciliation now finalizes `REJECTED` and `EXPIRED` rows left on `AWAITING_APPROVAL` runs.
- `MessageRouter`'s coordinator is now a required dependency. The old defaulted instance let a call site silently wire up a coordinator no waiter listens to.
- A new CI lane runs the concurrency-sensitive suites under `LIBDISPATCH_COOPERATIVE_POOL_STRICT=1`, the env var that forces a single cooperative worker. `SWIFT_MAX_CONCURRENCY_THREADS` only caps at the core count, so it gave no single-lane discrimination and the race guard would have passed CI regardless of ordering.

## Testing

`scripts/lint.sh` clean, `swift build` clean, `swift test` at 968 tests across 161 suites. The four concurrency suites also pass under the single-thread lane. actionlint and zizmor pass on the workflow change.

## Known follow-ups

- `TurnRunner.swift` still has one raw `Date()` on the proactive-breaker notice path, unrelated to resume persistence.
- The two Linux CI jobs share a `.build` cache key. Harmless; could be split later.
