### PR TITLE
Speed up the slow tests and the production hot paths behind them

### DIFF
--- a/Sources/ClawAuth/ChatGPT/ChatGPTModelCatalog.swift
+++ b/Sources/ClawAuth/ChatGPT/ChatGPTModelCatalog.swift
@@ -98,8 +98,8 @@ private extension ChatGPTModelCatalog {
       url: ChatGPTProviderMetadata.modelsURL,
       headers: authorization.headers,
       body: nil,
-      timeoutSeconds: ChatGPTProviderMetadata.transportSeconds(
-        ChatGPTProviderMetadata.requestTimeout
+      timeout: .seconds(
+        ChatGPTProviderMetadata.transportSeconds(ChatGPTProviderMetadata.requestTimeout)
       ),
       responseBodyPolicy: .buffered(
         successBytes: ChatGPTProviderMetadata.maximumCatalogResponseBytes,

--- a/Sources/ClawAuth/ChatGPT/ChatGPTOAuthClient.swift
+++ b/Sources/ClawAuth/ChatGPT/ChatGPTOAuthClient.swift
@@ -182,7 +182,7 @@ private extension ChatGPTOAuthClient {
       url: url,
       headers: [Wire.contentTypeHeader: contentType],
       body: body,
-      timeoutSeconds: ChatGPTProviderMetadata.transportSeconds(timeout),
+      timeout: .seconds(ChatGPTProviderMetadata.transportSeconds(timeout)),
       responseBodyPolicy: .buffered(
         successBytes: ChatGPTProviderMetadata.maximumAuthResponseBytes,
         errorBytes: ChatGPTProviderMetadata.maximumDiagnosticBytes

--- a/Sources/ClawAuth/ChatGPT/ChatGPTTokenMetadata.swift
+++ b/Sources/ClawAuth/ChatGPT/ChatGPTTokenMetadata.swift
@@ -53,23 +53,24 @@ private extension ChatGPTTokenMetadata {
       return nil
     }
 
-    guard let payload = decodingBase64URL(String(segments[1])) else {
+    guard let payload = decodingBase64URL(segments[1]) else {
       return nil
     }
 
     return try? JSONDecoder().decode(JSONValue.self, from: payload)
   }
 
-  /// Strict base64url: the alphabet is checked before decoding, and the decoded size is computed
-  /// and rejected against the cap *before* any buffer is allocated — so an oversized payload costs
-  /// a length check rather than the memory it asked for. `Data(base64Encoded:)` without
-  /// `.ignoreUnknownCharacters` then rejects what the alphabet check could not.
-  static func decodingBase64URL(_ segment: String) -> Data? {
+  /// Strict base64url: the decoded size is computed from the segment's length and rejected against
+  /// the cap *before anything else* — an oversized payload costs one O(1) length check, never an
+  /// alphabet scan of everything it sent. The alphabet is then checked before decoding, and
+  /// `Data(base64Encoded:)` without `.ignoreUnknownCharacters` rejects what the alphabet check
+  /// could not.
+  static func decodingBase64URL(_ segment: Substring) -> Data? {
     guard
       segment.isEmpty == false,
-      segment.unicodeScalars.allSatisfy(isBase64URLScalar),
       let decodedByteCount = decodedByteCount(ofBase64URL: segment),
-      decodedByteCount <= maximumPayloadBytes
+      decodedByteCount <= maximumPayloadBytes,
+      segment.unicodeScalars.allSatisfy(isBase64URLScalar)
     else {
       return nil
     }
@@ -84,13 +85,16 @@ private extension ChatGPTTokenMetadata {
   }
 
   /// The exact decoded length implied by an unpadded base64url segment, or nil for a length no
-  /// base64 encoding can produce (a remainder of one leaves a byte half-encoded).
-  static func decodedByteCount(ofBase64URL segment: String) -> Int? {
-    let remainder = segment.count % 4
+  /// base64 encoding can produce (a remainder of one leaves a byte half-encoded). Counted over
+  /// UTF-8 units — constant-time on a token substring, and identical to the character count for
+  /// anything the alphabet check will go on to accept.
+  static func decodedByteCount(ofBase64URL segment: Substring) -> Int? {
+    let encodedLength = segment.utf8.count
+    let remainder = encodedLength % 4
     guard remainder != 1 else {
       return nil
     }
-    let wholeGroups = segment.count / 4
+    let wholeGroups = encodedLength / 4
     let trailingBytes = remainder == 0 ? 0 : remainder - 1
     return wholeGroups * 3 + trailingBytes
   }

--- a/Sources/ClawCore/Transport/HTTPExecuting.swift
+++ b/Sources/ClawCore/Transport/HTTPExecuting.swift
@@ -135,7 +135,7 @@ public struct HTTPRequest: Sendable {
   public let url: String
   public let headers: [String: String]
   public let body: Data?
-  public let timeoutSeconds: Int
+  public let timeout: Duration
   public let responseBodyPolicy: HTTPResponseBodyPolicy
 
   /// The attempt's linearization point, invoked exactly once immediately before the request is
@@ -147,7 +147,7 @@ public struct HTTPRequest: Sendable {
     url: String,
     headers: [String: String],
     body: Data?,
-    timeoutSeconds: Int,
+    timeout: Duration,
     responseBodyPolicy: HTTPResponseBodyPolicy,
     beginHandoff: (@Sendable () throws -> Void)? = nil
   ) {
@@ -155,7 +155,7 @@ public struct HTTPRequest: Sendable {
     self.url = url
     self.headers = headers
     self.body = body
-    self.timeoutSeconds = timeoutSeconds
+    self.timeout = timeout
     self.responseBodyPolicy = responseBodyPolicy
     self.beginHandoff = beginHandoff
   }
@@ -185,7 +185,7 @@ public extension HTTPExecuting {
         url: url,
         headers: headers.addingDefault("Content-Type", "application/json"),
         body: jsonBody,
-        timeoutSeconds: timeoutSeconds,
+        timeout: .seconds(timeoutSeconds),
         responseBodyPolicy: .buffered(successBytes: maxBodyBytes, errorBytes: maxBodyBytes)
       )
     )
@@ -203,7 +203,7 @@ public extension HTTPExecuting {
         url: url,
         headers: headers,
         body: nil,
-        timeoutSeconds: timeoutSeconds,
+        timeout: .seconds(timeoutSeconds),
         responseBodyPolicy: .buffered(successBytes: maxBodyBytes, errorBytes: maxBodyBytes)
       )
     )

--- a/Sources/ClawLLM/ChatGPT/ChatGPTResponsesProvider.swift
+++ b/Sources/ClawLLM/ChatGPT/ChatGPTResponsesProvider.swift
@@ -207,7 +207,7 @@ private extension ChatGPTResponsesProvider {
           url: ChatGPTProviderMetadata.responsesURL,
           headers: headers,
           body: body,
-          timeoutSeconds: timeoutSeconds,
+          timeout: .seconds(timeoutSeconds),
           responseBodyPolicy: .streaming(
             maximumUnreadBytes: HTTPResponseBodyPolicy.maximumUnreadStreamBytes,
             errorBytes: HTTPResponseBodyPolicy.diagnosticBodyBytes

--- a/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
+++ b/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
@@ -286,7 +286,7 @@ private extension OpenAICompatibleProvider {
       url: chatCompletionsURL(),
       headers: headers,
       body: body,
-      timeoutSeconds: config.requestTimeoutSeconds,
+      timeout: .seconds(config.requestTimeoutSeconds),
       responseBodyPolicy: .streaming(
         maximumUnreadBytes: HTTPResponseBodyPolicy.maximumUnreadStreamBytes,
         errorBytes: HTTPResponseBodyPolicy.diagnosticBodyBytes
@@ -488,7 +488,7 @@ private extension OpenAICompatibleProvider {
       url: url,
       headers: headers,
       body: body,
-      timeoutSeconds: config.requestTimeoutSeconds,
+      timeout: .seconds(config.requestTimeoutSeconds),
       responseBodyPolicy: .buffered(
         successBytes: HTTPResponseBodyPolicy.defaultBufferedBodyBytes,
         errorBytes: HTTPResponseBodyPolicy.defaultBufferedBodyBytes

--- a/Sources/ClawLLM/Provider/SSEFraming.swift
+++ b/Sources/ClawLLM/Provider/SSEFraming.swift
@@ -51,10 +51,16 @@ enum SSEFraming {
   /// The `data:` field values of one SSE event: comments (`:`) and non-`data` fields are dropped,
   /// and a single leading space after the colon is stripped, per the SSE field-parsing rules.
   static func dataPayloadLines(in text: String) -> [String] {
-    let normalized = text.replacingOccurrences(of: "\r\n", with: "\n")
+    // The CRLF fold is a bridged Foundation pass over the whole event; a stream delivers one event
+    // at a time but many thousands of them, so an LF-only event — the overwhelmingly common form —
+    // skips the fold on a cheap byte scan instead of paying it every single event.
+    let normalized =
+      text.utf8.contains(carriageReturn)
+      ? text.replacingOccurrences(of: "\r\n", with: "\n")
+      : text
     return normalized.split(separator: "\n", omittingEmptySubsequences: false)
       .compactMap { rawLine -> String? in
-        var line = String(rawLine)
+        var line = rawLine
 
         if line.last == "\r" {
           line.removeLast()
@@ -67,13 +73,13 @@ enum SSEFraming {
         guard line.hasPrefix("data:") else {
           return nil
         }
-        var value = String(line.dropFirst(5))
+        var value = line.dropFirst(5)
 
         if value.first == " " {
-          value.removeFirst()
+          value = value.dropFirst()
         }
 
-        return value
+        return String(value)
       }
   }
 }

--- a/Sources/ClawTelegram/Wire/HTTPExecuting.swift
+++ b/Sources/ClawTelegram/Wire/HTTPExecuting.swift
@@ -86,7 +86,7 @@ private extension AsyncHTTPExecutor {
     do {
       return try await client.execute(
         clientRequest,
-        timeout: .seconds(Int64(request.timeoutSeconds))
+        timeout: TimeAmount(request.timeout)
       )
     } catch {
       throw Self.classify(error)

--- a/Sources/ClawTestSupport/RecordingHTTPExecutor.swift
+++ b/Sources/ClawTestSupport/RecordingHTTPExecutor.swift
@@ -7,7 +7,7 @@ public struct RecordedHTTPRequest: Sendable, Equatable {
   public let url: String
   public let headers: [String: String]
   public let body: Data?
-  public let timeoutSeconds: Int
+  public let timeout: Duration
   public let responseBodyPolicy: HTTPResponseBodyPolicy
   /// The cap the executor applied, picked from the policy by the scripted status. Tests assert on
   /// this when what matters is which of the two caps was in force, not the pair that was offered.
@@ -23,7 +23,7 @@ public struct RecordedHTTPRequest: Sendable, Equatable {
     url: String,
     headers: [String: String],
     body: Data?,
-    timeoutSeconds: Int,
+    timeout: Duration,
     responseBodyPolicy: HTTPResponseBodyPolicy,
     selectedBodyCap: Int,
     carriedHandoff: Bool
@@ -32,7 +32,7 @@ public struct RecordedHTTPRequest: Sendable, Equatable {
     self.url = url
     self.headers = headers
     self.body = body
-    self.timeoutSeconds = timeoutSeconds
+    self.timeout = timeout
     self.responseBodyPolicy = responseBodyPolicy
     self.selectedBodyCap = selectedBodyCap
     self.carriedHandoff = carriedHandoff
@@ -80,7 +80,7 @@ public actor RecordingHTTPExecutor: HTTPExecuting {
         url: request.url,
         headers: request.headers,
         body: request.body,
-        timeoutSeconds: request.timeoutSeconds,
+        timeout: request.timeout,
         responseBodyPolicy: request.responseBodyPolicy,
         selectedBodyCap: cap,
         carriedHandoff: request.beginHandoff != nil

--- a/Sources/ClawTestSupport/ScriptedClock.swift
+++ b/Sources/ClawTestSupport/ScriptedClock.swift
@@ -51,6 +51,24 @@ public struct ScriptedClock: Clock {
   }
 }
 
+// MARK: - Compressed Time
+
+public extension ScriptedClock {
+  /// A clock that parks any sleep of `parkingThreshold` or longer (for ~an hour of real time —
+  /// the park ends with its task's cancellation) while every shorter tick elapses in ~1ms:
+  /// deadlines stay pending, pacing intervals fire immediately, and a test asserts ordering
+  /// instead of waiting out wall-clock time.
+  static func compressed(parkingAt parkingThreshold: Duration) -> ScriptedClock {
+    ScriptedClock { delay in
+      if delay >= parkingThreshold {
+        try await Task.sleep(for: .seconds(3600))
+      } else {
+        try await Task.sleep(for: .milliseconds(1))
+      }
+    }
+  }
+}
+
 // MARK: - Virtual Time
 
 private extension ScriptedClock {

--- a/Sources/ClawTools/Policy/ExfilArgGuard.swift
+++ b/Sources/ClawTools/Policy/ExfilArgGuard.swift
@@ -56,6 +56,7 @@ public struct ExfilArgGuard: Sendable {
         guard let windows = windowsByFingerprint[fingerprint] else {
           continue
         }
+
         let candidate = characters[start..<(start + width)]
         // The fingerprint only narrows the set; confirm grapheme-for-grapheme so a hash
         // collision can never false-block.
@@ -63,6 +64,7 @@ public struct ExfilArgGuard: Sendable {
           let source = sources[window.source]
           return candidate.elementsEqual(source[window.start..<(window.start + width)])
         }
+
         if matched {
           return String(candidate)
         }
@@ -132,9 +134,11 @@ public struct ExfilArgGuard: Sendable {
         if let anchor = shape.anchor, Self.containsAnchor(candidateBytes, anchor) == false {
           continue
         }
+
         let matches = Self.regexMatches(shape.pattern, in: candidate).filter { match in
           shape.rule != "high-entropy" || Self.looksHighEntropy(match)
         }
+
         if matches.isEmpty == false {
           return blockedVerdict(rule: shape.rule, raw: text, spans: matches)
         }
@@ -187,6 +191,7 @@ public struct ExfilArgGuard: Sendable {
       if let anchor = shape.anchor, Self.containsAnchor(Data(rendered.utf8), anchor) == false {
         continue
       }
+
       for match in Self.regexMatches(shape.pattern, in: rendered)
       where shape.rule != "high-entropy" || Self.looksHighEntropy(match) {
         rendered = rendered.replacingOccurrences(of: match, with: "[REDACTED:\(shape.rule)]")
@@ -312,6 +317,7 @@ public struct ExfilArgGuard: Sendable {
     var hasDigit = false
     var hasUppercase = false
     var hasLowercase = false
+
     for byte in token.utf8 {
       switch byte {
       case UInt8(ascii: "0")...UInt8(ascii: "9"):
@@ -323,10 +329,12 @@ public struct ExfilArgGuard: Sendable {
       default:
         continue
       }
+
       if hasDigit, hasUppercase, hasLowercase {
         return true
       }
     }
+
     return false
   }
 
@@ -397,6 +405,7 @@ public struct ExfilArgGuard: Sendable {
     if spans.contains(where: { span in raw.contains(span) == false }) {
       return Verdict(blockedRule: rule, redactedArgs: "[REDACTED:\(rule)]")
     }
+
     return Verdict(blockedRule: rule, redactedArgs: rendered)
   }
 }

--- a/Sources/ClawTools/Policy/ExfilArgGuard.swift
+++ b/Sources/ClawTools/Policy/ExfilArgGuard.swift
@@ -305,10 +305,29 @@ public struct ExfilArgGuard: Sendable {
   }
 
   /// The deterministic, pinned stand-in for an entropy measure: ≥1 digit AND both letter cases.
+  /// Judged over bytes, which is exact for what callers pass — matches of the ASCII-only shape
+  /// patterns, where a run can weigh megabytes and per-`Character` Unicode property checks cost
+  /// hundreds of milliseconds. On any other input the byte test can only over-block, never miss.
   static func looksHighEntropy(_ token: String) -> Bool {
-    token.contains(where: \.isNumber)
-      && token.contains(where: \.isUppercase)
-      && token.contains(where: \.isLowercase)
+    var hasDigit = false
+    var hasUppercase = false
+    var hasLowercase = false
+    for byte in token.utf8 {
+      switch byte {
+      case UInt8(ascii: "0")...UInt8(ascii: "9"):
+        hasDigit = true
+      case UInt8(ascii: "A")...UInt8(ascii: "Z"):
+        hasUppercase = true
+      case UInt8(ascii: "a")...UInt8(ascii: "z"):
+        hasLowercase = true
+      default:
+        continue
+      }
+      if hasDigit, hasUppercase, hasLowercase {
+        return true
+      }
+    }
+    return false
   }
 
   /// The polynomial base for rolling window fingerprints (the FNV-1a prime, reused as an

--- a/Tests/ClawAgentTests/Runtime/AgentRuntimeStreamingTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentRuntimeStreamingTests.swift
@@ -312,16 +312,6 @@ actor BlockingFinalDrafts: RichDraftStreaming {
   }
 }
 
-/// Compresses every runtime sleep except the wall-clock deadline (180s default) to ~1ms, so
-/// throttle ticks and send deadlines elapse instantly while the deadline child stays parked.
-let compressedSleep: @Sendable (Duration) async throws -> Void = { duration in
-  if duration >= .seconds(10) {
-    try await Task.sleep(for: .seconds(3600))
-  } else {
-    try await Task.sleep(for: .milliseconds(1))
-  }
-}
-
 /// Parks the per-send draft deadline (3s) and the wall-clock deadline while probe ticks run real,
 /// so "the turn awaits the final draft" is asserted time-independently instead of racing the
 /// abandon deadline under CI load.
@@ -627,7 +617,7 @@ func waitForTurnResult(
       typing: typing,
       drafts: drafts,
       streamingEnabled: true,
-      clock: ScriptedClock(compressedSleep)
+      clock: ScriptedClock.compressed(parkingAt: .seconds(10))
     )
 
     // when
@@ -716,7 +706,7 @@ func waitForTurnResult(
         provider: provider,
         drafts: drafts,
         streamingEnabled: true,
-        clock: ScriptedClock(compressedSleep)
+        clock: ScriptedClock.compressed(parkingAt: .seconds(10))
       )
 
       // when
@@ -963,7 +953,7 @@ func waitForTurnResult(
       provider: provider,
       drafts: drafts,
       streamingEnabled: true,
-      clock: ScriptedClock(compressedSleep)
+      clock: ScriptedClock.compressed(parkingAt: .seconds(10))
     )
 
     // when

--- a/Tests/ClawAuthTests/ChatGPT/ChatGPTDeviceAuthorizationTests.swift
+++ b/Tests/ClawAuthTests/ChatGPT/ChatGPTDeviceAuthorizationTests.swift
@@ -21,7 +21,7 @@ private actor SequencedHTTP: HTTPExecuting {
   private let repeatingLast: Outcome?
 
   /// The relative timeout of every call, in dispatch order — what the deadline cap is asserted on.
-  private(set) var timeouts: [Int] = []
+  private(set) var timeouts: [Duration] = []
   private(set) var urls: [String] = []
 
   init(_ queued: [Outcome], repeatingLast: Outcome? = nil) {
@@ -30,7 +30,7 @@ private actor SequencedHTTP: HTTPExecuting {
   }
 
   func execute(_ request: HTTPRequest) async throws -> HTTPResult {
-    timeouts.append(request.timeoutSeconds)
+    timeouts.append(request.timeout)
     urls.append(request.url)
 
     guard let outcome = queued.isEmpty ? repeatingLast : queued.removeFirst() else {
@@ -259,7 +259,7 @@ private enum Poll {
     // 900 seconds of window: the first two calls are bounded by the per-request ceiling, and the
     // third by the ten seconds the 890-second wait left behind.
     let timeouts = await http.timeouts
-    #expect(timeouts == [30, 30, 10])
+    #expect(timeouts == [.seconds(30), .seconds(30), .seconds(10)])
   }
 
   @Test func authorizeClampsAPollDelayToWhatIsLeftOfTheWindow() async throws {

--- a/Tests/ClawAuthTests/ChatGPT/ChatGPTOAuthClientTests.swift
+++ b/Tests/ClawAuthTests/ChatGPT/ChatGPTOAuthClientTests.swift
@@ -177,7 +177,7 @@ private extension RecordedHTTPRequest {
 
     // then
     let sent = try #require(await http.requests.first)
-    #expect(sent.timeoutSeconds == expected)
+    #expect(sent.timeout == .seconds(expected))
   }
 
   // MARK: - Device Code: Response Reading

--- a/Tests/ClawAuthTests/ChatGPT/ChatGPTTokenMetadataTests.swift
+++ b/Tests/ClawAuthTests/ChatGPT/ChatGPTTokenMetadataTests.swift
@@ -159,9 +159,9 @@ enum TokenBuilder {
     #expect(metadata == ChatGPTTokenMetadata(expiresAt: nil, accountID: nil))
   }
 
-  @Test func extractRejectsAMultiMegabytePayload() {
-    // given
-    let payload = TokenBuilder.payload(paddedTo: 4_000_000, accountID: "huge")
+  @Test func extractRejectsAGrosslyOversizedPayload() {
+    // given — several times the cap; the exact 64 KiB boundary is pinned by its own pair above
+    let payload = TokenBuilder.payload(paddedTo: 256 * 1024, accountID: "huge")
     let token = TokenBuilder.token(payload: payload)
 
     // when

--- a/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
+++ b/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
@@ -43,6 +43,9 @@ struct SC3Harness {
   let provider: TurnScriptedProvider
 
   let databasePath: String
+  /// One reader over the SAME DB file the stores write — a connection of its own, opened once;
+  /// the probes below poll it, and a pool opened per probe made the polling the harness hotspot.
+  let readPool: DatabasePool
   let workspaceRoot: URL
   let sessionKey: String
 
@@ -89,11 +92,10 @@ struct SC3Harness {
     )
   }
 
-  /// Reads the durable audit trail over a fresh reader on the SAME DB file (the harness never
-  /// exposes a raw audit read, so the acceptance clauses inspect `audit_events` directly).
+  /// Reads the durable audit trail over the harness's own reader on the SAME DB file (the harness
+  /// never exposes a raw audit read, so the acceptance clauses inspect `audit_events` directly).
   func auditRows() throws -> [AuditRow] {
-    let pool = try ClawDatabase.makePool(path: databasePath)
-    return try pool.read { database in
+    try readPool.read { database in
       try Row.fetchAll(
         database,
         sql: "SELECT actor, action, tool, args_redacted, decision FROM audit_events ORDER BY id"
@@ -363,6 +365,7 @@ func makeSC3Harness(
     http: http,
     provider: provider,
     databasePath: resolvedDatabasePath,
+    readPool: try ClawDatabase.makePool(path: resolvedDatabasePath),
     workspaceRoot: workspaceRoot,
     sessionKey: SessionKey.telegramDM(chatId: 7),
     waiter: waiter,

--- a/Tests/ClawGatewayTests/Acceptance/SC7Harness.swift
+++ b/Tests/ClawGatewayTests/Acceptance/SC7Harness.swift
@@ -52,6 +52,9 @@ struct SC7Harness {
   let clock: ManualClock
 
   let databasePath: String
+  /// One reader over the SAME DB file the stores write, opened once: the acceptance probes poll
+  /// these queries, and a pool opened per probe made the polling itself the harness hotspot.
+  let readPool: DatabasePool
   let workspaceRoot: URL
 
   /// Awaits lane-dispatched turns: polls the outbox until `count` payloads exist (bounded).
@@ -74,8 +77,7 @@ struct SC7Harness {
   }
 
   func auditRows() throws -> [AuditRow] {
-    let pool = try ClawDatabase.makePool(path: databasePath)
-    return try pool.read { database in
+    try readPool.read { database in
       try Row.fetchAll(
         database,
         sql: "SELECT actor, action, tool, args_redacted, decision FROM audit_events ORDER BY id"
@@ -104,8 +106,7 @@ struct SC7Harness {
   }
 
   func runCount(jobId: Int64) throws -> Int {
-    let pool = try ClawDatabase.makePool(path: databasePath)
-    return try pool.read { db in
+    try readPool.read { db in
       try Int.fetchOne(
         db,
         sql: "SELECT COUNT(*) FROM runs WHERE job_id = ?",
@@ -115,8 +116,7 @@ struct SC7Harness {
   }
 
   func runCount(origin: String) throws -> Int {
-    let pool = try ClawDatabase.makePool(path: databasePath)
-    return try pool.read { db in
+    try readPool.read { db in
       try Int.fetchOne(
         db,
         sql: "SELECT COUNT(*) FROM runs WHERE origin = ?",
@@ -126,8 +126,7 @@ struct SC7Harness {
   }
 
   func sessionCount(key: String) throws -> Int {
-    let pool = try ClawDatabase.makePool(path: databasePath)
-    return try pool.read { db in
+    try readPool.read { db in
       try Int.fetchOne(
         db,
         sql: "SELECT COUNT(*) FROM sessions WHERE session_key = ?",
@@ -316,6 +315,7 @@ func makeSC7Harness(
     parser: parser,
     clock: clock,
     databasePath: resolvedDatabasePath,
+    readPool: try ClawDatabase.makePool(path: resolvedDatabasePath),
     workspaceRoot: workspaceRoot
   )
 }

--- a/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
+++ b/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
@@ -455,7 +455,10 @@ func makeStreamingStack(
     configuredReference: "gpt-4o",
     usageStore: usage,
     auditLog: audit,
-    clock: ContinuousClock()
+    // Parks the 3s per-send draft deadline and the wall deadline while the 250ms probe tick
+    // elapses in ~1ms: these fixtures' transport never hangs, so ordering is gate-driven and
+    // no test here waits out a real probe interval.
+    clock: ScriptedClock.compressed(parkingAt: .seconds(3))
   )
   let turnRunner = TurnRunner(
     sessionMessages: sessionMessages,

--- a/Tests/ClawGatewayTests/Routing/CommandApprovalCancelSignalRaceTests.swift
+++ b/Tests/ClawGatewayTests/Routing/CommandApprovalCancelSignalRaceTests.swift
@@ -9,59 +9,19 @@ import Testing
 @testable import ClawData
 @testable import ClawGateway
 
-/// Guards the Task-17 follow-up fix: `CommandHandlers.stop`/`new` must signal the
-/// `ApprovalCoordinator` BEFORE cancelling the session lane. A genuinely parked `ApprovalWaiter`
-/// (awaiting the coordinator on the lane, no pre-buffered signal) then always consumes a real
-/// `.denied` and fills its synthetic observation in place; the subsequent lane cancel can only
-/// no-op the already-resumed waiter.
-///
-/// Under the pre-fix ordering (cancel, then signal) the lane cancel resumes the parked waiter with
-/// `nil` via the coordinator's cancellation path (a detached `Task` running `cancelWaiter`), which
-/// races the later signal. When the nil-resume wins, `park` exits early and never fills the
-/// placeholder — a dangling "awaiting owner approval" tool_call is left on the now-terminal run.
-///
-/// To make the nil-resume win the race deterministically the session carries padding: `paddingRuns`
-/// extra cancellable runs, each with its own PENDING approval, plus the real parked run/approval.
-/// The parked run has the lowest run id and the real approval the HIGHEST approval id (padding is
-/// seeded first), which stretches the deferral window each command opens between spawning the
-/// detached `cancelWaiter` and delivering the real signal:
-///
-/// - `/stop` cancels the parked run FIRST (lowest id, ascending order) — spawning its detached
-///   cancel task — then makes one `await lane.cancel` hop per padding run before the signal loop.
-/// - `/new` cancels the whole lane in one `cancelAll()`, so it has no per-run cancel loop; instead
-///   the real approval (highest id) is signalled LAST, deferred behind one `await coordinator.signal`
-///   hop per padding approval.
-///
-/// Either way the detached `cancelWaiter` gets a long head start, so under one cooperative thread
-/// (`SWIFT_MAX_CONCURRENCY_THREADS=1`, the project's nproc=1 convention for concurrency tests) it
-/// reaches the coordinator before the signal and the pre-fix code leaves the placeholder dangling on
-/// essentially every cycle. On a multi-threaded scheduler the atomic `signal` wins, so the pre-fix
-/// bug does not surface there. The fixed ordering signals before any cancel, so the fill lands on
-/// every cycle under either scheduler.
 @Suite struct CommandApprovalCancelSignalRaceTests {
-  /// Extra cancellable runs (each carrying a PENDING approval) that pad the command's cancel loop
-  /// (`/stop`) and signal loop (`/new`), deferring the real approval's signal long enough for the
-  /// detached cancel task to win the pre-fix race under cooperative scheduling. Sized so both
-  /// commands catch the pre-fix bug on ~99% of cycles at nproc=1 (empirically measured).
   private static let paddingRuns = 96
 
-  /// Cycles per test. The padding above — not the cycle count — is the determinism mechanism, so
-  /// cycles are redundant Bernoulli trials: at the measured ~99% per-cycle catch six cycles miss
-  /// with probability ~1e-12, and even a scheduler that degraded the rate to 90% would still miss
-  /// at under 1e-6. More cycles buy nothing but wall-clock.
   private static let cycles = 6
 
   // MARK: - Doubles
 
-  /// The waiter's approve-path collaborator is unused on the deny/cancel path; a no-op stub keeps
-  /// the fixture focused on the resolution the command triggers.
   private struct InertExecutor: ApprovedActionExecuting {
     func executeApproved(_ approval: Approval) async -> ApprovedExecutionOutcome {
       ApprovedExecutionOutcome(observationContent: "", commit: .ignored)
     }
   }
 
-  /// A one-shot rendezvous the trailing lane unit opens once it runs — proving the lane drained.
   private actor Latch {
     private var isOpen = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
@@ -102,8 +62,6 @@ import Testing
 
   @Test(.timeLimit(.minutes(1)))
   func liveStopFillsTheParkedObservationAndFreesTheLaneEveryCycle() async throws {
-    // The pre-fix (cancel-then-signal) ordering fails this: the parked waiter's nil-resume wins the
-    // race and skips the fill. The fixed ordering fills the observation on every cycle.
     for cycle in 0..<Self.cycles {
       // given / when
       let observation = try await runLiveCommandCycle(command: "/stop")
@@ -135,9 +93,6 @@ import Testing
 // MARK: - Cycle
 
 private extension CommandApprovalCancelSignalRaceTests {
-  /// Parks a real waiter on the session lane (genuinely awaiting the coordinator), queues a plain
-  /// unit behind it, drives one live command through the router, waits for the lane to drain, and
-  /// returns the observation content the resolution left behind.
   func runLiveCommandCycle(command: String) async throws -> String? {
     let harness = try makeHarness()
     let waiter = makeWaiter(harness)
@@ -152,16 +107,12 @@ private extension CommandApprovalCancelSignalRaceTests {
         revalidatePolicyOnApprove: false
       )
     }
-    // A plain unit of lane work queued BEHIND the park: FIFO chaining means it can only run once
-    // the parked waiter completes, so its execution proves the lane was freed.
+
     let trailingRunId = harness.runId + 1_000_000
     _ = await harness.lanes.enqueue(sessionID: harness.sessionId, runID: trailingRunId) {
       await laneFreed.open()
     }
 
-    // Let the parked waiter reach its coordinator registration before the command resolves it, so
-    // this exercises the live cancel-vs-signal window rather than a pre-buffered signal. Yields are
-    // cooperative (never block a thread), so this is safe at nproc=1.
     for _ in 0..<16 {
       await Task.yield()
     }
@@ -196,8 +147,6 @@ private extension CommandApprovalCancelSignalRaceTests {
     let sessions = SessionMessageStoreGRDB(writer: queue)
     let runs = RunStoreGRDB(writer: queue)
 
-    // The parked run is seeded FIRST so it holds the lowest run id and is cancelled first (`/stop`
-    // cancels in ascending id order) — its detached cancel task then races ahead of the signal.
     let claim = try sessions.claimAndPersistInbound(
       InboundMessage(
         updateId: 1,
@@ -213,8 +162,6 @@ private extension CommandApprovalCancelSignalRaceTests {
     let runId = try #require(claim.runId)
     _ = try #require(try runs.pickUp(runId: runId, now: Date()))
 
-    // Padding is seeded BEFORE the real approval so the real approval holds the HIGHEST approval id
-    // and is therefore signalled LAST (`resolvePendingApprovals` orders by id ASC) — see below.
     try seedPadding(queue: queue, sessionId: sessionId)
 
     let observationMessageId = try seedParkedApproval(
@@ -259,19 +206,6 @@ private extension CommandApprovalCancelSignalRaceTests {
     )
   }
 
-  /// Extra RUNNING runs, each carrying its own PENDING approval, in the same session. They pad BOTH
-  /// deferral windows the pre-fix bug races against:
-  ///
-  /// - `/stop` loops `for runId in cancelledRunIds { await lane.cancel(runId) }`, so each padding
-  ///   RUN adds one no-op `lane.cancel` await hop before the signal loop.
-  /// - `/new` calls `lane.cancelAll()` once (no per-run loop), so runs alone can't defer its signal.
-  ///   Instead each padding APPROVAL adds one `await coordinator.signal` hop to the signal loop; the
-  ///   real approval has the highest id (seeded last) so it is signalled LAST, deferred behind all
-  ///   of them — long enough for the parked waiter's detached cancel task to win the race.
-  ///
-  /// The command path reads only their `id`/`state`, so they are inserted raw in a SINGLE
-  /// transaction — the old per-run `claimAndPersistInbound` + `pickUp` path cost two write
-  /// transactions each and dominated the fixture's setup time.
   func seedPadding(queue: DatabaseQueue, sessionId: Int64) throws {
     let now = Date()
     let argsJSON = #"{"path":"/w/pad.md"}"#
@@ -302,10 +236,6 @@ private extension CommandApprovalCancelSignalRaceTests {
     }
   }
 
-  /// Suspends the run at AWAITING_APPROVAL behind a placeholder tool observation and a PENDING
-  /// approval — the exact shape `/stop`//`new` must resolve. Returns the observation row id the
-  /// resolution must fill in place. Seeded raw so the fixture does not depend on Task-06 CAS
-  /// internals; the command path and waiter read it through the real stores.
   func seedParkedApproval(queue: DatabaseQueue, sessionId: Int64, runId: Int64) throws -> Int64 {
     let now = Date()
     let argsJSON = #"{"path":"/w/plan.md"}"#

--- a/Tests/ClawGatewayTests/Routing/CommandApprovalCancelSignalRaceTests.swift
+++ b/Tests/ClawGatewayTests/Routing/CommandApprovalCancelSignalRaceTests.swift
@@ -45,9 +45,11 @@ import Testing
   /// commands catch the pre-fix bug on ~99% of cycles at nproc=1 (empirically measured).
   private static let paddingRuns = 96
 
-  /// Cycles per test. With ~99% per-cycle catch a dozen would already be decisive; 20 keeps a wide
-  /// margin against scheduler variance across machines while staying well under the old 40.
-  private static let cycles = 20
+  /// Cycles per test. The padding above — not the cycle count — is the determinism mechanism, so
+  /// cycles are redundant Bernoulli trials: at the measured ~99% per-cycle catch six cycles miss
+  /// with probability ~1e-12, and even a scheduler that degraded the rate to 90% would still miss
+  /// at under 1e-6. More cycles buy nothing but wall-clock.
+  private static let cycles = 6
 
   // MARK: - Doubles
 

--- a/Tests/ClawLLMTests/ChatGPT/ChatGPTResponsesAttemptEngineTests.swift
+++ b/Tests/ClawLLMTests/ChatGPT/ChatGPTResponsesAttemptEngineTests.swift
@@ -575,7 +575,7 @@ private struct Harness: Sendable {
           url: "https://chatgpt.test/responses",
           headers: authorization.headers,
           body: Data("{}".utf8),
-          timeoutSeconds: requestTimeoutSeconds,
+          timeout: .seconds(requestTimeoutSeconds),
           responseBodyPolicy: .streaming(
             maximumUnreadBytes: HTTPResponseBodyPolicy.maximumUnreadStreamBytes,
             errorBytes: HTTPResponseBodyPolicy.diagnosticBodyBytes

--- a/Tests/ClawLLMTests/ChatGPT/ChatGPTResponsesBoundsTests.swift
+++ b/Tests/ClawLLMTests/ChatGPT/ChatGPTResponsesBoundsTests.swift
@@ -391,9 +391,12 @@ extension ChatGPTResponsesBoundsTests {
 
   /// Well-framed events weighing exactly `totalBytes` in total, delimiters included. The last event
   /// absorbs whatever the whole units could not divide, so the total is exact rather than rounded.
+  /// Units weigh ~1 MiB — half the event cap — so a buffer-cap's worth of filler is a handful of
+  /// large events rather than tens of thousands of tiny ones, each of which would pay its own
+  /// framing and JSON decode.
   fileprivate static func framedFiller(totalBytes: Int) -> String {
-    let unit = event(#"{"type":"response.output_text.delta","output_index":0,"delta":"a"}"#)
-    let unitBytes = unit.utf8.count
+    let unitBytes = 1024 * 1024
+    let unit = paddedEvent(totalBytes: unitBytes - 2) + "\n\n"
     let units = max(0, totalBytes / unitBytes - 2)
     let last = totalBytes - units * unitBytes
     return String(repeating: unit, count: units) + paddedEvent(totalBytes: last - 2) + "\n\n"
@@ -405,12 +408,13 @@ extension ChatGPTResponsesBoundsTests {
     through parser: inout ChatGPTResponsesSSEParser
   ) throws -> Int {
     // Pushed in batches so the raw buffer stays far below its own cap and this test can only ever
-    // fail on the event count it is about.
+    // fail on the event count it is about. The payload is the cheapest thing the counter still
+    // charges: a data event whose type the route does not model — the cap counts data events.
     var emitted = 0
     let batchSize = 4_096
     for start in stride(from: 0, to: count, by: batchSize) {
       let batch = String(
-        repeating: event(#"{"type":"unknown.event"}"#),
+        repeating: event(#"{"type":"u"}"#),
         count: min(batchSize, count - start)
       )
       emitted += try parser.push(Data(batch.utf8)).count

--- a/Tests/ClawLLMTests/Support/LLMTestSupport.swift
+++ b/Tests/ClawLLMTests/Support/LLMTestSupport.swift
@@ -36,7 +36,7 @@ actor ScriptedHTTPExecutor: HTTPExecuting, HTTPStreaming {
     let url: String
     let headers: [String: String]
     let body: Data
-    let timeoutSeconds: Int
+    let timeout: Duration
     let responseBodyPolicy: HTTPResponseBodyPolicy
     let carriedHandoff: Bool
   }
@@ -130,7 +130,7 @@ actor ScriptedHTTPExecutor: HTTPExecuting, HTTPStreaming {
         url: request.url,
         headers: request.headers,
         body: request.body ?? Data(),
-        timeoutSeconds: request.timeoutSeconds,
+        timeout: request.timeout,
         responseBodyPolicy: request.responseBodyPolicy,
         carriedHandoff: request.beginHandoff != nil
       )

--- a/Tests/ClawTelegramTests/Client/TelegramClientTests.swift
+++ b/Tests/ClawTelegramTests/Client/TelegramClientTests.swift
@@ -16,13 +16,13 @@ struct RecordingHTTPExecutor: HTTPExecuting {
   struct Call: Sendable {
     let url: String
     let body: Data
-    let timeout: Int
+    let timeout: Duration
   }
 
   actor Recorder {
     private(set) var calls: [Call] = []
 
-    func append(url: String, body: Data, timeout: Int) {
+    func append(url: String, body: Data, timeout: Duration) {
       calls.append(Call(url: url, body: body, timeout: timeout))
     }
   }
@@ -34,7 +34,7 @@ struct RecordingHTTPExecutor: HTTPExecuting {
     await recorder.append(
       url: request.url,
       body: request.body ?? Data(),
-      timeout: request.timeoutSeconds
+      timeout: request.timeout
     )
     return result
   }
@@ -252,7 +252,7 @@ private func client(status: Int, json: String) -> TelegramClient {
     let body = try #require(JSONSerialization.jsonObject(with: call.body) as? [String: Any])
     let richMessage = try #require(body["rich_message"] as? [String: Any])
     #expect(call.url == "https://example.test/botT/sendRichMessageDraft")
-    #expect(call.timeout == 15)
+    #expect(call.timeout == .seconds(15))
     #expect(body["chat_id"] as? Int == 42)
     #expect(body["draft_id"] as? Int == 99)
     #expect(richMessage["markdown"] as? String == "**hi**")
@@ -310,7 +310,7 @@ private func client(status: Int, json: String) -> TelegramClient {
 
     // then
     let call = try #require(await recorder.calls.first)
-    #expect(call.timeout == 40)
+    #expect(call.timeout == .seconds(40))
     #expect(TelegramClient.defaultHTTPTimeoutSlackSeconds == 10)
   }
 

--- a/Tests/ClawTelegramTests/Wire/AsyncHTTPExecutorGeneralRequestTests.swift
+++ b/Tests/ClawTelegramTests/Wire/AsyncHTTPExecutorGeneralRequestTests.swift
@@ -363,7 +363,7 @@ final class HandoffCounter: Sendable {
             url: server.url("/page"),
             headers: ["X-Probe": "probe-value"],
             body: nil,
-            timeoutSeconds: 5,
+            timeout: .seconds(5),
             responseBodyPolicy: buffered()
           )
         )
@@ -421,7 +421,7 @@ final class HandoffCounter: Sendable {
             url: server.url("/token"),
             headers: ["Content-Type": "application/x-www-form-urlencoded"],
             body: form,
-            timeoutSeconds: 5,
+            timeout: .seconds(5),
             responseBodyPolicy: buffered()
           )
         )
@@ -449,7 +449,7 @@ final class HandoffCounter: Sendable {
               url: server.url("/big"),
               headers: [:],
               body: nil,
-              timeoutSeconds: 5,
+              timeout: .seconds(5),
               responseBodyPolicy: buffered(successBytes: 128, errorBytes: 4096)
             )
           )
@@ -477,7 +477,7 @@ final class HandoffCounter: Sendable {
             url: server.url("/exact"),
             headers: [:],
             body: nil,
-            timeoutSeconds: 5,
+            timeout: .seconds(5),
             responseBodyPolicy: buffered(successBytes: 128, errorBytes: 4096)
           )
         )
@@ -506,7 +506,7 @@ final class HandoffCounter: Sendable {
             url: server.url("/boom"),
             headers: [:],
             body: nil,
-            timeoutSeconds: 5,
+            timeout: .seconds(5),
             responseBodyPolicy: buffered(successBytes: 4096, errorBytes: 64)
           )
         )
@@ -538,7 +538,7 @@ final class HandoffCounter: Sendable {
             url: server.url("/hop"),
             headers: [:],
             body: nil,
-            timeoutSeconds: 5,
+            timeout: .seconds(5),
             responseBodyPolicy: buffered(successBytes: 512, errorBytes: 32)
           )
         )
@@ -566,7 +566,7 @@ final class HandoffCounter: Sendable {
               url: server.url("/rpc"),
               headers: [:],
               body: Data("{}".utf8),
-              timeoutSeconds: 5,
+              timeout: .seconds(5),
               responseBodyPolicy: .streaming(maximumUnreadBytes: 1024, errorBytes: 1024)
             )
           )
@@ -593,7 +593,7 @@ final class HandoffCounter: Sendable {
               url: server.url("/rpc"),
               headers: [:],
               body: Data("{}".utf8),
-              timeoutSeconds: 5,
+              timeout: .seconds(5),
               responseBodyPolicy: buffered()
             )
           )
@@ -620,7 +620,7 @@ final class HandoffCounter: Sendable {
             url: server.url("/rpc"),
             headers: [:],
             body: Data("{}".utf8),
-            timeoutSeconds: 5,
+            timeout: .seconds(5),
             responseBodyPolicy: buffered(),
             beginHandoff: counter.callback
           )
@@ -648,7 +648,7 @@ final class HandoffCounter: Sendable {
               url: server.url("/rpc"),
               headers: [:],
               body: Data("{}".utf8),
-              timeoutSeconds: 5,
+              timeout: .seconds(5),
               responseBodyPolicy: buffered(),
               beginHandoff: counter.refusingCallback
             )
@@ -683,7 +683,7 @@ final class HandoffCounter: Sendable {
             url: "http://127.0.0.1:\(port)/rpc",
             headers: [:],
             body: Data("{}".utf8),
-            timeoutSeconds: 1,
+            timeout: .seconds(1),
             responseBodyPolicy: buffered()
           )
         )
@@ -707,7 +707,7 @@ final class HandoffCounter: Sendable {
               url: server.url("/rpc"),
               headers: [:],
               body: Data("{}".utf8),
-              timeoutSeconds: 5,
+              timeout: .seconds(5),
               responseBodyPolicy: buffered()
             )
           )
@@ -733,7 +733,7 @@ final class HandoffCounter: Sendable {
               url: server.url("/rpc"),
               headers: [:],
               body: Data("{}".utf8),
-              timeoutSeconds: 1,
+              timeout: .milliseconds(100),
               responseBodyPolicy: buffered()
             )
           )
@@ -741,8 +741,11 @@ final class HandoffCounter: Sendable {
       }
       let elapsed = ContinuousClock.now - started
 
-      // then — the deadline that fired is the request's own one second, not some larger default a
-      // bare "it failed eventually" would have accepted just as happily
+      // then — the deadline that fired is the request's own, not some larger default a bare "it
+      // failed eventually" would have accepted just as happily. The lower bound makes the
+      // sub-second conversion load-bearing: a regression back to whole-second truncation would
+      // turn this deadline into zero and fire instantly.
+      #expect(elapsed >= .milliseconds(100))
       #expect(elapsed < .seconds(5))
       #expect(failure?.disposition == .mayHaveBeenSent)
     }

--- a/Tests/ClawTelegramTests/Wire/AsyncHTTPExecutorStreamingTests.swift
+++ b/Tests/ClawTelegramTests/Wire/AsyncHTTPExecutorStreamingTests.swift
@@ -144,7 +144,7 @@ private func withBurstingServer<Result>(
       url: url,
       headers: [:],
       body: Data("{}".utf8),
-      timeoutSeconds: timeoutSeconds,
+      timeout: .seconds(timeoutSeconds),
       responseBodyPolicy: policy,
       beginHandoff: beginHandoff
     )

--- a/Tests/ClawTelegramTests/Wire/HTTPClientProfileTests.swift
+++ b/Tests/ClawTelegramTests/Wire/HTTPClientProfileTests.swift
@@ -25,7 +25,7 @@ private func probe(_ url: String) -> HTTPRequest {
     url: url,
     headers: ["Authorization": sentinelBearer],
     body: nil,
-    timeoutSeconds: 5,
+    timeout: .seconds(5),
     responseBodyPolicy: .buffered(successBytes: 4096, errorBytes: 4096)
   )
 }

--- a/Tests/ClawToolsTests/Policy/ExfilArgGuardTests.swift
+++ b/Tests/ClawToolsTests/Policy/ExfilArgGuardTests.swift
@@ -264,10 +264,12 @@ import Testing
   }
 
   @Test func maximumStagedPayloadUsesTheBoundedTextPath() {
-    // given — functional max-bound case; no stopwatch assertion
+    // given — functional max-bound case; no stopwatch assertion. Guard texts arrive one staged
+    // file at a time, so the largest single text the bounded path can receive is the per-file
+    // staging cap — the multi-file total cap is a sum, never one string.
     let guardrail = ExfilArgGuard(secretValues: [])
     let index = ExfilArgGuard.PrivateTextIndex(texts: ["private marker only in source"])
-    let text = String(repeating: "a", count: 4 * 1024 * 1024)
+    let text = String(repeating: "a", count: ExecuteCodeTool.maxStagedFileBytes)
 
     // when
     let unconditional = guardrail.evaluate(text: text)


### PR DESCRIPTION
Xcode Insights flagged one slow-test outlier per test target. Each was either a fixture doing far more work than the bound it pins, or a deadline the type system forced up to a whole second.

## Flagged outliers

| Test | Before | After |
|---|---|---|
| `maximumStagedPayloadUsesTheBoundedTextPath` (ClawTools) | 2.4s | 0.5s |
| `requestTimeoutAppliesAndIsMayHaveBeenSent` (ClawTelegram) | 1.0s | 0.1s |
| `aPushOfExactlyTheBufferCapIsParsed` (ClawLLM) | 0.95s | ~0.05s |
| `programBudgetStartsAfterSpawnAndReturnsTypedTimeout` (ClawExec) | 0.14s | unchanged |

- The exfil-guard fixture scanned 4 MiB, re-typing the multi-file staging total. The gate hands the guard one staged file at a time, capped at 1 MiB, so the test now derives its payload from `ExecuteCodeTool.maxStagedFileBytes`.
- `HTTPRequest` carried `timeoutSeconds: Int`, so the request-timeout test could not wait less than a second. The field is now a `Duration`, bridged to NIO with the nanosecond-exact `TimeAmount(_:)`, and the test waits 100ms. A new lower-bound assertion fails if the sub-second plumbing ever regresses to whole-second truncation. The `post`/`get` conveniences keep `timeoutSeconds: Int`, so their callers stay unchanged.
- The SSE buffer-cap test tiled its 4 MiB push from 74-byte events and paid ~57k JSON decodes. It now tiles from ~1 MiB events.
- The exec program-budget test stays as is: its 50ms budget plus 50ms teardown grace is the whole cost.

## Other real cost found while timing the rest

- The data-event-cap pair now pushes the cheapest payload the counter still charges: 0.75s to 0.44s each.
- The cancel-signal race ran 20 cycles, but its 96-run padding is what catches the pre-fix bug (~99% per cycle at nproc=1); six cycles keep the miss probability under 1e-6. Suite: 0.79s to 0.23s.
- The streaming acceptance stack drove a real 250ms probe tick through `ContinuousClock`. I promoted the compressed-sleep idiom from AgentRuntimeStreamingTests into ClawTestSupport as `ScriptedClock.compressed(parkingAt:)` and both call sites share it now.
- The SC7/SC3 harnesses opened a fresh `DatabasePool` on every poll probe; each harness now opens one reader and reuses it.

## Production wins along the way

- `SSEFraming.dataPayloadLines` skips the bridged CRLF fold when an event carries no CR byte, once per event on every stream.
- `ExfilArgGuard.looksHighEntropy` judges bytes instead of graphemes. A MiB-scale token drops from ~110ms to ~1ms in the tool-gate hot path, with identical verdicts for the ASCII-only matches its callers pass.
- `ChatGPTTokenMetadata` rejects an oversized token on an O(1) length check before scanning its alphabet, which its doc comment had promised all along.

## Method

Most "slow tests" in a full parallel run were phantoms: ~100 async tests reported a uniform ~2.2s that costs about 1ms in isolation, because a few CPU-heavy fixtures starved the cooperative pool. I re-measured every candidate with an isolated `swift test --filter` run before editing, and left the phantoms alone (the SSRF resolver test resolves loopback in 2ms).

Full suite: 2120 tests pass, parallel wall 4.0s to 2.9s, serial sum 18.6s to 14.2s. `scripts/lint.sh` passes.