### PR TITLE
Sandbox execution foundation: contracts, config, and provenance-preserving resume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,20 @@ CLAW_SEARCH_API_KEY=
 # a fresh DNS canary probe confirms fake-IP mode; set it only for non-default pools.
 CLAW_WEBFETCH_EXEMPT_CIDRS=
 
+# Sandboxed code execution (macOS 26 arm64 only). Disabled by default; when enabled, image is
+# required and must be a digest-pinned reference from the registry allowlist.
+CLAW_EXEC_ENABLED=false
+CLAW_EXEC_IMAGE=
+# comma-separated lowercase registry hosts; default cgr.dev
+CLAW_EXEC_IMAGE_REGISTRIES=cgr.dev
+# VM caps: memory 256..8192 MiB (default 1024); CPUs >=1 and <= host CPUs when enabled (default 4)
+CLAW_EXEC_MEMORY_MIB=1024
+CLAW_EXEC_CPUS=4
+# guest program budget in seconds, 1..300 (default 30)
+CLAW_EXEC_TIMEOUT=30
+# second switch for full sandbox network egress; false by default
+CLAW_EXEC_ALLOW_EGRESS=false
+
 # Agentic loop bounds (optional; omit to use built-in defaults). Per run: max LLM round-trips and
 # max total tool calls.
 CLAW_MAX_TURNS=

--- a/Package.swift
+++ b/Package.swift
@@ -70,7 +70,7 @@ let package = Package(
       ]
     ),
     .target(name: "ClawTools", dependencies: ["ClawCore"]),
