### PR TITLE
Validate the sandbox before registering execute_code and report it in doctor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -93,7 +93,7 @@ let package = Package(
       name: "clawd",
       dependencies: [
         "ClawCore", "ClawData", "ClawSecrets", "ClawTelegram", "ClawGateway", "ClawLLM",
-        "ClawAgent", "ClawWorkspace", "ClawTools",
+        "ClawAgent", "ClawWorkspace", "ClawTools", "ClawExec",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "Logging", package: "swift-log"),

--- a/Package.swift
+++ b/Package.swift
@@ -94,6 +94,7 @@ let package = Package(
       dependencies: [
         "ClawCore", "ClawData", "ClawSecrets", "ClawTelegram", "ClawGateway", "ClawLLM",
         "ClawAgent", "ClawWorkspace", "ClawTools", "ClawExec",
+        .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "Logging", package: "swift-log"),

--- a/Sources/ClawGateway/Infrastructure/SandboxBootstrapper.swift
+++ b/Sources/ClawGateway/Infrastructure/SandboxBootstrapper.swift
@@ -43,6 +43,7 @@ public struct SandboxBootstrapper: Sendable {
         unavailableReason: "code execution is disabled"
       )
     }
+
     guard let backend, let maintenance else {
       return SandboxBootstrapResult(
         backend: nil,
@@ -73,6 +74,7 @@ public struct SandboxBootstrapper: Sendable {
         unavailableReason: health.lastError ?? "sandbox hardening canary failed"
       )
     }
+
     return SandboxBootstrapResult(
       backend: backend,
       maintenance: maintenance,

--- a/Sources/ClawGateway/Infrastructure/SandboxBootstrapper.swift
+++ b/Sources/ClawGateway/Infrastructure/SandboxBootstrapper.swift
@@ -1,0 +1,83 @@
+import ClawCore
+
+public struct SandboxBootstrapResult: Sendable {
+  public let backend: (any ExecutionBackend)?
+  public let maintenance: (any SandboxMaintenance)?
+  public let health: SandboxHealth?
+  public let unavailableReason: String?
+
+  public init(
+    backend: (any ExecutionBackend)?,
+    maintenance: (any SandboxMaintenance)?,
+    health: SandboxHealth?,
+    unavailableReason: String?
+  ) {
+    self.backend = backend
+    self.maintenance = maintenance
+    self.health = health
+    self.unavailableReason = unavailableReason
+  }
+}
+
+public struct SandboxBootstrapper: Sendable {
+  private let enabled: Bool
+  private let backend: (any ExecutionBackend)?
+  private let maintenance: (any SandboxMaintenance)?
+
+  public init(
+    enabled: Bool,
+    backend: (any ExecutionBackend)?,
+    maintenance: (any SandboxMaintenance)?
+  ) {
+    self.enabled = enabled
+    self.backend = backend
+    self.maintenance = maintenance
+  }
+
+  public func prepare() async -> SandboxBootstrapResult {
+    guard enabled else {
+      return SandboxBootstrapResult(
+        backend: nil,
+        maintenance: nil,
+        health: nil,
+        unavailableReason: "code execution is disabled"
+      )
+    }
+    guard let backend, let maintenance else {
+      return SandboxBootstrapResult(
+        backend: nil,
+        maintenance: nil,
+        health: nil,
+        unavailableReason: "sandbox backend is not configured"
+      )
+    }
+
+    switch await backend.probe() {
+    case .unavailable(let reason):
+      return SandboxBootstrapResult(
+        backend: nil,
+        maintenance: maintenance,
+        health: nil,
+        unavailableReason: reason
+      )
+    case .available:
+      break
+    }
+
+    let health = await maintenance.prepare()
+    guard health.isReady else {
+      return SandboxBootstrapResult(
+        backend: nil,
+        maintenance: maintenance,
+        health: health,
+        unavailableReason: health.lastError ?? "sandbox hardening canary failed"
+      )
+    }
+    return SandboxBootstrapResult(
+      backend: backend,
+      maintenance: maintenance,
+      health: health,
+      unavailableReason: nil
+    )
+  }
+}

--- a/Sources/ClawGateway/Infrastructure/SandboxLifecycleService.swift
+++ b/Sources/ClawGateway/Infrastructure/SandboxLifecycleService.swift
@@ -1,0 +1,32 @@
+import ClawCore
+import ServiceLifecycle
+
+/// Keeps the sandbox backend in the ServiceGroup shutdown graph. The service performs no periodic
+/// work; its only effect is awaiting the backend's cancellation-safe teardown before it exits.
+public struct SandboxLifecycleService: Service {
+  public static let idleInterval: Duration = .seconds(3600)
+
+  private let maintenance: any SandboxMaintenance
+  private let clock: any Clock<Duration>
+
+  public init(
+    maintenance: any SandboxMaintenance,
+    clock: any Clock<Duration> = ContinuousClock()
+  ) {
+    self.maintenance = maintenance
+    self.clock = clock
+  }
+
+  public func run() async throws {
+    await cancelWhenGracefulShutdown {
+      while Task.isCancelled == false {
+        do {
+          try await clock.sleep(for: Self.idleInterval)
+        } catch {
+          break
+        }
+      }
+    }
+    await maintenance.shutdown()
+  }
+}

--- a/Sources/ClawGateway/Infrastructure/SandboxLifecycleService.swift
+++ b/Sources/ClawGateway/Infrastructure/SandboxLifecycleService.swift
@@ -19,7 +19,7 @@ public struct SandboxLifecycleService: Service {
 
   public func run() async throws {
     await cancelWhenGracefulShutdown {
-      while Task.isCancelled == false {
+      while !Task.isCancelled {
         do {
           try await clock.sleep(for: Self.idleInterval)
         } catch {

--- a/Sources/ClawGateway/Response/SandboxHealthRows.swift
+++ b/Sources/ClawGateway/Response/SandboxHealthRows.swift
@@ -1,0 +1,131 @@
+import ClawCore
+
+public enum SandboxDoctorStatus: Sendable, Equatable {
+  case disabled
+  case linuxDeferred
+  case configOnly(availability: BackendAvailability)
+  case live(health: SandboxHealth)
+  case unavailable(reason: String)
+}
+
+public enum SandboxHealthRows {
+  public struct Row: Sendable, Equatable {
+    public let key: String
+    public let value: String
+    public let ok: Bool
+
+    public init(key: String, value: String, ok: Bool) {
+      self.key = key
+      self.value = value
+      self.ok = ok
+    }
+  }
+
+  public static func rows(for status: SandboxDoctorStatus) -> [Row] {
+    switch status {
+    case .disabled:
+      return [Row(key: "sandbox", value: "disabled by CLAW_EXEC_ENABLED", ok: true)]
+    case .linuxDeferred:
+      return [Row(key: "sandbox", value: "execute_code awaits the Linux backend", ok: true)]
+    case .configOnly(let availability):
+      return configOnlyRows(availability)
+    case .live(let health):
+      return liveRows(health)
+    case .unavailable(let reason):
+      return unavailableRows(reason: reason)
+    }
+  }
+}
+
+// MARK: - Config-Only Rows
+
+private extension SandboxHealthRows {
+  static func configOnlyRows(_ availability: BackendAvailability) -> [Row] {
+    switch availability {
+    case .available(let engineVersion):
+      return [
+        flag(key: "sandbox.available", value: true),
+        flag(key: "sandbox.os_ok", value: true),
+        Row(
+          key: "sandbox.engine_version",
+          value: "\(engineVersion) (minimum 1.0.0)",
+          ok: true
+        ),
+        flag(key: "sandbox.version_ok", value: true),
+        Row(
+          key: "sandbox.canary",
+          value: "deferred until live daemon startup",
+          ok: true
+        ),
+      ]
+    case .unavailable(let reason):
+      return [
+        flag(key: "sandbox.available", value: false),
+        Row(key: "sandbox.os_ok", value: "unknown", ok: false),
+        Row(
+          key: "sandbox.engine_version",
+          value: "unknown (minimum 1.0.0)",
+          ok: false
+        ),
+        flag(key: "sandbox.version_ok", value: false),
+        Row(key: "sandbox.last_error", value: reason, ok: false),
+      ]
+    }
+  }
+}
+
+// MARK: - Live Rows
+
+private extension SandboxHealthRows {
+  static func unavailableRows(reason: String) -> [Row] {
+    [
+      flag(key: "sandbox.available", value: false),
+      Row(key: "sandbox.os_ok", value: "unknown", ok: false),
+      Row(
+        key: "sandbox.engine_version",
+        value: "unknown (minimum 1.0.0)",
+        ok: false
+      ),
+      flag(key: "sandbox.version_ok", value: false),
+      Row(key: "sandbox.image_digest_ok", value: "not run", ok: false),
+      Row(key: "sandbox.caps_empty", value: "not run", ok: false),
+      Row(key: "sandbox.net_isolated", value: "not run", ok: false),
+      Row(key: "sandbox.caps_match", value: "not run", ok: false),
+      Row(key: "sandbox.reaper_ok", value: "not run", ok: false),
+      Row(key: "sandbox.rootfs_ro", value: "not run", ok: false),
+      Row(key: "sandbox.staging_ro", value: "not run", ok: false),
+      Row(key: "sandbox.interpreters_ok", value: "not run", ok: false),
+      Row(key: "sandbox.last_error", value: reason, ok: false),
+    ]
+  }
+
+  static func liveRows(_ health: SandboxHealth) -> [Row] {
+    [
+      flag(key: "sandbox.available", value: health.available),
+      flag(key: "sandbox.os_ok", value: health.osOK),
+      Row(
+        key: "sandbox.engine_version",
+        value: "\(health.engineVersion ?? "unknown") (minimum 1.0.0)",
+        ok: health.engineVersion != nil
+      ),
+      flag(key: "sandbox.version_ok", value: health.versionOK),
+      flag(key: "sandbox.image_digest_ok", value: health.imageDigestOK),
+      flag(key: "sandbox.caps_empty", value: health.capsEmpty),
+      flag(key: "sandbox.net_isolated", value: health.netIsolated),
+      flag(key: "sandbox.caps_match", value: health.capsMatch),
+      flag(key: "sandbox.reaper_ok", value: health.reaperOK),
+      flag(key: "sandbox.rootfs_ro", value: health.rootfsRO),
+      flag(key: "sandbox.staging_ro", value: health.stagingRO),
+      flag(key: "sandbox.interpreters_ok", value: health.interpretersOK),
+      Row(
+        key: "sandbox.last_error",
+        value: health.lastError ?? "none",
+        ok: health.lastError == nil
+      ),
+    ]
+  }
+
+  static func flag(key: String, value: Bool) -> Row {
+    Row(key: key, value: value ? "true" : "false", ok: value)
+  }
+}

--- a/Sources/ClawGateway/Response/SandboxHealthRows.swift
+++ b/Sources/ClawGateway/Response/SandboxHealthRows.swift
@@ -4,6 +4,7 @@ public enum SandboxDoctorStatus: Sendable, Equatable {
   case disabled
   case linuxDeferred
   case configOnly(availability: BackendAvailability)
+  case daemonManaged(availability: BackendAvailability)
   case live(health: SandboxHealth)
   case unavailable(reason: String)
 }
@@ -29,6 +30,8 @@ public enum SandboxHealthRows {
       return [Row(key: "sandbox", value: "execute_code awaits the Linux backend", ok: true)]
     case .configOnly(let availability):
       return configOnlyRows(availability)
+    case .daemonManaged(let availability):
+      return daemonManagedRows(availability)
     case .live(let health):
       return liveRows(health)
     case .unavailable(let reason):
@@ -37,40 +40,54 @@ public enum SandboxHealthRows {
   }
 }
 
-// MARK: - Config-Only Rows
+// MARK: - Version-Only Rows
 
 private extension SandboxHealthRows {
   static func configOnlyRows(_ availability: BackendAvailability) -> [Row] {
     switch availability {
     case .available(let engineVersion):
-      return [
-        flag(key: "sandbox.available", value: true),
-        flag(key: "sandbox.os_ok", value: true),
-        Row(
-          key: "sandbox.engine_version",
-          value: "\(engineVersion) (minimum 1.0.0)",
-          ok: true
-        ),
-        flag(key: "sandbox.version_ok", value: true),
-        Row(
-          key: "sandbox.canary",
-          value: "deferred until live daemon startup",
-          ok: true
-        ),
-      ]
+      return availableVersionRows(engineVersion)
+        + [Row(key: "sandbox.canary", value: "deferred until live daemon startup", ok: true)]
     case .unavailable(let reason):
-      return [
-        flag(key: "sandbox.available", value: false),
-        Row(key: "sandbox.os_ok", value: "unknown", ok: false),
-        Row(
-          key: "sandbox.engine_version",
-          value: "unknown (minimum 1.0.0)",
-          ok: false
-        ),
-        flag(key: "sandbox.version_ok", value: false),
-        Row(key: "sandbox.last_error", value: reason, ok: false),
-      ]
+      return unavailableVersionRows(reason)
     }
+  }
+
+  static func daemonManagedRows(_ availability: BackendAvailability) -> [Row] {
+    switch availability {
+    case .available(let engineVersion):
+      return availableVersionRows(engineVersion)
+        + [Row(key: "sandbox.canary", value: "owned by the running daemon", ok: true)]
+    case .unavailable(let reason):
+      return unavailableVersionRows(reason)
+    }
+  }
+
+  static func availableVersionRows(_ engineVersion: String) -> [Row] {
+    [
+      flag(key: "sandbox.available", value: true),
+      flag(key: "sandbox.os_ok", value: true),
+      Row(
+        key: "sandbox.engine_version",
+        value: "\(engineVersion) (minimum 1.0.0)",
+        ok: true
+      ),
+      flag(key: "sandbox.version_ok", value: true),
+    ]
+  }
+
+  static func unavailableVersionRows(_ reason: String) -> [Row] {
+    [
+      flag(key: "sandbox.available", value: false),
+      Row(key: "sandbox.os_ok", value: "unknown", ok: false),
+      Row(
+        key: "sandbox.engine_version",
+        value: "unknown (minimum 1.0.0)",
+        ok: false
+      ),
+      flag(key: "sandbox.version_ok", value: false),
+      Row(key: "sandbox.last_error", value: reason, ok: false),
+    ]
   }
 }
 

--- a/Sources/clawd/Composition/DaemonBuilder+Agent.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Agent.swift
@@ -33,9 +33,10 @@ extension DaemonBuilder {
   func makeAgentStack(
     provider: OpenAICompatibleProvider,
     workspace: FileSystemWorkspace,
-    costResolver: CostResolver
+    costResolver: CostResolver,
+    sandbox: SandboxStack
   ) -> AgentStack {
-    let toolDispatcher = makeToolDispatcher(workspace: workspace)
+    let toolDispatcher = makeToolDispatcher(workspace: workspace, sandbox: sandbox)
     let staticSubhash = policyStaticSubhash(toolDispatcher: toolDispatcher, workspace: workspace)
     let agent = makeAgent(
       provider: provider,

--- a/Sources/clawd/Composition/DaemonBuilder+Intake.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Intake.swift
@@ -52,7 +52,10 @@ extension DaemonBuilder {
   /// no-redirect `toolExecutor`; no `searchApiKey` ⇒ `web_search` is never constructed
   /// (unconfigured ⇒ absent). Tier-3 private texts load from DISK at gate-evaluation time,
   /// not the assembly snapshot, so the loader closure re-reads the workspace each call.
-  func makeToolDispatcher(workspace: FileSystemWorkspace) -> GatedToolDispatcher {
+  func makeToolDispatcher(
+    workspace: FileSystemWorkspace,
+    sandbox: SandboxStack
+  ) -> GatedToolDispatcher {
     let secretValues = secrets.redactionValues
     let redactor = SecretRedactor(secretValues: secretValues)
 
@@ -71,6 +74,22 @@ extension DaemonBuilder {
     if let searchApiKey = secrets.searchApiKey {
       tools.append(
         WebSearchTool(search: ExaSearchProvider(apiKey: searchApiKey, http: toolExecutor))
+      )
+    }
+
+    if let backend = sandbox.backend, sandbox.health?.isReady == true {
+      tools.append(
+        ExecuteCodeTool(
+          workspaceRoot: workspace.root,
+          backend: backend,
+          settings: ExecuteCodeSettings(
+            memoryMiB: config.exec.memoryMiB,
+            cpus: config.exec.cpus,
+            timeout: .seconds(config.exec.timeoutSeconds),
+            allowEgress: config.exec.allowEgress
+          ),
+          redactor: redactor
+        )
       )
     }
 

--- a/Sources/clawd/Composition/DaemonBuilder+Sandbox.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Sandbox.swift
@@ -32,23 +32,13 @@ enum SandboxBackendFactory {
       cpus: config.exec.cpus
     )
     let redactor = SecretRedactor(secretValues: secrets?.redactionValues ?? [])
-    let paths = [
-      config.stateRoot.path,
-      config.stateRoot.appendingPathComponent("exec-scratch").path,
-      FileManager.default.homeDirectoryForCurrentUser.path,
-      "/usr/local/bin/container",
-    ].sorted { first, second in
-      first.count > second.count
-    }
 
     return ContainerBackend(
       settings: settings,
       stateRoot: config.stateRoot,
       commands: SwiftSubprocessContainerCommandRunner(),
       sanitizeReason: { text in
-        paths.reduce(redactor.redact(text)) { partial, path in
-          partial.replacingOccurrences(of: path, with: "[HOST_PATH]")
-        }
+        redactor.redact(text)
       }
     )
   }

--- a/Sources/clawd/Composition/DaemonBuilder+Sandbox.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Sandbox.swift
@@ -1,0 +1,55 @@
+import ClawCore
+import ClawExec
+import ClawGateway
+import ClawTools
+import Foundation
+
+// MARK: - Sandbox Bootstrap
+
+extension DaemonBuilder {
+  typealias SandboxStack = SandboxBootstrapResult
+
+  func prepareSandbox() async -> SandboxStack {
+    let backend = SandboxBackendFactory.make(config: config, secrets: secrets)
+    return await SandboxBootstrapper(
+      enabled: config.exec.enabled,
+      backend: backend,
+      maintenance: backend
+    ).prepare()
+  }
+}
+
+// MARK: - Backend Factory
+
+enum SandboxBackendFactory {
+  static func make(config: AppConfig, secrets: Secrets?) -> ContainerBackend? {
+    guard config.exec.enabled, let image = config.exec.image else {
+      return nil
+    }
+    let settings = ExecSandboxSettings(
+      workloadImage: image,
+      memoryMiB: config.exec.memoryMiB,
+      cpus: config.exec.cpus
+    )
+    let redactor = SecretRedactor(secretValues: secrets?.redactionValues ?? [])
+    let paths = [
+      config.stateRoot.path,
+      config.stateRoot.appendingPathComponent("exec-scratch").path,
+      FileManager.default.homeDirectoryForCurrentUser.path,
+      "/usr/local/bin/container",
+    ].sorted { first, second in
+      first.count > second.count
+    }
+
+    return ContainerBackend(
+      settings: settings,
+      stateRoot: config.stateRoot,
+      commands: SwiftSubprocessContainerCommandRunner(),
+      sanitizeReason: { text in
+        paths.reduce(redactor.redact(text)) { partial, path in
+          partial.replacingOccurrences(of: path, with: "[HOST_PATH]")
+        }
+      }
+    )
+  }
+}

--- a/Sources/clawd/Composition/DaemonBuilder+Sandbox.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Sandbox.swift
@@ -15,7 +15,8 @@ extension DaemonBuilder {
       enabled: config.exec.enabled,
       backend: backend,
       maintenance: backend
-    ).prepare()
+    )
+    .prepare()
   }
 }
 
@@ -26,6 +27,7 @@ enum SandboxBackendFactory {
     guard config.exec.enabled, let image = config.exec.image else {
       return nil
     }
+
     let settings = ExecSandboxSettings(
       workloadImage: image,
       memoryMiB: config.exec.memoryMiB,

--- a/Sources/clawd/Composition/DaemonBuilder.swift
+++ b/Sources/clawd/Composition/DaemonBuilder.swift
@@ -6,6 +6,7 @@ import ClawTelegram
 import ClawWorkspace
 import Foundation
 import Logging
+import ServiceLifecycle
 
 /// The composition root. Holds the cross-cutting inputs `run()` resolves before wiring — config,
 /// secrets, stores, the two HTTP executors, the Telegram transport, and the logger — and `build()`
@@ -23,6 +24,7 @@ struct DaemonBuilder: Sendable {
   let logger: Logger
 
   func build() async -> Daemon {
+    let sandbox = await prepareSandbox()
     let coordination = TurnCoordination()
 
     // Hoisted so the schedule draft parser and the agent share one provider instance.
@@ -39,7 +41,8 @@ struct DaemonBuilder: Sendable {
     let agentStack = makeAgentStack(
       provider: provider,
       workspace: workspace,
-      costResolver: costResolver
+      costResolver: costResolver,
+      sandbox: sandbox
     )
 
     let turnRunner = makeTurnRunner(coordination: coordination, agentStack: agentStack)
@@ -62,8 +65,13 @@ struct DaemonBuilder: Sendable {
       workspace: workspace
     )
 
+    var services: [any Service] = [poller, dispatcher, scheduler, approvalFabric.expiry]
+    if let maintenance = sandbox.maintenance {
+      services.append(SandboxLifecycleService(maintenance: maintenance))
+    }
+
     return Daemon(
-      services: [poller, dispatcher, scheduler, approvalFabric.expiry],
+      services: services,
       boot: bootSequence(
         coordination: coordination,
         waiter: approvalFabric.waiter,

--- a/Sources/clawd/Subcommands/DoctorCommand.swift
+++ b/Sources/clawd/Subcommands/DoctorCommand.swift
@@ -196,6 +196,17 @@ private extension DoctorCommand {
         return SandboxHealthRows.rows(for: .configOnly(availability: availability))
       }
 
+      // A running daemon owns sandbox maintenance (reap + scratch sweep) and holds the
+      // single-instance lock for its whole lifetime. Acquiring it here proves no daemon can be
+      // mid-execution, so the destructive live canary is safe; failing to acquire it means a daemon
+      // is running and doctor must not reap its live VM or sweep its scratch.
+      let lockPath = config.stateRoot.appendingPathComponent(StateFile.lock).path
+      guard let lock = try? InstanceLock(path: lockPath) else {
+        let availability = await backend.versionAvailability()
+        return SandboxHealthRows.rows(for: .daemonManaged(availability: availability))
+      }
+      defer { lock.release() }
+
       let bootstrap = await SandboxBootstrapper(
         enabled: true,
         backend: backend,

--- a/Sources/clawd/Subcommands/DoctorCommand.swift
+++ b/Sources/clawd/Subcommands/DoctorCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import AsyncHTTPClient
 import ClawCore
 import ClawData
+import ClawExec
 import ClawGateway
 import ClawSecrets
 import ClawTelegram
@@ -39,6 +40,9 @@ struct DoctorCommand: AsyncParsableCommand {
     report.add(key: "config.max_tokens", value: "\(config.llm.maxOutputTokens)")
     if checkConfig {
       addConfigDetailRows(to: &report, config: config)
+      for row in await sandboxRows(config: config, live: false) {
+        report.add(key: row.key, value: row.value, ok: row.ok)
+      }
     }
 
     let secretsRow = SecretStoreResolver.doctorRow(
@@ -62,6 +66,9 @@ struct DoctorCommand: AsyncParsableCommand {
 
     addDatabaseRows(to: &report, config: config)
     await addConnectivityRows(to: &report, config: config)
+    for row in await sandboxRows(config: config, live: true) {
+      report.add(key: row.key, value: row.value, ok: row.ok)
+    }
 
     emit(report)
 
@@ -161,6 +168,50 @@ private extension DoctorCommand {
     }
 
     try? await httpClient.shutdown()
+  }
+}
+
+// MARK: - Sandbox Health
+
+private extension DoctorCommand {
+  func sandboxRows(
+    config: AppConfig,
+    live: Bool
+  ) async -> [SandboxHealthRows.Row] {
+    guard config.exec.enabled else {
+      return SandboxHealthRows.rows(for: .disabled)
+    }
+
+    #if os(Linux)
+      return SandboxHealthRows.rows(for: .linuxDeferred)
+    #else
+      guard let backend = SandboxBackendFactory.make(config: config, secrets: nil) else {
+        return SandboxHealthRows.rows(
+          for: .unavailable(reason: "sandbox backend is not configured")
+        )
+      }
+
+      guard live else {
+        let availability = await backend.versionAvailability()
+        return SandboxHealthRows.rows(for: .configOnly(availability: availability))
+      }
+
+      let bootstrap = await SandboxBootstrapper(
+        enabled: true,
+        backend: backend,
+        maintenance: backend
+      ).prepare()
+      await backend.shutdown()
+
+      if let health = bootstrap.health {
+        return SandboxHealthRows.rows(for: .live(health: health))
+      }
+      return SandboxHealthRows.rows(
+        for: .unavailable(
+          reason: bootstrap.unavailableReason ?? "sandbox health is unavailable"
+        )
+      )
+    #endif
   }
 }
 

--- a/Tests/ClawGatewayTests/Infrastructure/SandboxBootstrapperTests.swift
+++ b/Tests/ClawGatewayTests/Infrastructure/SandboxBootstrapperTests.swift
@@ -1,0 +1,104 @@
+import ClawCore
+import ClawTestSupport
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct SandboxBootstrapperTests {
+  @Test func disabledExecutionSkipsPrepareAndReturnsNoBackend() async {
+    // given
+    let backend = FakeExecutionBackend()
+    let bootstrapper = SandboxBootstrapper(
+      enabled: false,
+      backend: backend,
+      maintenance: backend
+    )
+
+    // when
+    let result = await bootstrapper.prepare()
+
+    // then
+    #expect(result.backend == nil)
+    #expect(result.maintenance == nil)
+    #expect(result.health == nil)
+    #expect(result.unavailableReason == "code execution is disabled")
+    #expect(await backend.prepareCallCount() == 0)
+  }
+
+  @Test func unavailableProbeFailsClosedWithoutRunningPrepare() async {
+    // given
+    let backend = FakeExecutionBackend(
+      availability: .unavailable(reason: "container engine is stopped")
+    )
+    let bootstrapper = SandboxBootstrapper(
+      enabled: true,
+      backend: backend,
+      maintenance: backend
+    )
+
+    // when
+    let result = await bootstrapper.prepare()
+
+    // then
+    #expect(result.backend == nil)
+    #expect(result.maintenance != nil)
+    #expect(result.health == nil)
+    #expect(result.unavailableReason == "container engine is stopped")
+    #expect(await backend.prepareCallCount() == 0)
+  }
+
+  @Test func failedCanaryKeepsMaintenanceButWithholdsBackend() async {
+    // given
+    let health = SandboxHealth(
+      available: true,
+      osOK: true,
+      engineVersion: "1.1.0",
+      versionOK: true,
+      imageDigestOK: true,
+      capsEmpty: true,
+      netIsolated: false,
+      capsMatch: true,
+      reaperOK: true,
+      rootfsRO: true,
+      stagingRO: true,
+      interpretersOK: true,
+      lastError: "canary reached the network"
+    )
+    let backend = FakeExecutionBackend(health: health)
+    let bootstrapper = SandboxBootstrapper(
+      enabled: true,
+      backend: backend,
+      maintenance: backend
+    )
+
+    // when
+    let result = await bootstrapper.prepare()
+
+    // then
+    #expect(result.backend == nil)
+    #expect(result.maintenance != nil)
+    #expect(result.health == health)
+    #expect(result.unavailableReason == "canary reached the network")
+    #expect(await backend.prepareCallCount() == 1)
+  }
+
+  @Test func passingProbeAndCanaryExposeTheBackend() async {
+    // given
+    let backend = FakeExecutionBackend()
+    let bootstrapper = SandboxBootstrapper(
+      enabled: true,
+      backend: backend,
+      maintenance: backend
+    )
+
+    // when
+    let result = await bootstrapper.prepare()
+
+    // then
+    #expect(result.backend != nil)
+    #expect(result.maintenance != nil)
+    #expect(result.health?.isReady == true)
+    #expect(result.unavailableReason == nil)
+    #expect(await backend.prepareCallCount() == 1)
+  }
+}

--- a/Tests/ClawGatewayTests/Infrastructure/SandboxLifecycleServiceTests.swift
+++ b/Tests/ClawGatewayTests/Infrastructure/SandboxLifecycleServiceTests.swift
@@ -1,0 +1,26 @@
+import ClawCore
+import ClawTestSupport
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct SandboxLifecycleServiceTests {
+  @Test func endingTheServiceRunsBackendShutdownOnce() async throws {
+    // given
+    let backend = FakeExecutionBackend()
+    let service = SandboxLifecycleService(
+      maintenance: backend,
+      clock: ScriptedClock { duration in
+        #expect(duration == SandboxLifecycleService.idleInterval)
+        await Task.yield()
+        throw CancellationError()
+      }
+    )
+
+    // when
+    try await service.run()
+
+    // then
+    #expect(await backend.shutdownCallCount() == 1)
+  }
+}

--- a/Tests/ClawGatewayTests/Response/SandboxHealthRowsTests.swift
+++ b/Tests/ClawGatewayTests/Response/SandboxHealthRowsTests.swift
@@ -1,0 +1,151 @@
+import ClawCore
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct SandboxHealthRowsTests {
+  @Test func disabledExecutionIsInformational() {
+    // given / when
+    let rows = SandboxHealthRows.rows(for: .disabled)
+
+    // then
+    #expect(
+      rows == [
+        .init(key: "sandbox", value: "disabled by CLAW_EXEC_ENABLED", ok: true)
+      ]
+    )
+  }
+
+  @Test func linuxDeferralIsInformational() {
+    // given / when
+    let rows = SandboxHealthRows.rows(for: .linuxDeferred)
+
+    // then
+    #expect(rows.count == 1)
+    #expect(rows[0].key == "sandbox")
+    #expect(rows[0].value == "execute_code awaits the Linux backend")
+    #expect(rows[0].ok)
+  }
+
+  @Test func configOnlyReportsVersionAndDefersTheCanary() {
+    // given / when
+    let rows = SandboxHealthRows.rows(
+      for: .configOnly(availability: .available(engineVersion: "1.1.0"))
+    )
+
+    // then
+    #expect(
+      rows.map(\.key) == [
+        "sandbox.available",
+        "sandbox.os_ok",
+        "sandbox.engine_version",
+        "sandbox.version_ok",
+        "sandbox.canary",
+      ]
+    )
+    #expect(rows.allSatisfy { $0.ok })
+    #expect(rows.last?.value == "deferred until live daemon startup")
+  }
+
+  @Test func configOnlyBelowFloorFailsClosed() {
+    // given / when
+    let rows = SandboxHealthRows.rows(
+      for: .configOnly(
+        availability: .unavailable(reason: "container 0.9.0 is below minimum 1.0.0")
+      )
+    )
+
+    // then
+    #expect(
+      rows.map(\.key) == [
+        "sandbox.available",
+        "sandbox.os_ok",
+        "sandbox.engine_version",
+        "sandbox.version_ok",
+        "sandbox.last_error",
+      ]
+    )
+    #expect(rows.allSatisfy { $0.ok == false })
+    #expect(rows.last?.value.contains("0.9.0") == true)
+  }
+
+  @Test func passingLiveSnapshotRendersEveryGateGreen() {
+    // given / when
+    let rows = SandboxHealthRows.rows(for: .live(health: .passingForTests))
+
+    // then
+    #expect(
+      rows.map(\.key) == [
+        "sandbox.available",
+        "sandbox.os_ok",
+        "sandbox.engine_version",
+        "sandbox.version_ok",
+        "sandbox.image_digest_ok",
+        "sandbox.caps_empty",
+        "sandbox.net_isolated",
+        "sandbox.caps_match",
+        "sandbox.reaper_ok",
+        "sandbox.rootfs_ro",
+        "sandbox.staging_ro",
+        "sandbox.interpreters_ok",
+        "sandbox.last_error",
+      ]
+    )
+    #expect(rows.allSatisfy { $0.ok })
+  }
+
+  @Test func failedLiveAssertionAndErrorAreBothLoud() {
+    // given
+    let health = SandboxHealth(
+      available: true,
+      osOK: true,
+      engineVersion: "1.1.0",
+      versionOK: true,
+      imageDigestOK: true,
+      capsEmpty: true,
+      netIsolated: false,
+      capsMatch: true,
+      reaperOK: true,
+      rootfsRO: true,
+      stagingRO: true,
+      interpretersOK: true,
+      lastError: "canary reached the network"
+    )
+
+    // when
+    let rows = SandboxHealthRows.rows(for: .live(health: health))
+
+    // then
+    #expect(rows.first { $0.key == "sandbox.net_isolated" }?.ok == false)
+    #expect(rows.first { $0.key == "sandbox.last_error" }?.ok == false)
+    #expect(rows.first { $0.key == "sandbox.last_error" }?.value == health.lastError)
+  }
+
+  @Test func unavailableBootstrapIsLoud() {
+    // given / when
+    let rows = SandboxHealthRows.rows(
+      for: .unavailable(reason: "container engine is stopped")
+    )
+
+    // then
+    #expect(
+      rows.map(\.key) == [
+        "sandbox.available",
+        "sandbox.os_ok",
+        "sandbox.engine_version",
+        "sandbox.version_ok",
+        "sandbox.image_digest_ok",
+        "sandbox.caps_empty",
+        "sandbox.net_isolated",
+        "sandbox.caps_match",
+        "sandbox.reaper_ok",
+        "sandbox.rootfs_ro",
+        "sandbox.staging_ro",
+        "sandbox.interpreters_ok",
+        "sandbox.last_error",
+      ]
+    )
+    #expect(rows.allSatisfy { $0.ok == false })
+    #expect(rows.last?.value == "container engine is stopped")
+  }
+}

--- a/Tests/ClawGatewayTests/Response/SandboxHealthRowsTests.swift
+++ b/Tests/ClawGatewayTests/Response/SandboxHealthRowsTests.swift
@@ -69,6 +69,48 @@ import Testing
     #expect(rows.last?.value.contains("0.9.0") == true)
   }
 
+  @Test func daemonManagedAvailableReportsVersionAndDaemonOwnedCanary() {
+    // given / when
+    let rows = SandboxHealthRows.rows(
+      for: .daemonManaged(availability: .available(engineVersion: "1.1.0"))
+    )
+
+    // then
+    #expect(
+      rows.map(\.key) == [
+        "sandbox.available",
+        "sandbox.os_ok",
+        "sandbox.engine_version",
+        "sandbox.version_ok",
+        "sandbox.canary",
+      ]
+    )
+    #expect(rows.allSatisfy { $0.ok })
+    #expect(rows.last?.value == "owned by the running daemon")
+  }
+
+  @Test func daemonManagedBelowFloorFailsClosed() {
+    // given / when
+    let rows = SandboxHealthRows.rows(
+      for: .daemonManaged(
+        availability: .unavailable(reason: "container 0.9.0 is below minimum 1.0.0")
+      )
+    )
+
+    // then
+    #expect(
+      rows.map(\.key) == [
+        "sandbox.available",
+        "sandbox.os_ok",
+        "sandbox.engine_version",
+        "sandbox.version_ok",
+        "sandbox.last_error",
+      ]
+    )
+    #expect(rows.allSatisfy { $0.ok == false })
+    #expect(rows.last?.value.contains("0.9.0") == true)
+  }
+
   @Test func passingLiveSnapshotRendersEveryGateGreen() {
     // given / when
     let rows = SandboxHealthRows.rows(for: .live(health: .passingForTests))


### PR DESCRIPTION
Prepares and validates the apple/container execution sandbox before the daemon freezes its tool registry, registers the dangerous `execute_code` tool only from a passing backend, reports the same health through `doctor`, and reaps the backend on graceful shutdown. This is Phase 4 of the sandbox code-execution work, building on the backend merged in #44.

An absent or failed sandbox is never a daemon startup failure: the daemon and every other service still start, and only `execute_code` goes missing.

## What changed

- **Graceful shutdown** (`SandboxLifecycleService`, ClawGateway): a ServiceLifecycle service that does no periodic work and awaits the backend's `shutdown()` once, so an in-flight VM and its scratch dir get reaped when the daemon exits.
- **Pre-registry bootstrap** (`SandboxBootstrapper`, ClawGateway; `SandboxBackendFactory`/`prepareSandbox()`, clawd): the enabled → probe → prepare decision. A disabled config, unavailable engine, or failed hardening canary each withholds the backend but keeps maintenance so shutdown can still clean up.
- **Conditional registration** (`DaemonBuilder`): the composition root prepares the sandbox first, then builds one tool registry. `execute_code` is appended only when `backend != nil && health.isReady`. The same tool list feeds the wire registry, the policy fingerprint, and the approved-action executor, so an approved run resolves the instance the surface advertised. The `ToolPolicyGate` `execEnabled` backstop stays independent of health.
- **Doctor rows** (`SandboxHealthRows`, ClawGateway; `DoctorCommand`): `doctor --check-config` runs the version probe only, never a canary, image pull, or VM. The live path always shuts its backend down before returning. Disabled and Linux-deferred report green; an owner-enabled failure on an unsupported host or a failed canary fails doctor.

A follow-up commit drops the backend factory's duplicated host-path list. `ContainerBackend.ownerSafe` already scrubs those paths through its own `sensitiveHostPaths`, so the factory closure now only redacts secrets, and the `exec-scratch` string lives in one place.

## Testing

Full hermetic suite green (1223 tests / 191 suites), lint clean. The mandatory real-backend acceptance run stays in Phase 5.
