### PR TITLE
Emit OpenRouter session_id to group a session's generations in the logs UI

### DIFF
--- a/Sources/ClawAgent/Runtime/AgentRuntime.swift
+++ b/Sources/ClawAgent/Runtime/AgentRuntime.swift
@@ -234,7 +234,8 @@ public struct AgentRuntime: Sendable {
         model: model,
         messages: wire,
         maxOutputTokens: budget.maxOutputTokens,
-        tools: definitions
+        tools: definitions,
+        sessionId: Self.sessionTraceId(sessionId: sessionId)
       )
 
       let response: ChatResponse
@@ -413,6 +414,10 @@ private extension AgentRuntime {
   /// `grep run=<id>` ties the turn's round-trips, tool calls, and outcome together.
   static func turnMetadata(runId: Int64, sessionId: Int64) -> Logger.Metadata {
     ["run": "\(runId)", "session": "\(sessionId)"]
+  }
+
+  static func sessionTraceId(sessionId: Int64) -> String {
+    "clawd-session-\(sessionId)"
   }
 
   /// Emits the one finished line for a turn; its level reflects severity — completed → info,

--- a/Sources/ClawCore/LLM/LLM.swift
+++ b/Sources/ClawCore/LLM/LLM.swift
@@ -38,6 +38,7 @@ public struct ChatRequest: Sendable, Equatable {
   public let stop: [String]?
   public let tools: [ToolDefinition]
   public let responseFormat: ResponseFormat?
+  public let sessionId: String?
 
   public init(
     model: String,
@@ -46,7 +47,8 @@ public struct ChatRequest: Sendable, Equatable {
     // swiftlint:disable:next discouraged_optional_collection
     stop: [String]? = nil,
     tools: [ToolDefinition] = [],
-    responseFormat: ResponseFormat? = nil
+    responseFormat: ResponseFormat? = nil,
+    sessionId: String? = nil
   ) {
     self.model = model
     self.messages = messages
@@ -54,6 +56,7 @@ public struct ChatRequest: Sendable, Equatable {
     self.stop = stop
     self.tools = tools
     self.responseFormat = responseFormat
+    self.sessionId = sessionId
   }
 }
 

--- a/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
+++ b/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
@@ -140,6 +140,10 @@ public struct OpenAICompatibleProvider: LLMProvider {
     status == 408 || status == 429 || (500..<600).contains(status)
   }
 
+  static func baseURLIsOpenRouter(_ baseURL: String) -> Bool {
+    URLComponents(string: baseURL)?.host?.lowercased() == "openrouter.ai"
+  }
+
   /// Reasoning models reject sampling params; detection is forward-looking (none are sent yet).
   static func isReasoningModel(_ model: String) -> Bool {
     model.hasPrefix("o1") || model.hasPrefix("o3") || model.hasPrefix("o4") || model.hasPrefix("o-")
@@ -174,6 +178,8 @@ public struct OpenAICompatibleProvider: LLMProvider {
         )
       )
     }
+
+    let sessionId = Self.baseURLIsOpenRouter(config.baseURL) ? request.sessionId : nil
     let payload = RequestBody(
       model: request.model,
       messages: wireMessages,
@@ -183,7 +189,8 @@ public struct OpenAICompatibleProvider: LLMProvider {
       stream: streaming,
       streamOptions: streaming ? StreamOptions(includeUsage: true) : nil,
       tools: wireTools.isEmpty ? nil : wireTools,
-      responseFormat: request.responseFormat
+      responseFormat: request.responseFormat,
+      sessionId: sessionId
     )
     return try JSONEncoder().encode(payload)
   }
@@ -394,6 +401,7 @@ private struct RequestBody: Encodable {
   // swiftlint:disable:next discouraged_optional_collection
   let tools: [WireToolDefinition]?
   let responseFormat: ResponseFormat?
+  let sessionId: String?
 
   func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: DynamicKey.self)
@@ -405,6 +413,7 @@ private struct RequestBody: Encodable {
     try container.encodeIfPresent(streamOptions, forKey: DynamicKey("stream_options"))
     try container.encodeIfPresent(stop, forKey: DynamicKey("stop"))
     try container.encodeIfPresent(tools, forKey: DynamicKey("tools"))
+    try container.encodeIfPresent(sessionId, forKey: DynamicKey("session_id"))
 
     if let responseFormat {
       try container.encode(

--- a/Tests/ClawAgentTests/Runtime/AgentRuntimeTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentRuntimeTests.swift
@@ -77,6 +77,33 @@ struct AgentRuntimeTests {
     #expect(usage.costUSD > 0)  // never a silent $0 (D1/F19)
   }
 
+  @Test("a turn stamps the request with the namespaced session trace id")
+  func turnStampsRequestWithSessionTraceId() async throws {
+    // given
+    let provider = StubProvider(.respond(okResponse(content: "hi")))
+    let runtime = makeRuntime(provider: provider)
+
+    // when
+    let outcome = try await runtime.runTurn(
+      runId: 1,
+      sessionId: 42,
+      chatId: 3,
+      buildResult: BuildResult(
+        messages: [ChatMessage(role: .user, content: "hi")],
+        ownerNotices: [],
+        hasPrivateDataAccess: false
+      ),
+      sessionTainted: false,
+      sessionHasPrivateData: false,
+      todayTokens: 0,
+      todayUSD: 0
+    )
+
+    // then — the request carries the OpenRouter-grouping id derived from the session id
+    _ = try requireCompleted(outcome.result)
+    #expect(await provider.lastRequest?.sessionId == "clawd-session-42")
+  }
+
   @Test("a turn issues a typing pulse before the provider answers")
   func turnIssuesTypingPulseBeforeProviderAnswers() async throws {
     // given — the provider can't answer until typing has fired at least once (gate-released on the

--- a/Tests/ClawAgentTests/Support/AgentTestSupport.swift
+++ b/Tests/ClawAgentTests/Support/AgentTestSupport.swift
@@ -20,6 +20,7 @@ actor StubProvider: LLMProvider {
 
   private let outcome: Outcome
   private(set) var calls = 0
+  private(set) var lastRequest: ChatRequest?
 
   init(_ outcome: Outcome) {
     self.outcome = outcome
@@ -27,6 +28,8 @@ actor StubProvider: LLMProvider {
 
   func complete(request: ChatRequest) async throws -> ChatResponse {
     calls += 1
+    lastRequest = request
+
     switch outcome {
     case .respond(let response): return response
     case .fail(let error): throw error

--- a/Tests/ClawLLMTests/Provider/OpenAICompatibleProviderTests.swift
+++ b/Tests/ClawLLMTests/Provider/OpenAICompatibleProviderTests.swift
@@ -100,6 +100,89 @@ import Testing
     #expect(jsonSchema["schema"] is [String: Any])
   }
 
+  @Test func emitsSessionIdWhenProviderIsOpenRouter() async throws {
+    // given — an OpenRouter base URL and a request carrying a session trace id
+    let exec = ScriptedHTTPExecutor([okStep()])
+    let provider = makeProvider(
+      config: makeConfig(baseURL: "https://openrouter.ai/api/v1"),
+      http: exec
+    )
+    let request = ChatRequest(
+      model: "gpt-4o",
+      messages: [ChatMessage(role: .user, content: "hi")],
+      maxOutputTokens: 256,
+      sessionId: "clawd-session-7"
+    )
+
+    // when
+    _ = try await provider.complete(request: request)
+
+    // then — the proprietary OpenRouter grouping field rides the body
+    let recorded = try #require(await exec.recorded.first)
+    let body = try decodeBody(recorded.body)
+    #expect(body["session_id"] as? String == "clawd-session-7")
+  }
+
+  @Test func omitsSessionIdWhenProviderIsNotOpenRouter() async throws {
+    // given — the same session-carrying request but a non-OpenRouter host
+    let exec = ScriptedHTTPExecutor([okStep()])
+    let provider = makeProvider(
+      config: makeConfig(baseURL: "https://api.openai.com/v1"),
+      http: exec
+    )
+    let request = ChatRequest(
+      model: "gpt-4o",
+      messages: [ChatMessage(role: .user, content: "hi")],
+      maxOutputTokens: 256,
+      sessionId: "clawd-session-7"
+    )
+
+    // when
+    _ = try await provider.complete(request: request)
+
+    // then — the key is absent so the body stays a plain OpenAI-compatible request
+    let recorded = try #require(await exec.recorded.first)
+    let body = try decodeBody(recorded.body)
+    #expect(body["session_id"] == nil)
+  }
+
+  @Test func omitsSessionIdWhenRequestHasNone() async throws {
+    // given — OpenRouter host but the request carries no session id
+    let exec = ScriptedHTTPExecutor([okStep()])
+    let provider = makeProvider(
+      config: makeConfig(baseURL: "https://openrouter.ai/api/v1"),
+      http: exec
+    )
+    let request = ChatRequest(
+      model: "gpt-4o",
+      messages: [ChatMessage(role: .user, content: "hi")],
+      maxOutputTokens: 256
+    )
+
+    // when
+    _ = try await provider.complete(request: request)
+
+    // then — nil session id encodes no key (not a null)
+    let recorded = try #require(await exec.recorded.first)
+    let body = try decodeBody(recorded.body)
+    #expect(body["session_id"] == nil)
+  }
+
+  @Test(
+    arguments: [
+      ("https://openrouter.ai/api/v1", true),
+      ("https://OpenRouter.ai/api/v1", true),
+      ("https://api.openai.com/v1", false),
+      ("http://localhost:11434/v1", false),
+      ("", false),
+      ("not a url", false),
+    ]
+  )
+  func baseURLIsOpenRouterDetectsHost(baseURL: String, expected: Bool) {
+    // given / when / then — detection is an exact, case-insensitive host match
+    #expect(OpenAICompatibleProvider.baseURLIsOpenRouter(baseURL) == expected)
+  }
+
   @Test func nullContentBecomesEmptyAndAbsentUsageBecomesNil() async throws {
     // given — Ollama-style: null content and no usage object
     let json = #"{"id":"x","choices":[{"index":0,"message":{"role":"assistant","content":null}}]}"#

--- a/Tests/ClawLLMTests/Support/LLMTestSupport.swift
+++ b/Tests/ClawLLMTests/Support/LLMTestSupport.swift
@@ -126,6 +126,7 @@ actor SleepRecorder {
 // MARK: - Builders
 
 func makeConfig(
+  baseURL: String = "https://api.test/v1",
   maxTokensField: MaxTokensField = .maxCompletionTokens,
   apiKey: String = "sk-test",
   model: String = "gpt-4o",
@@ -133,7 +134,7 @@ func makeConfig(
   retryBudget: Int = 3
 ) -> LLMConfig {
   LLMConfig(
-    baseURL: "https://api.test/v1",
+    baseURL: baseURL,
     model: model,
     apiKey: apiKey,
     maxTokensField: maxTokensField,


### PR DESCRIPTION
Groups a session's LLM generations under one OpenRouter "Session" in the OpenRouter Logs UI, so the multi-round tool loop of a turn (and all runs of a job/heartbeat/owner-chat session) read as one chain instead of scattered generations.

`ChatRequest` gains an optional `sessionId`. `OpenAICompatibleProvider` serializes it as OpenRouter's `session_id` body field, but only when the configured base URL's host is `openrouter.ai`. Any other provider, or a malformed URL, gets a plain OpenAI-compatible body with the field absent (not null), so a strict server never sees an unknown field. `AgentRuntime` sets the value to `clawd-session-<sessionId>`, mapping one OpenRouter session to one swift-claw session; the `/schedule` NL parser stays unset since it is a one-off parse, not a session turn.

This is observability only. It does not touch context assembly, isolation, or any run behavior. Gating is automatic by host, so there is no new environment variable or config knob, and swapping the provider drops the field on its own.

Covered by provider tests (the emitted JSON carries `session_id` for an OpenRouter host, omits it for another host and for a nil id), a host-detection test (case-insensitive host match, not a substring; malformed and empty URLs return false), and an `AgentRuntime` assertion that the built request carries the namespaced id.

Field reference: https://openrouter.ai/docs/guides/features/broadcast/overview#optional-trace-data