-    .target(name: "ClawTestSupport"),
+    .target(name: "ClawTestSupport", dependencies: ["ClawCore"]),
     .target(
       name: "ClawGateway",
       dependencies: [
@@ -91,7 +91,7 @@ let package = Package(
         .product(name: "Logging", package: "swift-log"),
       ]
     ),
-    .testTarget(name: "ClawCoreTests", dependencies: ["ClawCore"]),
+    .testTarget(name: "ClawCoreTests", dependencies: ["ClawCore", "ClawTestSupport"]),
     .testTarget(
       name: "ClawSecretsTests",
       dependencies: [

--- a/Sources/ClawCore/Config/AppConfig.swift
+++ b/Sources/ClawCore/Config/AppConfig.swift
@@ -1,5 +1,134 @@
 import Foundation
 
+public struct PinnedImageReference: Sendable, Equatable, CustomStringConvertible {
+  public let repository: String
+  public let digest: String
+
+  public var registryHost: String {
+    String(repository.split(separator: "/", maxSplits: 1)[0]).lowercased()
+  }
+
+  public var description: String {
+    "\(repository)@sha256:\(digest)"
+  }
+
+  public static func parse(_ rawValue: String) -> PinnedImageReference? {
+    guard rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines) else {
+      return nil
+    }
+    guard rawValue.contains("://") == false else {
+      return nil
+    }
+    guard let separator = rawValue.range(of: "@sha256:") else {
+      return nil
+    }
+    guard
+      rawValue.range(
+        of: "@sha256:",
+        range: separator.upperBound..<rawValue.endIndex
+      ) == nil
+    else {
+      return nil
+    }
+
+    let repository = String(rawValue[..<separator.lowerBound])
+    let digest = String(rawValue[separator.upperBound...])
+    guard digest.count == 64, digest.allSatisfy({ "0123456789abcdef".contains($0) }) else {
+      return nil
+    }
+
+    let components = repository.split(separator: "/", omittingEmptySubsequences: false)
+    guard components.count >= 2 else {
+      return nil
+    }
+    let registry = String(components[0])
+    guard isValidRegistryHost(registry) else {
+      return nil
+    }
+    let repositoryComponents = components.dropFirst().map(String.init)
+    guard repositoryComponents.allSatisfy(isValidRepositoryComponent) else {
+      return nil
+    }
+
+    return PinnedImageReference(repository: repository, digest: digest)
+  }
+
+  static func isValidRegistryHost(_ rawHost: String) -> Bool {
+    guard rawHost == rawHost.lowercased(), rawHost.isEmpty == false else {
+      return false
+    }
+    let pieces = rawHost.split(separator: ":", omittingEmptySubsequences: false)
+    guard pieces.count <= 2 else {
+      return false
+    }
+    let hostname = String(pieces[0])
+    if pieces.count == 2 {
+      let rawPort = pieces[1]
+      guard
+        rawPort.isEmpty == false,
+        rawPort.allSatisfy({ "0123456789".contains($0) }),
+        let port = Int(rawPort),
+        (1...65_535).contains(port)
+      else {
+        return false
+      }
+    }
+    guard hostname != "localhost", hostname.contains("."), hostname.contains("[") == false else {
+      return false
+    }
+    let labels = hostname.split(separator: ".", omittingEmptySubsequences: false)
+    guard labels.allSatisfy(isValidDNSLabel) else {
+      return false
+    }
+    guard labels.allSatisfy({ Int($0) != nil }) == false else {
+      return false
+    }
+    return true
+  }
+}
+
+// MARK: - Image Reference Validation
+
+private extension PinnedImageReference {
+  static func isValidDNSLabel(_ label: Substring) -> Bool {
+    guard (1...63).contains(label.count), label.first != "-", label.last != "-" else {
+      return false
+    }
+    return label.allSatisfy { character in
+      "abcdefghijklmnopqrstuvwxyz0123456789-".contains(character)
+    }
+  }
+
+  static func isValidRepositoryComponent(_ component: String) -> Bool {
+    guard component.isEmpty == false, component != ".", component != ".." else {
+      return false
+    }
+    return component.allSatisfy { character in
+      "abcdefghijklmnopqrstuvwxyz0123456789._-".contains(character)
+    }
+  }
+}
+
+public struct ExecConfig: Sendable, Equatable {
+  public let enabled: Bool
+  public let image: PinnedImageReference?
+  public let imageRegistryAllowlist: [String]
+  public let memoryMiB: Int
+  public let cpus: Int
+  public let timeoutSeconds: Int
+  public let allowEgress: Bool
+
+  public static let disabledDefault = ExecConfig(
+    enabled: false,
+    image: nil,
+    imageRegistryAllowlist: ["cgr.dev"],
+    memoryMiB: 1024,
+    cpus: 4,
+    timeoutSeconds: 30,
+    allowEgress: false
+  )
+}
+
 public struct AppConfig: Sendable, Equatable {
   public enum EnvKey {
     static let allowlist = "CLAW_ALLOWLIST"
@@ -32,6 +161,14 @@ public struct AppConfig: Sendable, Equatable {
     static let approvalExpiry = "CLAW_APPROVAL_EXPIRY"
 
     public static let webFetchExemptCIDRs = "CLAW_WEBFETCH_EXEMPT_CIDRS"
+
+    static let execEnabled = "CLAW_EXEC_ENABLED"
+    static let execImage = "CLAW_EXEC_IMAGE"
+    static let execImageRegistries = "CLAW_EXEC_IMAGE_REGISTRIES"
+    static let execMemoryMiB = "CLAW_EXEC_MEMORY_MIB"
+    static let execCPUs = "CLAW_EXEC_CPUS"
+    static let execTimeout = "CLAW_EXEC_TIMEOUT"
+    static let execAllowEgress = "CLAW_EXEC_ALLOW_EGRESS"
   }
 
   private enum EnvDefaults {
@@ -53,6 +190,11 @@ public struct AppConfig: Sendable, Equatable {
     static let approvalExpirySeconds = 3600
     static let approvalExpiryFloor = 60
     static let approvalExpiryCeiling = 86_400
+
+    static let execImageRegistries = ["cgr.dev"]
+    static let execMemoryMiB = 1024
+    static let execCPUs = 4
+    static let execTimeoutSeconds = 30
   }
 
   private static let stateRootPermissions = 0o700
@@ -77,6 +219,8 @@ public struct AppConfig: Sendable, Equatable {
 
   public let webFetchExemptCIDRs: [CIDR]
 
+  public let exec: ExecConfig
+
   public init(
     allowlist: Set<Int64>,
     stateRoot: URL,
@@ -92,7 +236,8 @@ public struct AppConfig: Sendable, Equatable {
     heartbeatQuietHours: QuietHours,
     heartbeatMaxPerDay: Int,
     approvalExpirySeconds: Int,
-    webFetchExemptCIDRs: [CIDR]
+    webFetchExemptCIDRs: [CIDR],
+    exec: ExecConfig
   ) {
     self.allowlist = allowlist
     self.stateRoot = stateRoot
@@ -109,6 +254,7 @@ public struct AppConfig: Sendable, Equatable {
     self.heartbeatMaxPerDay = heartbeatMaxPerDay
     self.approvalExpirySeconds = approvalExpirySeconds
     self.webFetchExemptCIDRs = webFetchExemptCIDRs
+    self.exec = exec
   }
 
   /// Loads and validates non-secret config from the environment. Secrets (the bot token / LLM key)
@@ -143,6 +289,7 @@ public struct AppConfig: Sendable, Equatable {
 
     let approvalExpirySeconds = try parseApprovalExpiry(env[EnvKey.approvalExpiry])
     let webFetchExemptCIDRs = try parseWebFetchExemptCIDRs(from: env[EnvKey.webFetchExemptCIDRs])
+    let exec = try parseExecConfig(from: env)
 
     return AppConfig(
       allowlist: allowlist,
@@ -159,7 +306,8 @@ public struct AppConfig: Sendable, Equatable {
       heartbeatQuietHours: heartbeat.quietHours,
       heartbeatMaxPerDay: heartbeat.maxPerDay,
       approvalExpirySeconds: approvalExpirySeconds,
-      webFetchExemptCIDRs: webFetchExemptCIDRs
+      webFetchExemptCIDRs: webFetchExemptCIDRs,
+      exec: exec
     )
   }
 }
@@ -515,6 +663,108 @@ private extension AppConfig {
       throw ConfigError.invalidApprovalExpiry(trimmed)
     }
 
+    return value
+  }
+}
+
+// MARK: - Execution Parsing
+
+private extension AppConfig {
+  static func parseExecConfig(from env: [String: String]) throws -> ExecConfig {
+    let enabled = try boolValue(
+      env[EnvKey.execEnabled],
+      key: EnvKey.execEnabled,
+      default: false
+    )
+    let registryAllowlist = try parseExecRegistryAllowlist(env[EnvKey.execImageRegistries])
+    let rawImage = env[EnvKey.execImage] ?? ""
+    let image: PinnedImageReference?
+    if rawImage.isEmpty {
+      image = nil
+    } else {
+      guard let parsed = PinnedImageReference.parse(rawImage) else {
+        throw ConfigError.invalidExecImage(rawImage)
+      }
+      guard registryAllowlist.contains(parsed.registryHost) else {
+        throw ConfigError.execImageRegistryNotAllowed(parsed.registryHost)
+      }
+      image = parsed
+    }
+    if enabled, image == nil {
+      throw ConfigError.invalidExecImage(rawImage)
+    }
+
+    let memoryMiB = try boundedExecInt(
+      env[EnvKey.execMemoryMiB],
+      default: EnvDefaults.execMemoryMiB,
+      range: 256...8192,
+      error: ConfigError.invalidExecMemoryMiB
+    )
+    let cpus = try boundedExecInt(
+      env[EnvKey.execCPUs],
+      default: EnvDefaults.execCPUs,
+      range: 1...Int.max,
+      error: ConfigError.invalidExecCPUs
+    )
+    if enabled, cpus > ProcessInfo.processInfo.activeProcessorCount {
+      throw ConfigError.invalidExecCPUs("\(cpus)")
+    }
+    let timeoutSeconds = try boundedExecInt(
+      env[EnvKey.execTimeout],
+      default: EnvDefaults.execTimeoutSeconds,
+      range: 1...300,
+      error: ConfigError.invalidExecTimeout
+    )
+    let allowEgress = try boolValue(
+      env[EnvKey.execAllowEgress],
+      key: EnvKey.execAllowEgress,
+      default: false
+    )
+
+    return ExecConfig(
+      enabled: enabled,
+      image: image,
+      imageRegistryAllowlist: registryAllowlist,
+      memoryMiB: memoryMiB,
+      cpus: cpus,
+      timeoutSeconds: timeoutSeconds,
+      allowEgress: allowEgress
+    )
+  }
+
+  static func parseExecRegistryAllowlist(_ rawValue: String?) throws -> [String] {
+    guard let rawValue else {
+      return EnvDefaults.execImageRegistries
+    }
+    let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.isEmpty == false else {
+      throw ConfigError.invalidExecImageRegistry(rawValue)
+    }
+
+    let hosts = trimmed.split(separator: ",", omittingEmptySubsequences: false).map { part in
+      part.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+    guard hosts.isEmpty == false,
+      hosts.allSatisfy(PinnedImageReference.isValidRegistryHost)
+    else {
+      throw ConfigError.invalidExecImageRegistry(rawValue)
+    }
+    return Array(Set(hosts)).sorted()
+  }
+
+  static func boundedExecInt(
+    _ rawValue: String?,
+    default fallback: Int,
+    range: ClosedRange<Int>,
+    error: (String) -> ConfigError
+  ) throws -> Int {
+    let trimmed = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard trimmed.isEmpty == false else {
+      return fallback
+    }
+    guard let value = Int(trimmed), range.contains(value) else {
+      throw error(trimmed)
+    }
     return value
   }
 }

--- a/Sources/ClawCore/Config/AppConfig.swift
+++ b/Sources/ClawCore/Config/AppConfig.swift
@@ -57,11 +57,12 @@ public struct PinnedImageReference: Sendable, Equatable, CustomStringConvertible
     guard rawHost == rawHost.lowercased(), rawHost.isEmpty == false else {
       return false
     }
+
     let pieces = rawHost.split(separator: ":", omittingEmptySubsequences: false)
     guard pieces.count <= 2 else {
       return false
     }
-    let hostname = String(pieces[0])
+
     if pieces.count == 2 {
       let rawPort = pieces[1]
       guard
@@ -73,9 +74,12 @@ public struct PinnedImageReference: Sendable, Equatable, CustomStringConvertible
         return false
       }
     }
+
+    let hostname = String(pieces[0])
     guard hostname != "localhost", hostname.contains("."), hostname.contains("[") == false else {
       return false
     }
+
     let labels = hostname.split(separator: ".", omittingEmptySubsequences: false)
     guard labels.allSatisfy(isValidDNSLabel) else {
       return false
@@ -83,6 +87,7 @@ public struct PinnedImageReference: Sendable, Equatable, CustomStringConvertible
     guard labels.allSatisfy({ Int($0) != nil }) == false else {
       return false
     }
+
     return true
   }
 }
@@ -676,7 +681,9 @@ private extension AppConfig {
       key: EnvKey.execEnabled,
       default: false
     )
+
     let registryAllowlist = try parseExecRegistryAllowlist(env[EnvKey.execImageRegistries])
+
     let rawImage = env[EnvKey.execImage] ?? ""
     let image: PinnedImageReference?
     if rawImage.isEmpty {
@@ -690,6 +697,7 @@ private extension AppConfig {
       }
       image = parsed
     }
+
     if enabled, image == nil {
       throw ConfigError.invalidExecImage(rawImage)
     }
@@ -700,6 +708,7 @@ private extension AppConfig {
       range: 256...8192,
       error: ConfigError.invalidExecMemoryMiB
     )
+
     let cpus = try boundedExecInt(
       env[EnvKey.execCPUs],
       default: EnvDefaults.execCPUs,
@@ -709,12 +718,14 @@ private extension AppConfig {
     if enabled, cpus > ProcessInfo.processInfo.activeProcessorCount {
       throw ConfigError.invalidExecCPUs("\(cpus)")
     }
+
     let timeoutSeconds = try boundedExecInt(
       env[EnvKey.execTimeout],
       default: EnvDefaults.execTimeoutSeconds,
       range: 1...300,
       error: ConfigError.invalidExecTimeout
     )
+
     let allowEgress = try boolValue(
       env[EnvKey.execAllowEgress],
       key: EnvKey.execAllowEgress,

--- a/Sources/ClawCore/Domain/Approval/Approval.swift
+++ b/Sources/ClawCore/Domain/Approval/Approval.swift
@@ -1,4 +1,3 @@
-import Crypto
 import Foundation
 
 /// Why a non-approve resolution happened — the audit `decision` column vocabulary.
@@ -148,11 +147,7 @@ public enum ApprovalNonce {
 /// the approve CAS. One helper so the two computations can never diverge.
 public enum ApprovalArgsHash {
   public static func sha256Hex(_ canonicalArgsJSON: String) -> String {
-    SHA256.hash(data: Data(canonicalArgsJSON.utf8))
-      .map { byte in
-        String(format: "%02x", byte)
-      }
-      .joined()
+    SHA256Digest.hex(canonicalArgsJSON)
   }
 }
 

--- a/Sources/ClawCore/Domain/Execution/ExecutionContracts.swift
+++ b/Sources/ClawCore/Domain/Execution/ExecutionContracts.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+public enum ExecLanguage: String, Sendable, Equatable, Codable {
+  case python
+  case sh
+}
+
+public enum FileMode: UInt16, Sendable, Equatable {
+  case readOnly = 0o400
+  case readExecute = 0o500
+}
+
+public struct StagedFile: Sendable, Equatable {
+  public let name: String
+  public let bytes: Data
+  public let mode: FileMode
+
+  public init(name: String, bytes: Data, mode: FileMode) {
+    self.name = name
+    self.bytes = bytes
+    self.mode = mode
+  }
+}
+
+public struct ExecutionRequest: Sendable, Equatable {
+  public let language: ExecLanguage
+  public let entrypoint: StagedFile
+  public let inputs: [StagedFile]
+  public let network: Bool
+  public let timeout: Duration
+
+  public init(
+    language: ExecLanguage,
+    entrypoint: StagedFile,
+    inputs: [StagedFile],
+    network: Bool,
+    timeout: Duration
+  ) {
+    self.language = language
+    self.entrypoint = entrypoint
+    self.inputs = inputs
+    self.network = network
+    self.timeout = timeout
+  }
+}
+
+public enum ExecTermination: Sendable, Equatable {
+  case exited(code: Int32)
+  case timedOutKilled
+  case cancelled
+  case startFailed(reason: String)
+  case unavailable(reason: String)
+}
+
+public struct ExecutionResult: Sendable, Equatable {
+  public let terminationReason: ExecTermination
+  public let stdout: String
+  public let stderr: String
+  public let truncatedRawBytes: Bool
+  public let wallClock: Duration
+
+  public init(
+    terminationReason: ExecTermination,
+    stdout: String,
+    stderr: String,
+    truncatedRawBytes: Bool,
+    wallClock: Duration
+  ) {
+    self.terminationReason = terminationReason
+    self.stdout = stdout
+    self.stderr = stderr
+    self.truncatedRawBytes = truncatedRawBytes
+    self.wallClock = wallClock
+  }
+}
+
+public enum BackendAvailability: Sendable, Equatable {
+  case available(engineVersion: String)
+  case unavailable(reason: String)
+}
+
+public struct SandboxHealth: Sendable, Equatable {
+  public let available: Bool
+  public let osOK: Bool
+  public let engineVersion: String?
+  public let versionOK: Bool
+  public let imageDigestOK: Bool
+  public let capsEmpty: Bool
+  public let netIsolated: Bool
+  public let capsMatch: Bool
+  public let reaperOK: Bool
+  public let rootfsRO: Bool
+  public let stagingRO: Bool
+  public let interpretersOK: Bool
+  public let lastError: String?
+
+  public init(
+    available: Bool,
+    osOK: Bool,
+    engineVersion: String?,
+    versionOK: Bool,
+    imageDigestOK: Bool,
+    capsEmpty: Bool,
+    netIsolated: Bool,
+    capsMatch: Bool,
+    reaperOK: Bool,
+    rootfsRO: Bool,
+    stagingRO: Bool,
+    interpretersOK: Bool,
+    lastError: String?
+  ) {
+    self.available = available
+    self.osOK = osOK
+    self.engineVersion = engineVersion
+    self.versionOK = versionOK
+    self.imageDigestOK = imageDigestOK
+    self.capsEmpty = capsEmpty
+    self.netIsolated = netIsolated
+    self.capsMatch = capsMatch
+    self.reaperOK = reaperOK
+    self.rootfsRO = rootfsRO
+    self.stagingRO = stagingRO
+    self.interpretersOK = interpretersOK
+    self.lastError = lastError
+  }
+
+  public var isReady: Bool {
+    available && osOK && versionOK && imageDigestOK && capsEmpty && netIsolated && capsMatch
+      && reaperOK && rootfsRO && stagingRO && interpretersOK && lastError == nil
+  }
+
+  public static let passingForTests = SandboxHealth(
+    available: true,
+    osOK: true,
+    engineVersion: "1.1.0",
+    versionOK: true,
+    imageDigestOK: true,
+    capsEmpty: true,
+    netIsolated: true,
+    capsMatch: true,
+    reaperOK: true,
+    rootfsRO: true,
+    stagingRO: true,
+    interpretersOK: true,
+    lastError: nil
+  )
+}
+
+public protocol ExecutionBackend: Sendable {
+  func probe() async -> BackendAvailability
+  func run(_ request: ExecutionRequest) async -> ExecutionResult
+}
+
+public protocol SandboxMaintenance: Sendable {
+  func prepare() async -> SandboxHealth
+  func shutdown() async
+}

--- a/Sources/ClawCore/Domain/Policy/PolicyFingerprint.swift
+++ b/Sources/ClawCore/Domain/Policy/PolicyFingerprint.swift
@@ -28,16 +28,18 @@ public enum PolicyFingerprint {
 
   /// The static inputs: the tool-registry surface (sorted by name — each tool contributes
   /// name, canonical `.sortedKeys` parameter JSON, `riskLevel.rawValue`, and the egress label),
-  /// then the llm base URL, the search-endpoint presence, the canonical workspace root, and the
-  /// web_fetch SSRF exemption list (sorted, so config order cannot move the hash). The exemption
-  /// list is egress policy: a change to it voids an outstanding `web_fetch` approval. Computed
-  /// once at the composition root and injected into `ContextBuilder`.
+  /// then the llm base URL, the search-endpoint presence, the canonical workspace root, the
+  /// web_fetch SSRF exemption list, and the normalized exec block (enabled state, pinned image,
+  /// sorted registry allowlist, caps, timeout, and egress switch). Sorted lists mean config
+  /// order cannot move the hash; a change to any egress-policy input voids an outstanding
+  /// approval. Computed once at the composition root and injected into `ContextBuilder`.
   public static func staticSubhash(
     tools: [ToolDefinition],
     llmBaseURL: String,
     searchEndpointPresent: Bool,
     workspaceRoot: String,
-    webFetchExemptCIDRs: [CIDR]
+    webFetchExemptCIDRs: [CIDR],
+    exec: ExecConfig
   ) -> String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.sortedKeys]
@@ -62,6 +64,15 @@ public enum PolicyFingerprint {
     parts.append(workspaceRoot)
     let exemptLabel = webFetchExemptCIDRs.map(\.description).sorted().joined(separator: ",")
     parts.append("webfetch_exempt:" + exemptLabel)
+    parts.append("exec.enabled:\(exec.enabled)")
+    parts.append("exec.image:\(exec.image?.description ?? "absent")")
+    parts.append(
+      "exec.registries:" + exec.imageRegistryAllowlist.sorted().joined(separator: ",")
+    )
+    parts.append("exec.memory_mib:\(exec.memoryMiB)")
+    parts.append("exec.cpus:\(exec.cpus)")
+    parts.append("exec.timeout_s:\(exec.timeoutSeconds)")
+    parts.append("exec.allow_egress:\(exec.allowEgress)")
 
     return hash(parts: parts)
   }

--- a/Sources/ClawCore/Domain/Support/SHA256Digest.swift
+++ b/Sources/ClawCore/Domain/Support/SHA256Digest.swift
@@ -1,0 +1,14 @@
+import Crypto
+import Foundation
+
+public enum SHA256Digest {
+  public static func hex(_ data: Data) -> String {
+    SHA256.hash(data: data).map { byte in
+      String(format: "%02x", byte)
+    }.joined()
+  }
+
+  public static func hex(_ text: String) -> String {
+    hex(Data(text.utf8))
+  }
+}

--- a/Sources/ClawCore/Errors/ConfigError.swift
+++ b/Sources/ClawCore/Errors/ConfigError.swift
@@ -13,6 +13,12 @@ public enum ConfigError: Error, Sendable, Equatable {
   case invalidApprovalExpiry(String)
   case invalidWebFetchExemptCIDR(String)
   case heartbeatOwnerUnresolved(allowlistCount: Int)
+  case invalidExecImage(String)
+  case invalidExecImageRegistry(String)
+  case execImageRegistryNotAllowed(String)
+  case invalidExecMemoryMiB(String)
+  case invalidExecCPUs(String)
+  case invalidExecTimeout(String)
 
   public var exitCode: Int32 {
     switch self {
@@ -30,6 +36,12 @@ public enum ConfigError: Error, Sendable, Equatable {
     case .invalidApprovalExpiry: ClawExitCode.configInvalid.rawValue
     case .invalidWebFetchExemptCIDR: ClawExitCode.configInvalid.rawValue
     case .heartbeatOwnerUnresolved: ClawExitCode.configInvalid.rawValue
+    case .invalidExecImage: ClawExitCode.configInvalid.rawValue
+    case .invalidExecImageRegistry: ClawExitCode.configInvalid.rawValue
+    case .execImageRegistryNotAllowed: ClawExitCode.configInvalid.rawValue
+    case .invalidExecMemoryMiB: ClawExitCode.configInvalid.rawValue
+    case .invalidExecCPUs: ClawExitCode.configInvalid.rawValue
+    case .invalidExecTimeout: ClawExitCode.configInvalid.rawValue
     }
   }
 }

--- a/Sources/ClawCore/Persistence/RunStore.swift
+++ b/Sources/ClawCore/Persistence/RunStore.swift
@@ -68,6 +68,48 @@ public struct SuspendedCommitReceipt: Sendable, Equatable {
   }
 }
 
+/// The safe, owner-facing rendering of an approved action for the `.toolCall` audit row: the tool
+/// name plus an already-redacted argument summary. The raw canonical arguments are never audited.
+public struct ApprovedExecutionAudit: Sendable, Equatable {
+  public let tool: String
+  public let argsRedacted: String
+
+  public init(tool: String, argsRedacted: String) {
+    self.tool = tool
+    self.argsRedacted = argsRedacted
+  }
+}
+
+/// Everything the post-execution resume persists for a claimed observation in ONE transaction: the
+/// observation `content` and its `status`, the state-guarded session provenance flags, and the
+/// `.toolCall` audit rendered from `audit`. `setTainted`/`setPrivateData` are applied only for a
+/// current or `/stop`-cancelled run; a superseded run keeps its flags off so the fresh window stays
+/// clean while its old transcript and audit still record what ran.
+public struct ClaimedObservationFill: Sendable, Equatable {
+  public let content: String
+  public let status: ToolObservationStatus
+  public let setTainted: Bool
+  public let setPrivateData: Bool
+  public let audit: ApprovedExecutionAudit
+  public let now: Date
+
+  public init(
+    content: String,
+    status: ToolObservationStatus,
+    setTainted: Bool,
+    setPrivateData: Bool,
+    audit: ApprovedExecutionAudit,
+    now: Date
+  ) {
+    self.content = content
+    self.status = status
+    self.setTainted = setTainted
+    self.setPrivateData = setPrivateData
+    self.audit = audit
+    self.now = now
+  }
+}
+
 public protocol RunStore: Sendable {
   /// PENDING → RUNNING through `RunFSM`, returning the run's origin in the same write; nil means
   /// the run is absent or no longer pending (one query, no separate origin read). `policyVersion`
@@ -140,23 +182,27 @@ public protocol RunStore: Sendable {
     notResumableObservationContent: String,
     now: Date
   ) throws(StoreError) -> ApprovedExecutionClaim
-  /// Approve resume, post-execution half: UPDATE the claimed placeholder observation in place
-  /// with the tool's real result. Only ever called after `claimApprovedExecution` returned
-  /// `.committed` for the same ids.
+  /// Approve resume, post-execution half: UPDATE the claimed placeholder observation in place with
+  /// the tool's real result, apply the state-guarded taint/private-data provenance, and append the
+  /// `.toolCall` audit — all in ONE transaction, so a fault rolls back content, flags, and audit
+  /// together. Only ever called after `claimApprovedExecution` returned `.committed` for the same
+  /// ids.
   func fillClaimedObservation(
     runId: Int64,
     observationMessageId: Int64,
-    content: String
+    fill: ClaimedObservationFill
   ) throws(StoreError)
   /// memory_write fused path (exactly-once): the memory item insert (via
-  /// `MemoryStoreGRDB.insertItem`) and the observation UPDATE share ONE txn, gated by the SAME
-  /// placeholder + AWAITING_APPROVAL → RUNNING guards as `claimApprovedExecution` — the side
-  /// effect is in-DB, so claim and effect fuse instead of splitting.
+  /// `MemoryStoreGRDB.insertItem`), the observation UPDATE, and the `.toolCall` audit share ONE
+  /// txn, gated by the SAME placeholder + AWAITING_APPROVAL → RUNNING guards as
+  /// `claimApprovedExecution` — the side effect is in-DB, so claim and effect fuse instead of
+  /// splitting.
   func applyApprovedMemoryWrite(  // swiftlint:disable:this function_parameter_count
     runId: Int64,
     observationMessageId: Int64,
     item: NewMemoryItem,
     observationContent: String,
+    audit: ApprovedExecutionAudit,
     notResumableObservationContent: String,
     now: Date
   ) throws(StoreError) -> ApprovedExecutionClaim

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB+SuspendResume.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB+SuspendResume.swift
@@ -122,15 +122,16 @@ extension RunStoreGRDB {
   public func fillClaimedObservation(
     runId: Int64,
     observationMessageId: Int64,
-    content: String
+    fill: ClaimedObservationFill
   ) throws(StoreError) {
     try database.writeMapping { db in
-      try Self.fillApprovedObservation(
+      try Self.fillClaimedObservation(
         db,
         runId: runId,
-        messageId: observationMessageId,
-        content: content
+        observationMessageId: observationMessageId,
+        fill: fill
       )
+      try claimedFillFault()
     }
   }
 
@@ -139,6 +140,7 @@ extension RunStoreGRDB {
     observationMessageId: Int64,
     item: NewMemoryItem,
     observationContent: String,
+    audit: ApprovedExecutionAudit,
     notResumableObservationContent: String,
     now: Date
   ) throws(StoreError) -> ApprovedExecutionClaim {
@@ -153,16 +155,24 @@ extension RunStoreGRDB {
       guard claim == .committed else {
         return claim
       }
-      // Exactly-once: the item insert shares this transaction with the observation fill, both
-      // gated by the claim guards above — the same db-scoped static `applyRemember` uses;
-      // MemoryStore.append would open its own txn and could not fuse.
+      // Exactly-once: the item insert shares this transaction with the observation fill and its
+      // audit, all gated by the claim guards above — the same db-scoped static `applyRemember`
+      // uses; MemoryStore.append would open its own txn and could not fuse.
       _ = try MemoryStoreGRDB.insertItem(db, item: item, now: now)
-      try Self.fillApprovedObservation(
+      try Self.fillClaimedObservation(
         db,
         runId: runId,
-        messageId: observationMessageId,
-        content: observationContent
+        observationMessageId: observationMessageId,
+        fill: ClaimedObservationFill(
+          content: observationContent,
+          status: .ok,
+          setTainted: false,
+          setPrivateData: false,
+          audit: audit,
+          now: now
+        )
       )
+      try claimedFillFault()
       return .committed
     }
   }
@@ -284,6 +294,61 @@ extension RunStoreGRDB {
     try db.execute(
       sql: "UPDATE messages SET content = ? WHERE id = ? AND run_id = ? AND role = 'tool'",
       arguments: [content, messageId, runId]
+    )
+  }
+
+  /// Fills a claimed observation with its result, the state-guarded provenance flags, and the
+  /// `.toolCall` audit in the caller's transaction so all three commit or roll back together.
+  static func fillClaimedObservation(
+    _ db: Database,
+    runId: Int64,
+    observationMessageId: Int64,
+    fill: ClaimedObservationFill
+  ) throws {
+    guard
+      let row = try Row.fetchOne(
+        db,
+        sql: "SELECT session_id, state FROM runs WHERE id = ?",
+        arguments: [runId]
+      ),
+      let state = RunState(rawValue: row["state"])
+    else {
+      throw StoreError.unexpected("run \(runId) is missing or has an unrecognized state")
+    }
+    let sessionId: Int64 = row["session_id"]
+
+    try fillApprovedObservation(
+      db,
+      runId: runId,
+      messageId: observationMessageId,
+      content: fill.content
+    )
+
+    // Provenance follows the run that claimed the action: a running or `/stop`-cancelled window
+    // still owns the taint, but a `/new`-superseded window already detainted, so re-flagging it
+    // would recontaminate the fresh window. The observation and audit above stay truthful either way.
+    if state == .running || state == .cancelled {
+      if fill.setTainted {
+        try setSessionTainted(db, sessionId: sessionId, now: fill.now)
+      }
+      if fill.setPrivateData {
+        try setSessionPrivateData(db, sessionId: sessionId, now: fill.now)
+      }
+    }
+
+    try AuditLogGRDB.insertAudit(
+      db,
+      AuditEvent(
+        actor: .assistant,
+        action: .toolCall,
+        tool: fill.audit.tool,
+        argsRedacted: fill.audit.argsRedacted,
+        resultSize: fill.content.utf8.count,
+        decision: fill.status.rawValue,
+        runId: runId,
+        sessionId: sessionId,
+        ts: fill.now
+      )
     )
   }
 }

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -5,17 +5,20 @@ import GRDB
 public struct RunStoreGRDB: RunStore {
   let database: MappedDatabase
   let suspendCommitFault: @Sendable () throws -> Void
+  let claimedFillFault: @Sendable () throws -> Void
 
   public init(writer: any DatabaseWriter) {
-    self.init(writer: writer, suspendCommitFault: {})
+    self.init(writer: writer, suspendCommitFault: {}, claimedFillFault: {})
   }
 
   init(
     writer: any DatabaseWriter,
-    suspendCommitFault: @escaping @Sendable () throws -> Void
+    suspendCommitFault: @escaping @Sendable () throws -> Void,
+    claimedFillFault: @escaping @Sendable () throws -> Void = {}
   ) {
     database = MappedDatabase(writer: writer)
     self.suspendCommitFault = suspendCommitFault
+    self.claimedFillFault = claimedFillFault
   }
 }
 

--- a/Sources/ClawGateway/Approval/ApprovedActionExecutor.swift
+++ b/Sources/ClawGateway/Approval/ApprovedActionExecutor.swift
@@ -54,23 +54,22 @@ public struct ApprovedActionExecutor: ApprovedActionExecuting {
   static let notResumableObservationContent =
     "The run was stopped before this approved action executed; nothing ran."
 
-  /// Placeholder audit rendering while the exact-value redactor is not yet injected: the executor
-  /// never writes the approval's raw canonical arguments into the audit log.
-  private static let opaqueApprovedArguments = "[REDACTED:approved-arguments]"
-
   private let tools: [String: any Tool]
   private let runs: any RunStore
+  private let redactArguments: @Sendable (String) -> String
   private let now: @Sendable () -> Date
   private let logger: Logger
 
   public init(
     tools: [String: any Tool],
     runs: any RunStore,
+    redactArguments: @escaping @Sendable (String) -> String,
     now: @escaping @Sendable () -> Date = { Date() },
     logger: Logger
   ) {
     self.tools = tools
     self.runs = runs
+    self.redactArguments = redactArguments
     self.now = now
     self.logger = logger
   }
@@ -114,48 +113,60 @@ private extension ApprovedActionExecutor {
       break
     }
 
-    let content = await executedContent(for: approval)
+    let payload = await executedPayload(for: approval)
 
     do {
       try runs.fillClaimedObservation(
         runId: approval.runId,
         observationMessageId: approval.observationMessageId,
         fill: ClaimedObservationFill(
-          content: content,
-          status: .ok,
-          setTainted: false,
-          setPrivateData: false,
-          audit: ApprovedExecutionAudit(
-            tool: approval.tool,
-            argsRedacted: Self.opaqueApprovedArguments
-          ),
+          content: payload.content,
+          status: payload.status,
+          setTainted: payload.ingestedUntrusted,
+          setPrivateData: payload.readPrivateData,
+          audit: audit(for: approval),
           now: now()
         )
       )
     } catch {
       logger.error("recording the executed result failed for run \(approval.runId): \(error)")
-      return ApprovedExecutionOutcome(observationContent: content, commit: .recordFailed)
+      return ApprovedExecutionOutcome(
+        observationContent: payload.content,
+        commit: .recordFailed
+      )
     }
-    return ApprovedExecutionOutcome(observationContent: content, commit: .committed)
+    return ApprovedExecutionOutcome(observationContent: payload.content, commit: .committed)
   }
 
-  /// Runs the claimed action and returns the observation content — a truthful error line when the
+  /// Runs the claimed action and returns its full payload — a truthful error payload when the
   /// recorded tool vanished or its args no longer parse.
-  func executedContent(for approval: Approval) async -> String {
+  func executedPayload(for approval: Approval) async -> ToolPayload {
     guard
       let tool = tools[approval.tool],
       let arguments = JSONValue.parse(approval.canonicalArgsJSON)
     else {
       logger.error("approved action \(approval.tool) has no registered tool or unparsable args")
-      return "That action could not run because its tool is no longer available."
+      return ToolPayload(
+        content: "That action could not run because its tool is no longer available.",
+        status: .error,
+        ingestedUntrusted: false
+      )
     }
     // Run to completion on the waiter task — direct await, NEVER `executeWithTimeout`'s
     // abandon-on-timeout race, so the observation is always truthful (file_write is atomic).
-    let payload = await tool.execute(
+    return await tool.execute(
       arguments: arguments,
       canonicalTarget: approval.canonicalTarget
     )
-    return payload.content
+  }
+
+  /// Renders the recorded args through the injected exact-secret redactor so raw canonical
+  /// arguments never enter the audit log.
+  func audit(for approval: Approval) -> ApprovedExecutionAudit {
+    ApprovedExecutionAudit(
+      tool: approval.tool,
+      argsRedacted: redactArguments(approval.canonicalArgsJSON)
+    )
   }
 }
 
@@ -190,10 +201,7 @@ private extension ApprovedActionExecutor {
         observationMessageId: approval.observationMessageId,
         item: request.item,
         observationContent: content,
-        audit: ApprovedExecutionAudit(
-          tool: approval.tool,
-          argsRedacted: Self.opaqueApprovedArguments
-        ),
+        audit: audit(for: approval),
         notResumableObservationContent: Self.notResumableObservationContent,
         now: now()
       )
@@ -249,10 +257,7 @@ private extension ApprovedActionExecutor {
           status: .error,
           setTainted: false,
           setPrivateData: false,
-          audit: ApprovedExecutionAudit(
-            tool: approval.tool,
-            argsRedacted: Self.opaqueApprovedArguments
-          ),
+          audit: audit(for: approval),
           now: now()
         )
       )

--- a/Sources/ClawGateway/Approval/ApprovedActionExecutor.swift
+++ b/Sources/ClawGateway/Approval/ApprovedActionExecutor.swift
@@ -54,6 +54,10 @@ public struct ApprovedActionExecutor: ApprovedActionExecuting {
   static let notResumableObservationContent =
     "The run was stopped before this approved action executed; nothing ran."
 
+  /// Placeholder audit rendering while the exact-value redactor is not yet injected: the executor
+  /// never writes the approval's raw canonical arguments into the audit log.
+  private static let opaqueApprovedArguments = "[REDACTED:approved-arguments]"
+
   private let tools: [String: any Tool]
   private let runs: any RunStore
   private let now: @Sendable () -> Date
@@ -116,7 +120,17 @@ private extension ApprovedActionExecutor {
       try runs.fillClaimedObservation(
         runId: approval.runId,
         observationMessageId: approval.observationMessageId,
-        content: content
+        fill: ClaimedObservationFill(
+          content: content,
+          status: .ok,
+          setTainted: false,
+          setPrivateData: false,
+          audit: ApprovedExecutionAudit(
+            tool: approval.tool,
+            argsRedacted: Self.opaqueApprovedArguments
+          ),
+          now: now()
+        )
       )
     } catch {
       logger.error("recording the executed result failed for run \(approval.runId): \(error)")
@@ -176,6 +190,10 @@ private extension ApprovedActionExecutor {
         observationMessageId: approval.observationMessageId,
         item: request.item,
         observationContent: content,
+        audit: ApprovedExecutionAudit(
+          tool: approval.tool,
+          argsRedacted: Self.opaqueApprovedArguments
+        ),
         notResumableObservationContent: Self.notResumableObservationContent,
         now: now()
       )
@@ -226,7 +244,17 @@ private extension ApprovedActionExecutor {
       try runs.fillClaimedObservation(
         runId: approval.runId,
         observationMessageId: approval.observationMessageId,
-        content: content
+        fill: ClaimedObservationFill(
+          content: content,
+          status: .error,
+          setTainted: false,
+          setPrivateData: false,
+          audit: ApprovedExecutionAudit(
+            tool: approval.tool,
+            argsRedacted: Self.opaqueApprovedArguments
+          ),
+          now: now()
+        )
       )
       return ApprovedExecutionOutcome(observationContent: content, commit: .committed)
     } catch {

--- a/Sources/ClawTestSupport/FakeExecutionBackend.swift
+++ b/Sources/ClawTestSupport/FakeExecutionBackend.swift
@@ -1,0 +1,64 @@
+import ClawCore
+import Foundation
+
+public actor FakeExecutionBackend: ExecutionBackend, SandboxMaintenance {
+  private let availability: BackendAvailability
+  private let health: SandboxHealth
+  private var results: [ExecutionResult]
+  private var requests: [ExecutionRequest] = []
+  private var prepareCalls = 0
+  private var shutdownCalls = 0
+
+  public init(
+    availability: BackendAvailability = .available(engineVersion: "1.1.0"),
+    health: SandboxHealth = .passingForTests,
+    results: [ExecutionResult] = []
+  ) {
+    self.availability = availability
+    self.health = health
+    self.results = results
+  }
+
+  public func enqueue(_ result: ExecutionResult) {
+    results.append(result)
+  }
+
+  public func probe() async -> BackendAvailability {
+    availability
+  }
+
+  public func run(_ request: ExecutionRequest) async -> ExecutionResult {
+    requests.append(request)
+    guard results.isEmpty == false else {
+      return ExecutionResult(
+        terminationReason: .unavailable(reason: "no scripted execution result"),
+        stdout: "",
+        stderr: "",
+        truncatedRawBytes: false,
+        wallClock: .zero
+      )
+    }
+    return results.removeFirst()
+  }
+
+  public func prepare() async -> SandboxHealth {
+    prepareCalls += 1
+    return health
+  }
+
+  public func shutdown() async {
+    shutdownCalls += 1
+  }
+
+  public func recordedRequests() -> [ExecutionRequest] {
+    requests
+  }
+
+  public func prepareCallCount() -> Int {
+    prepareCalls
+  }
+
+  public func shutdownCallCount() -> Int {
+    shutdownCalls
+  }
+}

--- a/Sources/clawd/Composition/DaemonBuilder+Approvals.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Approvals.swift
@@ -1,6 +1,7 @@
 import ClawAgent
 import ClawCore
 import ClawGateway
+import ClawTools
 import Foundation
 
 // MARK: - Coordination Fixtures & Approve-Resume Fabric
@@ -54,9 +55,13 @@ extension DaemonBuilder {
     turnRunner: TurnRunner
   ) -> ApprovalFabric {
     let contextBuilder = agentStack.contextBuilder
+    let argumentGuard = ExfilArgGuard(secretValues: secrets.redactionValues)
     let approvedExecutor = ApprovedActionExecutor(
       tools: agentStack.toolDispatcher.toolsByName,
       runs: stores.runs,
+      redactArguments: { arguments in
+        argumentGuard.renderRedacted(argsJSON: arguments)
+      },
       now: { Date() },
       logger: logger
     )

--- a/Sources/clawd/Composition/DaemonBuilder+Intake.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Intake.swift
@@ -93,9 +93,9 @@ extension DaemonBuilder {
   }
 
   /// Static sub-hash (classes 2–3): the same tool surface the gate enforces, plus the pinned
-  /// egress/policy config — the base URL, search presence, workspace root identity, and the
-  /// web_fetch SSRF exemption list. Secret values are never hashed. Injected into `ContextBuilder`,
-  /// which folds in the class-1 prompt materials and returns the combined `policy_version`.
+  /// egress/policy config: base URL, search presence, workspace identity, web_fetch SSRF
+  /// exemptions, and the normalized exec block. Secret values are never hashed. Injected into
+  /// `ContextBuilder`, which folds in class-1 prompt materials and returns `policy_version`.
   func policyStaticSubhash(
     toolDispatcher: GatedToolDispatcher,
     workspace: FileSystemWorkspace
@@ -105,7 +105,8 @@ extension DaemonBuilder {
       llmBaseURL: config.llm.baseURL,
       searchEndpointPresent: secrets.searchApiKey != nil,
       workspaceRoot: workspace.root.path,
-      webFetchExemptCIDRs: config.webFetchExemptCIDRs
+      webFetchExemptCIDRs: config.webFetchExemptCIDRs,
+      exec: config.exec
     )
   }
 }

--- a/Tests/ClawCoreTests/Config/AppConfigTests.swift
+++ b/Tests/ClawCoreTests/Config/AppConfigTests.swift
@@ -478,4 +478,214 @@ import Testing
       try AppConfig.load(environment: env)
     }
   }
+
+  @Test func execDefaultsToDisabledWithStableLowCoreSafeValues() throws {
+    // given
+    let env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+
+    // when
+    let config = try AppConfig.load(environment: env)
+
+    // then
+    #expect(config.exec == .disabledDefault)
+    #expect(config.exec.enabled == false)
+    #expect(config.exec.image == nil)
+    #expect(config.exec.imageRegistryAllowlist == ["cgr.dev"])
+    #expect(config.exec.memoryMiB == 1024)
+    #expect(config.exec.cpus == 4)
+    #expect(config.exec.timeoutSeconds == 30)
+    #expect(config.exec.allowEgress == false)
+  }
+
+  @Test func pinnedImageParserAcceptsOnlyAnExplicitRegistryAndLowercaseDigest() throws {
+    // given
+    let digest = String(repeating: "a", count: 64)
+
+    // when
+    let image = try #require(
+      PinnedImageReference.parse("cgr.dev/chainguard/python@sha256:\(digest)")
+    )
+
+    // then
+    #expect(image.repository == "cgr.dev/chainguard/python")
+    #expect(image.digest == digest)
+    #expect(image.registryHost == "cgr.dev")
+    #expect(image.description == "cgr.dev/chainguard/python@sha256:\(digest)")
+  }
+
+  @Test(arguments: [
+    "chainguard/python@sha256:" + String(repeating: "a", count: 64),
+    "https://cgr.dev/chainguard/python@sha256:" + String(repeating: "a", count: 64),
+    "cgr.dev/chainguard/python:latest",
+    "cgr.dev/chainguard/python@sha256:" + String(repeating: "A", count: 64),
+    "localhost/python@sha256:" + String(repeating: "a", count: 64),
+    "127.0.0.1/python@sha256:" + String(repeating: "a", count: 64),
+    "éxample.com/python@sha256:" + String(repeating: "a", count: 64),
+    "cgr.dev/pythön@sha256:" + String(repeating: "a", count: 64),
+    "cgr.dev:+443/python@sha256:" + String(repeating: "a", count: 64),
+    "cgr.dev/python@sha256:abc",
+    " cgr.dev/python@sha256:" + String(repeating: "a", count: 64),
+  ])
+  func pinnedImageParserRejectsAmbiguousOrUntrustedReferences(_ rawValue: String) {
+    // given / when / then
+    #expect(PinnedImageReference.parse(rawValue) == nil)
+  }
+
+  @Test func enabledExecParsesTheCompleteValidatedBlock() throws {
+    // given
+    let digest = String(repeating: "b", count: 64)
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[EnvKey.execEnabled] = "true"
+    env[EnvKey.execImage] = "images.example.com/team/python@sha256:\(digest)"
+    env[EnvKey.execImageRegistries] = "CGR.DEV, images.example.com, cgr.dev"
+    env[EnvKey.execMemoryMiB] = "512"
+    env[EnvKey.execCPUs] = "1"
+    env[EnvKey.execTimeout] = "45"
+    env[EnvKey.execAllowEgress] = "true"
+
+    // when
+    let config = try AppConfig.load(environment: env)
+
+    // then
+    #expect(config.exec.enabled)
+    #expect(
+      config.exec.image?.description
+        == "images.example.com/team/python@sha256:\(digest)"
+    )
+    #expect(config.exec.imageRegistryAllowlist == ["cgr.dev", "images.example.com"])
+    #expect(config.exec.memoryMiB == 512)
+    #expect(config.exec.cpus == 1)
+    #expect(config.exec.timeoutSeconds == 45)
+    #expect(config.exec.allowEgress)
+  }
+
+  @Test func disabledExecDoesNotApplyTheLiveHostCPUCeiling() throws {
+    // given: Linux CI may expose fewer than four CPUs; disabled parsing must remain stable
+    let aboveHost = ProcessInfo.processInfo.activeProcessorCount + 1
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[EnvKey.execCPUs] = "\(aboveHost)"
+
+    // when
+    let config = try AppConfig.load(environment: env)
+
+    // then
+    #expect(config.exec.enabled == false)
+    #expect(config.exec.cpus == aboveHost)
+  }
+
+  @Test func enabledExecRequiresAnImage() {
+    // given
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[EnvKey.execEnabled] = "true"
+    env[EnvKey.execCPUs] = "1"
+
+    // when / then
+    #expect(throws: ConfigError.invalidExecImage("")) {
+      try AppConfig.load(environment: env)
+    }
+  }
+
+  @Test func enabledExecRejectsAnImageOutsideTheRegistryAllowlist() {
+    // given
+    let rawImage =
+      "registry.example.com/team/python@sha256:" + String(repeating: "c", count: 64)
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[EnvKey.execEnabled] = "true"
+    env[EnvKey.execImage] = rawImage
+    env[EnvKey.execCPUs] = "1"
+
+    // when / then
+    #expect(
+      throws: ConfigError.execImageRegistryNotAllowed("registry.example.com")
+    ) {
+      try AppConfig.load(environment: env)
+    }
+  }
+
+  @Test func enabledExecRejectsCPUAboveTheLiveHostCap() {
+    // given
+    let rawCPUs = "\(ProcessInfo.processInfo.activeProcessorCount + 1)"
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[EnvKey.execEnabled] = "true"
+    env[EnvKey.execImage] =
+      "cgr.dev/chainguard/python@sha256:" + String(repeating: "d", count: 64)
+    env[EnvKey.execCPUs] = rawCPUs
+
+    // when / then
+    #expect(throws: ConfigError.invalidExecCPUs(rawCPUs)) {
+      try AppConfig.load(environment: env)
+    }
+  }
+
+  @Test func execImageWhitespaceFailsClosedAtTheConfigBoundary() {
+    // given
+    let rawImage =
+      " cgr.dev/chainguard/python@sha256:" + String(repeating: "e", count: 64)
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[EnvKey.execImage] = rawImage
+
+    // when / then
+    #expect(throws: ConfigError.invalidExecImage(rawImage)) {
+      try AppConfig.load(environment: env)
+    }
+  }
+
+  @Test(arguments: [
+    (
+      key: AppConfig.EnvKey.execMemoryMiB, value: "255",
+      error: ConfigError.invalidExecMemoryMiB("255")
+    ),
+    (
+      key: AppConfig.EnvKey.execMemoryMiB, value: "8193",
+      error: ConfigError.invalidExecMemoryMiB("8193")
+    ),
+    (
+      key: AppConfig.EnvKey.execMemoryMiB, value: "large",
+      error: ConfigError.invalidExecMemoryMiB("large")
+    ),
+    (key: AppConfig.EnvKey.execCPUs, value: "0", error: ConfigError.invalidExecCPUs("0")),
+    (key: AppConfig.EnvKey.execCPUs, value: "many", error: ConfigError.invalidExecCPUs("many")),
+    (key: AppConfig.EnvKey.execTimeout, value: "0", error: ConfigError.invalidExecTimeout("0")),
+    (key: AppConfig.EnvKey.execTimeout, value: "301", error: ConfigError.invalidExecTimeout("301")),
+    (
+      key: AppConfig.EnvKey.execTimeout, value: "later",
+      error: ConfigError.invalidExecTimeout("later")
+    ),
+  ])
+  func malformedExecBoundsFailClosed(
+    _ fixture: (key: String, value: String, error: ConfigError)
+  ) {
+    // given
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[fixture.key] = fixture.value
+
+    // when / then
+    #expect(throws: fixture.error) {
+      try AppConfig.load(environment: env)
+    }
+  }
+
+  @Test(arguments: ["", "localhost", "127.0.0.1", "bad host"])
+  func invalidOrEmptyRegistryAllowlistFailsClosed(_ rawValue: String) {
+    // given
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[EnvKey.execImageRegistries] = rawValue
+
+    // when / then
+    #expect(throws: ConfigError.invalidExecImageRegistry(rawValue)) {
+      try AppConfig.load(environment: env)
+    }
+  }
+
+  @Test(arguments: [AppConfig.EnvKey.execEnabled, AppConfig.EnvKey.execAllowEgress])
+  func malformedExecBooleansFailClosed(_ key: String) {
+    // given
+    var env = envWithLLM([EnvKey.stateRoot: NSTemporaryDirectory()])
+    env[key] = "sometimes"
+
+    // when / then
+    #expect(throws: ConfigError.invalidBool(key: key, value: "sometimes")) {
+      try AppConfig.load(environment: env)
+    }
+  }
 }

--- a/Tests/ClawCoreTests/Domain/Execution/ExecutionContractsTests.swift
+++ b/Tests/ClawCoreTests/Domain/Execution/ExecutionContractsTests.swift
@@ -1,0 +1,140 @@
+import ClawTestSupport
+import Foundation
+import Testing
+
+@testable import ClawCore
+
+@Suite struct ExecutionContractsTests {
+  private let passingHealth = SandboxHealth(
+    available: true,
+    osOK: true,
+    engineVersion: "1.1.0",
+    versionOK: true,
+    imageDigestOK: true,
+    capsEmpty: true,
+    netIsolated: true,
+    capsMatch: true,
+    reaperOK: true,
+    rootfsRO: true,
+    stagingRO: true,
+    interpretersOK: true,
+    lastError: nil
+  )
+
+  @Test func requestCarriesOnlyApprovedGuestInputs() {
+    // given
+    let entrypoint = StagedFile(
+      name: ".clawd-entrypoint.py",
+      bytes: Data("print('ok')".utf8),
+      mode: .readExecute
+    )
+    let input = StagedFile(name: "notes.txt", bytes: Data("hello".utf8), mode: .readOnly)
+
+    // when
+    let request = ExecutionRequest(
+      language: .python,
+      entrypoint: entrypoint,
+      inputs: [input],
+      network: false,
+      timeout: .seconds(30)
+    )
+
+    // then
+    #expect(request.language == .python)
+    #expect(request.entrypoint == entrypoint)
+    #expect(request.inputs == [input])
+    #expect(request.network == false)
+    #expect(request.timeout == .seconds(30))
+    #expect(FileMode.readOnly.rawValue == 0o400)
+    #expect(FileMode.readExecute.rawValue == 0o500)
+  }
+
+  @Test func healthIsReadyOnlyWhenEveryGatePasses() {
+    // given / when / then
+    #expect(passingHealth.isReady)
+    #expect(SandboxHealth.passingForTests == passingHealth)
+
+    let failed = SandboxHealth(
+      available: true,
+      osOK: true,
+      engineVersion: "1.1.0",
+      versionOK: true,
+      imageDigestOK: true,
+      capsEmpty: true,
+      netIsolated: false,
+      capsMatch: true,
+      reaperOK: true,
+      rootfsRO: true,
+      stagingRO: true,
+      interpretersOK: true,
+      lastError: "network escaped"
+    )
+    #expect(failed.isReady == false)
+  }
+
+  @Test func fakeRecordsRequestsAndNeverInventsSuccess() async {
+    // given
+    let scripted = ExecutionResult(
+      terminationReason: .exited(code: 0),
+      stdout: "ok\n",
+      stderr: "",
+      truncatedRawBytes: false,
+      wallClock: .milliseconds(8)
+    )
+    let backend = FakeExecutionBackend(results: [scripted])
+    let request = ExecutionRequest(
+      language: .sh,
+      entrypoint: StagedFile(
+        name: ".clawd-entrypoint.sh",
+        bytes: Data("printf ok".utf8),
+        mode: .readExecute
+      ),
+      inputs: [],
+      network: false,
+      timeout: .seconds(5)
+    )
+
+    // when
+    let first = await backend.run(request)
+    let second = await backend.run(request)
+    let health = await backend.prepare()
+    await backend.shutdown()
+
+    // then
+    #expect(first == scripted)
+    #expect(
+      second.terminationReason
+        == .unavailable(reason: "no scripted execution result")
+    )
+    #expect(await backend.recordedRequests() == [request, request])
+    #expect(await backend.probe() == .available(engineVersion: "1.1.0"))
+    #expect(health == .passingForTests)
+    #expect(await backend.prepareCallCount() == 1)
+    #expect(await backend.shutdownCallCount() == 1)
+  }
+
+  @Test func fakeCanBeReScriptedAfterConstruction() async {
+    // given
+    let backend = FakeExecutionBackend(results: [])
+    let result = ExecutionResult(
+      terminationReason: .timedOutKilled,
+      stdout: "",
+      stderr: "",
+      truncatedRawBytes: false,
+      wallClock: .seconds(2)
+    )
+    let request = ExecutionRequest(
+      language: .python,
+      entrypoint: StagedFile(name: "entry.py", bytes: Data(), mode: .readExecute),
+      inputs: [],
+      network: false,
+      timeout: .seconds(1)
+    )
+
+    // when
+    await backend.enqueue(result)
+
+    // then
+    #expect(await backend.run(request) == result)
+  }
+}

--- a/Tests/ClawCoreTests/Domain/Policy/PolicyFingerprintTests.swift
+++ b/Tests/ClawCoreTests/Domain/Policy/PolicyFingerprintTests.swift
@@ -54,14 +54,16 @@ import Testing
     llm: String = "https://llm.example",
     search: Bool = false,
     root: String = "/workspace",
-    exempt: [CIDR] = []
+    exempt: [CIDR] = [],
+    exec: ExecConfig = .disabledDefault
   ) -> String {
     PolicyFingerprint.staticSubhash(
       tools: tools,
       llmBaseURL: llm,
       searchEndpointPresent: search,
       workspaceRoot: root,
-      webFetchExemptCIDRs: exempt
+      webFetchExemptCIDRs: exempt,
+      exec: exec
     )
   }
 
@@ -153,6 +155,64 @@ import Testing
 
     // when / then
     #expect(subhash(exempt: [poolV4, poolV6]) == subhash(exempt: [poolV6, poolV4]))
+  }
+
+  private func execConfig(
+    enabled: Bool = false,
+    imageCharacter: Character? = nil,
+    registries: [String] = ["cgr.dev"],
+    memoryMiB: Int = 1024,
+    cpus: Int = 4,
+    timeoutSeconds: Int = 30,
+    allowEgress: Bool = false
+  ) throws -> ExecConfig {
+    let image = try imageCharacter.map { character in
+      try #require(
+        PinnedImageReference.parse(
+          "cgr.dev/chainguard/python@sha256:" + String(repeating: character, count: 64)
+        )
+      )
+    }
+    return ExecConfig(
+      enabled: enabled,
+      image: image,
+      imageRegistryAllowlist: registries,
+      memoryMiB: memoryMiB,
+      cpus: cpus,
+      timeoutSeconds: timeoutSeconds,
+      allowEgress: allowEgress
+    )
+  }
+
+  @Test func everyExecPolicyFieldIsAnInputClass() throws {
+    // given
+    let baseline = try execConfig()
+    let mutations = try [
+      execConfig(enabled: true),
+      execConfig(imageCharacter: "a"),
+      execConfig(registries: ["cgr.dev", "images.example.com"]),
+      execConfig(memoryMiB: 2048),
+      execConfig(cpus: 2),
+      execConfig(timeoutSeconds: 60),
+      execConfig(allowEgress: true),
+    ]
+
+    // when
+    let baselineHash = subhash(exec: baseline)
+    let mutationHashes = mutations.map { config in subhash(exec: config) }
+
+    // then: each field change produces a different policy fingerprint
+    #expect(mutationHashes.allSatisfy { $0 != baselineHash })
+    #expect(Set(mutationHashes).count == mutations.count)
+  }
+
+  @Test func execRegistryOrderDoesNotChangeTheFingerprint() throws {
+    // given
+    let forward = try execConfig(registries: ["cgr.dev", "images.example.com"])
+    let reverse = try execConfig(registries: ["images.example.com", "cgr.dev"])
+
+    // when / then: sorting makes equivalent registry sets produce the same fingerprint
+    #expect(subhash(exec: forward) == subhash(exec: reverse))
   }
 
   // MARK: - combined

