### PR TITLE
Public-release docs: README rewrite, guides, license, and policies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,3 +117,11 @@ CLAW_HEARTBEAT_MAX_PER_DAY=
 # Approvals
 # seconds a pending tool approval stays live before auto-deny (60..86400; default 3600)
 CLAW_APPROVAL_EXPIRY=
+
+# Logging
+# swift-log level: trace, debug, info, notice, warning, error, critical (default info)
+CLAW_LOG_LEVEL=
+
+# Persona & behavior are NOT env vars: they live in Markdown files under
+# <stateRoot>/workspace/ (SOUL.md, AGENTS.md, TOOLS.md, USER.md, MEMORY.md, HEARTBEAT.md).
+# See docs/CUSTOMIZATION.md.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,17 @@ jobs:
           path: dist
       - name: Assemble SHA256SUMS
         run: |
-          cp .env.example dist/.env.example
+          # Setup files ship with the release so users verify them against SHA256SUMS
+          # instead of fetching mutable copies from main. The leading dot is dropped
+          # because a release asset name must survive GitHub's sanitization unchanged,
+          # or the download stops matching its manifest entry.
+          cp .env.example dist/clawd.env.example
+          cp deploy/run-clawd.sh deploy/swift-claw.service \
+             deploy/com.ivanmagda.swift-claw.plist dist/
           cd dist
           cat linux/clawd-linux-x86_64.sha256 macos/clawd-macos-arm64.sha256 > SHA256SUMS
-          sha256sum .env.example >> SHA256SUMS
+          sha256sum clawd.env.example run-clawd.sh swift-claw.service \
+                    com.ivanmagda.swift-claw.plist >> SHA256SUMS
           cat SHA256SUMS
       - name: Publish GitHub Release
         env:
@@ -109,4 +116,7 @@ jobs:
             dist/linux/clawd-linux-x86_64 \
             dist/macos/clawd-macos-arm64 \
             dist/SHA256SUMS \
-            dist/.env.example
+            dist/clawd.env.example \
+            dist/run-clawd.sh \
+            dist/swift-claw.service \
+            dist/com.ivanmagda.swift-claw.plist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,6 @@ jobs:
           path: dist
       - name: Assemble SHA256SUMS
         run: |
-          # Setup files ship with the release so users verify them against SHA256SUMS
-          # instead of fetching mutable copies from main. The leading dot is dropped
-          # because a release asset name must survive GitHub's sanitization unchanged,
-          # or the download stops matching its manifest entry.
           cp .env.example dist/clawd.env.example
           cp deploy/run-clawd.sh deploy/swift-claw.service \
              deploy/com.ivanmagda.swift-claw.plist dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,8 +94,10 @@ jobs:
           path: dist
       - name: Assemble SHA256SUMS
         run: |
+          cp .env.example dist/.env.example
           cd dist
           cat linux/clawd-linux-x86_64.sha256 macos/clawd-macos-arm64.sha256 > SHA256SUMS
+          sha256sum .env.example >> SHA256SUMS
           cat SHA256SUMS
       - name: Publish GitHub Release
         env:
@@ -107,4 +109,4 @@ jobs:
             dist/linux/clawd-linux-x86_64 \
             dist/macos/clawd-macos-arm64 \
             dist/SHA256SUMS \
-            .env.example
+            dist/.env.example

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v8
         with:
           path: dist
@@ -103,4 +106,5 @@ jobs:
           gh release create "${GITHUB_REF_NAME}" "${flags[@]}" \
             dist/linux/clawd-linux-x86_64 \
             dist/macos/clawd-macos-arm64 \
-            dist/SHA256SUMS
+            dist/SHA256SUMS \
+            .env.example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ swift-claw — a persistent, always-on, **single-owner personal AI assistant** c
 - Product scope, phasing, success criteria → `docs/PRD.md`.
 - Cited background research → `docs/research/`.
 - Building, running, or operating `clawd` locally → `docs/LOCAL_DEV.md`.
+- Changing any user-visible surface (a command, flag, env var, default, secret, or install/release step) → update the public set in lockstep: `README.md`, `docs/GETTING_STARTED.md`, `docs/CUSTOMIZATION.md`, `deploy/README.md`. They document each other's state, so a change in one usually invalidates a sibling.
 
 ## Non-negotiable conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,14 @@ For vulnerabilities, never open a public issue. Follow [SECURITY.md](SECURITY.md
 
 ## Development setup
 
-You need a Swift 6.3 toolchain.
+You need a Swift 6.3 toolchain and SwiftLint (the lint gate exits 1 without it):
+
+```bash
+brew install swiftlint                          # macOS
+sudo apt-get install -y libsqlite3-dev          # Linux, for the SQLite headers GRDB links
+```
+
+Then:
 
 ```bash
 swift build            # build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+Thanks for your interest in swift-claw.
+
+## Open an issue first
+
+Please open an issue and agree on the approach before sending a pull request.
+swift-claw is a single-maintainer project with a normative spec; a short issue
+discussion saves you from building something that can't merge. Small fixes
+(typos, broken links, obvious one-liners) can skip straight to a PR.
+
+For bug reports, include your platform, the output of `clawd doctor --json`
+(it redacts secrets), and steps to reproduce.
+
+For vulnerabilities, never open a public issue. Follow [SECURITY.md](SECURITY.md).
+
+## Development setup
+
+You need a Swift 6.3 toolchain.
+
+```bash
+swift build            # build
+swift test             # run the suite
+scripts/lint.sh --fix  # auto-apply swift-format + SwiftLint fixes
+scripts/lint.sh        # verify; must pass before committing
+```
+
+Day-to-day commands, including how to run the daemon locally, live in
+[docs/LOCAL_DEV.md](docs/LOCAL_DEV.md).
+
+## What a pull request needs
+
+- A linked issue with an agreed approach (except trivial fixes).
+- `scripts/lint.sh` and `swift test` green. CI enforces both on macOS and Linux.
+- Tests for behavior changes, structured as Given-When-Then
+  (`// given` / `// when` / `// then`). [docs/TESTING.md](docs/TESTING.md) is
+  the rubric for what earns a test.
+- Design changes reflected in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+  That document is normative: where code and spec disagree, the spec wins,
+  so change both together.
+
+## Ground rules
+
+- Swift 6 strict concurrency throughout: mutable state lives in actors, domain
+  types are `Sendable` value types.
+- Security policy is enforced in code, never in the prompt. Untrusted input
+  (messages, web content, tool output, stored memory) is data, not instructions.
+- Reuse before you add: search for an existing helper, constant, or test double
+  before writing a second copy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,12 +27,22 @@ sudo apt-get install -y libsqlite3-dev          # SQLite headers GRDB links agai
 docker pull ghcr.io/realm/swiftlint:0.65.0      # the image CI lints with
 ```
 
-On Linux, run SwiftLint through that image (CI does the same), or put a `swiftlint`
-wrapper on your `PATH` so `scripts/lint.sh` finds it:
+On Linux, put a wrapper on your `PATH` so `scripts/lint.sh` finds SwiftLint and runs the
+same checks as everywhere else:
 
 ```bash
-docker run --rm -v "$PWD:/work" -w /work ghcr.io/realm/swiftlint:0.65.0 swiftlint lint --strict
+sudo tee /usr/local/bin/swiftlint >/dev/null <<'EOF'
+#!/bin/sh
+exec docker run --rm -v "$PWD:$PWD" -w "$PWD" \
+  --entrypoint swiftlint ghcr.io/realm/swiftlint:0.65.0 "$@"
+EOF
+sudo chmod +x /usr/local/bin/swiftlint
 ```
+
+Mounting the working directory at its own path keeps reported file paths usable. Run the
+gate with `scripts/lint.sh` rather than calling `swiftlint` yourself: warnings are not
+failures by default, so a bare `--strict` run reports the accepted force-unwrap warnings
+and exits nonzero on a clean checkout.
 
 Then:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,19 @@ For vulnerabilities, never open a public issue. Follow [SECURITY.md](SECURITY.md
 You need a Swift 6.3 toolchain and SwiftLint (the lint gate exits 1 without it):
 
 ```bash
-brew install swiftlint                          # macOS
-sudo apt-get install -y libsqlite3-dev          # Linux, for the SQLite headers GRDB links
+# macOS
+brew install swiftlint
+
+# Linux
+sudo apt-get install -y libsqlite3-dev          # SQLite headers GRDB links against
+docker pull ghcr.io/realm/swiftlint:0.65.0      # the image CI lints with
+```
+
+On Linux, run SwiftLint through that image (CI does the same), or put a `swiftlint`
+wrapper on your `PATH` so `scripts/lint.sh` finds it:
+
+```bash
+docker run --rm -v "$PWD:/work" -w /work ghcr.io/realm/swiftlint:0.65.0 swiftlint lint --strict
 ```
 
 Then:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,8 @@ EOF
 sudo chmod +x /usr/local/bin/swiftlint
 ```
 
-Mounting the working directory at its own path keeps reported file paths usable. Run the
+Mounting the working directory at its own path keeps the paths SwiftLint prints usable on
+the host. Run the
 gate with `scripts/lint.sh` rather than calling `swiftlint` yourself: warnings are not
 failures by default, so a bare `--strict` run reports the accepted force-unwrap warnings
 and exits nonzero on a clean checkout.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ivan Magda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,138 @@
 # swift-claw
 
