### PR TITLE
Reuse existing helpers and collapse duplicated control flow

### DIFF
--- a/Sources/ClawAgent/Runtime/AgentRuntime.swift
+++ b/Sources/ClawAgent/Runtime/AgentRuntime.swift
@@ -272,7 +272,7 @@ public struct AgentRuntime: Sendable {
       }
 
       if costPolicy == .metered, recordedRunUSD + preflight.costUSD > budget.perRunUSD {
-        return outcome(.budgetStopped(cap: "per-run spend"))
+        return outcome(.budgetStopped(cap: BudgetGate.perRunSpendCap))
       }
       if case .deny(let cap) = gate.preflight(
         todayTokens: todayTokens + recordedRunTokens,

--- a/Sources/ClawAuth/ChatGPT/ChatGPTModelCatalog.swift
+++ b/Sources/ClawAuth/ChatGPT/ChatGPTModelCatalog.swift
@@ -52,7 +52,7 @@ public struct ChatGPTModelCatalog: Sendable, ChatGPTModelCatalogFetching {
   public func fetch(authorization: LLMRequestAuthorization) async throws -> [ChatGPTCatalogModel] {
     let response = try await send(authorization: authorization)
 
-    guard Self.successStatuses.contains(response.statusCode) else {
+    guard HTTPResponseBodyPolicy.isSuccess(response.statusCode) else {
       // Lossy on purpose: a diagnostic body that is not valid UTF-8 is still a diagnostic.
       // swiftlint:disable:next optional_data_string_conversion
       let body = String(decoding: response.body, as: UTF8.self)
@@ -87,8 +87,6 @@ private enum Catalog {
 // MARK: - Requests
 
 private extension ChatGPTModelCatalog {
-  static let successStatuses = 200..<300
-
   /// Caps both bodies at read time — a success body is the payload, a non-success one is a
   /// diagnostic worth only its first few kilobytes, and neither is worth materializing whole before
   /// anything trims it.

--- a/Sources/ClawAuth/ChatGPT/ChatGPTOAuthClient.swift
+++ b/Sources/ClawAuth/ChatGPT/ChatGPTOAuthClient.swift
@@ -156,7 +156,6 @@ private enum Wire {
   static let authorizationCodeGrant = "authorization_code"
   static let refreshTokenGrant = "refresh_token"
 
-  static let successStatuses = 200..<300
   /// Both mean the same thing on a device poll: keep waiting.
   static let pendingStatuses: Set<Int> = [403, 404]
   static let throttledStatus = 429
@@ -199,17 +198,14 @@ private extension ChatGPTOAuthClient {
   }
 
   static func jsonBody(_ fields: [String: String]) throws -> Data {
-    let encoder = JSONEncoder()
-    // Sorted keys so the body a test pins is the body every run produces.
-    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
-    do {
-      return try encoder.encode(fields)
-    } catch {
+    // Sorted keys (via CanonicalJSON) so the body a test pins is the body every run produces.
+    guard let json = CanonicalJSON.encode(fields) else {
       // A dictionary of strings has nothing in it that can fail to encode, so reaching here is a
       // defect in this file rather than anything the network or the vendor did — not a `transport`,
       // which a caller would answer by spending its retry budget on a request that cannot improve.
       throw ChatGPTOAuthFailure.malformedResponse(detail: "the request body could not be encoded")
     }
+    return Data(json.utf8)
   }
 
   /// Field order is the caller's, and every byte outside the RFC 3986 unreserved set becomes an
@@ -262,7 +258,7 @@ private extension ChatGPTOAuthClient {
     of response: HTTPResult,
     redacting secrets: [String]
   ) throws -> [String: JSONValue] {
-    guard Wire.successStatuses.contains(response.statusCode) else {
+    guard HTTPResponseBodyPolicy.isSuccess(response.statusCode) else {
       throw failure(for: response, redacting: secrets)
     }
     guard

--- a/Sources/ClawCore/Domain/Memory/Memory.swift
+++ b/Sources/ClawCore/Domain/Memory/Memory.swift
@@ -20,6 +20,24 @@ public enum Importance: Int, Sendable, Equatable, Comparable, CaseIterable {
   public static func < (lhs: Importance, rhs: Importance) -> Bool {
     lhs.rawValue < rhs.rawValue
   }
+
+  /// The wire/owner-facing vocabulary; the `Int` rawValue is the storage form.
+  public var wireLabel: String {
+    switch self {
+    case .low: "low"
+    case .normal: "normal"
+    case .high: "high"
+    }
+  }
+
+  public init?(wireLabel: String) {
+    switch wireLabel {
+    case "low": self = .low
+    case "normal": self = .normal
+    case "high": self = .high
+    default: return nil
+    }
+  }
 }
 
 public enum MemorySource: String, Sendable, Equatable {

--- a/Sources/ClawCore/Domain/Memory/MemoryWriteArguments.swift
+++ b/Sources/ClawCore/Domain/Memory/MemoryWriteArguments.swift
@@ -31,14 +31,11 @@ public enum MemoryWriteArguments {
     switch arguments.objectValue?["importance"]?.stringValue {
     case nil:
       importance = .normal
-    case "low":
-      importance = .low
-    case "normal":
-      importance = .normal
-    case "high":
-      importance = .high
-    default:
-      return .invalid(reason: "importance must be low, normal, or high.")
+    case .some(let raw):
+      guard let parsed = Importance(wireLabel: raw) else {
+        return .invalid(reason: "importance must be low, normal, or high.")
+      }
+      importance = parsed
     }
 
     let sensitivity: Sensitivity
@@ -76,14 +73,5 @@ public enum MemoryWriteArguments {
   public static func canonicalTarget(for request: MemoryWriteRequest) -> String {
     let hash16 = String(SHA256Digest.hex(request.item.text).prefix(16))
     return "memory_item:\(request.item.kind.rawValue):\(hash16)"
-  }
-
-  /// Owner-facing label for the Int-raw `Importance` (the wire vocabulary is the string form).
-  public static func importanceLabel(_ importance: Importance) -> String {
-    switch importance {
-    case .low: "low"
-    case .normal: "normal"
-    case .high: "high"
-    }
   }
 }

--- a/Sources/ClawCore/Domain/Scheduling/OccurrencePolicy.swift
+++ b/Sources/ClawCore/Domain/Scheduling/OccurrencePolicy.swift
@@ -45,11 +45,10 @@ public struct OccurrencePolicy: Sendable {
   /// when nothing valid remains to arm: a one-shot whose instant has passed, or (pathological)
   /// a rule with no upcoming occurrence.
   public func armOccurrence(for validated: ValidatedSchedule, at nowDate: Date) -> Date? {
-    guard let envelope = validated.recurrence else {
-      return validated.firstOccurrence > nowDate ? validated.firstOccurrence : nil
-    }
-
-    guard let timezone = TimeZone(identifier: validated.timezone) else {
+    guard
+      let envelope = validated.recurrence,
+      let timezone = TimeZone(identifier: validated.timezone)
+    else {
       return validated.firstOccurrence > nowDate ? validated.firstOccurrence : nil
     }
 

--- a/Sources/ClawCore/Errors/ConfigError.swift
+++ b/Sources/ClawCore/Errors/ConfigError.swift
@@ -25,33 +25,6 @@ public enum ConfigError: Error, Sendable, Equatable {
   case invalidExecCPUs(String)
   case invalidExecTimeout(String)
 
-  public var exitCode: Int32 {
-    switch self {
-    case .invalidAllowlist: ClawExitCode.configInvalid.rawValue
-    case .unwritableStateRoot: ClawExitCode.configInvalid.rawValue
-    case .missingLLMBaseURL: ClawExitCode.configInvalid.rawValue
-    case .missingLLMModel: ClawExitCode.configInvalid.rawValue
-    case .invalidMaxTokensField: ClawExitCode.configInvalid.rawValue
-    case .invalidStructuredOutput: ClawExitCode.configInvalid.rawValue
-    case .emptyQualifiedModelSuffix: ClawExitCode.configInvalid.rawValue
-    case .oversizedQualifiedModelSuffix: ClawExitCode.configInvalid.rawValue
-    case .unsafeQualifiedModelSuffix: ClawExitCode.configInvalid.rawValue
-    case .structuredOutputUnsupportedOnRoute: ClawExitCode.configInvalid.rawValue
-    case .invalidMaxTokens: ClawExitCode.configInvalid.rawValue
-    case .invalidBudget: ClawExitCode.configInvalid.rawValue
-    case .invalidBool: ClawExitCode.configInvalid.rawValue
-    case .invalidTimezone: ClawExitCode.configInvalid.rawValue
-    case .invalidQuietHours: ClawExitCode.configInvalid.rawValue
-    case .invalidScheduling: ClawExitCode.configInvalid.rawValue
-    case .invalidApprovalExpiry: ClawExitCode.configInvalid.rawValue
-    case .invalidWebFetchExemptCIDR: ClawExitCode.configInvalid.rawValue
-    case .heartbeatOwnerUnresolved: ClawExitCode.configInvalid.rawValue
-    case .invalidExecImage: ClawExitCode.configInvalid.rawValue
-    case .invalidExecImageRegistry: ClawExitCode.configInvalid.rawValue
-    case .execImageRegistryNotAllowed: ClawExitCode.configInvalid.rawValue
-    case .invalidExecMemoryMiB: ClawExitCode.configInvalid.rawValue
-    case .invalidExecCPUs: ClawExitCode.configInvalid.rawValue
-    case .invalidExecTimeout: ClawExitCode.configInvalid.rawValue
-    }
-  }
+  /// Every config error is a configuration-invalid failure, so one exit code covers them all.
+  public var exitCode: Int32 { ClawExitCode.configInvalid.rawValue }
 }

--- a/Sources/ClawData/Stores/Approval/ApprovalStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Approval/ApprovalStoreGRDB.swift
@@ -326,7 +326,7 @@ extension ApprovalStoreGRDB {
       return []
     }
 
-    let placeholders = runIds.map { _ in "?" }.joined(separator: ", ")
+    let placeholders = databaseQuestionMarks(count: runIds.count)
     var arguments: [any DatabaseValueConvertible] = [ApprovalState.pending.rawValue]
     arguments.append(contentsOf: runIds)
     let pending = try fetchApprovals(

--- a/Sources/ClawData/Stores/Memory/RetrieverGRDB.swift
+++ b/Sources/ClawData/Stores/Memory/RetrieverGRDB.swift
@@ -40,7 +40,7 @@ public struct RetrieverGRDB: Retriever {
       }
 
       if excludedMessageIds.isEmpty == false {
-        let placeholders = excludedMessageIds.map { _ in "?" }.joined(separator: ", ")
+        let placeholders = databaseQuestionMarks(count: excludedMessageIds.count)
         sql += "\n  AND m.id NOT IN (\(placeholders))"
         arguments += StatementArguments(excludedMessageIds)
       }

--- a/Sources/ClawGateway/Response/DoctorReport.swift
+++ b/Sources/ClawGateway/Response/DoctorReport.swift
@@ -76,17 +76,9 @@ public struct DoctorReport: Sendable {
   }
 
   public func renderText() -> String {
-    let sections = DoctorGroup.allCases.compactMap { group -> String? in
-      let rows = checks.filter { $0.group == group }
-
-      guard !rows.isEmpty else {
-        return nil
-      }
-
-      return renderSection(group: group, rows: rows)
-    }
-
-    return sections.joined(separator: "\n\n")
+    nonEmptyGroups()
+      .map { renderSection(group: $0.group, rows: $0.rows) }
+      .joined(separator: "\n\n")
   }
 
   public func renderTelegramSummary() -> String {
@@ -96,15 +88,7 @@ public struct DoctorReport: Sendable {
       ? "clawd: all systems healthy"
       : "clawd: \(failingCount) \(failingCount == 1 ? "check" : "checks") failing"
 
-    let sections = DoctorGroup.allCases.compactMap { group -> String? in
-      let rows = checks.filter { $0.group == group }
-
-      guard !rows.isEmpty else {
-        return nil
-      }
-
-      return summarySection(group: group, rows: rows)
-    }
+    let sections = nonEmptyGroups().map { summarySection(group: $0.group, rows: $0.rows) }
 
     return ([verdict, ""] + sections).joined(separator: "\n")
   }
@@ -122,6 +106,15 @@ public struct DoctorReport: Sendable {
 
 private extension DoctorReport {
   static let headerStatusColumn = 40
+
+  /// The groups with at least one check, paired with their rows, in `DoctorGroup.allCases`
+  /// order — the shared partition behind both the text table and the Telegram summary.
+  func nonEmptyGroups() -> [(group: DoctorGroup, rows: [Check])] {
+    DoctorGroup.allCases.compactMap { group in
+      let rows = checks.filter { $0.group == group }
+      return rows.isEmpty ? nil : (group: group, rows: rows)
+    }
+  }
 
   func renderSection(group: DoctorGroup, rows: [Check]) -> String {
     let keyWidth = rows.map(\.key.count).max() ?? 0

--- a/Sources/ClawLLM/ChatGPT/ChatGPTResponsesProvider.swift
+++ b/Sources/ClawLLM/ChatGPT/ChatGPTResponsesProvider.swift
@@ -163,9 +163,7 @@ private extension ChatGPTResponsesProvider {
     // A stop string this route cannot honor, or a structured-output shape it does not accept, fails
     // before any network I/O rather than changing what the model was asked for.
     guard request.stop == nil else {
-      return .failure(
-        .terminal(status: nil, message: "the ChatGPT route has no stop-string contract to honor")
-      )
+      return .failure(ChatGPTResponsesRequestEncoder.unsupportedStopString)
     }
     guard request.responseFormat == nil else {
       return .failure(

--- a/Sources/ClawLLM/ChatGPT/ChatGPTResponsesRequestEncoder.swift
+++ b/Sources/ClawLLM/ChatGPT/ChatGPTResponsesRequestEncoder.swift
@@ -33,10 +33,7 @@ struct ChatGPTResponsesRequestEncoder: Sendable {
     // Dropping stop strings quietly would run the model against a contract the caller did not ask
     // for; the studied Codex route provides none to honor, so the request is refused whole.
     guard request.stop == nil else {
-      throw ProviderError.terminal(
-        status: nil,
-        message: "the ChatGPT route has no stop-string contract to honor"
-      )
+      throw Self.unsupportedStopString
     }
 
     let instructions = Self.instructions(from: request.messages)
@@ -76,6 +73,13 @@ extension ChatGPTResponsesRequestEncoder {
   static func wireModel(for model: String) -> String {
     unqualifiedModel(model)
   }
+
+  /// The refusal both the plan validation and the encoder raise when a caller supplies a stop
+  /// string: this route has no stop-string contract, so the request fails whole before network I/O.
+  static let unsupportedStopString = ProviderError.terminal(
+    status: nil,
+    message: "the ChatGPT route has no stop-string contract to honor"
+  )
 }
 
 // MARK: - Request Mapping

--- a/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
+++ b/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
@@ -154,12 +154,6 @@ public struct OpenAICompatibleProvider: LLMProvider {
     URLComponents(string: baseURL)?.host?.lowercased() == "openrouter.ai"
   }
 
-  /// Reasoning models reject sampling params; detection is forward-looking (none are sent yet).
-  static func isReasoningModel(_ model: String) -> Bool {
-    model.hasPrefix("o1") || model.hasPrefix("o3") || model.hasPrefix("o4") || model.hasPrefix("o-")
-      || model.contains("reasoning")
-  }
-
   func encode(request: ChatRequest, streaming: Bool = false) throws -> Data {
     let wireMessages = request.messages.map { message -> WireMessage in
       let wireCalls = message.toolCalls.map { call in

--- a/Sources/ClawLLM/Provider/SSEParser.swift
+++ b/Sources/ClawLLM/Provider/SSEParser.swift
@@ -140,17 +140,18 @@ public struct SSEParser: Sendable {
   /// accumulator that never received an id/name (malformed stream) and defaults empty
   /// arguments to `"{}"`, mirroring the blocking path's `parse(result:)` (same rule, two seams).
   private var assembledToolCalls: [ToolCall] {
-    toolCallAccumulators.keys.sorted().compactMap { index in
-      let accumulator = toolCallAccumulators[index] ?? ToolCallAccumulator()
-      guard !accumulator.id.isEmpty, !accumulator.name.isEmpty else {
-        return nil
+    toolCallAccumulators
+      .sorted { $0.key < $1.key }
+      .compactMap { _, accumulator in
+        guard !accumulator.id.isEmpty, !accumulator.name.isEmpty else {
+          return nil
+        }
+        return ToolCall(
+          id: accumulator.id,
+          name: accumulator.name,
+          argumentsJSON: accumulator.arguments.isEmpty ? "{}" : accumulator.arguments
+        )
       }
-      return ToolCall(
-        id: accumulator.id,
-        name: accumulator.name,
-        argumentsJSON: accumulator.arguments.isEmpty ? "{}" : accumulator.arguments
-      )
-    }
   }
 
   private mutating func accumulate(_ fragments: [DeltaToolCall]) throws {

--- a/Sources/ClawTestSupport/AgentRuntimeDoubles.swift
+++ b/Sources/ClawTestSupport/AgentRuntimeDoubles.swift
@@ -186,11 +186,11 @@ public struct EmptyWorkspace: WorkspaceReading {
   public init() {}
 
   public func load(file: WorkspaceFile, maxGraphemes: Int?) -> LoadedFile {
-    LoadedFile(outcome: .missing, text: "", graphemeCount: 0)
+    .missing
   }
 
   public func loadDailyLog(day: String, maxGraphemes: Int?) -> LoadedFile {
-    LoadedFile(outcome: .missing, text: "", graphemeCount: 0)
+    .missing
   }
 
   public func scanSkills() -> SkillScanResult {

--- a/Sources/ClawTools/Tools/MemoryWriteTool.swift
+++ b/Sources/ClawTools/Tools/MemoryWriteTool.swift
@@ -83,7 +83,7 @@ public struct MemoryWriteTool: Tool {
       blastRadius: """
         memory item, kind \(request.item.kind.rawValue), \
         sensitivity \(request.item.sensitivity.rawValue), \
-        importance \(MemoryWriteArguments.importanceLabel(request.item.importance))
+        importance \(request.item.importance.wireLabel)
         """,
       // The preview is the capped normalized text so the owner judges exactly what would be
       // stored — except exact loaded secret values, which are barred from every outbound reply;

--- a/Sources/ClawTools/Tools/WebSearchTool.swift
+++ b/Sources/ClawTools/Tools/WebSearchTool.swift
@@ -56,7 +56,7 @@ public struct WebSearchTool: Tool {
       )
     }
 
-    let requestedCount =
+    let count =
       arguments.objectValue?["count"]?.numberValue
       .map { requested in
         Int(
@@ -66,10 +66,6 @@ public struct WebSearchTool: Tool {
           )
         )
       } ?? Self.defaultCount
-    let count = min(
-      max(requestedCount, Self.countRange.lowerBound),
-      Self.countRange.upperBound
-    )
 
     let results: [SearchResult]
     do {

--- a/Tests/ClawLLMTests/Provider/OpenAICompatibleProviderTests.swift
+++ b/Tests/ClawLLMTests/Provider/OpenAICompatibleProviderTests.swift
@@ -788,11 +788,4 @@ import Testing
     #expect(messages[0].keys.sorted() == ["content", "role"])
     #expect(response.providerState == nil)
   }
-
-  @Test func isReasoningModelDetectsKnownPrefixes() {
-    // then
-    #expect(OpenAICompatibleProvider.isReasoningModel("o3-mini"))
-    #expect(OpenAICompatibleProvider.isReasoningModel("gpt-5-reasoning"))
-    #expect(OpenAICompatibleProvider.isReasoningModel("gpt-4o") == false)
-  }
 }


### PR DESCRIPTION
## What

A whole-project simplify review flagged 41 places that re-derive or repeat logic the codebase already has. This PR applies the safe subset: 13 behavior-preserving cleanups that call the canonical shared helper or collapse duplicated control flow. No functional change.

## Changes

**Reuse the helper that already exists**
- `AgentRuntime` uses `BudgetGate.perRunSpendCap` instead of the raw `"per-run spend"` literal, so the runtime and the gate emit the same cap name.
- ChatGPT success checks call `HTTPResponseBodyPolicy.isSuccess` rather than two private `200..<300` copies.
- `ChatGPTOAuthClient.jsonBody` delegates to `CanonicalJSON.encode` with the same `[.sortedKeys, .withoutEscapingSlashes]`, so pinned bodies stay byte-identical.
- Approval and Retriever GRDB stores build IN-clause placeholders with GRDB's `databaseQuestionMarks(count:)`, matching the four sibling call sites.
- The `EmptyWorkspace` test double returns `LoadedFile.missing` instead of open-coding the same value.
- The ChatGPT stop-string refusal is one hoisted `ProviderError.terminal` constant shared by the encoder and the provider.

**Collapse duplicated control flow**
- `ConfigError.exitCode` returns its single exit code; all 25 arms mapped to it.
- `Importance` gains `wireLabel` / `init?(wireLabel:)`, folding the two inverse string↔enum switches into one vocabulary.
- `OccurrencePolicy.armOccurrence` merges two guards that shared the same fallback.
- `DoctorReport` shares one `nonEmptyGroups()` partition between the text table and the Telegram summary.
- `SSEParser.assembledToolCalls` iterates sorted accumulator pairs and drops an unreachable `?? ToolCallAccumulator()`.
- `WebSearchTool` drops a re-clamp that could never change the value.
- Deletes the unused `isReasoningModel` helper and its only test.

## Not in scope

I left the higher-stakes findings for a focused follow-up: the security guards (SSRFGuard CIDR, ExfilArgGuard redaction), the store write/CAS refactors, routing-halt control-flow, the provider-accounting seam, the AppConfig trim-set cluster, the turn-runner hot path, and the new cross-module helper promotions. I also deferred the one real efficiency win (the `ContextBuilder` history recompute) and two uncertain items.

## Verification

- `scripts/lint.sh`: clean
- `swift build`: clean
- `swift test`: 2119 tests across 269 suites pass

I traced each change through the surrounding code to confirm it preserves behavior.