--- a/Tests/ClawCoreTests/Domain/Support/SHA256DigestTests.swift
+++ b/Tests/ClawCoreTests/Domain/Support/SHA256DigestTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+
+@testable import ClawCore
+
+@Suite struct SHA256DigestTests {
+  @Test func knownVectorsRenderLowercaseHex() {
+    // given / when / then
+    #expect(
+      SHA256Digest.hex(Data())
+        == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    )
+    #expect(
+      SHA256Digest.hex("abc")
+        == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    )
+  }
+
+  @Test func approvalArgsHashUsesTheCanonicalRenderer() {
+    // given
+    let canonicalJSON = #"{"a":1,"b":2}"#
+
+    // when / then
+    #expect(ApprovalArgsHash.sha256Hex(canonicalJSON) == SHA256Digest.hex(canonicalJSON))
+  }
+}

--- a/Tests/ClawCoreTests/Errors/ErrorTests.swift
+++ b/Tests/ClawCoreTests/Errors/ErrorTests.swift
@@ -31,5 +31,19 @@ import Testing
     #expect(
       ConfigError.invalidApprovalExpiry("999999").exitCode == ClawExitCode.configInvalid.rawValue
     )
+    #expect(ConfigError.invalidExecImage("bad").exitCode == ClawExitCode.configInvalid.rawValue)
+    #expect(
+      ConfigError.invalidExecImageRegistry("bad").exitCode
+        == ClawExitCode.configInvalid.rawValue
+    )
+    #expect(
+      ConfigError.execImageRegistryNotAllowed("bad").exitCode
+        == ClawExitCode.configInvalid.rawValue
+    )
+    #expect(
+      ConfigError.invalidExecMemoryMiB("bad").exitCode == ClawExitCode.configInvalid.rawValue
+    )
+    #expect(ConfigError.invalidExecCPUs("bad").exitCode == ClawExitCode.configInvalid.rawValue)
+    #expect(ConfigError.invalidExecTimeout("bad").exitCode == ClawExitCode.configInvalid.rawValue)
   }
 }