-A persistent, single-owner personal AI assistant controlled via Telegram, written in pure Swift. The daemon is `clawd`.
+[![CI](https://github.com/ivan-magda/swift-claw/actions/workflows/ci.yml/badge.svg)](https://github.com/ivan-magda/swift-claw/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/ivan-magda/swift-claw)](../../releases/latest)
+[![Swift 6.3](https://img.shields.io/badge/Swift-6.3-F05138?logo=swift&logoColor=white)](https://swift.org)
+[![Platforms](https://img.shields.io/badge/platforms-macOS%20%7C%20Linux-blue)](#install)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
-> Design docs live in [`docs/`](docs/) — `ARCHITECTURE.md` is the normative spec.
+**Your always-on personal AI assistant in Telegram. One pure-Swift daemon on hardware you own.**
 
-## Install a release binary
+`clawd` pairs a private Telegram bot with the LLM of your choice. It remembers what you
+tell it, runs scheduled and proactive tasks, and executes tools behind an approval gate,
+while every secret, message, and memory stays in a SQLite file on your disk.
 
-Download the binary for your platform from the [latest release](../../releases/latest), then verify it:
+## Features
+
+- **A real Telegram chat.** Answers stream in as live message drafts. `/stop` cancels a
+  turn, `/new` starts a fresh session, and voice notes transcribe on-device (macOS 26).
+- **Durable memory.** Confirmed facts and daily logs survive restarts in SQLite with
+  full-text recall, alongside workspace files you edit like notes.
+- **Proactive, on your clock.** "Every weekday at 07:00" schedules fire once per
+  occurrence across restarts and DST changes, and an opt-in heartbeat respects quiet hours.
+- **Tools behind a policy engine.** Web search and fetch sit behind an SSRF gate; writes
+  and code execution wait for an explicit tap-to-approve in Telegram. Policy lives in
+  code, and inbound content is treated as data, never as instructions.
+- **Sandboxed code execution.** Untrusted code runs in a fresh disposable VM per request
+  (macOS 26 arm64, off by default).
+- **Bring your own model.** Any OpenAI-compatible endpoint works, and `clawd auth login`
+  can run an eligible model on a ChatGPT subscription.
+- **One binary.** Swift 6 with strict concurrency, from the Telegram long-poll down to SQLite.
+
+## Install
+
+Download the binary for your platform from the [latest release](../../releases/latest)
+and verify it:
 
 ```bash
-sha256sum -c SHA256SUMS                      # Linux
-shasum -a 256 -c SHA256SUMS                   # macOS
-gh attestation verify clawd-linux-x86_64 -R ivan-magda/swift-claw
+shasum -a 256 -c SHA256SUMS          # macOS (on Linux: sha256sum -c SHA256SUMS)
+gh attestation verify clawd-macos-arm64 -R ivan-magda/swift-claw
+install -m755 clawd-macos-arm64 /usr/local/bin/clawd
 ```
 
-`-c` checks every entry in `SHA256SUMS`; a `FAILED open or read` line for the platform binary you didn't download is expected.
+`-c` checks every entry in `SHA256SUMS`; a `FAILED open or read` line for the binary you
+didn't download is expected.
 
-- **macOS:** first run is blocked by Gatekeeper for an unsigned binary — clear the quarantine flag: `xattr -d com.apple.quarantine ./clawd-macos-arm64`.
-- **Linux:** the binary links the system SQLite — install it if missing: `sudo apt-get install -y libsqlite3-0`.
+- **macOS:** Gatekeeper blocks the unsigned binary on first run. Clear it:
+  `xattr -d com.apple.quarantine /usr/local/bin/clawd`.
+- **Linux:** the binary links the system SQLite: `sudo apt-get install -y libsqlite3-0`.
 
-## Build from source
-
-Requires the Swift 6.3.x toolchain.
+Or build from source with a Swift 6.3 toolchain:
 
 ```bash
-swift build            # debug → .build/debug/clawd
-swift build -c release # release → .build/release/clawd
-swift test             # run the suite
+git clone https://github.com/ivan-magda/swift-claw.git && cd swift-claw
+swift build -c release    # the binary lands at .build/release/clawd
 ```
 
-See [`docs/LOCAL_DEV.md`](docs/LOCAL_DEV.md) for running the daemon and [`deploy/README.md`](deploy/README.md) for supervised deployment.
+## Quick start
+
+Create a bot with [@BotFather](https://t.me/BotFather) (`/newbot`) and copy its token. Then:
+
+```bash
+# 1. Configure: fill in the BotFather token, CLAW_LLM_BASE_URL,
+#    CLAW_LLM_MODEL, and CLAW_LLM_API_KEY.
+mkdir -p ~/.swift-claw
+cp .env.example ~/.swift-claw/clawd.env
+chmod 600 ~/.swift-claw/clawd.env
+
+# 2. Load the config and encrypt your secrets at rest:
+set -a && source ~/.swift-claw/clawd.env && set +a
+clawd secrets seal
+
+# 3. Health check, then run:
+clawd doctor
+clawd run
+```
+
+Now DM your bot. It replies with your numeric Telegram ID; put that in `CLAW_ALLOWLIST`
+in `clawd.env`, re-source, and restart. Your next message gets a real answer.
+
+The full walkthrough, including the ChatGPT-subscription route and troubleshooting,
+is in [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
+
+## Security model
+
+swift-claw assumes the person who runs it is the only person it serves.
+
+- **Default-deny.** Only allowlisted Telegram IDs get a conversation. Everyone else is
+  refused and shown their ID.
+- **Secrets encrypted at rest.** `clawd secrets seal` wraps the bot token and API keys in
+  an AES-GCM envelope. Plaintext env secrets remain available as a dev fallback that
+  warns on every boot.
+- **Approvals you can trust.** Consequential actions suspend into a durable state machine
+  until you tap Approve in Telegram. A forged or third-party callback cannot approve,
+  and pending approvals expire to deny.
+- **Prompt injection contained.** Messages, web content, tool output, and stored memory
+  enter the context as untrusted data. Once a turn has touched untrusted input and
+  private data, any action that could exfiltrate requires your approval.
+
+The full model is in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) (§12). To report a
+vulnerability, see [SECURITY.md](SECURITY.md).
+
+## Customize your agent
+
+Persona and behavior live in Markdown files under `~/.swift-claw/workspace/`:
+
+| File | Shapes |
+|---|---|
+| `SOUL.md` | Personality and tone |
+| `AGENTS.md` | Behavior rules |
+| `TOOLS.md` | When and how to use tools |
+| `USER.md` | Who you are (kept private) |
+| `HEARTBEAT.md` | The proactive heartbeat checklist |
+
+Runtime knobs are environment variables: the model route (`CLAW_LLM_MODEL`), USD
+budgets, schedules and quiet hours, voice locales, sandbox limits.
+[`.env.example`](.env.example) documents every variable;
+[docs/CUSTOMIZATION.md](docs/CUSTOMIZATION.md) is the guide.
+
+## Documentation
+
+| You want to | Read |
+|---|---|
+| Set it up end to end | [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) |
+| Make it yours | [docs/CUSTOMIZATION.md](docs/CUSTOMIZATION.md) |
+| Run it as a service | [deploy/README.md](deploy/README.md) |
+| Develop and test locally | [docs/LOCAL_DEV.md](docs/LOCAL_DEV.md) |
+| Understand the design | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
+| Report a vulnerability | [SECURITY.md](SECURITY.md) |
+
+## Contributing
+
+Contributions are welcome. Open an issue to discuss what you have in mind before
+sending a pull request; [CONTRIBUTING.md](CONTRIBUTING.md) has the details and the
+lint/test gate.
+
+## License
+
+[MIT](LICENSE) © Ivan Magda

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ gh attestation verify "$ASSET" -R ivan-magda/swift-claw
   `sudo mkdir -p /usr/local/bin`.
 - **Linux:** the binary links the system SQLite: `sudo apt-get install -y libsqlite3-0`.
 
-Or build from source with a Swift 6.3 toolchain:
+Or build from source with a Swift 6.3 toolchain. On Linux, install the SQLite headers
+first (`sudo apt-get install -y libsqlite3-dev`); the runtime package alone will not link:
 
 ```bash
 git clone https://github.com/ivan-magda/swift-claw.git && cd swift-claw
@@ -94,10 +95,15 @@ clawd secrets seal
 
 # 3. Sealing copies the secrets out; it does not edit the file. Delete the
 #    CLAW_TELEGRAM_BOT_TOKEN, CLAW_LLM_API_KEY, and CLAW_SEARCH_API_KEY lines
-#    from ~/.swift-claw/clawd.env yourself, then open a fresh shell.
+#    from ~/.swift-claw/clawd.env yourself.
+```
 
-# 4. Health check, then run.
-clawd doctor
+Open a fresh shell so the deleted secrets leave your environment, then load the remaining
+config and start the daemon:
+
+```bash
+set -a && source ~/.swift-claw/clawd.env && set +a
+clawd doctor --check-config
 clawd run
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@
 **Your always-on personal AI assistant in Telegram. One pure-Swift daemon on hardware you own.**
 
 `clawd` pairs a private Telegram bot with the LLM of your choice. It remembers what you
-tell it, runs scheduled and proactive tasks, and executes tools behind an approval gate,
-while every secret, message, and memory stays in a SQLite file on your disk.
+tell it, runs scheduled and proactive tasks, and executes tools behind an approval gate.
+Everything it keeps lives in one directory on your own machine: a SQLite database,
+encrypted secret envelopes, and Markdown files you can edit by hand.
 
 ## Features
 
 - **A real Telegram chat.** Answers stream in as live message drafts. `/stop` cancels a
   turn, `/new` starts a fresh session, and voice notes transcribe on-device (macOS 26).
-- **Durable memory.** Confirmed facts and daily logs survive restarts in SQLite with
-  full-text recall, alongside workspace files you edit like notes.
+- **Durable memory.** Facts you confirm persist in SQLite with full-text recall, next to
+  workspace Markdown files that hold your profile, notes, and daily logs.
 - **Proactive, on your clock.** "Every weekday at 07:00" schedules fire once per
   occurrence across restarts and DST changes, and an opt-in heartbeat respects quiet hours.
 - **Tools behind a policy engine.** Web search and fetch sit behind an SSRF gate; writes
@@ -31,27 +32,30 @@ while every secret, message, and memory stays in a SQLite file on your disk.
 
 ## Install
 
-Download the binary for your platform from the [latest release](../../releases/latest)
-and verify it:
+Download **the binary for your platform and `SHA256SUMS`** from the
+[latest release](../../releases/latest), then verify and install:
 
 ```bash
-shasum -a 256 -c SHA256SUMS          # macOS (on Linux: sha256sum -c SHA256SUMS)
-gh attestation verify clawd-macos-arm64 -R ivan-magda/swift-claw
-install -m755 clawd-macos-arm64 /usr/local/bin/clawd
+ASSET=clawd-macos-arm64                # Linux: clawd-linux-x86_64
+
+shasum -a 256 -c SHA256SUMS            # Linux: sha256sum -c SHA256SUMS
+gh attestation verify "$ASSET" -R ivan-magda/swift-claw
+sudo install -m755 "$ASSET" /usr/local/bin/clawd
 ```
 
 `-c` checks every entry in `SHA256SUMS`; a `FAILED open or read` line for the binary you
 didn't download is expected.
 
 - **macOS:** Gatekeeper blocks the unsigned binary on first run. Clear it:
-  `xattr -d com.apple.quarantine /usr/local/bin/clawd`.
+  `sudo xattr -d com.apple.quarantine /usr/local/bin/clawd`.
 - **Linux:** the binary links the system SQLite: `sudo apt-get install -y libsqlite3-0`.
 
 Or build from source with a Swift 6.3 toolchain:
 
 ```bash
 git clone https://github.com/ivan-magda/swift-claw.git && cd swift-claw
-swift build -c release    # the binary lands at .build/release/clawd
+swift build -c release
+sudo install -m755 .build/release/clawd /usr/local/bin/clawd
 ```
 
 ## Quick start
@@ -59,42 +63,53 @@ swift build -c release    # the binary lands at .build/release/clawd
 Create a bot with [@BotFather](https://t.me/BotFather) (`/newbot`) and copy its token. Then:
 
 ```bash
-# 1. Configure: fill in the BotFather token, CLAW_LLM_BASE_URL,
-#    CLAW_LLM_MODEL, and CLAW_LLM_API_KEY.
+# 1. Fetch the config template, then fill in the BotFather token,
+#    CLAW_LLM_BASE_URL, CLAW_LLM_MODEL, and CLAW_LLM_API_KEY.
 mkdir -p ~/.swift-claw
-cp .env.example ~/.swift-claw/clawd.env
+curl -fsSL https://raw.githubusercontent.com/ivan-magda/swift-claw/main/.env.example \
+  -o ~/.swift-claw/clawd.env
 chmod 600 ~/.swift-claw/clawd.env
 
 # 2. Load the config and encrypt your secrets at rest:
 set -a && source ~/.swift-claw/clawd.env && set +a
 clawd secrets seal
 
-# 3. Health check, then run:
+# 3. Sealing copies the secrets; it does not remove them. Delete the
+#    CLAW_TELEGRAM_BOT_TOKEN, CLAW_LLM_API_KEY, and CLAW_SEARCH_API_KEY
+#    lines from ~/.swift-claw/clawd.env now, then re-source it.
+
+# 4. Health check, then run:
 clawd doctor
 clawd run
 ```
 
-Now DM your bot. It replies with your numeric Telegram ID; put that in `CLAW_ALLOWLIST`
-in `clawd.env`, re-source, and restart. Your next message gets a real answer.
+Now send `/start` to your bot. It replies with your numeric Telegram ID; put that in
+`CLAW_ALLOWLIST` in `clawd.env`, re-source, and restart. Your next message gets a real
+answer. (Only `/start` reveals the ID: any other message from a stranger gets a bare
+refusal.)
 
-The full walkthrough, including the ChatGPT-subscription route and troubleshooting,
-is in [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
+Running on a ChatGPT subscription instead of an API key? Do
+[step 8](docs/GETTING_STARTED.md#8-chatgpt-subscription-instead-of-an-api-key)
+of the walkthrough before you start the daemon. The full guide, including
+troubleshooting, is in [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
 
 ## Security model
 
 swift-claw assumes the person who runs it is the only person it serves.
 
 - **Default-deny.** Only allowlisted Telegram IDs get a conversation. Everyone else is
-  refused and shown their ID.
+  refused, and `/start` returns the sender's own numeric ID so you can allowlist them.
 - **Secrets encrypted at rest.** `clawd secrets seal` wraps the bot token and API keys in
   an AES-GCM envelope. Plaintext env secrets remain available as a dev fallback that
   warns on every boot.
-- **Approvals you can trust.** Consequential actions suspend into a durable state machine
-  until you tap Approve in Telegram. A forged or third-party callback cannot approve,
-  and pending approvals expire to deny.
+- **Approvals you can trust.** File writes and code execution always suspend into a
+  durable state machine until you tap Approve in Telegram. A forged or third-party
+  callback cannot approve, and pending approvals expire to deny.
 - **Prompt injection contained.** Messages, web content, tool output, and stored memory
-  enter the context as untrusted data. Once a turn has touched untrusted input and
-  private data, any action that could exfiltrate requires your approval.
+  enter the context as untrusted data. Once a session has both ingested untrusted content
+  and read your private files, fetching an arbitrary URL also needs your approval; traffic
+  to pinned endpoints such as your LLM and search providers is instead scanned for private
+  content and secret-shaped values.
 
 The full model is in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) (§12). To report a
 vulnerability, see [SECURITY.md](SECURITY.md).
@@ -103,13 +118,13 @@ vulnerability, see [SECURITY.md](SECURITY.md).
 
 Persona and behavior live in Markdown files under `~/.swift-claw/workspace/`:
 
-| File | Shapes |
-|---|---|
-| `SOUL.md` | Personality and tone |
-| `AGENTS.md` | Behavior rules |
-| `TOOLS.md` | When and how to use tools |
-| `USER.md` | Who you are (kept private) |
-| `HEARTBEAT.md` | The proactive heartbeat checklist |
+| File | Shapes | Trust |
+|---|---|---|
+| `SOUL.md` | Personality and tone | System prompt |
+| `AGENTS.md` | Behavior rules | System prompt |
+| `TOOLS.md` | When and how to use tools | System prompt |
+| `USER.md` | Who you are | Untrusted, labeled |
+| `HEARTBEAT.md` | The proactive heartbeat checklist | Heartbeat runs only |
 
 Runtime knobs are environment variables: the model route (`CLAW_LLM_MODEL`), USD
 budgets, schedules and quiet hours, voice locales, sandbox limits.

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ Then verify and install from your download directory:
 cd ~/Downloads
 ASSET=clawd-macos-arm64                                 # Linux: clawd-linux-x86_64
 
-shasum -a 256 --ignore-missing -c SHA256SUMS            # Linux: sha256sum --ignore-missing -c SHA256SUMS
-sudo install -m755 "$ASSET" /usr/local/bin/clawd
+shasum -a 256 --ignore-missing -c SHA256SUMS &&        # Linux: sha256sum --ignore-missing -c SHA256SUMS
+  sudo install -m755 "$ASSET" /usr/local/bin/clawd
 ```
 
-`--ignore-missing` checks only the files you actually downloaded. Every one of them must
-print `OK` and the command must exit 0; anything else means stop.
+`--ignore-missing` checks only the files you actually downloaded. The `&&` matters: it
+stops the install if verification fails. Every downloaded file must print `OK`.
 
 Every binary also carries a build provenance attestation. If you have the
 [GitHub CLI](https://cli.github.com) installed and logged in (`gh auth login`), verify it:

--- a/README.md
+++ b/README.md
@@ -9,21 +9,22 @@
 **Your always-on personal AI assistant in Telegram. One pure-Swift daemon on hardware you own.**
 
 `clawd` pairs a private Telegram bot with the LLM of your choice. It remembers what you
-tell it, runs scheduled and proactive tasks, and executes tools behind an approval gate.
-Everything it keeps lives in one directory on your own machine: a SQLite database,
-encrypted secret envelopes, and Markdown files you can edit by hand.
+tell it and runs scheduled and proactive tasks. Consequential tool calls wait for your
+approval. Everything it keeps stays in one directory on your own machine: a SQLite
+database, encrypted secret envelopes, and Markdown files you edit by hand.
 
 ## Features
 
 - **A real Telegram chat.** Answers stream in as live message drafts. `/stop` cancels a
-  turn, `/new` starts a fresh session, and voice notes transcribe on-device (macOS 26).
+  turn, `/new` starts a fresh session, and clawd transcribes voice notes on-device
+  (macOS 26).
 - **Durable memory.** Facts you confirm persist in SQLite with full-text recall, next to
   workspace Markdown files that hold your profile, notes, and daily logs.
 - **Proactive, on your clock.** "Every weekday at 07:00" schedules fire once per
   occurrence across restarts and DST changes, and an opt-in heartbeat respects quiet hours.
 - **Tools behind a policy engine.** `web_fetch` sits behind an SSRF gate; writes and code
   execution wait for an explicit tap-to-approve in Telegram. Policy lives in code, and
-  inbound content is treated as data, never as instructions.
+  clawd treats inbound content as data, never as instructions.
 - **Sandboxed code execution.** Untrusted code runs in a fresh disposable VM per request
   (macOS 26 arm64, off by default).
 - **Bring your own model.** Any OpenAI-compatible endpoint works, and `clawd auth login`
@@ -47,8 +48,8 @@ shasum -a 256 --ignore-missing -c SHA256SUMS &&        # Linux: sha256sum --igno
   sudo install -m755 "$ASSET" /usr/local/bin/clawd
 ```
 
-`--ignore-missing` checks only the files you actually downloaded. The `&&` matters: it
-stops the install if verification fails. Every downloaded file must print `OK`.
+`--ignore-missing` checks only the files you downloaded. The `&&` stops the install if
+verification fails. Every downloaded file must print `OK`.
 
 Every binary also carries a build provenance attestation. If you have the
 [GitHub CLI](https://cli.github.com) installed and logged in (`gh auth login`), verify it:
@@ -126,18 +127,18 @@ troubleshooting, is in [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
 
 ## Security model
 
-swift-claw assumes the person who runs it is the only person it serves.
+swift-claw assumes you are the only person it serves.
 
-- **Default-deny.** Only allowlisted Telegram IDs get a conversation. Everyone else is
-  refused, and `/start` returns the sender's own numeric ID so you can allowlist them.
-  `CLAW_ALLOWLIST` only ever adds: revoking an ID means deleting its row from the database
-  ([details](docs/CUSTOMIZATION.md#everything-else)).
+- **Default-deny.** Only allowlisted Telegram IDs get a conversation. clawd refuses
+  everyone else, and answers `/start` with the sender's own numeric ID so you can
+  allowlist them. `CLAW_ALLOWLIST` only ever adds, so revoking an ID means deleting its
+  row from the database ([details](docs/CUSTOMIZATION.md#everything-else)).
 - **Secrets encrypted at rest.** `clawd secrets seal` wraps the bot token and API keys in
   an AES-GCM envelope. Plaintext env secrets remain available as a dev fallback that
   warns on every boot.
-- **Approvals you can trust.** File writes, memory writes, and code execution always
-  suspend into a durable state machine until you tap Approve in Telegram. A forged or
-  third-party callback cannot approve, and pending approvals expire to deny.
+- **Approvals are durable and unforgeable.** File writes, memory writes, and code
+  execution suspend into a durable state machine until you tap Approve in Telegram. A
+  forged or third-party callback cannot approve, and pending approvals expire to deny.
 - **Prompt injection contained.** Messages, web content, tool output, and stored memory
   enter the context as untrusted data. Once a session has both ingested untrusted content
   and pulled your private files into context, fetching an arbitrary URL also needs your

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ encrypted secret envelopes, and Markdown files you can edit by hand.
   workspace Markdown files that hold your profile, notes, and daily logs.
 - **Proactive, on your clock.** "Every weekday at 07:00" schedules fire once per
   occurrence across restarts and DST changes, and an opt-in heartbeat respects quiet hours.
-- **Tools behind a policy engine.** Web search and fetch sit behind an SSRF gate; writes
-  and code execution wait for an explicit tap-to-approve in Telegram. Policy lives in
-  code, and inbound content is treated as data, never as instructions.
+- **Tools behind a policy engine.** `web_fetch` sits behind an SSRF gate; writes and code
+  execution wait for an explicit tap-to-approve in Telegram. Policy lives in code, and
+  inbound content is treated as data, never as instructions.
 - **Sandboxed code execution.** Untrusted code runs in a fresh disposable VM per request
   (macOS 26 arm64, off by default).
 - **Bring your own model.** Any OpenAI-compatible endpoint works, and `clawd auth login`
@@ -32,22 +32,35 @@ encrypted secret envelopes, and Markdown files you can edit by hand.
 
 ## Install
 
+Releases carry two binaries: `clawd-macos-arm64` (Apple Silicon) and `clawd-linux-x86_64`.
+On any other architecture, build from source below.
+
 Download **the binary for your platform and `SHA256SUMS`** from the
-[latest release](../../releases/latest), then verify and install:
+[latest release](../../releases/latest), then verify and install from your download
+directory:
 
 ```bash
-ASSET=clawd-macos-arm64                # Linux: clawd-linux-x86_64
+cd ~/Downloads
+ASSET=clawd-macos-arm64                                 # Linux: clawd-linux-x86_64
 
-shasum -a 256 -c SHA256SUMS            # Linux: sha256sum -c SHA256SUMS
-gh attestation verify "$ASSET" -R ivan-magda/swift-claw
+shasum -a 256 --ignore-missing -c SHA256SUMS            # Linux: sha256sum --ignore-missing -c SHA256SUMS
 sudo install -m755 "$ASSET" /usr/local/bin/clawd
 ```
 
-`-c` checks every entry in `SHA256SUMS`; a `FAILED open or read` line for the binary you
-didn't download is expected.
+`--ignore-missing` checks only the files you actually downloaded. Expect one `OK` line and
+exit status 0; anything else means stop.
+
+Every binary also carries a build provenance attestation. If you have the
+[GitHub CLI](https://cli.github.com) installed and logged in (`gh auth login`), verify it:
+
+```bash
+gh attestation verify "$ASSET" -R ivan-magda/swift-claw
+```
 
 - **macOS:** Gatekeeper blocks the unsigned binary on first run. Clear it:
   `sudo xattr -d com.apple.quarantine /usr/local/bin/clawd`.
+  On a Mac without Homebrew, create the install directory first:
+  `sudo mkdir -p /usr/local/bin`.
 - **Linux:** the binary links the system SQLite: `sudo apt-get install -y libsqlite3-0`.
 
 Or build from source with a Swift 6.3 toolchain:
@@ -63,22 +76,27 @@ sudo install -m755 .build/release/clawd /usr/local/bin/clawd
 Create a bot with [@BotFather](https://t.me/BotFather) (`/newbot`) and copy its token. Then:
 
 ```bash
-# 1. Fetch the config template, then fill in the BotFather token,
-#    CLAW_LLM_BASE_URL, CLAW_LLM_MODEL, and CLAW_LLM_API_KEY.
-mkdir -p ~/.swift-claw
+# 1. Fetch the config template.
+mkdir -p -m 700 ~/.swift-claw
 curl -fsSL https://raw.githubusercontent.com/ivan-magda/swift-claw/main/.env.example \
   -o ~/.swift-claw/clawd.env
 chmod 600 ~/.swift-claw/clawd.env
+```
 
-# 2. Load the config and encrypt your secrets at rest:
+**Now edit `~/.swift-claw/clawd.env`** and set the BotFather token plus your provider's
+`CLAW_LLM_BASE_URL`, `CLAW_LLM_MODEL`, and `CLAW_LLM_API_KEY`. The template ships with
+placeholder values that will not work. Then:
+
+```bash
+# 2. Load the config and encrypt your secrets at rest.
 set -a && source ~/.swift-claw/clawd.env && set +a
 clawd secrets seal
 
-# 3. Sealing copies the secrets; it does not remove them. Delete the
-#    CLAW_TELEGRAM_BOT_TOKEN, CLAW_LLM_API_KEY, and CLAW_SEARCH_API_KEY
-#    lines from ~/.swift-claw/clawd.env now, then re-source it.
+# 3. Sealing copies the secrets out; it does not edit the file. Delete the
+#    CLAW_TELEGRAM_BOT_TOKEN, CLAW_LLM_API_KEY, and CLAW_SEARCH_API_KEY lines
+#    from ~/.swift-claw/clawd.env yourself, then open a fresh shell.
 
-# 4. Health check, then run:
+# 4. Health check, then run.
 clawd doctor
 clawd run
 ```
@@ -102,14 +120,14 @@ swift-claw assumes the person who runs it is the only person it serves.
 - **Secrets encrypted at rest.** `clawd secrets seal` wraps the bot token and API keys in
   an AES-GCM envelope. Plaintext env secrets remain available as a dev fallback that
   warns on every boot.
-- **Approvals you can trust.** File writes and code execution always suspend into a
-  durable state machine until you tap Approve in Telegram. A forged or third-party
-  callback cannot approve, and pending approvals expire to deny.
+- **Approvals you can trust.** File writes, memory writes, and code execution always
+  suspend into a durable state machine until you tap Approve in Telegram. A forged or
+  third-party callback cannot approve, and pending approvals expire to deny.
 - **Prompt injection contained.** Messages, web content, tool output, and stored memory
   enter the context as untrusted data. Once a session has both ingested untrusted content
-  and read your private files, fetching an arbitrary URL also needs your approval; traffic
-  to pinned endpoints such as your LLM and search providers is instead scanned for private
-  content and secret-shaped values.
+  and pulled your private files into context, fetching an arbitrary URL also needs your
+  approval. Your LLM and search providers are pinned destinations that clawd cannot be
+  redirected away from.
 
 The full model is in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) (§12). To report a
 vulnerability, see [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ encrypted secret envelopes, and Markdown files you can edit by hand.
 Releases carry two binaries: `clawd-macos-arm64` (Apple Silicon) and `clawd-linux-x86_64`.
 On any other architecture, build from source below.
 
-Download **the binary for your platform and `SHA256SUMS`** from the
-[latest release](../../releases/latest), then verify and install from your download
-directory:
+From the [latest release](../../releases/latest), download **the binary for your platform,
+`SHA256SUMS`, and `clawd.env.example`** (the config template, used in the quick start).
+Then verify and install from your download directory:
 
 ```bash
 cd ~/Downloads
@@ -47,8 +47,8 @@ shasum -a 256 --ignore-missing -c SHA256SUMS            # Linux: sha256sum --ign
 sudo install -m755 "$ASSET" /usr/local/bin/clawd
 ```
 
-`--ignore-missing` checks only the files you actually downloaded. Expect one `OK` line and
-exit status 0; anything else means stop.
+`--ignore-missing` checks only the files you actually downloaded. Every one of them must
+print `OK` and the command must exit 0; anything else means stop.
 
 Every binary also carries a build provenance attestation. If you have the
 [GitHub CLI](https://cli.github.com) installed and logged in (`gh auth login`), verify it:
@@ -72,17 +72,24 @@ swift build -c release
 sudo install -m755 .build/release/clawd /usr/local/bin/clawd
 ```
 
+From a source checkout the config template is `.env.example` in the repository root, and
+the service files are under `deploy/`.
+
 ## Quick start
 
 Create a bot with [@BotFather](https://t.me/BotFather) (`/newbot`) and copy its token. Then:
 
+Download `clawd.env.example` from the same release as your binary, verify it against
+`SHA256SUMS` alongside the binary, and use it as your config:
+
 ```bash
-# 1. Fetch the config template.
+# 1. Install the verified template.
 mkdir -p -m 700 ~/.swift-claw
-curl -fsSL https://raw.githubusercontent.com/ivan-magda/swift-claw/main/.env.example \
-  -o ~/.swift-claw/clawd.env
-chmod 600 ~/.swift-claw/clawd.env
+install -m 600 clawd.env.example ~/.swift-claw/clawd.env
 ```
+
+Your shell runs this file with `source`, so take it from the checksummed release rather
+than an unverified copy.
 
 **Now edit `~/.swift-claw/clawd.env`** and set the BotFather token plus your provider's
 `CLAW_LLM_BASE_URL`, `CLAW_LLM_MODEL`, and `CLAW_LLM_API_KEY`. The template ships with
@@ -123,6 +130,8 @@ swift-claw assumes the person who runs it is the only person it serves.
 
 - **Default-deny.** Only allowlisted Telegram IDs get a conversation. Everyone else is
   refused, and `/start` returns the sender's own numeric ID so you can allowlist them.
+  `CLAW_ALLOWLIST` only ever adds: revoking an ID means deleting its row from the database
+  ([details](docs/CUSTOMIZATION.md#everything-else)).
 - **Secrets encrypted at rest.** `clawd secrets seal` wraps the bot token and API keys in
   an AES-GCM envelope. Plaintext env secrets remain available as a dev fallback that
   warns on every boot.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+`clawd` holds your Telegram credentials, LLM keys, and personal data, and it executes
+tools on your behalf. Security reports take priority over feature work.
+
+## Reporting a vulnerability
+
+Report privately through GitHub: **Security → [Report a vulnerability](../../security/advisories/new)**.
+Do not open a public issue for anything exploitable.
+
+Include the affected version or commit, reproduction steps, and the impact you see.
+You will get an acknowledgment within 7 days and a status update when the fix lands
+or the report is declined, with reasoning either way.
+
+## Scope
+
+Reports in these areas matter most:
+
+- Bypassing the Telegram allowlist (getting a conversation, or any action, without being allowlisted).
+- Bypassing the approval fabric: a forged or third-party callback that approves an action, or a consequential action that runs without approval.
+- Escaping the code-execution sandbox through clawd's integration (host paths, network, or secrets reachable from guest code without the documented opt-ins).
+- Defeating the exfiltration gate or the SSRF blocklist.
+- Secret exposure: plaintext at rest where encryption is promised, or secrets surviving log redaction.
+- Prompt injection that crosses a policy enforced in code. Model output that is merely odd or unhelpful is not a vulnerability.
+
+Vulnerabilities in upstream dependencies belong upstream; open a regular issue here
+asking for the version bump.
+
+## Supported versions
+
+The latest release and `main`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ Reports in these areas matter most:
 - Escaping the code-execution sandbox through clawd's integration (host paths, network, or secrets reachable from guest code without the documented opt-ins).
 - Defeating the exfiltration gate or the SSRF blocklist.
 - Secret exposure: plaintext at rest where encryption is promised, or secrets surviving log redaction.
-- Prompt injection that crosses a policy enforced in code. Model output that is merely odd or unhelpful is not a vulnerability.
+- Prompt injection that crosses a policy enforced in code. Odd or unhelpful model output is not a vulnerability.
 
 Vulnerabilities in upstream dependencies belong upstream; open a regular issue here
 asking for the version bump.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,7 +2,7 @@
 
 ## Install
 
-**Option A — release binary (recommended):** download `clawd-<platform>` + `SHA256SUMS` from the [latest release](../../../releases/latest), verify with `sha256sum -c SHA256SUMS` (Linux) or `shasum -a 256 -c SHA256SUMS` (macOS) and `gh attestation verify <binary> -R ivan-magda/swift-claw`, then `sudo install -m755 clawd-<platform> /usr/local/bin/clawd`. `-c` checks every entry in `SHA256SUMS`; a `FAILED open or read` line for the platform binary you didn't download is expected. On macOS clear quarantine: `sudo xattr -d com.apple.quarantine /usr/local/bin/clawd`. On Linux ensure `libsqlite3-0` is installed.
+**Option A — release binary (recommended):** download `clawd-<platform>` + `SHA256SUMS` from the [latest release](../../../releases/latest), verify with `sha256sum --ignore-missing -c SHA256SUMS` (Linux) or `shasum -a 256 --ignore-missing -c SHA256SUMS` (macOS), then `sudo install -m755 clawd-<platform> /usr/local/bin/clawd`. `--ignore-missing` checks only what you downloaded: every listed file must print `OK` and the command must exit 0. The release also carries `clawd.env.example` and the unit files below, all covered by the same manifest. Optionally check build provenance with `gh attestation verify <binary> -R ivan-magda/swift-claw` (needs the GitHub CLI, logged in). On macOS clear quarantine: `sudo xattr -d com.apple.quarantine /usr/local/bin/clawd`. On Linux ensure `libsqlite3-0` is installed.
 
 **Option B — build from source:**
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,7 +2,7 @@
 
 ## Install
 
-**Option A — release binary (recommended):** download `clawd-<platform>` + `SHA256SUMS` from the [latest release](../../../releases/latest), verify with `sha256sum -c SHA256SUMS` (Linux) or `shasum -a 256 -c SHA256SUMS` (macOS) and `gh attestation verify <binary> -R ivan-magda/swift-claw`, then `install -m755 clawd-<platform> /usr/local/bin/clawd`. `-c` checks every entry in `SHA256SUMS`; a `FAILED open or read` line for the platform binary you didn't download is expected. On macOS clear quarantine: `xattr -d com.apple.quarantine /usr/local/bin/clawd`. On Linux ensure `libsqlite3-0` is installed.
+**Option A — release binary (recommended):** download `clawd-<platform>` + `SHA256SUMS` from the [latest release](../../../releases/latest), verify with `sha256sum -c SHA256SUMS` (Linux) or `shasum -a 256 -c SHA256SUMS` (macOS) and `gh attestation verify <binary> -R ivan-magda/swift-claw`, then `sudo install -m755 clawd-<platform> /usr/local/bin/clawd`. `-c` checks every entry in `SHA256SUMS`; a `FAILED open or read` line for the platform binary you didn't download is expected. On macOS clear quarantine: `sudo xattr -d com.apple.quarantine /usr/local/bin/clawd`. On Linux ensure `libsqlite3-0` is installed.
 
 **Option B — build from source:**
 
@@ -21,5 +21,7 @@
 - `cp deploy/swift-claw.service ~/.config/systemd/user/`
 - `systemctl --user enable --now swift-claw.service`
 - `journalctl --user -u swift-claw -f`
+
+Both units are per-user: they start at login, not at boot, and stop at logout. To survive a reboot without a login, enable automatic login (or convert the macOS plist into a `/Library/LaunchDaemons` system service), and on Linux run `sudo loginctl enable-linger $USER`.
 
 A second `clawd` against the same state root refuses to boot (flock); a Telegram 409 is logged as critical. Distinct exit codes: 10 config, 11 secret, 12 already-running, 13 store.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,9 +2,21 @@
 
 ## Install
 
-**Option A — release binary (recommended):** download `clawd-<platform>` + `SHA256SUMS` from the [latest release](../../../releases/latest), verify with `sha256sum --ignore-missing -c SHA256SUMS` (Linux) or `shasum -a 256 --ignore-missing -c SHA256SUMS` (macOS), then `sudo install -m755 clawd-<platform> /usr/local/bin/clawd`. `--ignore-missing` checks only what you downloaded: every listed file must print `OK` and the command must exit 0. The release also carries `clawd.env.example` and the unit files below, all covered by the same manifest. Optionally check build provenance with `gh attestation verify <binary> -R ivan-magda/swift-claw` (needs the GitHub CLI, logged in). On macOS clear quarantine: `sudo xattr -d com.apple.quarantine /usr/local/bin/clawd`. On Linux ensure `libsqlite3-0` is installed.
+**Option A (release binary, recommended).** Download `clawd-<platform>` and `SHA256SUMS` from the [latest release](../../../releases/latest). The same release ships `clawd.env.example` and the unit files below, all under that one manifest.
 
-**Option B — build from source:**
+```bash
+shasum -a 256 --ignore-missing -c SHA256SUMS &&        # Linux: sha256sum --ignore-missing -c SHA256SUMS
+  sudo install -m755 clawd-<platform> /usr/local/bin/clawd
+```
+
+`--ignore-missing` checks only what you downloaded. Every listed file must print `OK`, and the `&&` stops the install if any does not. To also check build provenance, run `gh attestation verify <binary> -R ivan-magda/swift-claw` (needs the GitHub CLI, logged in).
+
+Platform notes:
+
+- **macOS:** clear quarantine with `sudo xattr -d com.apple.quarantine /usr/local/bin/clawd`.
+- **Linux:** install `libsqlite3-0`.
+
+**Option B (build from source).**
 
 1. `swift build -c release` → `sudo install -m755 .build/release/clawd /usr/local/bin/clawd`.
 2. `cp .env.example ~/.swift-claw/clawd.env`, fill in the token + allowlist, `chmod 600 ~/.swift-claw/clawd.env`.
@@ -22,6 +34,6 @@
 - `systemctl --user enable --now swift-claw.service`
 - `journalctl --user -u swift-claw -f`
 
-Both units are per-user: they start at login, not at boot, and stop at logout. On Linux, `sudo loginctl enable-linger $USER` keeps the service alive across logout and starts it at boot. On macOS, enable automatic login for the account. A `/Library/LaunchDaemons` service instead runs as root, where `$HOME` is `/var/root` and `run-clawd.sh` cannot find `~/.swift-claw/clawd.env`, so `clawd` exits 10 — set `UserName`, `CLAW_ENV_FILE`, and `CLAW_STATE_ROOT` in the plist if you take that path.
+Both units are per-user: they start at login, not at boot, and stop at logout. On Linux, `sudo loginctl enable-linger $USER` keeps the service alive across logout and starts it at boot. On macOS, enable automatic login for the account. A `/Library/LaunchDaemons` service instead runs as root, where `$HOME` is `/var/root` and `run-clawd.sh` cannot find `~/.swift-claw/clawd.env`, so `clawd` exits 10. If you take that path, set `UserName`, `CLAW_ENV_FILE`, and `CLAW_STATE_ROOT` in the plist.
 
 A second `clawd` against the same state root refuses to boot (flock); a Telegram 409 is logged as critical. Distinct exit codes: 10 config, 11 secret, 12 already-running, 13 store.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,22 +6,22 @@
 
 **Option B — build from source:**
 
-1. `swift build -c release` → copy `.build/release/clawd` to `/usr/local/bin/clawd`.
+1. `swift build -c release` → `sudo install -m755 .build/release/clawd /usr/local/bin/clawd`.
 2. `cp .env.example ~/.swift-claw/clawd.env`, fill in the token + allowlist, `chmod 600 ~/.swift-claw/clawd.env`.
 3. Verify: `clawd doctor` (config first, then DB/allowlist/connectivity).
 
 ## macOS (launchd)
 
-- `cp deploy/run-clawd.sh /usr/local/bin/ && chmod +x /usr/local/bin/run-clawd.sh`
-- `cp deploy/com.ivanmagda.swift-claw.plist ~/Library/LaunchAgents/`
+- `sudo install -m755 deploy/run-clawd.sh /usr/local/bin/run-clawd.sh`
+- `mkdir -p ~/Library/LaunchAgents && cp deploy/com.ivanmagda.swift-claw.plist ~/Library/LaunchAgents/`
 - `launchctl load ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist`
 
 ## Linux (systemd, user service)
 
-- `cp deploy/swift-claw.service ~/.config/systemd/user/`
+- `mkdir -p ~/.config/systemd/user && cp deploy/swift-claw.service ~/.config/systemd/user/`
 - `systemctl --user enable --now swift-claw.service`
 - `journalctl --user -u swift-claw -f`
 
-Both units are per-user: they start at login, not at boot, and stop at logout. To survive a reboot without a login, enable automatic login (or convert the macOS plist into a `/Library/LaunchDaemons` system service), and on Linux run `sudo loginctl enable-linger $USER`.
+Both units are per-user: they start at login, not at boot, and stop at logout. On Linux, `sudo loginctl enable-linger $USER` keeps the service alive across logout and starts it at boot. On macOS, enable automatic login for the account. A `/Library/LaunchDaemons` service instead runs as root, where `$HOME` is `/var/root` and `run-clawd.sh` cannot find `~/.swift-claw/clawd.env`, so `clawd` exits 10 — set `UserName`, `CLAW_ENV_FILE`, and `CLAW_STATE_ROOT` in the plist if you take that path.
 
 A second `clawd` against the same state root refuses to boot (flock); a Telegram 409 is logged as critical. Distinct exit codes: 10 config, 11 secret, 12 already-running, 13 store.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -1,0 +1,95 @@
+# Customizing Your Agent
+
+Two surfaces shape how your agent behaves: Markdown files in the workspace (persona,
+rules, profile) and environment variables (wiring, budgets, features). This guide covers
+both. [`.env.example`](../.env.example) stays the complete variable reference.
+
+## Workspace files
+
+The workspace lives at `<state root>/workspace/` (default `~/.swift-claw/workspace/`).
+Create any of these files and the daemon injects them into the model's context on the
+next turn; a missing file is skipped.
+
+| File | What it shapes |
+|---|---|
+| `SOUL.md` | Personality and tone. The place to say "answer tersely", "be playful", "reply in Russian". |
+| `AGENTS.md` | Behavior rules: how to act, what to prioritize, standing instructions. |
+| `TOOLS.md` | Guidance on when and how to use tools. |
+| `USER.md` | Your profile: who you are, context the agent should know. **Private data.** |
+| `MEMORY.md` | Long-lived memory the agent maintains. **Private data.** |
+| `HEARTBEAT.md` | A checklist read only by the proactive heartbeat, never by ordinary turns. |
+| `memory/YYYY-MM-DD.md` | Dated daily logs. |
+
+Two properties worth knowing:
+
+- **Workspace content is data, not instructions.** The files enter the context at the
+  untrusted tier, below the system prompt. They steer style and knowledge; they cannot
+  override the security policy, which is enforced in code.
+- **`USER.md` and `MEMORY.md` are private-data files.** A turn that reads one is marked
+  as having touched private data, and any exfiltration-capable action in such a turn
+  requires your explicit approval.
+
+Durable facts also live in the database: confirm something in chat ("remember that ...")
+and it persists in SQLite with full-text recall across restarts. `/memory` shows what is
+stored.
+
+## Model routing
+
+`CLAW_LLM_MODEL` selects the provider route:
+
+- **A plain model id** (`claude-sonnet-4-6`, `gpt-4o`, `openrouter/openai/gpt-5.4`) uses
+  the OpenAI-compatible Chat Completions route against `CLAW_LLM_BASE_URL` with
+  `CLAW_LLM_API_KEY`. This is the supported default and works with local servers too
+  (leave the key blank for no-auth endpoints).
+- **`openai-chatgpt/<model>`** uses the ChatGPT subscription route. `clawd auth login`
+  handles the OAuth flow and prints the exact value to set; base URL and API key are
+  unused there.
+
+Related knobs: `CLAW_LLM_STREAMING` (rich streamed drafts, on by default),
+`CLAW_LLM_MAX_TOKENS`, `CLAW_LLM_MAX_TOKENS_FIELD`, `CLAW_LLM_STRUCTURED_OUTPUT`.
+
+## Spending limits
+
+All optional; unset means the built-in defaults.
+
+| Variable | Controls |
+|---|---|
+| `CLAW_PER_RUN_USD` | Cap per single run |
+| `CLAW_PER_DAY_USD` | Daily kill-switch across everything |
+| `CLAW_PROACTIVE_PER_DAY_USD` | Nested daily cap for scheduled + heartbeat runs (default 2.00) |
+| `CLAW_MAX_TURNS` / `CLAW_MAX_TOOL_CALLS` | Bounds on the agentic loop per run |
+
+## Proactive behavior
+
+Schedules are created in chat and confirmed before they arm. The environment sets the
+frame: `CLAW_TIMEZONE` (IANA zone for schedule defaults and day boundaries),
+`CLAW_SCHED_MIN_INTERVAL_MINUTES`, `CLAW_SCHED_CATCHUP_MAX_AGE_MINUTES`.
+
+The heartbeat is off by default. `CLAW_HEARTBEAT_ENABLED=true` turns it on (requires
+exactly one allowlisted owner), then it works through `HEARTBEAT.md` up to
+`CLAW_HEARTBEAT_MAX_PER_DAY` times a day, every `CLAW_HEARTBEAT_INTERVAL_MINUTES`
+minutes, staying silent during `CLAW_HEARTBEAT_QUIET_HOURS` (default `22:00-09:00`).
+
+## Voice messages (macOS 26)
+
+On by default, on-device, off on other platforms. `CLAW_VOICE_LOCALES` takes a
+comma-separated priority list (`ru-RU,en-US`); there is no audio language detection, so
+every configured locale transcribes the note and the most confident transcript wins.
+The first use of a locale downloads its speech model.
+
+## Code execution sandbox (macOS 26 arm64)
+
+Off by default. `CLAW_EXEC_ENABLED=true` lets the agent run code in a fresh disposable
+VM per request, behind an exact-action approval. Resource limits
+(`CLAW_EXEC_MEMORY_MIB`, `CLAW_EXEC_CPUS`, `CLAW_EXEC_TIMEOUT`), the digest-pinned
+workload image, and the network opt-in (`CLAW_EXEC_ALLOW_EGRESS`) are documented in
+[`.env.example`](../.env.example) and [LOCAL_DEV.md](LOCAL_DEV.md).
+
+## Everything else
+
+- `CLAW_ALLOWLIST`: who may talk to the bot (comma-separated numeric Telegram IDs).
+- `CLAW_APPROVAL_EXPIRY`: seconds before a pending approval auto-denies (default 3600).
+- `CLAW_SEARCH_API_KEY`: Exa key; unset means the `web_search` tool is absent.
+- `CLAW_WEBFETCH_EXEMPT_CIDRS`: SSRF-blocklist exemptions for fake-IP VPN pools.
+- `CLAW_LOG_LEVEL`: `trace`, `debug`, `info` (default), `notice`, `warning`, `error`, `critical`.
+- `CLAW_STATE_ROOT`: where all of it lives (default `~/.swift-claw`).

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -88,9 +88,16 @@ All optional; unset means the built-in defaults.
 | Variable | Controls |
 |---|---|
 | `CLAW_PER_RUN_USD` | Cap per single run |
-| `CLAW_PER_DAY_USD` | Daily kill-switch across everything |
+| `CLAW_PER_DAY_USD` | Daily spend kill-switch |
 | `CLAW_PROACTIVE_PER_DAY_USD` | Nested daily cap for scheduled + heartbeat runs (default 2.00) |
 | `CLAW_MAX_TURNS` / `CLAW_MAX_TOOL_CALLS` | Bounds on the agentic loop per run |
+
+**On the ChatGPT subscription route these dollar caps do not gate.** A plan-included call
+has no metered cost to compare against, so `CLAW_PER_RUN_USD` and
+`CLAW_PROACTIVE_PER_DAY_USD` are inert there and usage records at zero USD.
+`CLAW_PER_DAY_USD` still binds indirectly, because the daily token ceiling derives from it;
+set `CLAW_DAY_TOKEN_CEILING` to control that directly. Token, turn, tool-call, and
+wall-clock bounds apply the same on both routes.
 
 ## Proactive behavior
 
@@ -120,7 +127,11 @@ workload image, and the network opt-in (`CLAW_EXEC_ALLOW_EGRESS`) are documented
 
 ## Everything else
 
-- `CLAW_ALLOWLIST`: who may talk to the bot (comma-separated numeric Telegram IDs).
+- `CLAW_ALLOWLIST`: numeric Telegram IDs, comma-separated, seeded into the allowlist at
+  every daemon start. **Seeding only adds.** The `allowlist` table in `claw.sqlite` is what
+  the daemon actually enforces, so removing an ID here does not revoke it. To revoke
+  access, stop the daemon, drop the ID from `CLAW_ALLOWLIST`, and delete the row:
+  `sqlite3 ~/.swift-claw/claw.sqlite "DELETE FROM allowlist WHERE user_id = <id>;"`
 - `CLAW_APPROVAL_EXPIRY`: seconds before a pending approval auto-denies (default 3600).
 - `CLAW_SEARCH_API_KEY`: Exa key; unset means the `web_search` tool is absent.
 - `CLAW_WEBFETCH_EXEMPT_CIDRS`: SSRF-blocklist exemptions for fake-IP VPN pools.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -131,10 +131,32 @@ workload image, and the network opt-in (`CLAW_EXEC_ALLOW_EGRESS`) are documented
   every daemon start. **Seeding only adds.** The `allowlist` table in `claw.sqlite` is what
   the daemon actually enforces, so removing an ID here does not revoke it. To revoke
   access, stop the daemon, drop the ID from `CLAW_ALLOWLIST`, and delete the row from the
-  database in your state root:
+  database in your state root (the `sqlite3` CLI is its own package on Linux:
+  `sudo apt-get install -y sqlite3`):
   `sqlite3 "${CLAW_STATE_ROOT:-$HOME/.swift-claw}/claw.sqlite" "DELETE FROM allowlist WHERE user_id = <id>;"`
 - `CLAW_APPROVAL_EXPIRY`: seconds before a pending approval auto-denies (default 3600).
-- `CLAW_SEARCH_API_KEY`: Exa key; unset means the `web_search` tool is absent.
+- `CLAW_SEARCH_API_KEY`: Exa key; unset means the `web_search` tool is absent. Adding it
+  after you have sealed does nothing on its own: once `secrets.enc` exists the daemon reads
+  secrets only from there. See [Adding a secret later](#adding-a-secret-later).
 - `CLAW_WEBFETCH_EXEMPT_CIDRS`: SSRF-blocklist exemptions for fake-IP VPN pools.
 - `CLAW_LOG_LEVEL`: `trace`, `debug`, `info` (default), `notice`, `warning`, `error`, `critical`.
 - `CLAW_STATE_ROOT`: where all of it lives (default `~/.swift-claw`).
+
+## Adding a secret later
+
+Sealing writes one envelope holding every runtime secret, and from then on the daemon
+ignores secrets in the environment. Turning on `web_search` months later, or rotating a
+key, therefore means resealing the whole set rather than adding a line to `clawd.env`.
+
+Stop the daemon first; sealing takes the same state-root lock. Put **all** the secrets you
+want back in the environment, not just the new one, since the reseal replaces the envelope:
+
+```bash
+export CLAW_TELEGRAM_BOT_TOKEN=...   # the values you deleted after the first seal
+export CLAW_LLM_API_KEY=...
+export CLAW_SEARCH_API_KEY=...       # the one you are adding
+clawd secrets seal
+```
+
+Then clear them from your shell (or close it), and start the daemon again. `clawd doctor`
+confirms the result: the `web_search` row turns from absent to configured.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -21,17 +21,19 @@ skipped.
 
 The trust tier decides how much authority the text carries:
 
-- **`SOUL.md`, `AGENTS.md`, and `TOOLS.md` join the system prompt.** They are yours to
-  write and the model treats them as trusted instruction. Editing one changes the policy
-  fingerprint, which is why a `file_write` to any of them is flagged as privileged and why
-  pending approvals do not survive the change. Nothing you put in them can loosen the
-  security policy, which lives in code rather than in the prompt.
+- **`SOUL.md`, `AGENTS.md`, and `TOOLS.md` join the system prompt.** You write them, and
+  the model treats them as trusted instruction. They also feed the policy fingerprint, so
+  editing one invalidates any approval still waiting on the old prompt. Nothing you put in
+  them can loosen the security policy, which lives in code rather than in the prompt.
 - **`USER.md` and `MEMORY.md` enter inside an untrusted, labeled wrapper**, below the
-  system prompt, so text that arrived there through poisoned memory cannot claim system
-  authority. Both count as private data for the exfiltration gate described below.
+  system prompt, so text that reached them through poisoned memory cannot claim system
+  authority. Both count as private data for the exfiltration gate below.
 
-Dated daily logs (`memory/YYYY-MM-DD.md`) are written and read on request; the context
-builder does not inject them automatically the way it does the files above.
+When the agent writes to `SOUL.md`, `AGENTS.md`, `USER.md`, or `MEMORY.md`, the approval
+card carries a privileged-file banner. `TOOLS.md` does not get one.
+
+The agent writes and reads dated daily logs (`memory/YYYY-MM-DD.md`) when a turn calls for
+one; the context builder never injects them the way it injects the files above.
 
 Durable facts also live in the database: confirm something in chat ("remember that ...")
 and it persists in SQLite with full-text recall across restarts. `/memory` shows what is
@@ -39,18 +41,30 @@ stored.
 
 ## When the agent asks permission
 
-Two separate mechanisms decide this, and it is worth knowing which one is speaking.
+Two mechanisms produce an approval card. They answer different questions.
 
-**By tool.** File writes and code execution always suspend the run and wait for you,
-whatever else happened in the session.
+**The tool's own risk tier.** File writes, memory writes, and code execution park the run
+every time, whatever else the session did.
 
-**By exfiltration risk.** Fetching an arbitrary URL waits for you once the session has
-done *both* of these: ingested untrusted content (a web page, tool output, stored memory)
-and read a private-data file (`USER.md`, `MEMORY.md`). One leg alone does not trigger it,
-so the first `web_fetch` of a clean session runs unprompted. Traffic to pinned endpoints,
-your LLM provider and the search backend, never parks for approval; those are protected
-by endpoint pinning plus an argument scan that blocks private-file content and
-secret-shaped tokens.
+**Exfiltration risk.** clawd holds a fetch to an arbitrary URL for your approval once the
+session has done *both* of these:
+
+- **Ingested untrusted content.** A web page, a file read, tool output, or a voice
+  transcript. Durable memory does not count: it is labeled untrusted but does not taint
+  the session on its own.
+- **Touched private data.** Assembling `USER.md`, `MEMORY.md`, or stored memory items into
+  the context is enough; no tool has to read them. Once you have filled in `USER.md`, this
+  leg is armed on essentially every turn, and it sticks for the session.
+
+One leg alone does not trigger the gate, so the first `web_fetch` of a clean session runs
+unprompted. `/new` clears both legs.
+
+Your LLM provider and the search backend are pinned endpoints and never park for approval.
+clawd defends them by pinning the destination rather than by asking: it cannot be aimed at
+an attacker's URL. It also scans outbound *tool* arguments for secret-shaped values, and,
+under the trifecta, for substrings of your private files. The prompt sent to your LLM
+carries `USER.md` and `MEMORY.md` verbatim by design, so treat your model provider as a
+party you trust with that content.
 
 ## Model routing
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -7,31 +7,50 @@ both. [`.env.example`](../.env.example) stays the complete variable reference.
 ## Workspace files
 
 The workspace lives at `<state root>/workspace/` (default `~/.swift-claw/workspace/`).
-Create any of these files and the daemon injects them into the model's context on the
-next turn; a missing file is skipped.
+Create any of these files and the daemon loads them on the next turn; a missing file is
+skipped.
 
-| File | What it shapes |
-|---|---|
-| `SOUL.md` | Personality and tone. The place to say "answer tersely", "be playful", "reply in Russian". |
-| `AGENTS.md` | Behavior rules: how to act, what to prioritize, standing instructions. |
-| `TOOLS.md` | Guidance on when and how to use tools. |
-| `USER.md` | Your profile: who you are, context the agent should know. **Private data.** |
-| `MEMORY.md` | Long-lived memory the agent maintains. **Private data.** |
-| `HEARTBEAT.md` | A checklist read only by the proactive heartbeat, never by ordinary turns. |
-| `memory/YYYY-MM-DD.md` | Dated daily logs. |
+| File | What it shapes | Trust tier |
+|---|---|---|
+| `SOUL.md` | Personality and tone. The place to say "answer tersely", "be playful", "reply in Russian". | System prompt |
+| `AGENTS.md` | Behavior rules: how to act, what to prioritize, standing instructions. | System prompt |
+| `TOOLS.md` | Guidance on when and how to use tools. | System prompt |
+| `USER.md` | Your profile: who you are, context the agent should know. | Untrusted, labeled |
+| `MEMORY.md` | Long-lived memory the agent maintains. | Untrusted, labeled |
+| `HEARTBEAT.md` | A checklist the proactive heartbeat reads, never ordinary turns. | Heartbeat runs only |
 
-Two properties worth knowing:
+The trust tier decides how much authority the text carries:
 
-- **Workspace content is data, not instructions.** The files enter the context at the
-  untrusted tier, below the system prompt. They steer style and knowledge; they cannot
-  override the security policy, which is enforced in code.
-- **`USER.md` and `MEMORY.md` are private-data files.** A turn that reads one is marked
-  as having touched private data, and any exfiltration-capable action in such a turn
-  requires your explicit approval.
+- **`SOUL.md`, `AGENTS.md`, and `TOOLS.md` join the system prompt.** They are yours to
+  write and the model treats them as trusted instruction. Editing one changes the policy
+  fingerprint, which is why a `file_write` to any of them is flagged as privileged and why
+  pending approvals do not survive the change. Nothing you put in them can loosen the
+  security policy, which lives in code rather than in the prompt.
+- **`USER.md` and `MEMORY.md` enter inside an untrusted, labeled wrapper**, below the
+  system prompt, so text that arrived there through poisoned memory cannot claim system
+  authority. Both count as private data for the exfiltration gate described below.
+
+Dated daily logs (`memory/YYYY-MM-DD.md`) are written and read on request; the context
+builder does not inject them automatically the way it does the files above.
 
 Durable facts also live in the database: confirm something in chat ("remember that ...")
 and it persists in SQLite with full-text recall across restarts. `/memory` shows what is
 stored.
+
+## When the agent asks permission
+
+Two separate mechanisms decide this, and it is worth knowing which one is speaking.
+
+**By tool.** File writes and code execution always suspend the run and wait for you,
+whatever else happened in the session.
+
+**By exfiltration risk.** Fetching an arbitrary URL waits for you once the session has
+done *both* of these: ingested untrusted content (a web page, tool output, stored memory)
+and read a private-data file (`USER.md`, `MEMORY.md`). One leg alone does not trigger it,
+so the first `web_fetch` of a clean session runs unprompted. Traffic to pinned endpoints,
+your LLM provider and the search backend, never parks for approval; those are protected
+by endpoint pinning plus an argument scan that blocks private-file content and
+secret-shaped tokens.
 
 ## Model routing
 
@@ -61,8 +80,8 @@ All optional; unset means the built-in defaults.
 
 ## Proactive behavior
 
-Schedules are created in chat and confirmed before they arm. The environment sets the
-frame: `CLAW_TIMEZONE` (IANA zone for schedule defaults and day boundaries),
+You create schedules in chat, and you confirm each one before it arms. The environment
+sets the frame: `CLAW_TIMEZONE` (IANA zone for schedule defaults and day boundaries),
 `CLAW_SCHED_MIN_INTERVAL_MINUTES`, `CLAW_SCHED_CATCHUP_MAX_AGE_MINUTES`.
 
 The heartbeat is off by default. `CLAW_HEARTBEAT_ENABLED=true` turns it on (requires

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -1,14 +1,14 @@
 # Customizing Your Agent
 
-Two surfaces shape how your agent behaves: Markdown files in the workspace (persona,
-rules, profile) and environment variables (wiring, budgets, features). This guide covers
-both. [`.env.example`](../.env.example) stays the complete variable reference.
+You shape your agent in two places: Markdown files in the workspace (persona, rules,
+profile) and environment variables (wiring, budgets, features).
+[`.env.example`](../.env.example) stays the complete variable reference.
 
 ## Workspace files
 
 The workspace lives at `<state root>/workspace/` (default `~/.swift-claw/workspace/`).
-Create any of these files and the daemon loads them on the next turn; a missing file is
-skipped.
+Create any of these files and the daemon loads them on the next turn; it skips the ones
+you leave out.
 
 | File | What it shapes | Trust tier |
 |---|---|---|
@@ -41,7 +41,7 @@ stored.
 
 ## When the agent asks permission
 
-Two mechanisms produce an approval card. They answer different questions.
+clawd shows an approval card for two reasons.
 
 **The tool's own risk tier.** File writes, memory writes, and code execution park the run
 every time, whatever else the session did.
@@ -59,10 +59,10 @@ session has done *both* of these:
 One leg alone does not trigger the gate, so the first `web_fetch` of a clean session runs
 unprompted. `/new` clears both legs.
 
-Your LLM provider and the search backend are pinned endpoints and never park for approval.
-clawd defends them by pinning the destination rather than by asking: it cannot be aimed at
-an attacker's URL. It also scans outbound *tool* arguments for secret-shaped values, and,
-under the trifecta, for substrings of your private files. The prompt sent to your LLM
+Your LLM provider and the search backend are pinned destinations, so they never park for
+approval: no injected instruction can aim clawd at an attacker's URL instead. clawd also
+scans outbound *tool* arguments for secret-shaped values, and, under the trifecta, for
+substrings of your private files. The prompt sent to your LLM
 carries `USER.md` and `MEMORY.md` verbatim by design, so treat your model provider as a
 party you trust with that content.
 
@@ -94,7 +94,7 @@ All optional; unset means the built-in defaults.
 
 **On the ChatGPT subscription route these dollar caps do not gate.** A plan-included call
 has no metered cost to compare against, so `CLAW_PER_RUN_USD` and
-`CLAW_PROACTIVE_PER_DAY_USD` are inert there and usage records at zero USD.
+`CLAW_PROACTIVE_PER_DAY_USD` are inert there, and clawd records the usage at zero USD.
 `CLAW_PER_DAY_USD` still binds indirectly, because the daily token ceiling derives from it;
 set `CLAW_DAY_TOKEN_CEILING` to control that directly. Token, turn, tool-call, and
 wall-clock bounds apply the same on both routes.
@@ -129,7 +129,7 @@ workload image, and the network opt-in (`CLAW_EXEC_ALLOW_EGRESS`) are documented
 
 - `CLAW_ALLOWLIST`: numeric Telegram IDs, comma-separated, seeded into the allowlist at
   every daemon start. **Seeding only adds.** The `allowlist` table in `claw.sqlite` is what
-  the daemon actually enforces, so removing an ID here does not revoke it. To revoke
+  the daemon enforces, so removing an ID here does not revoke it. To revoke
   access, stop the daemon, drop the ID from `CLAW_ALLOWLIST`, and delete the row from the
   database in your state root (the `sqlite3` CLI is its own package on Linux:
   `sudo apt-get install -y sqlite3`):

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -130,8 +130,9 @@ workload image, and the network opt-in (`CLAW_EXEC_ALLOW_EGRESS`) are documented
 - `CLAW_ALLOWLIST`: numeric Telegram IDs, comma-separated, seeded into the allowlist at
   every daemon start. **Seeding only adds.** The `allowlist` table in `claw.sqlite` is what
   the daemon actually enforces, so removing an ID here does not revoke it. To revoke
-  access, stop the daemon, drop the ID from `CLAW_ALLOWLIST`, and delete the row:
-  `sqlite3 ~/.swift-claw/claw.sqlite "DELETE FROM allowlist WHERE user_id = <id>;"`
+  access, stop the daemon, drop the ID from `CLAW_ALLOWLIST`, and delete the row from the
+  database in your state root:
+  `sqlite3 "${CLAW_STATE_ROOT:-$HOME/.swift-claw}/claw.sqlite" "DELETE FROM allowlist WHERE user_id = <id>;"`
 - `CLAW_APPROVAL_EXPIRY`: seconds before a pending approval auto-denies (default 3600).
 - `CLAW_SEARCH_API_KEY`: Exa key; unset means the `web_search` tool is absent.
 - `CLAW_WEBFETCH_EXEMPT_CIDRS`: SSRF-blocklist exemptions for fake-IP VPN pools.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -165,8 +165,10 @@ an unverified source:
 
 ```bash
 cd ~/Downloads
-shasum -a 256 --ignore-missing -c SHA256SUMS    # Linux: sha256sum --ignore-missing -c SHA256SUMS
-mkdir -p deploy && mv run-clawd.sh swift-claw.service com.ivanmagda.swift-claw.plist deploy/ 2>/dev/null
+UNIT=com.ivanmagda.swift-claw.plist    # Linux: swift-claw.service
+
+shasum -a 256 --ignore-missing -c SHA256SUMS &&    # Linux: sha256sum --ignore-missing -c SHA256SUMS
+  mkdir -p deploy && mv run-clawd.sh "$UNIT" deploy/
 ```
 
 The deployment guide's commands read from `deploy/`, so run them from the directory that
@@ -209,9 +211,14 @@ verbatim and config validation rejects it. Substitute a real model slug, for exa
 `CLAW_LLM_MODEL=openai-chatgpt/gpt-5.4`, or run `clawd auth login` again once the network
 settles.
 
-Start the daemon again once the value is in place: `clawd run`, or
-`launchctl load ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist` /
-`systemctl --user start swift-claw.service`.
+Paste the value into `clawd.env`, then:
+
+- **Setting up for the first time?** Go back to [step 3](#3-seal-your-secrets) and continue
+  through the guide. Do not start the daemon yet; the remaining steps need the state root
+  to themselves.
+- **Already had clawd running?** Start it again: `clawd run`, or
+  `launchctl load ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist` /
+  `systemctl --user start swift-claw.service`.
 
 This route is unofficial and vendor-dependent; details and caveats in
 [LOCAL_DEV.md](LOCAL_DEV.md#chatgpt-subscription-auth).

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -5,8 +5,9 @@ command and what success looks like.
 
 ## What you need
 
-- **A machine that stays on.** An Apple Silicon Mac (macOS 15 or newer; voice
-  transcription and the code sandbox need macOS 26) or a Linux box with `libsqlite3-0`.
+- **A machine that stays on.** A Mac on macOS 15 or newer, or a Linux box with
+  `libsqlite3-0`. Voice transcription needs macOS 26, and the code sandbox needs macOS 26
+  on Apple Silicon; everything else runs anywhere.
 - **A Telegram account.**
 - **LLM access.** Either an OpenAI-compatible endpoint with an API key (Anthropic,
   OpenAI, OpenRouter, or a local server), or a ChatGPT subscription.
@@ -15,8 +16,9 @@ Install `clawd` first: release binary or source build, both covered in the
 [README](../README.md#install). The steps below assume `clawd` is on your `PATH`.
 
 **On a ChatGPT subscription?** Do [step 8](#8-chatgpt-subscription-instead-of-an-api-key)
-right after step 2, before you start the daemon. It gives you the `CLAW_LLM_MODEL` value
-that steps 4 and 5 need, and it cannot run while `clawd` is running.
+right after step 2, before you start the daemon. Step 8 gives you the `CLAW_LLM_MODEL`
+value that every later step needs, and `clawd auth login` will not start while the daemon
+holds the state-root lock.
 
 ## 1. Create your bot
 
@@ -43,9 +45,10 @@ Edit `~/.swift-claw/clawd.env` and set four values:
 - `CLAW_LLM_MODEL`: the model id, e.g. `claude-sonnet-4-6`.
 - `CLAW_LLM_API_KEY`: the provider key (leave blank for local servers without auth).
 
-On a ChatGPT subscription, leave `CLAW_LLM_BASE_URL` and `CLAW_LLM_API_KEY` blank and get
-your `CLAW_LLM_MODEL` value from [step 8](#8-chatgpt-subscription-instead-of-an-api-key)
-now.
+On a ChatGPT subscription, clear the prefilled `CLAW_LLM_BASE_URL` and `CLAW_LLM_API_KEY`,
+then get your `CLAW_LLM_MODEL` value from
+[step 8](#8-chatgpt-subscription-instead-of-an-api-key) now. Every later step needs it: a
+plain model id with an empty base URL fails config validation.
 
 Everything else has a working default. `clawd` never loads this file on its own; you
 source it into the shell before each command:
@@ -70,7 +73,8 @@ and in any backup of that directory. The daemon now reads them from the encrypte
 and refuses to fall back to plaintext if the store is present but broken.
 
 Skipping this step works for a first try. The daemon then uses the plaintext env values
-and warns on every boot.
+and warns on every boot. (If you did step 8 first, `clawd auth login` already sealed the
+state root, so the encrypted backend is in force and there is no plaintext fallback.)
 
 ## 4. Health check
 
@@ -112,32 +116,54 @@ fresh session.
 ## 6. Make it yours
 
 Persona, behavior rules, and your profile live in Markdown files under
-`~/.swift-claw/workspace/`. Start with `SOUL.md` for personality and `USER.md` for who
-you are. [CUSTOMIZATION.md](CUSTOMIZATION.md) covers all of them, plus the environment
-knobs for budgets, schedules, voice locales, and the code sandbox.
+`~/.swift-claw/workspace/`. The daemon creates that directory empty and ships no
+templates, so create the files yourself:
+
+```bash
+cat > ~/.swift-claw/workspace/SOUL.md <<'EOF'
+Answer briefly. Skip pleasantries. Say when you are unsure.
+EOF
+
+cat > ~/.swift-claw/workspace/USER.md <<'EOF'
+I live in Berlin and work as an iOS developer.
+EOF
+```
+
+The agent picks them up on the next turn. [CUSTOMIZATION.md](CUSTOMIZATION.md) covers
+every file and its trust tier, plus the environment knobs for budgets, schedules, voice
+locales, and the code sandbox.
 
 ## 7. Keep it running
 
 To restart `clawd` after a crash and start it on login, install it under launchd (macOS)
 or systemd (Linux). [deploy/README.md](../deploy/README.md) has the unit files and the
-three commands per platform.
+three commands per platform. Those files live in the repository, not in the release, so
+fetch them if you installed a release binary:
 
-Both units are **per-user**, so they follow your login session: they start when you log
-in and stop when you log out, rather than at boot. For a machine you administer and want
-truly always-on:
+```bash
+curl -fsSLO https://raw.githubusercontent.com/ivan-magda/swift-claw/main/deploy/run-clawd.sh
+curl -fsSLO https://raw.githubusercontent.com/ivan-magda/swift-claw/main/deploy/swift-claw.service            # Linux
+curl -fsSLO https://raw.githubusercontent.com/ivan-magda/swift-claw/main/deploy/com.ivanmagda.swift-claw.plist  # macOS
+```
 
-- **macOS:** enable automatic login for the account, or convert the LaunchAgent into a
-  system-wide LaunchDaemon under `/Library/LaunchDaemons`.
-- **Linux:** allow the user manager to run without a session:
+Both units are **per-user**: they start when you log in, not at boot, and they stop when
+you log out. For a machine you administer and want always-on:
+
+- **Linux:** let the user manager run without a session with
   `sudo loginctl enable-linger $USER`. Without it, a service you installed over SSH stops
   when you disconnect and does not come back after a reboot.
+- **macOS:** enable automatic login for the account. That keeps the LaunchAgent, which is
+  the simple path. A system LaunchDaemon in `/Library/LaunchDaemons` runs as root, where
+  `$HOME` is `/var/root`, so the wrapper looks for its config in the wrong place and
+  `clawd` exits 10. If you go that route, pin the account and paths explicitly with
+  `UserName`, `CLAW_ENV_FILE`, and `CLAW_STATE_ROOT` in the plist.
 
 ## 8. ChatGPT subscription instead of an API key
 
-Optional, and an alternative to `CLAW_LLM_BASE_URL` plus `CLAW_LLM_API_KEY` rather than
-an addition. **Stop `clawd` first** (Ctrl-C, or `launchctl unload` / `systemctl --user
-stop`): logging in takes the same state-root lock the daemon holds, and with the daemon
-up it exits with "clawd is running for this state root."
+This route replaces `CLAW_LLM_BASE_URL` and `CLAW_LLM_API_KEY`. **Stop `clawd` first**
+(Ctrl-C, or `launchctl unload` / `systemctl --user stop`): logging in takes the same
+state-root lock the daemon holds, and while the daemon runs, `clawd auth login` exits with
+"clawd is running for this state root."
 
 ```bash
 clawd auth login

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -29,7 +29,7 @@ the identity of your bot, so treat it like a password.
 ## 2. Configure
 
 ```bash
-mkdir -p ~/.swift-claw
+mkdir -p -m 700 ~/.swift-claw
 curl -fsSL https://raw.githubusercontent.com/ivan-magda/swift-claw/main/.env.example \
   -o ~/.swift-claw/clawd.env
 chmod 600 ~/.swift-claw/clawd.env
@@ -68,9 +68,17 @@ This encrypts the bot token and API keys into `~/.swift-claw/secrets.enc` with a
 
 Sealing copies the secrets out of your environment; it does not edit `clawd.env`. Delete
 or blank the `CLAW_TELEGRAM_BOT_TOKEN`, `CLAW_LLM_API_KEY`, and `CLAW_SEARCH_API_KEY`
-lines yourself, then re-source the file. Until you do, the plaintext values stay on disk
-and in any backup of that directory. The daemon now reads them from the encrypted store,
-and refuses to fall back to plaintext if the store is present but broken.
+lines yourself. Until you do, the plaintext values stay on disk and in any backup of that
+directory. The daemon now reads them from the encrypted store, and refuses to fall back to
+plaintext if the store is present but broken.
+
+Sourcing the file again does not undo the export: your current shell still holds the
+values it read before you edited them. Open a fresh shell and source the sanitized file
+there:
+
+```bash
+set -a && source ~/.swift-claw/clawd.env && set +a
+```
 
 Skipping this step works for a first try. The daemon then uses the plaintext env values
 and warns on every boot. (If you did step 8 first, `clawd auth login` already sealed the
@@ -79,14 +87,21 @@ state root, so the encrypted backend is in force and there is no plaintext fallb
 ## 4. Health check
 
 ```bash
-clawd doctor
+clawd doctor --check-config
 ```
 
 Healthy output shows `OK` on the `config` row and `backend=encrypted` on the `secrets`
-row (`backend=env (WARN: plaintext)` if you skipped sealing). Doctor also probes the
-database, Telegram connectivity (`getMe`), and the optional tool backends.
-`clawd doctor --check-config` validates config and secrets without touching the network;
-`--json` prints a machine-readable report.
+row (`backend=env (WARN: plaintext)` if you skipped sealing).
+
+Use `--check-config` until you have allowlisted yourself in step 5. The full `clawd
+doctor` also checks the database, and with an empty allowlist the `allowlist.owners` row
+fails and the command exits 1, which at this stage tells you nothing you did not already
+know. Once your ID is in `CLAW_ALLOWLIST`, run the full check:
+
+```bash
+clawd doctor          # adds database, Telegram getMe, and tool-backend probes
+clawd doctor --json   # same checks, machine-readable
+```
 
 ## 5. Run and say hello
 
@@ -141,10 +156,15 @@ three commands per platform. Those files live in the repository, not in the rele
 fetch them if you installed a release binary:
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/ivan-magda/swift-claw/main/deploy/run-clawd.sh
-curl -fsSLO https://raw.githubusercontent.com/ivan-magda/swift-claw/main/deploy/swift-claw.service            # Linux
-curl -fsSLO https://raw.githubusercontent.com/ivan-magda/swift-claw/main/deploy/com.ivanmagda.swift-claw.plist  # macOS
+mkdir -p deploy
+base=https://raw.githubusercontent.com/ivan-magda/swift-claw/main/deploy
+curl -fsSL "$base/run-clawd.sh" -o deploy/run-clawd.sh
+curl -fsSL "$base/swift-claw.service" -o deploy/swift-claw.service                            # Linux
+curl -fsSL "$base/com.ivanmagda.swift-claw.plist" -o deploy/com.ivanmagda.swift-claw.plist    # macOS
 ```
+
+The deployment guide's commands read from `deploy/`, so run them from the directory that
+now holds it.
 
 Both units are **per-user**: they start when you log in, not at boot, and they stop when
 you log out. For a machine you administer and want always-on:

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -9,10 +9,14 @@ command and what success looks like.
   transcription and the code sandbox need macOS 26) or a Linux box with `libsqlite3-0`.
 - **A Telegram account.**
 - **LLM access.** Either an OpenAI-compatible endpoint with an API key (Anthropic,
-  OpenAI, OpenRouter, or a local server), or a ChatGPT subscription (step 8).
+  OpenAI, OpenRouter, or a local server), or a ChatGPT subscription.
 
 Install `clawd` first: release binary or source build, both covered in the
 [README](../README.md#install). The steps below assume `clawd` is on your `PATH`.
+
+**On a ChatGPT subscription?** Do [step 8](#8-chatgpt-subscription-instead-of-an-api-key)
+right after step 2, before you start the daemon. It gives you the `CLAW_LLM_MODEL` value
+that steps 4 and 5 need, and it cannot run while `clawd` is running.
 
 ## 1. Create your bot
 
@@ -24,9 +28,12 @@ the identity of your bot, so treat it like a password.
 
 ```bash
 mkdir -p ~/.swift-claw
-cp .env.example ~/.swift-claw/clawd.env
+curl -fsSL https://raw.githubusercontent.com/ivan-magda/swift-claw/main/.env.example \
+  -o ~/.swift-claw/clawd.env
 chmod 600 ~/.swift-claw/clawd.env
 ```
+
+(Working from a source checkout? `cp .env.example ~/.swift-claw/clawd.env` does the same.)
 
 Edit `~/.swift-claw/clawd.env` and set four values:
 
@@ -35,6 +42,10 @@ Edit `~/.swift-claw/clawd.env` and set four values:
   e.g. `https://api.anthropic.com/v1`.
 - `CLAW_LLM_MODEL`: the model id, e.g. `claude-sonnet-4-6`.
 - `CLAW_LLM_API_KEY`: the provider key (leave blank for local servers without auth).
+
+On a ChatGPT subscription, leave `CLAW_LLM_BASE_URL` and `CLAW_LLM_API_KEY` blank and get
+your `CLAW_LLM_MODEL` value from [step 8](#8-chatgpt-subscription-instead-of-an-api-key)
+now.
 
 Everything else has a working default. `clawd` never loads this file on its own; you
 source it into the shell before each command:
@@ -50,10 +61,13 @@ clawd secrets seal
 ```
 
 This encrypts the bot token and API keys into `~/.swift-claw/secrets.enc` with a key in
-`~/.swift-claw/secret.key` (mode 0600). Afterwards, delete or blank the
-`CLAW_TELEGRAM_BOT_TOKEN`, `CLAW_LLM_API_KEY`, and `CLAW_SEARCH_API_KEY` lines in
-`clawd.env`; the daemon now reads them from the encrypted store, and refuses to fall
-back to plaintext if the store is present but broken.
+`~/.swift-claw/secret.key` (mode 0600).
+
+Sealing copies the secrets out of your environment; it does not edit `clawd.env`. Delete
+or blank the `CLAW_TELEGRAM_BOT_TOKEN`, `CLAW_LLM_API_KEY`, and `CLAW_SEARCH_API_KEY`
+lines yourself, then re-source the file. Until you do, the plaintext values stay on disk
+and in any backup of that directory. The daemon now reads them from the encrypted store,
+and refuses to fall back to plaintext if the store is present but broken.
 
 Skipping this step works for a first try. The daemon then uses the plaintext env values
 and warns on every boot.
@@ -76,9 +90,12 @@ database, Telegram connectivity (`getMe`), and the optional tool backends.
 clawd run
 ```
 
-DM your bot in Telegram. Because the allowlist is still empty, it answers:
+Send `/start` to your bot in Telegram. Because the allowlist is still empty, it answers:
 
 > This is a private bot. Your Telegram user ID is 12345678. Ask the owner to add it to the allowlist.
+
+Only `/start` gets that reply. Any other message from a non-allowlisted sender gets a
+bare "Sorry, this is a private bot." with no ID, so `/start` is how you learn the number.
 
 That number is you. Stop the daemon (Ctrl-C), set it in `clawd.env`:
 
@@ -87,7 +104,7 @@ CLAW_ALLOWLIST=12345678
 ```
 
 Re-source the env file, start `clawd run` again, and send another message. This time
-the model answers, streamed into the chat as a growing draft. You have a working agent.
+the model answers, streamed into the chat as a growing draft.
 
 Two commands to know from day one: `/stop` cancels the current turn, `/new` starts a
 fresh session.
@@ -99,22 +116,39 @@ Persona, behavior rules, and your profile live in Markdown files under
 you are. [CUSTOMIZATION.md](CUSTOMIZATION.md) covers all of them, plus the environment
 knobs for budgets, schedules, voice locales, and the code sandbox.
 
-## 7. Run it as a service
+## 7. Keep it running
 
-For an assistant that survives reboots and logouts, install `clawd` under launchd
-(macOS) or systemd (Linux). [deploy/README.md](../deploy/README.md) has the unit files
-and the three commands per platform.
+To restart `clawd` after a crash and start it on login, install it under launchd (macOS)
+or systemd (Linux). [deploy/README.md](../deploy/README.md) has the unit files and the
+three commands per platform.
 
-## 8. Optional: ChatGPT subscription instead of an API key
+Both units are **per-user**, so they follow your login session: they start when you log
+in and stop when you log out, rather than at boot. For a machine you administer and want
+truly always-on:
+
+- **macOS:** enable automatic login for the account, or convert the LaunchAgent into a
+  system-wide LaunchDaemon under `/Library/LaunchDaemons`.
+- **Linux:** allow the user manager to run without a session:
+  `sudo loginctl enable-linger $USER`. Without it, a service you installed over SSH stops
+  when you disconnect and does not come back after a reboot.
+
+## 8. ChatGPT subscription instead of an API key
+
+Optional, and an alternative to `CLAW_LLM_BASE_URL` plus `CLAW_LLM_API_KEY` rather than
+an addition. **Stop `clawd` first** (Ctrl-C, or `launchctl unload` / `systemctl --user
+stop`): logging in takes the same state-root lock the daemon holds, and with the daemon
+up it exits with "clawd is running for this state root."
 
 ```bash
 clawd auth login
 ```
 
-completes a device-code login, discovers eligible models, and prints the exact
+This completes a device-code login, discovers eligible models, and prints the exact
 `CLAW_LLM_MODEL=openai-chatgpt/<model>` value to paste into `clawd.env`. On that route
 `CLAW_LLM_BASE_URL` and `CLAW_LLM_API_KEY` are unused; the credential lives encrypted in
-the state root. This route is unofficial and vendor-dependent; details and caveats in
+the state root. Start the daemon again once the value is in place.
+
+This route is unofficial and vendor-dependent; details and caveats in
 [LOCAL_DEV.md](LOCAL_DEV.md#chatgpt-subscription-auth).
 
 ## Troubleshooting
@@ -122,9 +156,10 @@ the state root. This route is unofficial and vendor-dependent; details and cavea
 - **Exit codes are diagnostic:** 10 invalid config, 11 secret loading failed, 12 another
   instance holds the lock, 13 storage error. `clawd doctor` explains the specifics.
 - **The bot ignores you:** confirm your numeric ID is in `CLAW_ALLOWLIST` and that you
-  restarted after changing it; the allowlist is seeded at boot.
+  restarted after changing it; the daemon seeds the allowlist at boot.
+- **You cannot find your Telegram ID:** send `/start`, not an ordinary message.
 - **A second daemon won't start:** by design. One `clawd` per state root, enforced with
-  a file lock.
+  a file lock. `clawd auth login` and `clawd secrets seal` take the same lock.
 - **Telegram reports a 409 conflict:** another process is long-polling the same bot
   token, usually a forgotten instance on another machine.
 - **Voice notes get a canned refusal:** voice transcription needs macOS 26; on Linux and

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -28,14 +28,17 @@ the identity of your bot, so treat it like a password.
 
 ## 2. Configure
 
+Your shell executes this file with `source`, so use the copy that ships with the release
+you verified rather than fetching one over the network:
+
 ```bash
 mkdir -p -m 700 ~/.swift-claw
-curl -fsSL https://raw.githubusercontent.com/ivan-magda/swift-claw/main/.env.example \
-  -o ~/.swift-claw/clawd.env
-chmod 600 ~/.swift-claw/clawd.env
+install -m 600 clawd.env.example ~/.swift-claw/clawd.env    # from your download directory
 ```
 
-(Working from a source checkout? `cp .env.example ~/.swift-claw/clawd.env` does the same.)
+`clawd.env.example` is a release asset covered by `SHA256SUMS`, so the checksum step from
+[Install](../README.md#install) already verified it. From a source checkout, use
+`install -m 600 .env.example ~/.swift-claw/clawd.env` instead.
 
 Edit `~/.swift-claw/clawd.env` and set four values:
 
@@ -152,15 +155,18 @@ locales, and the code sandbox.
 
 To restart `clawd` after a crash and start it on login, install it under launchd (macOS)
 or systemd (Linux). [deploy/README.md](../deploy/README.md) has the unit files and the
-three commands per platform. Those files live in the repository, not in the release, so
-fetch them if you installed a release binary:
+three commands per platform.
+
+If you installed a release binary, download the unit files from that same release:
+`run-clawd.sh`, plus `swift-claw.service` (Linux) or `com.ivanmagda.swift-claw.plist`
+(macOS). They are covered by `SHA256SUMS`, so verify them before use. `run-clawd.sh` gets
+installed as root and executed at every login, which is reason enough not to take it from
+an unverified source:
 
 ```bash
-mkdir -p deploy
-base=https://raw.githubusercontent.com/ivan-magda/swift-claw/main/deploy
-curl -fsSL "$base/run-clawd.sh" -o deploy/run-clawd.sh
-curl -fsSL "$base/swift-claw.service" -o deploy/swift-claw.service                            # Linux
-curl -fsSL "$base/com.ivanmagda.swift-claw.plist" -o deploy/com.ivanmagda.swift-claw.plist    # macOS
+cd ~/Downloads
+shasum -a 256 --ignore-missing -c SHA256SUMS    # Linux: sha256sum --ignore-missing -c SHA256SUMS
+mkdir -p deploy && mv run-clawd.sh swift-claw.service com.ivanmagda.swift-claw.plist deploy/ 2>/dev/null
 ```
 
 The deployment guide's commands read from `deploy/`, so run them from the directory that
@@ -180,10 +186,13 @@ you log out. For a machine you administer and want always-on:
 
 ## 8. ChatGPT subscription instead of an API key
 
-This route replaces `CLAW_LLM_BASE_URL` and `CLAW_LLM_API_KEY`. **Stop `clawd` first**
-(Ctrl-C, or `launchctl unload` / `systemctl --user stop`): logging in takes the same
-state-root lock the daemon holds, and while the daemon runs, `clawd auth login` exits with
-"clawd is running for this state root."
+This route replaces `CLAW_LLM_BASE_URL` and `CLAW_LLM_API_KEY`. **Stop `clawd` first**:
+logging in takes the same state-root lock the daemon holds, and while the daemon runs,
+`clawd auth login` exits with "clawd is running for this state root."
+
+- Foreground: Ctrl-C.
+- macOS: `launchctl unload ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist`
+- Linux: `systemctl --user stop swift-claw.service`
 
 ```bash
 clawd auth login
@@ -192,7 +201,17 @@ clawd auth login
 This completes a device-code login, discovers eligible models, and prints the exact
 `CLAW_LLM_MODEL=openai-chatgpt/<model>` value to paste into `clawd.env`. On that route
 `CLAW_LLM_BASE_URL` and `CLAW_LLM_API_KEY` are unused; the credential lives encrypted in
-the state root. Start the daemon again once the value is in place.
+the state root.
+
+If the model list cannot be read, login still succeeds and stores the credential, but it
+prints the assignment as a form with `<model>` left as a literal placeholder. Paste that
+verbatim and config validation rejects it. Substitute a real model slug, for example
+`CLAW_LLM_MODEL=openai-chatgpt/gpt-5.4`, or run `clawd auth login` again once the network
+settles.
+
+Start the daemon again once the value is in place: `clawd run`, or
+`launchctl load ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist` /
+`systemctl --user start swift-claw.service`.
 
 This route is unofficial and vendor-dependent; details and caveats in
 [LOCAL_DEV.md](LOCAL_DEV.md#chatgpt-subscription-auth).
@@ -204,6 +223,9 @@ This route is unofficial and vendor-dependent; details and caveats in
 - **The bot ignores you:** confirm your numeric ID is in `CLAW_ALLOWLIST` and that you
   restarted after changing it; the daemon seeds the allowlist at boot.
 - **You cannot find your Telegram ID:** send `/start`, not an ordinary message.
+- **Someone you removed can still talk to the bot:** `CLAW_ALLOWLIST` seeds the database
+  and never deletes from it. Revoking takes a row deletion; see
+  [CUSTOMIZATION.md](CUSTOMIZATION.md#everything-else).
 - **A second daemon won't start:** by design. One `clawd` per state root, enforced with
   a file lock. `clawd auth login` and `clawd secrets seal` take the same lock.
 - **Telegram reports a 409 conflict:** another process is long-polling the same bot

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,7 +1,6 @@
 # Getting Started
 
-From nothing to a running assistant that answers you in Telegram. Every step shows the
-command and what success looks like.
+From nothing to a running assistant that answers you in Telegram.
 
 ## What you need
 
@@ -98,8 +97,7 @@ row (`backend=env (WARN: plaintext)` if you skipped sealing).
 
 Use `--check-config` until you have allowlisted yourself in step 5. The full `clawd
 doctor` also checks the database, and with an empty allowlist the `allowlist.owners` row
-fails and the command exits 1, which at this stage tells you nothing you did not already
-know. Once your ID is in `CLAW_ALLOWLIST`, run the full check:
+fails and the command exits 1. Once your ID is in `CLAW_ALLOWLIST`, run the full check:
 
 ```bash
 clawd doctor          # adds database, Telegram getMe, and tool-backend probes
@@ -126,7 +124,7 @@ CLAW_ALLOWLIST=12345678
 ```
 
 Re-source the env file, start `clawd run` again, and send another message. This time
-the model answers, streamed into the chat as a growing draft.
+the model answers, and clawd streams the reply in as a growing draft.
 
 Two commands to know from day one: `/stop` cancels the current turn, `/new` starts a
 fresh session.
@@ -159,8 +157,8 @@ three commands per platform.
 
 If you installed a release binary, download the unit files from that same release:
 `run-clawd.sh`, plus `swift-claw.service` (Linux) or `com.ivanmagda.swift-claw.plist`
-(macOS). They are covered by `SHA256SUMS`, so verify them before use. `run-clawd.sh` gets
-installed as root and executed at every login, which is reason enough not to take it from
+(macOS). `SHA256SUMS` covers them, so verify before use. You install `run-clawd.sh` as
+root and your machine runs it at every login, which is reason enough not to take it from
 an unverified source:
 
 ```bash
@@ -205,8 +203,8 @@ This completes a device-code login, discovers eligible models, and prints the ex
 `CLAW_LLM_BASE_URL` and `CLAW_LLM_API_KEY` are unused; the credential lives encrypted in
 the state root.
 
-If the model list cannot be read, login still succeeds and stores the credential, but it
-prints the assignment as a form with `<model>` left as a literal placeholder. Paste that
+If clawd cannot read the model list, `clawd auth login` still succeeds and stores the
+credential, but prints the assignment with `<model>` left as a literal placeholder. Paste that
 verbatim and config validation rejects it. Substitute a real model slug, for example
 `CLAW_LLM_MODEL=openai-chatgpt/gpt-5.4`, or run `clawd auth login` again once the network
 settles.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,131 @@
+# Getting Started
+
+From nothing to a running assistant that answers you in Telegram. Every step shows the
+command and what success looks like.
+
+## What you need
+
+- **A machine that stays on.** An Apple Silicon Mac (macOS 15 or newer; voice
+  transcription and the code sandbox need macOS 26) or a Linux box with `libsqlite3-0`.
+- **A Telegram account.**
+- **LLM access.** Either an OpenAI-compatible endpoint with an API key (Anthropic,
+  OpenAI, OpenRouter, or a local server), or a ChatGPT subscription (step 8).
+
+Install `clawd` first: release binary or source build, both covered in the
+[README](../README.md#install). The steps below assume `clawd` is on your `PATH`.
+
+## 1. Create your bot
+
+Open [@BotFather](https://t.me/BotFather) in Telegram, send `/newbot`, pick a name and a
+username. BotFather replies with a token like `123456789:AAF...`. Copy it; that token is
+the identity of your bot, so treat it like a password.
+
+## 2. Configure
+
+```bash
+mkdir -p ~/.swift-claw
+cp .env.example ~/.swift-claw/clawd.env
+chmod 600 ~/.swift-claw/clawd.env
+```
+
+Edit `~/.swift-claw/clawd.env` and set four values:
+
+- `CLAW_TELEGRAM_BOT_TOKEN`: the BotFather token.
+- `CLAW_LLM_BASE_URL`: your provider's OpenAI-compatible endpoint,
+  e.g. `https://api.anthropic.com/v1`.
+- `CLAW_LLM_MODEL`: the model id, e.g. `claude-sonnet-4-6`.
+- `CLAW_LLM_API_KEY`: the provider key (leave blank for local servers without auth).
+
+Everything else has a working default. `clawd` never loads this file on its own; you
+source it into the shell before each command:
+
+```bash
+set -a && source ~/.swift-claw/clawd.env && set +a
+```
+
+## 3. Seal your secrets
+
+```bash
+clawd secrets seal
+```
+
+This encrypts the bot token and API keys into `~/.swift-claw/secrets.enc` with a key in
+`~/.swift-claw/secret.key` (mode 0600). Afterwards, delete or blank the
+`CLAW_TELEGRAM_BOT_TOKEN`, `CLAW_LLM_API_KEY`, and `CLAW_SEARCH_API_KEY` lines in
+`clawd.env`; the daemon now reads them from the encrypted store, and refuses to fall
+back to plaintext if the store is present but broken.
+
+Skipping this step works for a first try. The daemon then uses the plaintext env values
+and warns on every boot.
+
+## 4. Health check
+
+```bash
+clawd doctor
+```
+
+Healthy output shows `OK` on the `config` row and `backend=encrypted` on the `secrets`
+row (`backend=env (WARN: plaintext)` if you skipped sealing). Doctor also probes the
+database, Telegram connectivity (`getMe`), and the optional tool backends.
+`clawd doctor --check-config` validates config and secrets without touching the network;
+`--json` prints a machine-readable report.
+
+## 5. Run and say hello
+
+```bash
+clawd run
+```
+
+DM your bot in Telegram. Because the allowlist is still empty, it answers:
+
+> This is a private bot. Your Telegram user ID is 12345678. Ask the owner to add it to the allowlist.
+
+That number is you. Stop the daemon (Ctrl-C), set it in `clawd.env`:
+
+```bash
+CLAW_ALLOWLIST=12345678
+```
+
+Re-source the env file, start `clawd run` again, and send another message. This time
+the model answers, streamed into the chat as a growing draft. You have a working agent.
+
+Two commands to know from day one: `/stop` cancels the current turn, `/new` starts a
+fresh session.
+
+## 6. Make it yours
+
+Persona, behavior rules, and your profile live in Markdown files under
+`~/.swift-claw/workspace/`. Start with `SOUL.md` for personality and `USER.md` for who
+you are. [CUSTOMIZATION.md](CUSTOMIZATION.md) covers all of them, plus the environment
+knobs for budgets, schedules, voice locales, and the code sandbox.
+
+## 7. Run it as a service
+
+For an assistant that survives reboots and logouts, install `clawd` under launchd
+(macOS) or systemd (Linux). [deploy/README.md](../deploy/README.md) has the unit files
+and the three commands per platform.
+
+## 8. Optional: ChatGPT subscription instead of an API key
+
+```bash
+clawd auth login
+```
+
+completes a device-code login, discovers eligible models, and prints the exact
+`CLAW_LLM_MODEL=openai-chatgpt/<model>` value to paste into `clawd.env`. On that route
+`CLAW_LLM_BASE_URL` and `CLAW_LLM_API_KEY` are unused; the credential lives encrypted in
+the state root. This route is unofficial and vendor-dependent; details and caveats in
+[LOCAL_DEV.md](LOCAL_DEV.md#chatgpt-subscription-auth).
+
+## Troubleshooting
+
+- **Exit codes are diagnostic:** 10 invalid config, 11 secret loading failed, 12 another
+  instance holds the lock, 13 storage error. `clawd doctor` explains the specifics.
+- **The bot ignores you:** confirm your numeric ID is in `CLAW_ALLOWLIST` and that you
+  restarted after changing it; the allowlist is seeded at boot.
+- **A second daemon won't start:** by design. One `clawd` per state root, enforced with
+  a file lock.
+- **Telegram reports a 409 conflict:** another process is long-polling the same bot
+  token, usually a forgotten instance on another machine.
+- **Voice notes get a canned refusal:** voice transcription needs macOS 26; on Linux and
+  older macOS the feature is off.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -211,7 +211,9 @@ verbatim and config validation rejects it. Substitute a real model slug, for exa
 `CLAW_LLM_MODEL=openai-chatgpt/gpt-5.4`, or run `clawd auth login` again once the network
 settles.
 
-Paste the value into `clawd.env`, then:
+Paste the value into `clawd.env`. If you are switching an existing installation, also
+clear `CLAW_LLM_STRUCTURED_OUTPUT`: this route accepts only `off`, and any other value
+fails config validation with exit 10. Then:
 
 - **Setting up for the first time?** Go back to [step 3](#3-seal-your-secrets) and continue
   through the guide. Do not start the daemon yet; the remaining steps need the state root

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -255,8 +255,8 @@ LaunchDaemon-vs-LaunchAgent open question):
 
 ### Seal (first-time setup)
 
-Reads `CLAW_TELEGRAM_BOT_TOKEN` and `CLAW_LLM_API_KEY` from the environment
-and writes two files under `~/.swift-claw/`:
+Reads `CLAW_TELEGRAM_BOT_TOKEN`, `CLAW_LLM_API_KEY`, and `CLAW_SEARCH_API_KEY`
+from the environment and writes two files under `~/.swift-claw/`:
 
 - `secrets.enc` — encrypted envelope
 - `secret.key` — AES key (mode 0600)
@@ -266,12 +266,13 @@ set -a && source ~/.swift-claw/clawd.env && set +a
 .build/debug/clawd secrets seal
 ```
 
-After sealing, remove the two secret lines from `clawd.env`:
+Sealing does not edit `clawd.env`. Remove the secret lines yourself:
 
 ```
 # delete or blank these after sealing:
 CLAW_TELEGRAM_BOT_TOKEN=...
 CLAW_LLM_API_KEY=...
+CLAW_SEARCH_API_KEY=...
 ```
 
 Keep the non-secret config (`CLAW_LLM_BASE_URL`, `CLAW_LLM_MODEL`, etc.).

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -204,8 +204,9 @@ call through the trifecta approval.
 
 **If the tool never appears** (calls are refused as unknown), `clawd doctor` explains why. It is
 absent — by design, fail-closed — on Linux, macOS 15, Intel macOS, with `CLAW_EXEC_ENABLED=false`,
-with an unpinned `CLAW_EXEC_IMAGE` override, when the `container` CLI is missing or below `1.0.0`, or
-when any hardening canary assertion failed. An owner-enabled sandbox that fails a gate prints a loud
+when the `container` CLI is missing or below `1.0.0`, or when any hardening canary assertion failed.
+An unpinned `CLAW_EXEC_IMAGE` override is stricter still: config validation rejects it and the
+process exits 10, so no daemon runs at all. An owner-enabled sandbox that fails a gate prints a loud
 error row rather than silently degrading.
 
 ---


### PR DESCRIPTION
Prepares the repo's public-facing surface. No code changes.

## What's here

- **LICENSE**: MIT.
- **SECURITY.md**: private reporting via GitHub security advisories, a scoped list of what counts (allowlist/approval/sandbox/exfil-gate bypasses, secret exposure), and what doesn't.
- **CONTRIBUTING.md**: issue-first contribution flow, dev setup, the lint/test gate, and the ground rules (strict concurrency, policy-in-code, reuse-before-add).
- **README rewrite**: hero with a one-line value proposition and badges, feature summary, verified-install block, quick start, security model summary, customization table, and a docs-by-goal index. Follows the Standard Readme skeleton with the concise-delegating shape used by Khoj/gptme: the README sells and routes, depth lives in docs/.
- **docs/GETTING_STARTED.md**: BotFather-to-running-agent walkthrough with a verification step per stage and a troubleshooting section, modeled on Hermes's Telegram guide.
- **docs/CUSTOMIZATION.md**: the workspace persona files (SOUL.md, AGENTS.md, USER.md, ...) documented for the first time, plus model routing and every env knob group.
- **.env.example**: two gaps closed: CLAW_LOG_LEVEL was functional but undocumented, and the workspace files now have a pointer.

## Verification

- Full git history scanned with gitleaks (798 commits): every hit is a fake fixture token in tests or CVE prose in a research doc. Nothing real.
- Every command, env var, default, and message string in the new docs was checked against the source (AppConfig, WorkspaceFile, MessageRouter, LOCAL_DEV.md).
- All relative links resolve; the release/CI badges go live once the repo is public and a first release exists.

The visibility flip and the v0.1.0 tag stay manual, per plan. CI checks on this PR will stay red until billing is fixed; zero steps run, so red here says nothing about the content.