--- a/Tests/ClawDataTests/Stores/Run/ApprovedMemoryWriteExactlyOnceTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/ApprovedMemoryWriteExactlyOnceTests.swift
@@ -82,6 +82,7 @@ import Testing
       observationMessageId: receipt.observationMessageId,
       item: item,
       observationContent: "Saved memory item.",
+      audit: ApprovedExecutionAudit(tool: "memory_write", argsRedacted: "[REDACTED]"),
       notResumableObservationContent: "stopped",
       now: now
     )
@@ -90,6 +91,7 @@ import Testing
       observationMessageId: receipt.observationMessageId,
       item: item,
       observationContent: "Saved memory item.",
+      audit: ApprovedExecutionAudit(tool: "memory_write", argsRedacted: "[REDACTED]"),
       notResumableObservationContent: "stopped",
       now: now
     )
@@ -110,5 +112,13 @@ import Testing
       ) ?? 0
     }
     #expect(observationCount == 1)
+    let auditCount = try queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM audit_events WHERE run_id = ? AND action = ?",
+        arguments: [runId, AuditAction.toolCall.rawValue]
+      ) ?? 0
+    }
+    #expect(auditCount == 1)
   }
 }

--- a/Tests/ClawDataTests/Stores/Run/ApprovedResumeStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/ApprovedResumeStoreTests.swift
@@ -18,7 +18,9 @@ import Testing
 
   /// A run suspended to AWAITING_APPROVAL through the real reducer, with an assistant anchor and a
   /// placeholder observation row persisted (the shape Task 14's `commitSuspendedTurn` leaves).
-  private func makeSuspendedFixture() throws -> Fixture {
+  private func makeSuspendedFixture(
+    claimedFillFault: @escaping @Sendable () throws -> Void = {}
+  ) throws -> Fixture {
     let queue = try ClawDatabase.makeInMemoryQueue()
     try ClawDatabase.migrate(queue)
     let sessions = SessionMessageStoreGRDB(writer: queue)
@@ -35,7 +37,11 @@ import Testing
     )
     let sessionId = try #require(claim.sessionId)
     let runId = try #require(claim.runId)
-    let runs = RunStoreGRDB(writer: queue)
+    let runs = RunStoreGRDB(
+      writer: queue,
+      suspendCommitFault: {},
+      claimedFillFault: claimedFillFault
+    )
     _ = try #require(try runs.pickUp(runId: runId, now: Date()))
 
     let observationMessageId = try queue.write { db -> Int64 in
@@ -81,6 +87,59 @@ import Testing
         arguments: [messageId]
       )
     }
+  }
+
+  private func sessionFlags(_ env: Fixture) throws -> (tainted: Bool, privateData: Bool) {
+    try env.queue.read { db in
+      let row = try #require(
+        try Row.fetchOne(
+          db,
+          sql: "SELECT tainted, has_private_data FROM sessions WHERE id = ?",
+          arguments: [env.sessionId]
+        )
+      )
+      return (row["tainted"], row["has_private_data"])
+    }
+  }
+
+  private func toolAuditRows(_ env: Fixture) throws -> [Row] {
+    try env.queue.read { db in
+      try Row.fetchAll(
+        db,
+        sql: """
+          SELECT actor, action, tool, args_redacted, result_size, decision, run_id, session_id, ts
+          FROM audit_events
+          WHERE run_id = ? AND action = ?
+          ORDER BY id
+          """,
+        arguments: [env.runId, AuditAction.toolCall.rawValue]
+      )
+    }
+  }
+
+  private func fill(
+    _ env: Fixture,
+    content: String,
+    status: ToolObservationStatus = .ok,
+    setTainted: Bool = false,
+    setPrivateData: Bool = false,
+    now: Date = Date(timeIntervalSince1970: 1_700_000_000)
+  ) throws {
+    try env.runs.fillClaimedObservation(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      fill: ClaimedObservationFill(
+        content: content,
+        status: status,
+        setTainted: setTainted,
+        setPrivateData: setPrivateData,
+        audit: ApprovedExecutionAudit(
+          tool: "file_write",
+          argsRedacted: #"{"path":"plan.md"}"#
+        ),
+        now: now
+      )
+    )
   }
 
   @Test func claimApprovedExecutionFlipsTheRunAndLeavesThePlaceholder() throws {
@@ -136,11 +195,7 @@ import Testing
       notResumableObservationContent: "stopped",
       now: Date()
     )
-    try env.runs.fillClaimedObservation(
-      runId: env.runId,
-      observationMessageId: env.observationMessageId,
-      content: "first"
-    )
+    try fill(env, content: "first")
 
     // when — a duplicate signal replays the claim against the filled observation
     let replay = try env.runs.claimApprovedExecution(
@@ -260,11 +315,7 @@ import Testing
       notResumableObservationContent: "stopped",
       now: Date()
     )
-    try env.runs.fillClaimedObservation(
-      runId: env.runId,
-      observationMessageId: env.observationMessageId,
-      content: "Wrote 12 B."
-    )
+    try fill(env, content: "Wrote 12 B.")
 
     // when
     let outcome = try env.runs.settleClaimedApprovalAtBoot(
@@ -293,6 +344,10 @@ import Testing
       observationMessageId: env.observationMessageId,
       item: item,
       observationContent: "Saved to memory as project.",
+      audit: ApprovedExecutionAudit(
+        tool: "memory_write",
+        argsRedacted: #"{"kind":"project","text":"[REDACTED]"}"#
+      ),
       notResumableObservationContent: "stopped",
       now: Date()
     )
@@ -307,6 +362,10 @@ import Testing
       try messageContent(env.queue, env.observationMessageId) == "Saved to memory as project."
     )
     #expect(try runState(env.queue, env.runId) == RunState.running.rawValue)
+    let audits = try toolAuditRows(env)
+    #expect(audits.count == 1)
+    #expect(audits[0]["tool"] == "memory_write")
+    #expect(audits[0]["decision"] == ToolObservationStatus.ok.rawValue)
   }
 
   @Test func applyApprovedMemoryWriteIsExactlyOnce() throws {
@@ -318,6 +377,7 @@ import Testing
       observationMessageId: env.observationMessageId,
       item: item,
       observationContent: "Saved.",
+      audit: ApprovedExecutionAudit(tool: "memory_write", argsRedacted: "[REDACTED]"),
       notResumableObservationContent: "stopped",
       now: Date()
     )
@@ -328,6 +388,7 @@ import Testing
       observationMessageId: env.observationMessageId,
       item: item,
       observationContent: "Saved again.",
+      audit: ApprovedExecutionAudit(tool: "memory_write", argsRedacted: "[REDACTED]"),
       notResumableObservationContent: "stopped",
       now: Date()
     )
@@ -354,6 +415,7 @@ import Testing
       observationMessageId: env.observationMessageId,
       item: item,
       observationContent: "Saved.",
+      audit: ApprovedExecutionAudit(tool: "memory_write", argsRedacted: "[REDACTED]"),
       notResumableObservationContent: "The session was stopped before this action ran.",
       now: Date()
     )
@@ -404,11 +466,7 @@ import Testing
       notResumableObservationContent: "stopped",
       now: Date()
     )
-    try env.runs.fillClaimedObservation(
-      runId: env.runId,
-      observationMessageId: env.observationMessageId,
-      content: "first"
-    )
+    try fill(env, content: "first")
     let secondPlaceholderId = try suspendAgain(env)
 
     // when — a boot replay re-runs approval #1's claim against its already-filled observation
@@ -436,6 +494,7 @@ import Testing
       observationMessageId: env.observationMessageId,
       item: item,
       observationContent: "Saved.",
+      audit: ApprovedExecutionAudit(tool: "memory_write", argsRedacted: "[REDACTED]"),
       notResumableObservationContent: "stopped",
       now: Date()
     )
@@ -447,6 +506,7 @@ import Testing
       observationMessageId: env.observationMessageId,
       item: item,
       observationContent: "Saved again.",
+      audit: ApprovedExecutionAudit(tool: "memory_write", argsRedacted: "[REDACTED]"),
       notResumableObservationContent: "stopped",
       now: Date()
     )
@@ -546,5 +606,141 @@ import Testing
       )
     }
     #expect(auditDecision == ApprovalDecision.stalePolicy.rawValue)
+  }
+
+  @Test func typedFillUpdatesObservationFlagsAndAuditInOneCommit() throws {
+    // given
+    let env = try makeSuspendedFixture()
+    _ = try env.runs.claimApprovedExecution(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      notResumableObservationContent: "stopped",
+      now: Date()
+    )
+    let committedAt = Date(timeIntervalSince1970: 1_700_000_123)
+
+    // when
+    try fill(
+      env,
+      content: "sandbox output",
+      status: .blockedArgs,
+      setTainted: true,
+      setPrivateData: true,
+      now: committedAt
+    )
+
+    // then
+    #expect(try messageContent(env.queue, env.observationMessageId) == "sandbox output")
+    let flags = try sessionFlags(env)
+    #expect(flags.tainted)
+    #expect(flags.privateData)
+    let audits = try toolAuditRows(env)
+    #expect(audits.count == 1)
+    #expect(audits[0]["actor"] == AuditActor.assistant.rawValue)
+    #expect(audits[0]["tool"] == "file_write")
+    #expect(audits[0]["args_redacted"] == #"{"path":"plan.md"}"#)
+    #expect(audits[0]["result_size"] == Data("sandbox output".utf8).count)
+    #expect(audits[0]["decision"] == ToolObservationStatus.blockedArgs.rawValue)
+    #expect(audits[0]["run_id"] == env.runId)
+    #expect(audits[0]["session_id"] == env.sessionId)
+    let auditTimestamp: Date = audits[0]["ts"]
+    #expect(auditTimestamp == committedAt)
+  }
+
+  @Test func cancelledRunStillCommitsProvenanceFromACompletedAction() throws {
+    // given: the action claimed RUNNING, then /stop won while it executed
+    let env = try makeSuspendedFixture()
+    _ = try env.runs.claimApprovedExecution(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      notResumableObservationContent: "stopped",
+      now: Date()
+    )
+    _ = try env.runs.cancelActiveRun(
+      sessionId: env.sessionId,
+      reason: .cancelled,
+      now: Date()
+    )
+
+    // when
+    try fill(env, content: "completed before cancellation", setTainted: true, setPrivateData: true)
+
+    // then
+    #expect(try runState(env.queue, env.runId) == RunState.cancelled.rawValue)
+    #expect(try sessionFlags(env).tainted)
+    #expect(try sessionFlags(env).privateData)
+    #expect(try toolAuditRows(env).count == 1)
+  }
+
+  @Test func supersededRunFillsAndAuditsWithoutRetainingOldWindowProvenance() throws {
+    // given: the action claimed RUNNING, then /new superseded and detainted the window
+    let env = try makeSuspendedFixture()
+    _ = try env.runs.claimApprovedExecution(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      notResumableObservationContent: "stopped",
+      now: Date()
+    )
+    _ = try env.runs.supersedeSessionRuns(sessionId: env.sessionId, now: Date())
+
+    // when
+    try fill(env, content: "old-window output", setTainted: true, setPrivateData: true)
+
+    // then: old transcript/audit remain truthful; the fresh window stays clean
+    #expect(try runState(env.queue, env.runId) == RunState.superseded.rawValue)
+    #expect(try messageContent(env.queue, env.observationMessageId) == "old-window output")
+    #expect(try sessionFlags(env).tainted == false)
+    #expect(try sessionFlags(env).privateData == false)
+    #expect(try toolAuditRows(env).count == 1)
+  }
+
+  @Test func fillFaultRollsBackContentFlagsAndAuditTogether() throws {
+    // given
+    let env = try makeSuspendedFixture(claimedFillFault: {
+      throw StoreError.unexpected("claimed fill fault")
+    })
+    _ = try env.runs.claimApprovedExecution(
+      runId: env.runId,
+      observationMessageId: env.observationMessageId,
+      notResumableObservationContent: "stopped",
+      now: Date()
+    )
+
+    // when / then
+    #expect(throws: StoreError.unexpected("claimed fill fault")) {
+      try fill(env, content: "must roll back", setTainted: true, setPrivateData: true)
+    }
+    #expect(try messageContent(env.queue, env.observationMessageId) == Self.placeholder)
+    #expect(try sessionFlags(env).tainted == false)
+    #expect(try sessionFlags(env).privateData == false)
+    #expect(try toolAuditRows(env).isEmpty)
+  }
+
+  @Test func memoryFillFaultRollsBackClaimItemObservationAndAuditTogether() throws {
+    // given
+    let env = try makeSuspendedFixture(claimedFillFault: {
+      throw StoreError.unexpected("claimed fill fault")
+    })
+    let item = NewMemoryItem(text: "must not persist", kind: .project, sessionId: env.sessionId)
+
+    // when / then
+    #expect(throws: StoreError.unexpected("claimed fill fault")) {
+      try env.runs.applyApprovedMemoryWrite(
+        runId: env.runId,
+        observationMessageId: env.observationMessageId,
+        item: item,
+        observationContent: "must roll back",
+        audit: ApprovedExecutionAudit(tool: "memory_write", argsRedacted: "[REDACTED]"),
+        notResumableObservationContent: "stopped",
+        now: Date()
+      )
+    }
+    let memoryCount = try env.queue.read { db in
+      try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM memory_items")
+    }
+    #expect(memoryCount == 0)
+    #expect(try runState(env.queue, env.runId) == RunState.awaitingApproval.rawValue)
+    #expect(try messageContent(env.queue, env.observationMessageId) == Self.placeholder)
+    #expect(try toolAuditRows(env).isEmpty)
   }
 }

--- a/Tests/ClawDataTests/Stores/Run/OutboxStepSequenceTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/OutboxStepSequenceTests.swift
@@ -124,7 +124,14 @@ import Testing
     try fixture.runs.fillClaimedObservation(
       runId: fixture.runId,
       observationMessageId: receipt.observationMessageId,
-      content: "wrote it"
+      fill: ClaimedObservationFill(
+        content: "wrote it",
+        status: .ok,
+        setTainted: false,
+        setPrivateData: false,
+        audit: ApprovedExecutionAudit(tool: "file_write", argsRedacted: "{}"),
+        now: Date()
+      )
     )
     return receipt
   }

--- a/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
+++ b/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
@@ -252,6 +252,7 @@ func makeSC3Harness(
   let approvedExecutor = ApprovedActionExecutor(
     tools: dispatcher.toolsByName,
     runs: stores.runs,
+    redactArguments: { $0 },
     now: { Date() },
     logger: logger
   )

--- a/Tests/ClawGatewayTests/Routing/ApprovalWaiterTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ApprovalWaiterTests.swift
@@ -186,6 +186,7 @@ import Testing
         ?? ApprovedActionExecutor(
           tools: ["file_write": StubTool(toolName: "file_write", result: "Wrote 12 B.")],
           runs: env.runs,
+          redactArguments: { $0 },
           now: { Date() },
           logger: Logger(label: "test")
         ),

--- a/Tests/ClawGatewayTests/Routing/ApprovedActionExecutorTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ApprovedActionExecutorTests.swift
@@ -18,26 +18,63 @@ import Testing
     }
   }
 
-  /// A ClawCore `Tool` double that records execution and can stall past its own declared timeout —
-  /// the executor must still await it to completion (§6.6, never the read-tool abandon race).
+  private actor ExecutionGate {
+    private var started = false
+    private var released = false
+    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func arriveAndWait() async {
+      started = true
+      for waiter in startedWaiters {
+        waiter.resume()
+      }
+      startedWaiters.removeAll()
+      guard released == false else { return }
+      await withCheckedContinuation { continuation in
+        releaseWaiters.append(continuation)
+      }
+    }
+
+    func waitUntilStarted() async {
+      guard started == false else { return }
+      await withCheckedContinuation { continuation in
+        startedWaiters.append(continuation)
+      }
+    }
+
+    func release() {
+      released = true
+      for waiter in releaseWaiters {
+        waiter.resume()
+      }
+      releaseWaiters.removeAll()
+    }
+  }
+
   private struct RecordingWriteTool: Tool {
     let toolName: String
-    let result: String
-    let status: ToolObservationStatus
-    let stallFor: Duration?
+    let payload: ToolPayload
+    let gate: ExecutionGate?
     let probe: ExecutionProbe?
 
     init(
       toolName: String,
       result: String,
       status: ToolObservationStatus = .ok,
-      stallFor: Duration? = nil,
+      ingestedUntrusted: Bool = false,
+      readPrivateData: Bool = false,
+      gate: ExecutionGate? = nil,
       probe: ExecutionProbe? = nil
     ) {
       self.toolName = toolName
-      self.result = result
-      self.status = status
-      self.stallFor = stallFor
+      payload = ToolPayload(
+        content: result,
+        status: status,
+        ingestedUntrusted: ingestedUntrusted,
+        readPrivateData: readPrivateData
+      )
+      self.gate = gate
       self.probe = probe
     }
 
@@ -57,10 +94,8 @@ import Testing
 
     func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
       await probe?.mark()
-      if let stallFor {
-        try? await Task.sleep(for: stallFor)
-      }
-      return ToolPayload(content: result, status: status, ingestedUntrusted: false)
+      await gate?.arriveAndWait()
+      return payload
     }
   }
 
@@ -172,11 +207,13 @@ import Testing
   private func makeExecutor(
     _ env: Fixture,
     tools: [any Tool],
-    runs: (any RunStore)? = nil
+    runs: (any RunStore)? = nil,
+    redactArguments: @escaping @Sendable (String) -> String = { $0 }
   ) -> ApprovedActionExecutor {
     ApprovedActionExecutor(
       tools: Dictionary(uniqueKeysWithValues: tools.map { ($0.definition.name, $0) }),
       runs: runs ?? env.runs,
+      redactArguments: redactArguments,
       now: { Date() },
       logger: Logger(label: "test")
     )
@@ -195,6 +232,36 @@ import Testing
   private func runState(_ env: Fixture) throws -> String? {
     try env.queue.read { db in
       try String.fetchOne(db, sql: "SELECT state FROM runs WHERE id = ?", arguments: [env.runId])
+    }
+  }
+
+  private func sessionFlags(_ env: Fixture) throws -> (tainted: Bool, privateData: Bool) {
+    try env.queue.read { db in
+      let row = try #require(
+        try Row.fetchOne(
+          db,
+          sql: "SELECT tainted, has_private_data FROM sessions WHERE id = ?",
+          arguments: [env.sessionId]
+        )
+      )
+      return (row["tainted"], row["has_private_data"])
+    }
+  }
+
+  private func lastToolAudit(_ env: Fixture) throws -> Row {
+    try env.queue.read { db in
+      try #require(
+        try Row.fetchOne(
+          db,
+          sql: """
+            SELECT tool, args_redacted, result_size, decision
+            FROM audit_events
+            WHERE run_id = ? AND action = ?
+            ORDER BY id DESC LIMIT 1
+            """,
+          arguments: [env.runId, AuditAction.toolCall.rawValue]
+        )
+      )
     }
   }
 
@@ -219,27 +286,149 @@ import Testing
   }
 
   @Test func awaitsAStallingToolToCompletionWithoutTheTimeoutAbandonRace() async throws {
-    // given — the tool stalls 20ms past its own 1ms declared timeout; the executor must NOT abandon
+    // given
     let env = try makeSuspendedFixture()
+    let gate = ExecutionGate()
     let executor = makeExecutor(
       env,
       tools: [
         RecordingWriteTool(
           toolName: "file_write",
-          result: "the slow write finished",
-          stallFor: .milliseconds(20)
+          result: "the gated write finished",
+          gate: gate
         )
       ]
     )
 
-    // when
-    let outcome = await executor.executeApproved(
-      approval(env, tool: "file_write", argsJSON: #"{"path":"plan.md"}"#)
+    // when: the tool remains suspended until the test releases the signal
+    let execution = Task {
+      await executor.executeApproved(
+        approval(env, tool: "file_write", argsJSON: #"{"path":"plan.md"}"#)
+      )
+    }
+    await gate.waitUntilStarted()
+    await gate.release()
+    let outcome = await execution.value
+
+    // then: approved execution awaits completion and records the truthful result
+    #expect(outcome.observationContent == "the gated write finished")
+    #expect(try messageContent(env) == "the gated write finished")
+  }
+
+  @Test func fullPayloadStatusProvenanceAndRedactedArgsReachTheFill() async throws {
+    // given
+    let env = try makeSuspendedFixture()
+    let secret = "owner-secret-value"
+    let rawArgs = #"{"code":"owner-secret-value"}"#
+    let executor = makeExecutor(
+      env,
+      tools: [
+        RecordingWriteTool(
+          toolName: "execute_code",
+          result: "exit 9",
+          status: .error,
+          ingestedUntrusted: true,
+          readPrivateData: true
+        )
+      ],
+      redactArguments: { arguments in
+        arguments.replacingOccurrences(of: secret, with: "[REDACTED:secret-value]")
+      }
     )
 
-    // then — the observation is truthful: the completed result, never a "timed out but maybe applied"
-    #expect(outcome.observationContent == "the slow write finished")
-    #expect(try messageContent(env) == "the slow write finished")
+    // when
+    let outcome = await executor.executeApproved(
+      approval(env, tool: "execute_code", argsJSON: rawArgs, target: "code_exec:sh:abcd")
+    )
+
+    // then
+    #expect(outcome.commit == .committed)
+    #expect(outcome.observationContent == "exit 9")
+    #expect(try sessionFlags(env).tainted)
+    #expect(try sessionFlags(env).privateData)
+    let audit = try lastToolAudit(env)
+    #expect(audit["tool"] == "execute_code")
+    #expect(audit["decision"] == ToolObservationStatus.error.rawValue)
+    let argsRedacted: String = audit["args_redacted"]
+    #expect(argsRedacted == #"{"code":"[REDACTED:secret-value]"}"#)
+    #expect(argsRedacted.contains(secret) == false)
+  }
+
+  @Test func stopDuringExecutionRetainsCompletedPayloadProvenance() async throws {
+    // given
+    let env = try makeSuspendedFixture()
+    let gate = ExecutionGate()
+    let executor = makeExecutor(
+      env,
+      tools: [
+        RecordingWriteTool(
+          toolName: "execute_code",
+          result: "completed output",
+          ingestedUntrusted: true,
+          readPrivateData: true,
+          gate: gate
+        )
+      ]
+    )
+    let execution = Task {
+      await executor.executeApproved(
+        approval(env, tool: "execute_code", argsJSON: "{}", target: "code_exec:sh:abcd")
+      )
+    }
+    await gate.waitUntilStarted()
+
+    // when: claim is already RUNNING; /stop wins before the fill
+    _ = try env.runs.cancelActiveRun(
+      sessionId: env.sessionId,
+      reason: .cancelled,
+      now: Date()
+    )
+    await gate.release()
+    let outcome = await execution.value
+
+    // then
+    #expect(outcome.commit == .committed)
+    #expect(try runState(env) == RunState.cancelled.rawValue)
+    #expect(try messageContent(env) == "completed output")
+    #expect(try sessionFlags(env).tainted)
+    #expect(try sessionFlags(env).privateData)
+  }
+
+  @Test func newDuringExecutionNeverRetaintsTheFreshWindow() async throws {
+    // given
+    let env = try makeSuspendedFixture()
+    let gate = ExecutionGate()
+    let executor = makeExecutor(
+      env,
+      tools: [
+        RecordingWriteTool(
+          toolName: "execute_code",
+          result: "old-window output",
+          ingestedUntrusted: true,
+          readPrivateData: true,
+          gate: gate
+        )
+      ]
+    )
+    let execution = Task {
+      await executor.executeApproved(
+        approval(env, tool: "execute_code", argsJSON: "{}", target: "code_exec:sh:abcd")
+      )
+    }
+    await gate.waitUntilStarted()
+
+    // when: /new supersedes/detaints after claim but before fill
+    _ = try env.runs.supersedeSessionRuns(sessionId: env.sessionId, now: Date())
+    await gate.release()
+    let outcome = await execution.value
+
+    // then: old observation and audit are truthful; fresh-window flags remain clear
+    #expect(outcome.commit == .committed)
+    #expect(try runState(env) == RunState.superseded.rawValue)
+    #expect(try messageContent(env) == "old-window output")
+    #expect(try sessionFlags(env).tainted == false)
+    #expect(try sessionFlags(env).privateData == false)
+    #expect(try lastToolAudit(env)["tool"] == "execute_code")
   }
 
   @Test func memoryWriteFusesTheInsertAndIsExactlyOnce() async throws {

--- a/Tests/ClawGatewayTests/Routing/ApprovedActionExecutorTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ApprovedActionExecutorTests.swift
@@ -401,16 +401,17 @@ import Testing
     func fillClaimedObservation(
       runId: Int64,
       observationMessageId: Int64,
-      content: String
+      fill: ClaimedObservationFill
     ) throws(StoreError) {
       throw StoreError.diskFull
     }
 
-    func applyApprovedMemoryWrite(
+    func applyApprovedMemoryWrite(  // swiftlint:disable:this function_parameter_count
       runId: Int64,
       observationMessageId: Int64,
       item: NewMemoryItem,
       observationContent: String,
+      audit: ApprovedExecutionAudit,
       notResumableObservationContent: String,
       now: Date
     ) throws(StoreError) -> ApprovedExecutionClaim {

--- a/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
+++ b/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
@@ -113,20 +113,21 @@ struct CancellingBeforeAssistantCommitRuns: RunStore {
   func fillClaimedObservation(
     runId: Int64,
     observationMessageId: Int64,
-    content: String
+    fill: ClaimedObservationFill
   ) throws(StoreError) {
     try base.fillClaimedObservation(
       runId: runId,
       observationMessageId: observationMessageId,
-      content: content
+      fill: fill
     )
   }
 
-  func applyApprovedMemoryWrite(
+  func applyApprovedMemoryWrite(  // swiftlint:disable:this function_parameter_count
     runId: Int64,
     observationMessageId: Int64,
     item: NewMemoryItem,
     observationContent: String,
+    audit: ApprovedExecutionAudit,
     notResumableObservationContent: String,
     now: Date
   ) throws(StoreError) -> ApprovedExecutionClaim {
@@ -135,6 +136,7 @@ struct CancellingBeforeAssistantCommitRuns: RunStore {
       observationMessageId: observationMessageId,
       item: item,
       observationContent: observationContent,
+      audit: audit,
       notResumableObservationContent: notResumableObservationContent,
       now: now
     )
@@ -276,20 +278,21 @@ struct CancellingBeforeDegradedCommitRuns: RunStore {
   func fillClaimedObservation(
     runId: Int64,
     observationMessageId: Int64,
-    content: String
+    fill: ClaimedObservationFill
   ) throws(StoreError) {
     try base.fillClaimedObservation(
       runId: runId,
       observationMessageId: observationMessageId,
-      content: content
+      fill: fill
     )
   }
 
-  func applyApprovedMemoryWrite(
+  func applyApprovedMemoryWrite(  // swiftlint:disable:this function_parameter_count
     runId: Int64,
     observationMessageId: Int64,
     item: NewMemoryItem,
     observationContent: String,
+    audit: ApprovedExecutionAudit,
     notResumableObservationContent: String,
     now: Date
   ) throws(StoreError) -> ApprovedExecutionClaim {
@@ -298,6 +301,7 @@ struct CancellingBeforeDegradedCommitRuns: RunStore {
       observationMessageId: observationMessageId,
       item: item,
       observationContent: observationContent,
+      audit: audit,
       notResumableObservationContent: notResumableObservationContent,
       now: now
     )
@@ -413,15 +417,16 @@ struct DiskFullRuns: RunStore {
   func fillClaimedObservation(
     runId: Int64,
     observationMessageId: Int64,
-    content: String
+    fill: ClaimedObservationFill
   ) throws(StoreError) {
     throw StoreError.diskFull
   }
-  func applyApprovedMemoryWrite(
+  func applyApprovedMemoryWrite(  // swiftlint:disable:this function_parameter_count
     runId: Int64,
     observationMessageId: Int64,
     item: NewMemoryItem,
     observationContent: String,
+    audit: ApprovedExecutionAudit,
     notResumableObservationContent: String,
     now: Date
   ) throws(StoreError) -> ApprovedExecutionClaim {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,6 +83,7 @@ clawd
 | `ClawLLM` | lib | OpenAI-compatible Chat Completions client + OpenAI-shaped message model; usage/cost; retries; **SSE streaming (v1)**. | `OpenAICompatibleProvider`, `ChatMessage`, `ChatRequest`, `ChatResponse`, `ToolCall`, `Usage`, `CostTable`, `SSEParser` |
 | `ClawWorkspace` | lib | Identity/memory files (`SOUL/AGENTS/USER/TOOLS/MEMORY.md`, `memory/*.md`, `skills/*`), Yams frontmatter, caps + untrusted-tier injection. | `WorkspaceStore`, `WorkspaceFile`, `MemoryDoc`, `FrontmatterParser` |
 | `ClawTools` | lib | Tool registry + read-only tools (v1); policy gate + approval orchestration arrive in the P-tools phase (Inc 5a). | `ToolRegistry`, `ToolContext`; `WebSearchTool`, `WebFetchTool`, `FileReadTool` (v1); `PolicyGate`, `ApprovalCoordinator` [Inc5a] |
+| `ClawExec` | lib | macOS 26 arm64 execution implementation: fixed-path swift-subprocess adapter, apple/container argv, disposable scratch, serialized VM lifecycle, probe/reap/canary maintenance. Linux supplies no backend until Inc 6. | `ContainerBackend`, `ExecSandboxSettings` |
 | `ClawAgent` | lib | Agent runtime: context assembly, the run loop, budgets, cancellation, the per-session lane. | `AgentRuntime`, `ContextBuilder`, `RunBudget`, `SessionActor` |
 | `ClawGateway` | lib | Wiring: `ServiceGroup`, Services, routing, access control, session resolution, outbox dispatch, shutdown. | `Gateway`, `TelegramPollerService`, `SchedulerService` [Inc4], `Router`, `AccessControl`, `RateLimiter`, `OutboxDispatcher` |
 | `clawd` | exe | Thin entry: load config + secrets → acquire startup lock → build ServiceGroup → run. | `main` |
@@ -114,6 +115,7 @@ form `ARCHITECTURE.md §N` is used, sparingly.
 | §10 Tool system & policy | `ToolRegistry`, `FileReadTool`, `FileWriteTool`, `MemoryWriteTool`, `WebFetchTool`, `WebSearchTool`, `WorkspacePathContainment` (ClawTools); `Tool`, `ToolDefinition`, `RiskLevel`, `ToolDispatching` (ClawCore) |
 | §11 Approval system | `Approval`, `ApprovalFSM`, `PendingToolAction`, `RecordedToolAction` (ClawCore); `ApprovalStoreGRDB` (ClawData); the §6.2/§6.5 gateway symbols above |
 | §12 Security & trust | `SecretRedactor`, `SSRFGuard`, `FakeIPDetector`, `ExfilArgGuard`, `CanonicalURL`, `ToolOutputCap` (ClawTools); `ContextTier` provenance labels, `LabeledContext`, and the `ResolvedAddress`/`CIDR` address vocabulary (ClawCore) |
+| §13 Execution / sandbox | `ExecutionBackend`, `SandboxMaintenance`, execution value types (ClawCore); `ExecuteCodeTool` (ClawTools); `ContainerBackend`, `ExecSandboxSettings` (ClawExec); `SandboxLifecycleService`, `SandboxHealthRows` (ClawGateway) |
 | §15 Config & secrets | `AppConfig`, `QuietHours`, `SecretStore` seam (ClawCore); `EncryptedFileSecretStore`, `EnvSecretStore`, `SecretStoreResolver` (ClawSecrets) |
 | §16 Observability | `DoctorReport`, `SchedulerHealth`, `ApprovalsHealthRows` (ClawGateway); `ApprovalsHealth`, `RunsHealth`, `AuditLog` (ClawCore); `AuditLogGRDB` (ClawData) |
 | §19 Error taxonomy | `ClawCore/Errors/` (`ClawExitCode`, `ConfigError`, `TelegramError`, `StoreError`, `ProviderError`); `ClawDatabase.classifyError` → `throws(StoreError)` seam (ClawData) |
@@ -244,7 +246,9 @@ model proposes tool_call
                         │            policy_version → execute ORIGINALLY-RECORDED args
                         ├─ reject   → cancel safely
                         └─ expire (approval-expiry ticker, default 1h) → DENY (terminal)
-       • dangerous  → refuse unless explicitly enabled in config
+       • dangerous  → absent from the registry unless explicitly enabled in config; once
+                        registered, ALWAYS suspend through ApprovalCoordinator (never auto-run),
+                        and execute only inside its declared sandbox after approval
        • LETHAL-TRIFECTA GATE (§12): if session.tainted && privileged/egress action,
          FORCE the approval path in code regardless of the tool's own tier.
   └─ AuditLog.append(actor, tool, args-redacted, decision, result-size, ts, run_id, session_id)
@@ -483,16 +487,55 @@ A **state machine** persisted in `approvals` so it survives restart. See §7.1 c
 - **Secrets:** never in replies or logs. **Exact-value redaction** of the loaded secret values (bot token, api keys, age-decrypted material) is the **PRIMARY** mechanism at both the log boundary and the outbound-reply boundary (the values are already in memory — cheap, deterministic); pattern-based scanning is **secondary** defense-in-depth. The gateway owns the destination chat id; outbound controls strip auto-fetching image/link elements.
 - **Accepted v1 limitation — `file_write` symlink TOCTOU.** `file_write` re-validates the approved path against the live filesystem at execution time (§10.2), but the directory creation, staging, and rename that follow are path-based, so a process racing the daemon on the same host could swap a parent directory for a symlink inside that window and redirect the write outside the workspace. This is **out of the v1 threat model** for the same reason §7 drops in-DB hash-chaining: a same-host attacker running as the daemon's user does not need the race — they can already write anywhere the daemon can. The four layers above defend against a subverted *model*, not a hostile co-resident process. If hardening is added later, bind the containment validation and the write to the same filesystem object (descriptor-relative, no-follow traversal; `openat2` + `RESOLVE_BENEATH` is Linux-only, Darwin needs a manual `O_NOFOLLOW` ancestor walk) — do not claim the race is closed without that.
 
-## 13. Execution / sandbox architecture (Inc 5b)
+## 13. Execution / sandbox architecture (Inc 5b macOS; Inc 6 Linux)
 
 - **`ExecutionBackend` protocol** (`Sendable`), driven via `swiftlang/swift-subprocess`:
-  - **macOS:** `ContainerBackend` shells out to the `apple/container` CLI — **VM-per-container** via Virtualization.framework (a container escape needs a *hypervisor* escape).
-  - **Linux:** `PodmanMicroVMBackend` (Podman/runc-in-microVM or gVisor `runsc`) behind the same protocol. (Backend choice is a genuinely open question — §21.)
-- **Isolation unit (explicit):** **one untrusted execution = one disposable, never-reused VM** with scratch staged and destroyed per run. The **warm pool amortizes only the boot of a fresh instance** — it never reuses an instance across jobs.
-- **Secure-by-default exec:** no host bind-mounts (stage inputs into a scratch dir), egress denied unless opted in, `--cap-drop ALL`, rootless, resource caps (≈1GB/4CPU), `--init` reaper, deterministic timeouts (stop-signal then SIGKILL), `closeAllUnknownFileDescriptors` on Linux.
-- **Staging is a gated data-crossing, not free:** apply the same canonicalize + workspace-scope + secret-shaped-content checks to the staging path as to FS tools (anti confused-deputy). When egress is opted in, treat the run as `canExfiltrate=true` and require approval if the session is tainted.
-- Prefer **shelling to the CLI** over embedding the pre-1.0 `containerization` library (looser coupling, separate process tree). Backend state lives in an `actor`.
-- **`sandbox-exec`/Seatbelt** only as defense-in-depth around the launcher — never the sole boundary.
+  - **macOS 26+ arm64 (Inc 5b):** `ContainerBackend` shells out to the fixed
+    `/usr/local/bin/container` apple/container CLI. Every container receives its own
+    Virtualization.framework VM; a container escape therefore still needs a hypervisor escape.
+  - **Linux (Inc 6):** the backend remains open behind the same protocol. A pinned Linux-host
+    spike must prove lifecycle, no-egress, opted-in egress, resource caps/cgroups, rootless
+    operation, and cleanup. If the selected backend is not a hardware-virtualized microVM, PRD
+    FR-X1 must be amended before implementation.
+- **Feature floor:** the package remains macOS 15 compatible, but `execute_code` is absent unless
+  the host is macOS 26 or newer on arm64. Linux, macOS 15, and Intel macOS fail closed and doctor
+  explains why. No macOS-15 degraded mode exists.
+- **Isolation unit:** one untrusted execution = one fresh disposable, never-reused VM. Scratch is
+  created and destroyed per run. No warm pool, snapshot clone, or interactive persistent session
+  ships in this increment.
+- **Secure-by-default launcher:** no live workspace, home, or ambient host path is mounted. The
+  sole host mount is the daemon-owned per-execution scratch directory containing bounded copies of
+  approved inputs; it is mounted at `/work` with the explicit `readonly` option. Every run uses a
+  read-only root filesystem plus `/tmp` tmpfs, `--cap-drop ALL`, `--init`, explicit CPU/memory caps,
+  a digest-pinned workload image, an explicit interpreter entrypoint, deterministic identity, and
+  unconditional cleanup. apple/container owns the init image: the backend resolves its exact
+  runtime reference, pulls it over HTTPS, passes it explicitly, and reports it as a
+  version-coupled trust dependency without claiming digest verification the CLI cannot expose.
+- **Network is explicit in both directions:** default execution emits
+  `--network none --no-dns`; owner-approved `network: true` emits `--network default`. Omitting
+  `--network` is forbidden because apple/container attaches the default network and grants full
+  egress. Networked execution is `canExfiltrate=true` and remains dangerous/approval-gated.
+- **Staging is a gated data crossing:** every source is an existing regular workspace-relative
+  file resolved through canonical realpath containment. The approval binds source path, realpath,
+  byte count, and SHA-256; execution re-resolves and re-hashes before copying. Code and every
+  staged file always pass exact-secret and secret-shape scanning; networked runs additionally pass
+  the MEMORY/USER substring tier.
+- **Backend state lives in an actor, but actor isolation is not a run limiter.** A stored `Task`
+  chain serializes the whole spawn → execution → cleanup operation across suspension points, so at
+  most one VM contributes its peak memory footprint.
+- **Timeout and output:** the program budget starts after spawn; the whole call returns within that
+  budget plus a 20-second teardown allowance. The launcher explicitly configures process-group
+  teardown, drains stdout/stderr concurrently, retains at most 1 MiB per stream while continuing
+  to drain, and then destroys the named container and scratch on every exit path.
+- **Maintenance and doctor:** `SandboxMaintenance.prepare()` reaps owned leftovers, pre-pulls the
+  pinned workload and exact runtime-owned init references, and boots a hardening canary. Any
+  failed host, version, digest, capability, network, resource, reaper, rootfs, staging, or
+  interpreter assertion keeps `execute_code` out of the registry. `shutdown()` cancels the
+  execution chain and reaps again.
+- **swift-subprocess is only a launcher.** It provides no isolation. Pin exact release 0.5.0, use
+  streaming capture and an explicit teardown sequence, and keep the hardware VM as the boundary.
+- `sandbox-exec`/Seatbelt may wrap the launcher only as optional defense-in-depth; it is never the
+  isolation boundary.
 
 ## 14. Scheduler architecture (Inc 4)
 
@@ -522,6 +565,7 @@ A **state machine** persisted in `approvals` so it survives restart. See §7.1 c
 | scheduler | `last_tick_at`, `due_count`, `last_misfire` |
 | runs | `in_flight`, `oldest_run_age`, `last_FAILED` |
 | spend | `today_usd`, `remaining_budget` (per-run + per-day) |
+| sandbox | `available`, `os_ok`, `engine_version`, `version_ok`, `image_digest_ok`, `caps_empty`, `net_isolated`, `caps_match`, `reaper_ok`, `rootfs_ro`, `staging_ro`, `interpreters_ok`, `last_error` |
 | config/secret | validation result — **printed first** if it errored |
 
 - **Audit:** ordinary append-only (§7.2) — useful for "why did it do that." No tamper-evidence claim in v1.
@@ -530,6 +574,8 @@ A **state machine** persisted in `approvals` so it survives restart. See §7.1 c
 ## 17. Deployment & portability
 
 - **Build:** SwiftPM (**platform floor macOS 15** — `Calendar.RecurrenceRule` requires it, Inc 4/§14); two release binaries: a **macOS-native `arm64` binary** and a **Linux `x86_64` binary built natively in the `swift:6.3-noble` container** with `--static-swift-stdlib` (the Swift runtime is bundled; the system `libsqlite3` is the sole external runtime dependency). A musl **Static Linux SDK** → fully-static/distroless image is deferred: GRDB v7 declares SQLite as a `.systemLibrary` and the musl SDK ships none, so a musl cross-compile can't link (see §18 Deployment escape hatch).
+`execute_code` has its own stricter runtime gate: macOS 26+ arm64. It stays absent on every other
+build; the portable `ExecutionBackend` types and all fake-backed tests still compile on Linux.
 - **Portability is enforced continuously:** a **GRDB + FTS5 build+test gate runs on both macOS and Linux on every PR** (`ci.yml`) — the portability gate is live, not deferred. Portable protocol seams + AsyncHTTPClient/OpenAI-compat choices are kept throughout; pragmatic macOS-native code is permitted behind a protocol and covered by the Linux CI gate.
 - **Supervise:** launchd plist (macOS) / systemd unit (Linux), with throttling (§4). Logs to stdout/stderr.
 - **CI:** the macOS + Linux **GRDB + FTS5 build+test gate** (`ci.yml`) runs on every PR and blocks merge; releases (`release.yml`) publish as **GitHub Releases with SHA256 checksums + build-provenance attestations**, not a container image.
@@ -611,8 +657,8 @@ Re-cut for the approved v1 scope. **Inc 0–3 = the v1 daily-driver milestone**:
 | **3** | Memory & workspace + read-only tools | Workspace files injected at the **untrusted tier** (budgeted, caps, flush-before-compact); durable facts on confirm; `memory_items` + **FTS5 recall** across restarts; `/memory`; `web_search`/`web_fetch` + file READ at **`safe`** tier with the **exfil gate**. |
 | **4** | Scheduler & proactive | "Every weekday 07:00 Europe/Berlin…" fires once per occurrence across restarts/DST; **confirm-before-arm**; reduced-privilege runs; clock-gap catch-up cap; delivery via outbox; opt-in heartbeat with quiet hours. *(Scope reconciliation: the external research roadmap bundles memory/workspace into its "Increment 4" — this repo shipped those in Inc 3a; this increment is scheduler/proactive only.)* |
 | **5a** | Approval fabric + write tools | *Prep first: add `approval-requested/granted/denied` audit cases + a per-run prompt/workspace fingerprint for `policy_version` to bind to.* Then a consequential **write** tool (`file_write`/`memory_write`, `ask` tier) requires explicit approval via the **durable FSM** (**callback auth + ≥128-bit nonce + suspend-to-`AWAITING_APPROVAL` + boot reconciliation + expiry ticker**); a **forged or third-party callback cannot approve**; the **enforced lethal-trifecta gate** (upgraded from Inc 3b's ephemeral grant to the durable FSM) forces approval on a tainted privileged/egress action. **No virtualization.** |
-| **5b** | Sandbox + code execution | Built on 5a's approval fabric: untrusted code (`execute_code`, `dangerous` tier) runs in a **per-exec disposable VM** (no host FS/network by default) behind approval; the staging path is gated like the file tools; an opted-in-egress run is `canExfiltrate=true`. **Prereqs:** resolve the Linux backend (§21) + pin the base image + add a sandbox check to doctor. |
-| **6** | Linux portability & deployment | Same source → running, supervised binary on a fresh Linux box (systemd); the **macOS + Linux GRDB+FTS5 build+test CI gate already landed early** (`ci.yml`, §17), so the remainder here is the **musl Static Linux SDK → distroless packaging, which stays deferred/optional** (§17/§18 escape hatch). |
+| **5b** | Sandbox + code execution (macOS) | Built on 5a's approval fabric: on macOS 26 arm64, untrusted code (`execute_code`, `dangerous`) runs in one fresh disposable apple/container VM behind exact-action approval. No live host path/network is exposed by default; staged copies are containment/secret/hash gated; opted-in egress is `canExfiltrate=true`; doctor fails closed. **Prerequisite:** verify and pin the workload image. |
+| **6** | Linux sandbox + portability & deployment | Resolve and implement the Linux `ExecutionBackend` after a pinned host spike and FR-X1 conformance/amendment; keep the existing macOS + Linux GRDB/FTS5 gate; complete the remaining supervised Linux packaging work. |
 
 *(Later/optional: image input to a vision model; native Anthropic adapter w/ prompt caching; Hummingbird `/v1/chat/completions` REST; MCP via official SDK + Linux SSE transport; voice transcription; multi-provider fallback; per-call USD dashboards.)*
 
@@ -620,7 +666,9 @@ Re-cut for the approved v1 scope. **Inc 0–3 = the v1 daily-driver milestone**:
 
 Genuinely-open (decided ones have moved into the body above):
 
-- **Linux sandbox backend:** Podman+microVM vs gVisor `runsc` (decide before Inc 5b).
+- **Linux sandbox backend (decide before Inc 6):** KVM-backed microVM versus a documented PRD
+  amendment for a userspace-kernel profile; rootless Podman + gVisor remains only a candidate until
+  the pinned Linux-host spike proves its cgroup, network, and cleanup behavior.
 - MCP transport on Linux: custom AHC SSE transport vs Stdio-only.
 - Rolling summary vs aggressive compaction + just-in-time retrieval (treat rolling summary as one strategy; keep out-of-window references).
 

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -88,6 +88,87 @@ pool set `CLAW_WEBFETCH_EXEMPT_CIDRS` (see `.env.example`).
 
 ---
 
+## Sandbox workload image (macOS 26 arm64)
+
+`execute_code` is disabled by default and the distribution does not silently select an image.
+The verified development image pin for this release is:
+
+```text
+cgr.dev/chainguard/python@sha256:55cd38584d1bba1913a1d58da07184cbe512724bc03e822e269404c73cd4c9cd
+```
+
+The pinned arm64 image provides `/usr/bin/python` and `/bin/sh`, has OCI ENTRYPOINT
+`["/usr/bin/python"]`, and runs as nonroot uid `65532`. clawd always supplies an explicit
+entrypoint. Re-verify before replacing the digest; never copy a moving tag into
+`CLAW_EXEC_IMAGE`.
+
+```bash
+brew install cosign
+
+set -euo pipefail
+IMAGE_TAG=cgr.dev/chainguard/python:latest-dev
+IMAGE_DIGEST=sha256:55cd38584d1bba1913a1d58da07184cbe512724bc03e822e269404c73cd4c9cd
+IMAGE_REF=cgr.dev/chainguard/python@${IMAGE_DIGEST}
+ISSUER=https://token.actions.githubusercontent.com
+IDENTITY='^https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main$'
+EVIDENCE_DIR="${HOME}/.swift-claw/image-evidence/${IMAGE_DIGEST#sha256:}"
+install -d -m 0700 "${EVIDENCE_DIR}"
+
+/usr/local/bin/container image pull \
+  --scheme https --progress none --platform linux/arm64 "${IMAGE_TAG}"
+/usr/local/bin/container image inspect "${IMAGE_TAG}" | grep -q "${IMAGE_DIGEST}"
+
+cosign verify \
+  --certificate-oidc-issuer "${ISSUER}" \
+  --certificate-identity-regexp "${IDENTITY}" "${IMAGE_REF}" \
+  > "${EVIDENCE_DIR}/signature.json"
+cosign verify-attestation --type https://slsa.dev/provenance/v1 \
+  --certificate-oidc-issuer "${ISSUER}" \
+  --certificate-identity-regexp "${IDENTITY}" "${IMAGE_REF}" \
+  > "${EVIDENCE_DIR}/slsa-v1.intoto.jsonl"
+cosign verify-attestation --type https://apko.dev/image-configuration \
+  --certificate-oidc-issuer "${ISSUER}" \
+  --certificate-identity-regexp "${IDENTITY}" "${IMAGE_REF}" \
+  > "${EVIDENCE_DIR}/apko.intoto.jsonl"
+cosign verify-attestation --type https://spdx.dev/Document \
+  --certificate-oidc-issuer "${ISSUER}" \
+  --certificate-identity-regexp "${IDENTITY}" "${IMAGE_REF}" \
+  > "${EVIDENCE_DIR}/spdx.intoto.jsonl"
+test -s "${EVIDENCE_DIR}/signature.json"
+test -s "${EVIDENCE_DIR}/slsa-v1.intoto.jsonl"
+test -s "${EVIDENCE_DIR}/apko.intoto.jsonl"
+test -s "${EVIDENCE_DIR}/spdx.intoto.jsonl"
+
+/usr/local/bin/container run --rm \
+  --scheme https --progress none --platform linux/arm64 \
+  --network none --no-dns --cap-drop ALL --read-only --tmpfs /tmp \
+  --entrypoint /bin/sh "${IMAGE_REF}" -c '
+    test -x /usr/bin/python
+    test -x /bin/sh
+    test "$(id -u)" = 65532
+  '
+```
+
+After those checks pass, set the non-secret execution configuration in
+`~/.swift-claw/clawd.env`:
+
+```bash
+CLAW_EXEC_ENABLED=true
+CLAW_EXEC_IMAGE=cgr.dev/chainguard/python@sha256:55cd38584d1bba1913a1d58da07184cbe512724bc03e822e269404c73cd4c9cd
+CLAW_EXEC_IMAGE_REGISTRIES=cgr.dev
+CLAW_EXEC_MEMORY_MIB=1024
+CLAW_EXEC_CPUS=4
+CLAW_EXEC_TIMEOUT=30
+CLAW_EXEC_ALLOW_EGRESS=false
+```
+
+Re-pin on an upstream advisory or an intentional maintenance review. Repeat signature plus all
+three attestation checks, interpreter/user inspection, hardening canary, and the mandatory
+`ContainerBackendRealAcceptanceTests` command before changing the configured digest. Automated
+mirroring and refresh scheduling are outside this increment.
+
+---
+
 ## Secrets
 
 ### Seal (first-time setup)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -168,8 +168,16 @@ Requirements tagged *(v1)* are part of the daily-driver milestone (§9); others 
 - **FR-C4.** Audit events for job create/execute/cancel/failure. Proactive runs have their own daily spend budget.
 
 ### 6.9 Execution / sandbox *(later phase)*
-- **FR-X1.** Shell/code execution runs inside a **hardware-virtualization sandbox** behind an `ExecutionBackend` protocol: `apple/container` on macOS, a microVM backend on Linux. One untrusted execution = one disposable, never-reused VM (scratch staged and destroyed per run).
-- **FR-X2.** Secure-by-default exec: no host bind-mounts, egress denied unless opted in, capabilities dropped, resource caps, deterministic timeouts. The staging path applies the same canonicalize + workspace-scope + secret-shaped-content checks as the file tools; an opted-in-egress exec run is treated as `canExfiltrate=true`.
+- **FR-X1.** Shell/code execution runs behind an `ExecutionBackend` protocol. Inc 5b supplies
+  `apple/container` on macOS 26+ arm64: one untrusted execution = one disposable, never-reused
+  hardware-virtualized VM. Linux gets a separately chosen backend in Inc 6; until a pinned
+  Linux-host spike proves a microVM-conformant design, the Linux choice remains open.
+- **FR-X2.** Secure-by-default exec exposes no live workspace, home, or ambient host bind mount.
+  Approved inputs are copied into one daemon-owned, per-execution ephemeral scratch directory and
+  that copy is the sole host mount, explicitly read-only. Egress is denied unless opted in;
+  capabilities are dropped; resource caps and deterministic timeouts are explicit. Staging applies
+  the same canonicalize + workspace-scope + secret-shaped-content checks as file tools and binds
+  realpath/bytes by SHA-256; opted-in egress is `canExfiltrate=true`.
 
 ### 6.10 Operator UX
 - **FR-O1.** *(commands land with their features)* Telegram command menu: at minimum `/start`, `/help`, `/status`, `/new`, `/stop`, `/cost` in v1; `/memory`, `/retry` in v1; `/model`, `/approve`, `/reject`, `/schedule`, `/cancel` as their features land.
@@ -213,7 +221,7 @@ Distilled from the verified best-practices research:
 | Phase | Capability | Headline outcome |
 |---|---|---|
 | **v1 — Daily driver** | §5.1, §5.2, §5.3 | Supervised default-deny Telegram DM → real OpenAI-compatible **streaming** LLM answer; persisted; multi-turn; per-session FIFO lane + `/stop` + `/new`; durable memory on confirm + FTS5 recall; read-only `web_search`/`web_fetch`/file-read (`safe`, exfil-gated); USD breaker; onboarding; non-text handling; graceful degradation; export/delete; `doctor`; survives restart. |
-| **P-tools** | §5.4 | Write/shell tools + in-code policy gate + Telegram approval flow (callback auth + nonce + FSM) + sandbox (`apple/container` / Linux microVM) + enforced lethal-trifecta gate. *Delivered in two increments — **5a** (approval fabric + write tools, no virtualization) then **5b** (sandbox + code execution); see [`ARCHITECTURE.md` §20].* |
+| **P-tools** | §5.4 | Write/shell tools + in-code policy gate + Telegram approval flow (callback auth + nonce + FSM) + sandbox (`apple/container` in Inc 5b on macOS 26 arm64; Linux backend in Inc 6) + enforced lethal-trifecta gate. *Delivered in two increments — **5a** (approval fabric + write tools, no virtualization) then **5b** (sandbox + code execution); see [`ARCHITECTURE.md` §20].* |
 | **P-schedule** | §5.5 | NL reminders; restart-safe DST-correct scheduler; confirm-before-arm; reduced-privilege proactive runs; opt-in heartbeat with quiet hours; delivery to DM. |
 | **P-portability** | — | Linux portability + deployment (static SDK, distroless/systemd, CI Linux gate). |
 | **Roadmap (later)** | — | Image/vision input; native Anthropic adapter (prompt caching); pairing flow; sqlite-vec recall (behind a protocol). |
@@ -245,13 +253,15 @@ Each criterion is backed by an **automated acceptance test** (per-requirement ve
 ## 12. Risks & open questions
 
 - **R1.** Telegram thin-client correctness (offset ordering, 409 conflict, 429 flood-control) — mitigated by the FR-G2 durability invariant + single-instance guard + typed 409 + tests.
-- **R2.** `apple/container` is macOS-26/Apple-Silicon-only — a Linux sandbox backend must be chosen before P-tools.
+- **R2.** `apple/container` is macOS-26/Apple-Silicon-only. Inc 5b therefore ships the macOS
+  backend only; Linux execution remains absent until Inc 6 resolves and proves its backend.
 - **R3.** OpenAI-compat shims lag native features (Anthropic prompt caching, some tool-calling quirks) — acceptable; the `LLMProvider` protocol leaves an escape hatch.
 - **R4.** `sqlite-vec` (vector search) requires a custom SQLite amalgamation + separate Linux re-validation — keep strictly behind a protocol and deferred; FTS5/BM25 is the v1 recall mechanism.
 - **R5.** Prompt injection has no reliable model-level fix — rely on least-privilege, the enforced trifecta gate, and approvals, not a classifier; the memory-write scan is defense-in-depth only.
 - **R6.** GRDB + FTS5 on Linux is contributor-supported (FTS5 may not be compiled into the platform SQLite) — mitigated by vendoring the SQLite amalgamation with FTS5 compiled in and a Linux CI job; risk is **Low (macOS) / Med (Linux until our own CI exists)**.
 - **OQ1.** HTML vs MarkdownV2 as the default Telegram parse mode (HTML is less 400-prone).
-- **OQ2.** Linux sandbox backend (P-tools): Podman + microVM vs gVisor `runsc`.
+- **OQ2.** Linux sandbox backend (Inc 6): KVM-backed microVM versus an explicitly amended
+  userspace-kernel profile, decided only after the pinned Linux-host spike.
 
 *(Resolved and removed from open questions: memory write policy = confirm-on-write; context counting unit = graphemes; memory caps = 2200/1375; error-on-overflow is the v1 contract.)*
 


### PR DESCRIPTION
## Summary

Foundation for macOS sandboxed code execution: the execution contracts, fail-closed config, the exec-to-policy binding, and the approval-resume path that carries full tool provenance. The `execute_code` tool and the `ClawExec` container backend land in later increments; this branch is the substrate under them.

## What's here

- **Normative docs.** `ARCHITECTURE.md`/`PRD.md` now define the approved boundary: `execute_code` runs on macOS 26+ arm64 inside a fresh disposable apple/container VM; the Linux backend moves to a later increment; the sole host mount is a daemon-owned read-only scratch directory; a registered `dangerous` tool always parks for approval and never auto-runs.
- **Pinned workload image.** `LOCAL_DEV.md` documents the operator workflow and pins `cgr.dev/chainguard/python@sha256:55cd38584d1bba1913a1d58da07184cbe512724bc03e822e269404c73cd4c9cd`, verified here with a cosign signature plus SLSA/apko/SPDX attestations against Chainguard's build identity, and an in-VM interpreter/uid check.
- **Execution contracts** (`ClawCore`): the `ExecutionBackend`/`SandboxMaintenance` protocols, the request/result/health value types (all `Sendable`), a canonical `SHA256Digest.hex`, and a scripted `FakeExecutionBackend` that returns an explicit "unavailable" rather than inventing a successful run.
- **Fail-closed exec config** (`AppConfig.exec`), default-off. When enabled it requires a digest-pinned image from an allowlisted registry, and the host CPU ceiling applies only when enabled (so a disabled config still parses on low-core CI). The `PinnedImageReference` parser rejects tags, schemes, uppercase digests, implicit Docker Hub names, and IP/localhost registries.
- **Policy binding.** The normalized exec block folds into `policy_version`, so changing any exec field (enablement, image, allowlist, caps, timeout, egress) voids an outstanding approval.
- **Transactional provenance.** The approved-execution fill commits observation content, state-guarded session provenance (taint / private-data), and the `.toolCall` audit in one transaction, and rolls them back together on failure. Approved execution now carries the tool's full result (status and provenance), and audit arguments pass through the same secret redactor the policy gate uses, so raw arguments never reach `audit_events`.

## Out of scope (later increments)

The `execute_code` tool, the `ClawExec` container backend, argv construction, the doctor health rows, and the shutdown service. This branch is contracts, config, and resume only.

## Verification

- `swift build --build-tests` green; full suite is 1115 tests across 179 suites, 0 failures.
- `scripts/lint.sh` exits clean. Three warnings are intentional: the six-parameter policy-fingerprint signature, a config file over the length threshold (the parser is co-located by design), and the `sh` enum case whose two-letter name is the wire value.
- No live container runs here; that arrives with the backend.
