### PR TITLE
User-friendly installation: install.sh, INSTALL.md, and first-run fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ CLAW_TELEGRAM_BOT_TOKEN=123456:replace-with-BotFather-token
 # comma-separated numeric Telegram user IDs, e.g. 12345678 (empty is allowed — onboarding still boots)
 CLAW_ALLOWLIST=
 # optional; defaults to ~/.swift-claw
-CLAW_STATE_ROOT=
+# CLAW_STATE_ROOT=
 # long-poll seconds
 CLAW_POLL_TIMEOUT=30
 

--- a/.env.example
+++ b/.env.example
@@ -6,11 +6,10 @@
 # the value and breaks parsing.
 # --- SECRETS ---
 # Production path: run `clawd secrets seal` once to encrypt these into <stateRoot>/secrets.enc
-# (key in <stateRoot>/secret.key, mode 0600 — keep it OUT of your state-root backup boundary), then
-# you may remove the plaintext secret lines (CLAW_TELEGRAM_BOT_TOKEN, CLAW_LLM_API_KEY,
-# CLAW_SEARCH_API_KEY). If EITHER secrets.enc OR secret.key exists, the encrypted backend is
-# REQUIRED (no silent env fallback). Leaving these set uses the warned dev fallback (plaintext
-# on disk).
+# (key in <stateRoot>/secret.key, mode 0600 — keep it OUT of your state-root backup boundary);
+# sealing blanks these lines in your env file automatically (`--no-scrub` to keep them).
+# If EITHER secrets.enc OR secret.key exists, the encrypted backend is REQUIRED (no silent
+# env fallback). Leaving these set uses the warned dev fallback (plaintext on disk).
 CLAW_TELEGRAM_BOT_TOKEN=123456:replace-with-BotFather-token
 # comma-separated numeric Telegram user IDs, e.g. 12345678 (empty is allowed — onboarding still boots)
 CLAW_ALLOWLIST=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
           sh install.sh --uninstall
           test ! -e "$HOME/.swift-claw/bin/clawd"
           test -f "$HOME/.swift-claw/clawd.env"
-          sh install.sh --uninstall --purge || true
+          sh install.sh --uninstall --purge
+          test ! -e "$HOME/.swift-claw"
 
   workflow-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,26 @@ jobs:
       - name: Build and run tests
         run: swift test
 
+  install-script:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Install, re-run, uninstall against the latest release
+        run: |
+          sh install.sh
+          "$HOME/.swift-claw/bin/clawd" --version
+          sh install.sh                      # idempotent upgrade path
+          sh install.sh --uninstall
+          test ! -e "$HOME/.swift-claw/bin/clawd"
+          test -f "$HOME/.swift-claw/clawd.env"
+          sh install.sh --uninstall --purge || true
+
   workflow-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ runner.arch }}-spm-
       - name: Build and run tests
         run: swift test
+        # A silent test-process death once left no diagnostics at all; the backtracer
+        # turns the next one into a stack trace.
+        env:
+          SWIFT_BACKTRACE: enable=yes
       - name: Re-run the concurrency-sensitive suites on one cooperative thread
         env:
           LIBDISPATCH_COOPERATIVE_POOL_STRICT: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ runner.arch }}-spm-
       - name: Build and run tests
         run: swift test
-        # A silent test-process death once left no diagnostics at all; the backtracer
-        # turns the next one into a stack trace.
         env:
           SWIFT_BACKTRACE: enable=yes
       - name: Re-run the concurrency-sensitive suites on one cooperative thread

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,3 +34,13 @@ jobs:
           persist-credentials: false
       - name: Run swiftlint
         uses: docker://ghcr.io/realm/swiftlint:0.65.0
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Run shellcheck
+        run: shellcheck -s sh install.sh deploy/run-clawd.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,9 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -96,12 +99,16 @@ jobs:
         run: |
           cp .env.example dist/clawd.env.example
           cp deploy/run-clawd.sh deploy/swift-claw.service \
-             deploy/com.ivanmagda.swift-claw.plist dist/
+             deploy/com.ivanmagda.swift-claw.plist install.sh dist/
           cd dist
           cat linux/clawd-linux-x86_64.sha256 macos/clawd-macos-arm64.sha256 > SHA256SUMS
           sha256sum clawd.env.example run-clawd.sh swift-claw.service \
-                    com.ivanmagda.swift-claw.plist >> SHA256SUMS
+                    com.ivanmagda.swift-claw.plist install.sh >> SHA256SUMS
           cat SHA256SUMS
+      - name: Attest checksum manifest
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/SHA256SUMS
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -115,4 +122,5 @@ jobs:
             dist/clawd.env.example \
             dist/run-clawd.sh \
             dist/swift-claw.service \
-            dist/com.ivanmagda.swift-claw.plist
+            dist/com.ivanmagda.swift-claw.plist \
+            dist/install.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ swift-claw — a persistent, always-on, **single-owner personal AI assistant** c
 - Product scope, phasing, success criteria → `docs/PRD.md`.
 - Cited background research → `docs/research/`.
 - Building, running, or operating `clawd` locally → `docs/LOCAL_DEV.md`.
-- Changing any user-visible surface (a command, flag, env var, default, secret, or install/release step) → update the public set in lockstep: `README.md`, `docs/GETTING_STARTED.md`, `docs/CUSTOMIZATION.md`, `deploy/README.md`. They document each other's state, so a change in one usually invalidates a sibling.
+- Changing any user-visible surface (a command, flag, env var, default, secret, or install/release step) → update the public set in lockstep: `README.md`, `docs/GETTING_STARTED.md`, `docs/INSTALL.md`, `docs/CUSTOMIZATION.md`, `deploy/README.md`. They document each other's state, so a change in one usually invalidates a sibling.
 
 ## Non-negotiable conventions
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ sudo install -m755 .build/release/clawd /usr/local/bin/clawd
 4. Say hello once in the foreground: `clawd run`, then send `/start` to your bot. The
    refusal shows your numeric ID; set it as `CLAW_ALLOWLIST=<id>` in `clawd.env`, then
    Ctrl-C.
-5. Re-source the env file, check health with `clawd doctor`, and start the service with
-   the command doctor prints.
+5. Check health and start the service:
+   `set -a && . ~/.swift-claw/clawd.env && set +a && clawd doctor`, then run the start
+   command doctor prints.
 
 The full walkthrough, including the ChatGPT-subscription route and troubleshooting, is
 in [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).

--- a/README.md
+++ b/README.md
@@ -41,39 +41,17 @@ database, encrypted secret envelopes, and Markdown files you edit by hand.
 
 ## Install
 
-Releases carry two binaries: `clawd-macos-arm64` (Apple Silicon) and `clawd-linux-x86_64`.
-On any other architecture, build from source below.
-
-From the [latest release](../../releases/latest), download **the binary for your platform,
-`SHA256SUMS`, and `clawd.env.example`** (the config template, used in the quick start).
-Then verify and install from your download directory:
-
 ```bash
-cd ~/Downloads
-ASSET=clawd-macos-arm64                                 # Linux: clawd-linux-x86_64
-
-shasum -a 256 --ignore-missing -c SHA256SUMS &&        # Linux: sha256sum --ignore-missing -c SHA256SUMS
-  sudo install -m755 "$ASSET" /usr/local/bin/clawd
+curl -fsSL https://raw.githubusercontent.com/ivan-magda/swift-claw/main/install.sh | sh
 ```
 
-`--ignore-missing` checks only the files you downloaded. The `&&` stops the install if
-verification fails. Every downloaded file must print `OK`.
+Everything lands in `~/.swift-claw` — no sudo. The script verifies every download
+against the release checksums, stages the service files, and prints the next steps.
+Pin a release with `curl … | CLAWD_VERSION=v0.2.0 sh`, read the
+[script source](install.sh) first, or follow the manual route in
+[docs/INSTALL.md](docs/INSTALL.md) (macOS 15+ arm64; Linux x86_64 with glibc 2.38+).
 
-Every binary also carries a build provenance attestation. If you have the
-[GitHub CLI](https://cli.github.com) installed and logged in (`gh auth login`), verify it:
-
-```bash
-gh attestation verify "$ASSET" -R ivan-magda/swift-claw
-```
-
-- **macOS:** Gatekeeper blocks the unsigned binary on first run. Clear it:
-  `sudo xattr -d com.apple.quarantine /usr/local/bin/clawd`.
-  On a Mac without Homebrew, create the install directory first:
-  `sudo mkdir -p /usr/local/bin`.
-- **Linux:** the binary links the system SQLite: `sudo apt-get install -y libsqlite3-0`.
-
-Or build from source with a Swift 6.3 toolchain. On Linux, install the SQLite headers
-first (`sudo apt-get install -y libsqlite3-dev`); the runtime package alone will not link:
+Or build from source with a Swift 6.3 toolchain (Linux needs `libsqlite3-dev`):
 
 ```bash
 git clone https://github.com/ivan-magda/swift-claw.git && cd swift-claw
@@ -81,57 +59,21 @@ swift build -c release
 sudo install -m755 .build/release/clawd /usr/local/bin/clawd
 ```
 
-From a source checkout the config template is `.env.example` in the repository root, and
-the service files are under `deploy/`.
-
 ## Quick start
 
-Create a bot with [@BotFather](https://t.me/BotFather) (`/newbot`) and copy its token. Then:
+1. Get a bot token from [@BotFather](https://t.me/BotFather) (send `/newbot`).
+2. Edit `~/.swift-claw/clawd.env` — set the token and your LLM provider
+   (`CLAW_LLM_BASE_URL`, `CLAW_LLM_MODEL`, `CLAW_LLM_API_KEY`).
+3. Load the config and encrypt your secrets at rest:
+   `set -a && . ~/.swift-claw/clawd.env && set +a && clawd secrets seal`
+4. Say hello once in the foreground: `clawd run`, then send `/start` to your bot. The
+   refusal shows your numeric ID; set it as `CLAW_ALLOWLIST=<id>` in `clawd.env`, then
+   Ctrl-C.
+5. Re-source the env file, check health with `clawd doctor`, and start the service with
+   the command doctor prints.
 
-Download `clawd.env.example` from the same release as your binary, verify it against
-`SHA256SUMS` alongside the binary, and use it as your config:
-
-```bash
-# 1. Install the verified template.
-mkdir -p -m 700 ~/.swift-claw
-install -m 600 clawd.env.example ~/.swift-claw/clawd.env
-```
-
-Your shell runs this file with `source`, so take it from the checksummed release rather
-than an unverified copy.
-
-**Now edit `~/.swift-claw/clawd.env`** and set the BotFather token plus your provider's
-`CLAW_LLM_BASE_URL`, `CLAW_LLM_MODEL`, and `CLAW_LLM_API_KEY`. The template ships with
-placeholder values that will not work. Then:
-
-```bash
-# 2. Load the config and encrypt your secrets at rest.
-set -a && source ~/.swift-claw/clawd.env && set +a
-clawd secrets seal
-
-# 3. Sealing copies the secrets out; it does not edit the file. Delete the
-#    CLAW_TELEGRAM_BOT_TOKEN, CLAW_LLM_API_KEY, and CLAW_SEARCH_API_KEY lines
-#    from ~/.swift-claw/clawd.env yourself.
-```
-
-Open a fresh shell so the deleted secrets leave your environment, then load the remaining
-config and start the daemon:
-
-```bash
-set -a && source ~/.swift-claw/clawd.env && set +a
-clawd doctor --check-config
-clawd run
-```
-
-Now send `/start` to your bot. It replies with your numeric Telegram ID; put that in
-`CLAW_ALLOWLIST` in `clawd.env`, re-source, and restart. Your next message gets a real
-answer. (Only `/start` reveals the ID: any other message from a stranger gets a bare
-refusal.)
-
-Running on a ChatGPT subscription instead of an API key? Do
-[step 8](docs/GETTING_STARTED.md#8-chatgpt-subscription-instead-of-an-api-key)
-of the walkthrough before you start the daemon. The full guide, including
-troubleshooting, is in [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
+The full walkthrough, including the ChatGPT-subscription route and troubleshooting, is
+in [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
 
 ## Security model
 
@@ -178,8 +120,9 @@ budgets, schedules and quiet hours, voice locales, sandbox limits.
 | You want to | Read |
 |---|---|
 | Set it up end to end | [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) |
+| Install, update, or uninstall | [docs/INSTALL.md](docs/INSTALL.md) |
 | Make it yours | [docs/CUSTOMIZATION.md](docs/CUSTOMIZATION.md) |
-| Run it as a service | [deploy/README.md](deploy/README.md) |
+| Run it as a service | [docs/INSTALL.md](docs/INSTALL.md#4-running-as-a-service) |
 | Develop and test locally | [docs/LOCAL_DEV.md](docs/LOCAL_DEV.md) |
 | Understand the design | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
 | Report a vulnerability | [SECURITY.md](SECURITY.md) |

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -321,10 +321,17 @@ private extension MessageRouter {
     }
     return try await turnDispatch.dispatch(rawUpdate: rawUpdate, message: message, text: text)
   }
+}
 
+// MARK: - Unauthorized Reply
+
+extension MessageRouter {
+  /// The `/start` refusal doubles as onboarding: its last line is pasteable into clawd.env.
   static func unauthorizedStartText(userId: Int64) -> String {
     """
-    This is a private bot. Your Telegram user ID is \(userId). Ask the owner to add it to the allowlist.
+    This is a private bot. Your Telegram user ID is \(userId). To authorize it, the owner \
+    adds this line to clawd.env and restarts clawd:
+    CLAW_ALLOWLIST=\(userId)
     """
   }
 }

--- a/Sources/ClawSecrets/SecureFilePublisher.swift
+++ b/Sources/ClawSecrets/SecureFilePublisher.swift
@@ -7,9 +7,9 @@ import Foundation
 #endif
 
 /// The publication protocol's own error vocabulary. Callers translate it into their seam type
-/// (`SecretStoreError`, `LLMCredentialStoreError`) — it never leaves `ClawSecrets`, and it carries
-/// only state-root filenames, never an absolute path and never bytes read from a file.
-enum SecureFileError: Error, Sendable, Equatable {
+/// (`SecretStoreError`, `LLMCredentialStoreError`) or render it into a user-facing reason — it
+/// carries only entry filenames, never an absolute path and never bytes read from a file.
+package enum SecureFileError: Error, Sendable, Equatable {
   /// Metadata policy refused the entry: not a regular file, wrong owner, or wrong mode.
   case insecure(String)
   case unreadable(String)
@@ -48,7 +48,7 @@ struct SecureFileFacts: Sendable, Equatable {
 /// swapped underneath the operation is left alone. A (device, inode) pair alone is not that pin:
 /// Linux filesystems reuse a freed inode number for the next file created, so size and mtime —
 /// captured after the last write, and unchanged by the commit's fsync/rename — complete it.
-struct SecureFileIdentity: Sendable, Equatable {
+package struct SecureFileIdentity: Sendable, Equatable {
   let device: dev_t
   let inode: ino_t
   let ownerUID: uid_t
@@ -57,13 +57,15 @@ struct SecureFileIdentity: Sendable, Equatable {
   let modificationNanoseconds: Int64
 }
 
-/// Crash-safe publication and bounded, no-follow reads for the files `SecretStatePaths` names.
+/// Crash-safe publication and bounded, no-follow reads for owner-only files — the entries
+/// `SecretStatePaths` names, and any other 0600 file whose previous contents must survive a
+/// failed rewrite (the seal-time env-file scrub).
 ///
 /// The type encodes the distinction the callers depend on: **throwing means nothing was linked into
 /// place**, so the previous value is intact and a retry is free. **Returning means the commit
 /// landed** — either durably or, when the parent directory could not be proven synced, uncertainly.
 /// A caller holding an uncertain outcome must reload the path rather than assume the write was lost.
-struct SecureFilePublisher: Sendable {
+package struct SecureFilePublisher: Sendable {
   static let ownerOnlyPermissions: UInt32 = 0o600
   /// Strips the file-type bits from `st_mode`.
   static let permissionBitsMask: UInt32 = 0o777
@@ -75,7 +77,7 @@ struct SecureFilePublisher: Sendable {
   /// key and the envelope. A failpoint that could only say "fail the commit" would always fire on
   /// the key — the first publication — and a test meaning to exercise the envelope's rollback would
   /// quietly stop reaching the envelope at all.
-  struct Failpoint: Sendable, Equatable {
+  package struct Failpoint: Sendable, Equatable {
     enum Step: Sendable, Equatable {
       case tempWrite
       case fileSync
@@ -99,7 +101,7 @@ struct SecureFilePublisher: Sendable {
   }
 
   /// How a publication claims the target name.
-  enum PublicationMode: Sendable, Equatable {
+  package enum PublicationMode: Sendable, Equatable {
     /// `rename`: the target is meant to be replaced, and whatever holds the name is clobbered
     /// atomically.
     case replace
@@ -121,7 +123,7 @@ struct SecureFilePublisher: Sendable {
 
   /// The two ways a commit can have landed. There is no third: a publication that did not claim the
   /// target name throws instead.
-  enum PublicationOutcome: Sendable, Equatable {
+  package enum PublicationOutcome: Sendable, Equatable {
     case published(SecureFileIdentity)
     /// The name was claimed but the parent directory was not proven durable, so a crash now could
     /// still lose it. The bytes are readable at the path either way.
@@ -144,7 +146,7 @@ struct SecureFilePublisher: Sendable {
 
   private let failpoint: Failpoint?
 
-  init(failpoint: Failpoint? = nil) {
+  package init(failpoint: Failpoint? = nil) {
     self.failpoint = failpoint
   }
 
@@ -154,7 +156,7 @@ struct SecureFilePublisher: Sendable {
   /// ever points at them, so no crash can expose a half-written entry under the target name.
   ///
   /// `mode` decides only how the name is claimed; everything above it is identical.
-  func publish(
+  package func publish(
     _ bytes: Data,
     to url: URL,
     mode: PublicationMode = .replace

--- a/Sources/clawd/Composition/ServiceStartHint.swift
+++ b/Sources/clawd/Composition/ServiceStartHint.swift
@@ -7,8 +7,14 @@ enum StartReadiness {
   case notReady
 
   static func from(reportOK: Bool, failingKeys: [String]) -> StartReadiness {
-    if reportOK { return .ready }
-    if failingKeys == ["allowlist.owners"] { return .readyAwaitingOwner }
+    if reportOK {
+      return .ready
+    }
+
+    if failingKeys == ["allowlist.owners"] {
+      return .readyAwaitingOwner
+    }
+
     return .notReady
   }
 }
@@ -24,23 +30,34 @@ enum ServiceStartHint {
     isLinux: Bool,
     uid: UInt32
   ) -> String? {
-    guard readiness != .notReady, !daemonRunning else { return nil }
+    guard readiness != .notReady, !daemonRunning else {
+      return nil
+    }
+
     let opener =
       readiness == .readyAwaitingOwner
-      ? "Checks passed (no owner allowlisted yet — start the daemon, then send /start "
-        + "to your bot to get your ID)."
+      ? "Checks passed (no owner allowlisted yet — start the daemon, then send /start to your bot to get your ID)."
       : "All checks passed."
+
     guard unitInstalled else {
-      return opener + " To keep clawd running as a service, see "
-        + "https://github.com/ivan-magda/swift-claw/blob/main/docs/INSTALL.md"
+      return """
+        \(opener)
+        To keep clawd running as a service, see https://github.com/ivan-magda/swift-claw/blob/main/docs/INSTALL.md
+        """
     }
+
     guard serviceManagerAvailable else {
       return opener + " Start the daemon with: clawd run"
     }
+
     let startCommand =
       isLinux
       ? "systemctl --user enable --now swift-claw.service"
       : "launchctl bootstrap gui/\(uid) ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist"
-    return opener + " Start the service:\n  " + startCommand
+
+    return """
+      \(opener)
+      Start the service:\n  \(startCommand)
+      """
   }
 }

--- a/Sources/clawd/Composition/ServiceStartHint.swift
+++ b/Sources/clawd/Composition/ServiceStartHint.swift
@@ -26,6 +26,7 @@ enum ServiceStartHint {
     readiness: StartReadiness,
     daemonRunning: Bool,
     unitInstalled: Bool,
+    unitLoaded: Bool,
     serviceManagerAvailable: Bool,
     isLinux: Bool,
     uid: UInt32
@@ -50,10 +51,17 @@ enum ServiceStartHint {
       return opener + " Start the daemon with: clawd run"
     }
 
-    let startCommand =
-      isLinux
-      ? "systemctl --user enable --now swift-claw.service"
-      : "launchctl bootstrap gui/\(uid) ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist"
+    let startCommand: String
+    if isLinux {
+      startCommand = "systemctl --user enable --now swift-claw.service"
+    } else if unitLoaded {
+      // launchd rejects bootstrap for a label it already holds; kickstart is the
+      // command that starts a loaded-but-stopped agent.
+      startCommand = "launchctl kickstart -k gui/\(uid)/com.ivanmagda.swift-claw"
+    } else {
+      startCommand =
+        "launchctl bootstrap gui/\(uid) ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist"
+    }
 
     return """
       \(opener)

--- a/Sources/clawd/Composition/ServiceStartHint.swift
+++ b/Sources/clawd/Composition/ServiceStartHint.swift
@@ -1,0 +1,46 @@
+/// Whether doctor's results permit starting the daemon. An empty allowlist alone is the
+/// expected onboarding state — the daemon must run for `/start` to reveal the owner's ID —
+/// so it is start-ready, unlike any other failing check.
+enum StartReadiness {
+  case ready
+  case readyAwaitingOwner
+  case notReady
+
+  static func from(reportOK: Bool, failingKeys: [String]) -> StartReadiness {
+    if reportOK { return .ready }
+    if failingKeys == ["allowlist.owners"] { return .readyAwaitingOwner }
+    return .notReady
+  }
+}
+
+/// The line a healthy `clawd doctor` ends with: the exact command that keeps the daemon
+/// running, so a passing check never dead-ends. Silent while unhealthy or already running.
+enum ServiceStartHint {
+  static func text(
+    readiness: StartReadiness,
+    daemonRunning: Bool,
+    unitInstalled: Bool,
+    serviceManagerAvailable: Bool,
+    isLinux: Bool,
+    uid: UInt32
+  ) -> String? {
+    guard readiness != .notReady, !daemonRunning else { return nil }
+    let opener =
+      readiness == .readyAwaitingOwner
+      ? "Checks passed (no owner allowlisted yet — start the daemon, then send /start "
+        + "to your bot to get your ID)."
+      : "All checks passed."
+    guard unitInstalled else {
+      return opener + " To keep clawd running as a service, see "
+        + "https://github.com/ivan-magda/swift-claw/blob/main/docs/INSTALL.md"
+    }
+    guard serviceManagerAvailable else {
+      return opener + " Start the daemon with: clawd run"
+    }
+    let startCommand =
+      isLinux
+      ? "systemctl --user enable --now swift-claw.service"
+      : "launchctl bootstrap gui/\(uid) ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist"
+    return opener + " Start the service:\n  " + startCommand
+  }
+}

--- a/Sources/clawd/Subcommands/DoctorCommand.swift
+++ b/Sources/clawd/Subcommands/DoctorCommand.swift
@@ -70,6 +70,11 @@ struct DoctorCommand: AsyncParsableCommand {
 
     emit(report)
 
+    if !json, let hint = serviceStartHint(report: report, config: config) {
+      // swiftlint:disable:next no_print_in_production
+      print(hint)
+    }
+
     if !secretsRow.ok {
       throw ExitCode(ClawExitCode.secretLoadFailed.rawValue)
     }
@@ -289,6 +294,44 @@ private extension DoctorCommand {
     )
     report.add(contentsOf: DoctorHealth.schedulerChecks(stores: stores, config: config, now: now))
     report.add(contentsOf: DoctorHealth.approvalChecks(stores: stores, config: config, now: now))
+  }
+}
+
+// MARK: - Service Hint
+
+private extension DoctorCommand {
+  func serviceStartHint(report: DoctorReport, config: AppConfig) -> String? {
+    let lockPath = config.stateRoot.appendingPathComponent(StateFile.lock).path
+    let daemonRunning: Bool
+    if let lock = try? InstanceLock(path: lockPath) {
+      lock.release()
+      daemonRunning = false
+    } else {
+      daemonRunning = true
+    }
+    let failingKeys = report.checks.filter { check in
+      !check.ok
+    }.map(\.key)
+    #if os(Linux)
+      let unitPath = NSHomeDirectory() + "/.config/systemd/user/swift-claw.service"
+      let isLinux = true
+      let serviceManagerAvailable = FileManager.default.fileExists(
+        atPath: "/run/systemd/system"
+      )
+    #else
+      let unitPath =
+        NSHomeDirectory() + "/Library/LaunchAgents/com.ivanmagda.swift-claw.plist"
+      let isLinux = false
+      let serviceManagerAvailable = true
+    #endif
+    return ServiceStartHint.text(
+      readiness: .from(reportOK: report.ok, failingKeys: failingKeys),
+      daemonRunning: daemonRunning,
+      unitInstalled: FileManager.default.fileExists(atPath: unitPath),
+      serviceManagerAvailable: serviceManagerAvailable,
+      isLinux: isLinux,
+      uid: getuid()
+    )
   }
 }
 

--- a/Sources/clawd/Subcommands/DoctorCommand.swift
+++ b/Sources/clawd/Subcommands/DoctorCommand.swift
@@ -324,22 +324,44 @@ private extension DoctorCommand {
       let serviceManagerAvailable = FileManager.default.fileExists(
         atPath: "/run/systemd/system"
       )
+      let unitLoaded = false
     #else
       let unitPath =
         NSHomeDirectory() + "/Library/LaunchAgents/com.ivanmagda.swift-claw.plist"
       let isLinux = false
       let serviceManagerAvailable = true
+      let unitLoaded = launchAgentLoaded(uid: getuid())
     #endif
 
     return ServiceStartHint.text(
       readiness: .from(reportOK: report.ok, failingKeys: failingKeys),
       daemonRunning: daemonRunning,
       unitInstalled: FileManager.default.fileExists(atPath: unitPath),
+      unitLoaded: unitLoaded,
       serviceManagerAvailable: serviceManagerAvailable,
       isLinux: isLinux,
       uid: getuid()
     )
   }
+
+  #if !os(Linux)
+    /// `launchctl print` exits 0 only when launchd holds the label in the user's GUI
+    /// domain; any probe failure degrades to "not loaded" so the hint stays printable.
+    func launchAgentLoaded(uid: uid_t) -> Bool {
+      let probe = Process()
+      probe.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+      probe.arguments = ["print", "gui/\(uid)/com.ivanmagda.swift-claw"]
+      probe.standardOutput = FileHandle.nullDevice
+      probe.standardError = FileHandle.nullDevice
+      do {
+        try probe.run()
+      } catch {
+        return false
+      }
+      probe.waitUntilExit()
+      return probe.terminationStatus == 0
+    }
+  #endif
 }
 
 // MARK: - Output

--- a/Sources/clawd/Subcommands/DoctorCommand.swift
+++ b/Sources/clawd/Subcommands/DoctorCommand.swift
@@ -300,18 +300,24 @@ private extension DoctorCommand {
 // MARK: - Service Hint
 
 private extension DoctorCommand {
-  func serviceStartHint(report: DoctorReport, config: AppConfig) -> String? {
+  func serviceStartHint(
+    report: DoctorReport,
+    config: AppConfig
+  ) -> String? {
     let lockPath = config.stateRoot.appendingPathComponent(StateFile.lock).path
     let daemonRunning: Bool
+
     if let lock = try? InstanceLock(path: lockPath) {
       lock.release()
       daemonRunning = false
     } else {
       daemonRunning = true
     }
+
     let failingKeys = report.checks.filter { check in
       !check.ok
     }.map(\.key)
+
     #if os(Linux)
       let unitPath = NSHomeDirectory() + "/.config/systemd/user/swift-claw.service"
       let isLinux = true
@@ -324,6 +330,7 @@ private extension DoctorCommand {
       let isLinux = false
       let serviceManagerAvailable = true
     #endif
+
     return ServiceStartHint.text(
       readiness: .from(reportOK: report.ok, failingKeys: failingKeys),
       daemonRunning: daemonRunning,

--- a/Sources/clawd/Subcommands/EnvFileSecretScrubber.swift
+++ b/Sources/clawd/Subcommands/EnvFileSecretScrubber.swift
@@ -7,9 +7,11 @@ enum EnvFileSecretScrubber {
   ) -> (contents: String, scrubbedKeys: [String]) {
     var scrubbedKeys: [String] = []
     let lines = contents.split(separator: "\n", omittingEmptySubsequences: false)
+
     let rewritten = lines.map { line in
       scrubLine(String(line), keys: keys, scrubbedKeys: &scrubbedKeys)
     }
+
     return (rewritten.joined(separator: "\n"), scrubbedKeys)
   }
 }
@@ -23,11 +25,18 @@ private extension EnvFileSecretScrubber {
     scrubbedKeys: inout [String]
   ) -> String {
     for key in keys {
-      guard let prefix = assignmentPrefix(of: line, key: key) else { continue }
-      guard line.count > prefix.count else { continue }
+      guard let prefix = assignmentPrefix(of: line, key: key) else {
+        continue
+      }
+
+      guard line.count > prefix.count else {
+        continue
+      }
+
       scrubbedKeys.append(key)
       return prefix
     }
+
     return line
   }
 
@@ -36,13 +45,19 @@ private extension EnvFileSecretScrubber {
   static func assignmentPrefix(of line: String, key: String) -> String? {
     var head = Substring(line)
     let indent = head.prefix(while: { $0 == " " || $0 == "\t" })
+
     head = head.dropFirst(indent.count)
     var exportPrefix = ""
+
     if head.hasPrefix("export ") {
       exportPrefix = "export "
       head = head.dropFirst(exportPrefix.count)
     }
-    guard head.hasPrefix("\(key)=") else { return nil }
+
+    guard head.hasPrefix("\(key)=") else {
+      return nil
+    }
+
     return String(indent) + exportPrefix + key + "="
   }
 }

--- a/Sources/clawd/Subcommands/EnvFileSecretScrubber.swift
+++ b/Sources/clawd/Subcommands/EnvFileSecretScrubber.swift
@@ -1,0 +1,48 @@
+/// Blanks the values of sealed secret assignments in an env file's text, leaving every other
+/// byte untouched, so plaintext secrets leave the disk without hand-editing a working config.
+enum EnvFileSecretScrubber {
+  static func scrub(
+    contents: String,
+    keys: [String]
+  ) -> (contents: String, scrubbedKeys: [String]) {
+    var scrubbedKeys: [String] = []
+    let lines = contents.split(separator: "\n", omittingEmptySubsequences: false)
+    let rewritten = lines.map { line in
+      scrubLine(String(line), keys: keys, scrubbedKeys: &scrubbedKeys)
+    }
+    return (rewritten.joined(separator: "\n"), scrubbedKeys)
+  }
+}
+
+// MARK: - Line Rewriting
+
+private extension EnvFileSecretScrubber {
+  static func scrubLine(
+    _ line: String,
+    keys: [String],
+    scrubbedKeys: inout [String]
+  ) -> String {
+    for key in keys {
+      guard let prefix = assignmentPrefix(of: line, key: key) else { continue }
+      guard line.count > prefix.count else { continue }
+      scrubbedKeys.append(key)
+      return prefix
+    }
+    return line
+  }
+
+  /// Everything up to and including the `=` when the line assigns `key` (optionally
+  /// indented and/or `export`-prefixed), else nil.
+  static func assignmentPrefix(of line: String, key: String) -> String? {
+    var head = Substring(line)
+    let indent = head.prefix(while: { $0 == " " || $0 == "\t" })
+    head = head.dropFirst(indent.count)
+    var exportPrefix = ""
+    if head.hasPrefix("export ") {
+      exportPrefix = "export "
+      head = head.dropFirst(exportPrefix.count)
+    }
+    guard head.hasPrefix("\(key)=") else { return nil }
+    return String(indent) + exportPrefix + key + "="
+  }
+}

--- a/Sources/clawd/Subcommands/SecretsCommand.swift
+++ b/Sources/clawd/Subcommands/SecretsCommand.swift
@@ -19,6 +19,16 @@ struct SecretsCommand: AsyncParsableCommand {
       abstract: "Encrypt the env secrets into <stateRoot>/secrets.enc."
     )
 
+    @Option(
+      name: .customLong("env-file"),
+      help:
+        "Env file to scrub sealed secrets from (default: $CLAW_ENV_FILE or ~/.swift-claw/clawd.env)."
+    )
+    var envFile: String?
+
+    @Flag(name: .customLong("no-scrub"), help: "Leave plaintext secret lines in the env file.")
+    var noScrub = false
+
     func run() async throws {
       let environment = ProcessInfo.processInfo.environment
       let config: AppConfig
@@ -46,15 +56,20 @@ struct SecretsCommand: AsyncParsableCommand {
       let paths = SecretStatePaths(stateRoot: config.stateRoot)
       let envelopePath = paths.runtimeEnvelope.path
       let keyPath = paths.key.path
+      let scrubOutcome: SealScrubOutcome? =
+        noScrub
+        ? nil
+        : Self.scrubEnvFile(
+          at: resolvedEnvFilePath(environment: environment),
+          keys: [
+            EnvSecretStore.EnvKey.botToken,
+            EnvSecretStore.EnvKey.llmApiKey,
+            EnvSecretStore.EnvKey.searchApiKey,
+          ]
+        )
       // swiftlint:disable:next no_print_in_production
       print(
-        """
-        Sealed secrets → \(envelopePath)
-        Key → \(keyPath) (mode 0600 — keep this OUTSIDE your state-root backup boundary)
-        You may now remove the plaintext \(EnvSecretStore.EnvKey.botToken) / \
-        \(EnvSecretStore.EnvKey.llmApiKey) /
-        \(EnvSecretStore.EnvKey.searchApiKey) from the env.
-        """
+        Self.sealSummary(envelopePath: envelopePath, keyPath: keyPath, scrubOutcome: scrubOutcome)
       )
     }
   }
@@ -97,5 +112,84 @@ extension SecretsCommand.Seal {
       )
       throw ExitCode(ClawExitCode.alreadyRunning.rawValue)
     }
+  }
+}
+
+// MARK: - Env-File Scrub
+
+enum SealScrubOutcome: Equatable {
+  case scrubbed(keys: [String], path: String)
+  case alreadyClean(path: String)
+  case fileAbsent(path: String)
+  case failed(path: String, reason: String)
+}
+
+extension SecretsCommand.Seal {
+  func resolvedEnvFilePath(environment: [String: String]) -> String {
+    if let explicit = envFile { return explicit }
+    if let fromEnv = environment["CLAW_ENV_FILE"] { return fromEnv }
+    return NSHomeDirectory() + "/.swift-claw/clawd.env"
+  }
+
+  /// Blanks sealed secret values in the env file, writing atomically and preserving 0600.
+  static func scrubEnvFile(at path: String, keys: [String]) -> SealScrubOutcome {
+    guard FileManager.default.fileExists(atPath: path) else {
+      return .fileAbsent(path: path)
+    }
+    guard let data = FileManager.default.contents(atPath: path),
+      let contents = String(data: data, encoding: .utf8)
+    else {
+      return .failed(path: path, reason: "unreadable or not UTF-8")
+    }
+    let result = EnvFileSecretScrubber.scrub(contents: contents, keys: keys)
+    guard !result.scrubbedKeys.isEmpty else { return .alreadyClean(path: path) }
+    let tempPath = path + ".seal-scrub.tmp"
+    do {
+      try result.contents.write(toFile: tempPath, atomically: false, encoding: .utf8)
+      try FileManager.default.setAttributes(
+        [.posixPermissions: 0o600],
+        ofItemAtPath: tempPath
+      )
+      _ = try FileManager.default.replaceItemAt(
+        URL(fileURLWithPath: path),
+        withItemAt: URL(fileURLWithPath: tempPath)
+      )
+    } catch {
+      try? FileManager.default.removeItem(atPath: tempPath)
+      return .failed(path: path, reason: "\(error)")
+    }
+    return .scrubbed(keys: result.scrubbedKeys, path: path)
+  }
+
+  static func sealSummary(
+    envelopePath: String,
+    keyPath: String,
+    scrubOutcome: SealScrubOutcome?
+  ) -> String {
+    var summary = """
+      Sealed secrets → \(envelopePath)
+      Key → \(keyPath) (mode 0600 — keep this OUTSIDE your state-root backup boundary)
+      """
+    let manualNote = """
+      Remove the plaintext \(EnvSecretStore.EnvKey.botToken) / \
+      \(EnvSecretStore.EnvKey.llmApiKey) / \(EnvSecretStore.EnvKey.searchApiKey) \
+      values from your env file yourself.
+      """
+    switch scrubOutcome {
+    case .scrubbed(let keys, let path):
+      summary += "\nBlanked \(keys.joined(separator: ", ")) in \(path)."
+      summary += "\nYour current shell still holds the old values; open a fresh shell "
+      summary += "before running the daemon."
+    case .alreadyClean(let path):
+      summary += "\nNo plaintext secret values found in \(path)."
+    case .fileAbsent(let path):
+      summary += "\nNo env file at \(path) — nothing to scrub. " + manualNote
+    case .failed(let path, let reason):
+      summary += "\nWARNING: could not scrub \(path) (\(reason))."
+      summary += "\nThe plaintext secret values are still in \(path) — " + manualNote
+    case nil:
+      summary += "\n" + manualNote
+    }
+    return summary
   }
 }

--- a/Sources/clawd/Subcommands/SecretsCommand.swift
+++ b/Sources/clawd/Subcommands/SecretsCommand.swift
@@ -131,7 +131,8 @@ extension SecretsCommand.Seal {
     return NSHomeDirectory() + "/.swift-claw/clawd.env"
   }
 
-  /// Blanks sealed secret values in the env file, writing atomically and preserving 0600.
+  /// Blanks sealed secret values in the env file via crash-safe publication (0600 temp, fsync,
+  /// POSIX rename): on any failure the original file is left intact, and the result is mode 0600.
   static func scrubEnvFile(at path: String, keys: [String]) -> SealScrubOutcome {
     guard FileManager.default.fileExists(atPath: path) else {
       return .fileAbsent(path: path)
@@ -149,21 +150,13 @@ extension SecretsCommand.Seal {
       return .alreadyClean(path: path)
     }
 
-    let tempPath = "\(path).seal-scrub.tmp"
     do {
-      try result.contents.write(toFile: tempPath, atomically: false, encoding: .utf8)
-
-      try FileManager.default.setAttributes(
-        [.posixPermissions: 0o600],
-        ofItemAtPath: tempPath
-      )
-
-      _ = try FileManager.default.replaceItemAt(
-        URL(fileURLWithPath: path),
-        withItemAt: URL(fileURLWithPath: tempPath)
+      _ = try SecureFilePublisher().publish(
+        Data(result.contents.utf8),
+        to: URL(fileURLWithPath: path),
+        mode: .replace
       )
     } catch {
-      try? FileManager.default.removeItem(atPath: tempPath)
       return .failed(path: path, reason: "\(error)")
     }
 

--- a/Sources/clawd/Subcommands/SecretsCommand.swift
+++ b/Sources/clawd/Subcommands/SecretsCommand.swift
@@ -136,20 +136,28 @@ extension SecretsCommand.Seal {
     guard FileManager.default.fileExists(atPath: path) else {
       return .fileAbsent(path: path)
     }
-    guard let data = FileManager.default.contents(atPath: path),
+
+    guard
+      let data = FileManager.default.contents(atPath: path),
       let contents = String(data: data, encoding: .utf8)
     else {
       return .failed(path: path, reason: "unreadable or not UTF-8")
     }
+
     let result = EnvFileSecretScrubber.scrub(contents: contents, keys: keys)
-    guard !result.scrubbedKeys.isEmpty else { return .alreadyClean(path: path) }
-    let tempPath = path + ".seal-scrub.tmp"
+    guard !result.scrubbedKeys.isEmpty else {
+      return .alreadyClean(path: path)
+    }
+
+    let tempPath = "\(path).seal-scrub.tmp"
     do {
       try result.contents.write(toFile: tempPath, atomically: false, encoding: .utf8)
+
       try FileManager.default.setAttributes(
         [.posixPermissions: 0o600],
         ofItemAtPath: tempPath
       )
+
       _ = try FileManager.default.replaceItemAt(
         URL(fileURLWithPath: path),
         withItemAt: URL(fileURLWithPath: tempPath)
@@ -158,6 +166,7 @@ extension SecretsCommand.Seal {
       try? FileManager.default.removeItem(atPath: tempPath)
       return .failed(path: path, reason: "\(error)")
     }
+
     return .scrubbed(keys: result.scrubbedKeys, path: path)
   }
 
@@ -170,11 +179,13 @@ extension SecretsCommand.Seal {
       Sealed secrets → \(envelopePath)
       Key → \(keyPath) (mode 0600 — keep this OUTSIDE your state-root backup boundary)
       """
+
     let manualNote = """
       Remove the plaintext \(EnvSecretStore.EnvKey.botToken) / \
       \(EnvSecretStore.EnvKey.llmApiKey) / \(EnvSecretStore.EnvKey.searchApiKey) \
       values from your env file yourself.
       """
+
     switch scrubOutcome {
     case .scrubbed(let keys, let path):
       summary += "\nBlanked \(keys.joined(separator: ", ")) in \(path)."
@@ -190,6 +201,7 @@ extension SecretsCommand.Seal {
     case nil:
       summary += "\n" + manualNote
     }
+
     return summary
   }
 }

--- a/Sources/clawd/Subcommands/SecretsCommand.swift
+++ b/Sources/clawd/Subcommands/SecretsCommand.swift
@@ -133,34 +133,37 @@ extension SecretsCommand.Seal {
 
   /// Blanks sealed secret values in the env file via crash-safe publication (0600 temp, fsync,
   /// POSIX rename): on any failure the original file is left intact, and the result is mode 0600.
+  /// A symlinked env file is resolved first, so the target is rewritten and the link preserved.
   static func scrubEnvFile(at path: String, keys: [String]) -> SealScrubOutcome {
     guard FileManager.default.fileExists(atPath: path) else {
       return .fileAbsent(path: path)
     }
 
+    let resolvedPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+
     guard
-      let data = FileManager.default.contents(atPath: path),
+      let data = FileManager.default.contents(atPath: resolvedPath),
       let contents = String(data: data, encoding: .utf8)
     else {
-      return .failed(path: path, reason: "unreadable or not UTF-8")
+      return .failed(path: resolvedPath, reason: "unreadable or not UTF-8")
     }
 
     let result = EnvFileSecretScrubber.scrub(contents: contents, keys: keys)
     guard !result.scrubbedKeys.isEmpty else {
-      return .alreadyClean(path: path)
+      return .alreadyClean(path: resolvedPath)
     }
 
     do {
       _ = try SecureFilePublisher().publish(
         Data(result.contents.utf8),
-        to: URL(fileURLWithPath: path),
+        to: URL(fileURLWithPath: resolvedPath),
         mode: .replace
       )
     } catch {
-      return .failed(path: path, reason: "\(error)")
+      return .failed(path: resolvedPath, reason: "\(error)")
     }
 
-    return .scrubbed(keys: result.scrubbedKeys, path: path)
+    return .scrubbed(keys: result.scrubbedKeys, path: resolvedPath)
   }
 
   static func sealSummary(

--- a/Tests/ClawGatewayTests/Routing/UnauthorizedStartTextTests.swift
+++ b/Tests/ClawGatewayTests/Routing/UnauthorizedStartTextTests.swift
@@ -1,0 +1,17 @@
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct UnauthorizedStartTextTests {
+  @Test func refusalCarriesACopyPasteableAllowlistLine() {
+    // given
+    let userId: Int64 = 12_345_678
+
+    // when
+    let text = MessageRouter.unauthorizedStartText(userId: userId)
+
+    // then — the owner can paste the last line into clawd.env verbatim
+    #expect(text.contains("This is a private bot."))
+    #expect(text.hasSuffix("CLAW_ALLOWLIST=12345678"))
+  }
+}

--- a/Tests/ClawdCompositionTests/EnvFileSecretScrubberTests.swift
+++ b/Tests/ClawdCompositionTests/EnvFileSecretScrubberTests.swift
@@ -83,6 +83,35 @@ import Testing
     #expect((mode as? NSNumber)?.intValue == 0o600)
   }
 
+  @Test func scrubbingViaSymlinkRewritesTheTargetAndPreservesTheLink() throws {
+    // given — a real env file plus a symlink pointing at it
+    let dir = try makeTemporaryRoot(prefix: "claw-scrub-link")
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let targetPath = dir.appendingPathComponent("clawd.env").path
+    let linkPath = dir.appendingPathComponent("clawd.env.link").path
+    try "CLAW_TELEGRAM_BOT_TOKEN=123:abc\nCLAW_LLM_MODEL=m\n"
+      .write(toFile: targetPath, atomically: true, encoding: .utf8)
+    try FileManager.default.createSymbolicLink(
+      atPath: linkPath,
+      withDestinationPath: targetPath
+    )
+
+    // when — scrubbing through the symlink path
+    let outcome = SecretsCommand.Seal.scrubEnvFile(
+      at: linkPath,
+      keys: ["CLAW_TELEGRAM_BOT_TOKEN"]
+    )
+
+    // then — the outcome names the resolved path, the target is blanked, the link survives
+    let resolvedPath = URL(fileURLWithPath: linkPath).resolvingSymlinksInPath().path
+    #expect(outcome == .scrubbed(keys: ["CLAW_TELEGRAM_BOT_TOKEN"], path: resolvedPath))
+    let rewritten = try String(contentsOfFile: targetPath, encoding: .utf8)
+    #expect(rewritten == "CLAW_TELEGRAM_BOT_TOKEN=\nCLAW_LLM_MODEL=m\n")
+    // attributesOfItem uses lstat semantics, so it sees the link itself, not the target.
+    let linkType = try FileManager.default.attributesOfItem(atPath: linkPath)[.type]
+    #expect(linkType as? FileAttributeType == .typeSymbolicLink)
+  }
+
   @Test func absentFileYieldsFileAbsentNotAnError() {
     // given / when
     let outcome = SecretsCommand.Seal.scrubEnvFile(

--- a/Tests/ClawdCompositionTests/EnvFileSecretScrubberTests.swift
+++ b/Tests/ClawdCompositionTests/EnvFileSecretScrubberTests.swift
@@ -1,0 +1,109 @@
+import ClawTestSupport
+import Foundation
+import Testing
+
+@testable import clawd
+
+@Suite struct EnvFileSecretScrubberTests {
+  @Test func blanksOnlyTheListedSecretKeysAndKeepsEverythingElse() {
+    // given — an env file with secrets, comments, and non-secret assignments
+    let contents = """
+      # --- SECRETS ---
+      CLAW_TELEGRAM_BOT_TOKEN=123456:real-token
+      CLAW_ALLOWLIST=12345678
+      export CLAW_LLM_API_KEY=sk-live-key
+        CLAW_SEARCH_API_KEY=exa-key
+      CLAW_LLM_MODEL=claude-sonnet-4-6
+      """
+
+    // when
+    let result = EnvFileSecretScrubber.scrub(
+      contents: contents,
+      keys: ["CLAW_TELEGRAM_BOT_TOKEN", "CLAW_LLM_API_KEY", "CLAW_SEARCH_API_KEY"]
+    )
+
+    // then — secret values are blanked in place; structure, comments, other keys untouched
+    #expect(
+      result.contents == """
+        # --- SECRETS ---
+        CLAW_TELEGRAM_BOT_TOKEN=
+        CLAW_ALLOWLIST=12345678
+        export CLAW_LLM_API_KEY=
+          CLAW_SEARCH_API_KEY=
+        CLAW_LLM_MODEL=claude-sonnet-4-6
+        """
+    )
+    #expect(
+      result.scrubbedKeys == [
+        "CLAW_TELEGRAM_BOT_TOKEN", "CLAW_LLM_API_KEY", "CLAW_SEARCH_API_KEY",
+      ]
+    )
+  }
+
+  @Test func reportsNothingScrubbedWhenValuesAreAlreadyBlankOrKeysAbsent() {
+    // given — secrets already blank or missing entirely
+    let contents = """
+      CLAW_TELEGRAM_BOT_TOKEN=
+      CLAW_LLM_MODEL=claude-sonnet-4-6
+      """
+
+    // when
+    let result = EnvFileSecretScrubber.scrub(
+      contents: contents,
+      keys: ["CLAW_TELEGRAM_BOT_TOKEN", "CLAW_LLM_API_KEY", "CLAW_SEARCH_API_KEY"]
+    )
+
+    // then — the file is returned unchanged and no keys are reported
+    #expect(result.contents == contents)
+    #expect(result.scrubbedKeys.isEmpty)
+  }
+}
+
+@Suite struct SealScrubFileTests {
+  @Test func scrubsTheFileInPlacePreservingMode0600() throws {
+    // given — a 0600 env file holding real-looking secrets
+    let dir = try makeTemporaryRoot(prefix: "claw-scrub")
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let filePath = dir.appendingPathComponent("clawd.env").path
+    try "CLAW_TELEGRAM_BOT_TOKEN=123:abc\nCLAW_LLM_MODEL=m\n"
+      .write(toFile: filePath, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: filePath)
+
+    // when
+    let outcome = SecretsCommand.Seal.scrubEnvFile(
+      at: filePath,
+      keys: ["CLAW_TELEGRAM_BOT_TOKEN"]
+    )
+
+    // then — value blanked, mode preserved, outcome names the key
+    #expect(outcome == .scrubbed(keys: ["CLAW_TELEGRAM_BOT_TOKEN"], path: filePath))
+    let rewritten = try String(contentsOfFile: filePath, encoding: .utf8)
+    #expect(rewritten == "CLAW_TELEGRAM_BOT_TOKEN=\nCLAW_LLM_MODEL=m\n")
+    let mode = try FileManager.default.attributesOfItem(atPath: filePath)[.posixPermissions]
+    #expect((mode as? NSNumber)?.intValue == 0o600)
+  }
+
+  @Test func absentFileYieldsFileAbsentNotAnError() {
+    // given / when
+    let outcome = SecretsCommand.Seal.scrubEnvFile(
+      at: "/nonexistent/clawd.env",
+      keys: ["CLAW_TELEGRAM_BOT_TOKEN"]
+    )
+
+    // then
+    #expect(outcome == .fileAbsent(path: "/nonexistent/clawd.env"))
+  }
+
+  @Test func summaryWarnsLoudlyWhenScrubFailed() {
+    // given / when — a failed scrub must tell the user plaintext is still on disk
+    let summary = SecretsCommand.Seal.sealSummary(
+      envelopePath: "/root/secrets.enc",
+      keyPath: "/root/secret.key",
+      scrubOutcome: .failed(path: "/root/clawd.env", reason: "permission denied")
+    )
+
+    // then
+    #expect(summary.contains("WARNING"))
+    #expect(summary.contains("still in /root/clawd.env"))
+  }
+}

--- a/Tests/ClawdCompositionTests/ServiceStartHintTests.swift
+++ b/Tests/ClawdCompositionTests/ServiceStartHintTests.swift
@@ -1,0 +1,94 @@
+import Testing
+
+@testable import clawd
+
+@Suite struct ServiceStartHintTests {
+  @Test func healthyIdleMachineWithInstalledUnitGetsThePlatformStartCommand() {
+    // given / when
+    let macHint = ServiceStartHint.text(
+      readiness: .ready,
+      daemonRunning: false,
+      unitInstalled: true,
+      serviceManagerAvailable: true,
+      isLinux: false,
+      uid: 501
+    )
+    let linuxHint = ServiceStartHint.text(
+      readiness: .ready,
+      daemonRunning: false,
+      unitInstalled: true,
+      serviceManagerAvailable: true,
+      isLinux: true,
+      uid: 1000
+    )
+
+    // then
+    #expect(macHint?.contains("launchctl bootstrap gui/501") == true)
+    #expect(linuxHint?.contains("systemctl --user enable --now swift-claw.service") == true)
+  }
+
+  @Test func emptyAllowlistOnboardingStateStillGetsAStartCommandWithStartGuidance() {
+    // given / when — the daemon must run for /start to reveal the owner's ID
+    let hint = ServiceStartHint.text(
+      readiness: .readyAwaitingOwner,
+      daemonRunning: false,
+      unitInstalled: true,
+      serviceManagerAvailable: true,
+      isLinux: false,
+      uid: 501
+    )
+
+    // then
+    #expect(hint?.contains("launchctl bootstrap gui/501") == true)
+    #expect(hint?.contains("/start") == true)
+  }
+
+  @Test func noHintWhileNotReadyOrAlreadyRunning() {
+    // given / when / then — a failing report or a live daemon must not suggest starting
+    #expect(
+      ServiceStartHint.text(
+        readiness: .notReady,
+        daemonRunning: false,
+        unitInstalled: true,
+        serviceManagerAvailable: true,
+        isLinux: false,
+        uid: 501
+      ) == nil
+    )
+    #expect(
+      ServiceStartHint.text(
+        readiness: .ready,
+        daemonRunning: true,
+        unitInstalled: true,
+        serviceManagerAvailable: true,
+        isLinux: false,
+        uid: 501
+      ) == nil
+    )
+  }
+
+  @Test func missingUnitOrServiceManagerFallsBackHonestly() {
+    // given / when
+    let noUnit = ServiceStartHint.text(
+      readiness: .ready,
+      daemonRunning: false,
+      unitInstalled: false,
+      serviceManagerAvailable: true,
+      isLinux: false,
+      uid: 501
+    )
+    let noSystemd = ServiceStartHint.text(
+      readiness: .ready,
+      daemonRunning: false,
+      unitInstalled: true,
+      serviceManagerAvailable: false,
+      isLinux: true,
+      uid: 1000
+    )
+
+    // then — never print a command the machine cannot run
+    #expect(noUnit?.contains("docs/INSTALL.md") == true)
+    #expect(noSystemd?.contains("clawd run") == true)
+    #expect(noSystemd?.contains("systemctl") == false)
+  }
+}

--- a/Tests/ClawdCompositionTests/ServiceStartHintTests.swift
+++ b/Tests/ClawdCompositionTests/ServiceStartHintTests.swift
@@ -9,6 +9,7 @@ import Testing
       readiness: .ready,
       daemonRunning: false,
       unitInstalled: true,
+      unitLoaded: false,
       serviceManagerAvailable: true,
       isLinux: false,
       uid: 501
@@ -17,6 +18,7 @@ import Testing
       readiness: .ready,
       daemonRunning: false,
       unitInstalled: true,
+      unitLoaded: false,
       serviceManagerAvailable: true,
       isLinux: true,
       uid: 1000
@@ -27,12 +29,47 @@ import Testing
     #expect(linuxHint?.contains("systemctl --user enable --now swift-claw.service") == true)
   }
 
+  @Test func loadedButStoppedLaunchAgentGetsKickstartBecauseBootstrapWouldBeRejected() {
+    // given / when
+    let hint = ServiceStartHint.text(
+      readiness: .ready,
+      daemonRunning: false,
+      unitInstalled: true,
+      unitLoaded: true,
+      serviceManagerAvailable: true,
+      isLinux: false,
+      uid: 501
+    )
+
+    // then
+    #expect(hint?.contains("launchctl kickstart -k gui/501/com.ivanmagda.swift-claw") == true)
+    #expect(hint?.contains("bootstrap") == false)
+  }
+
+  @Test func unloadedLaunchAgentStillGetsTheBootstrapCommand() {
+    // given / when
+    let hint = ServiceStartHint.text(
+      readiness: .ready,
+      daemonRunning: false,
+      unitInstalled: true,
+      unitLoaded: false,
+      serviceManagerAvailable: true,
+      isLinux: false,
+      uid: 501
+    )
+
+    // then
+    #expect(hint?.contains("launchctl bootstrap gui/501") == true)
+    #expect(hint?.contains("kickstart") == false)
+  }
+
   @Test func emptyAllowlistOnboardingStateStillGetsAStartCommandWithStartGuidance() {
     // given / when — the daemon must run for /start to reveal the owner's ID
     let hint = ServiceStartHint.text(
       readiness: .readyAwaitingOwner,
       daemonRunning: false,
       unitInstalled: true,
+      unitLoaded: false,
       serviceManagerAvailable: true,
       isLinux: false,
       uid: 501
@@ -50,6 +87,7 @@ import Testing
         readiness: .notReady,
         daemonRunning: false,
         unitInstalled: true,
+        unitLoaded: false,
         serviceManagerAvailable: true,
         isLinux: false,
         uid: 501
@@ -60,6 +98,7 @@ import Testing
         readiness: .ready,
         daemonRunning: true,
         unitInstalled: true,
+        unitLoaded: true,
         serviceManagerAvailable: true,
         isLinux: false,
         uid: 501
@@ -73,6 +112,7 @@ import Testing
       readiness: .ready,
       daemonRunning: false,
       unitInstalled: false,
+      unitLoaded: false,
       serviceManagerAvailable: true,
       isLinux: false,
       uid: 501
@@ -81,6 +121,7 @@ import Testing
       readiness: .ready,
       daemonRunning: false,
       unitInstalled: true,
+      unitLoaded: false,
       serviceManagerAvailable: false,
       isLinux: true,
       uid: 1000

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,39 +1,20 @@
-# Deploying clawd
+# deploy/
 
-## Install
+Service files shipped with every release:
 
-**Option A (release binary, recommended).** Download `clawd-<platform>` and `SHA256SUMS` from the [latest release](../../../releases/latest). The same release ships `clawd.env.example` and the unit files below, all under that one manifest.
+- `run-clawd.sh` — wrapper that sources `clawd.env` and execs `clawd run`.
+- `com.ivanmagda.swift-claw.plist` — launchd LaunchAgent (macOS).
+- `swift-claw.service` — systemd user service (Linux).
 
-```bash
-shasum -a 256 --ignore-missing -c SHA256SUMS &&        # Linux: sha256sum --ignore-missing -c SHA256SUMS
-  sudo install -m755 clawd-<platform> /usr/local/bin/clawd
-```
+Install, start, update, and uninstall instructions — for both the scripted
+`~/.swift-claw` layout and the manual `/usr/local/bin` layout — live in
+[docs/INSTALL.md](../docs/INSTALL.md).
 
-`--ignore-missing` checks only what you downloaded. Every listed file must print `OK`, and the `&&` stops the install if any does not. To also check build provenance, run `gh attestation verify <binary> -R ivan-magda/swift-claw` (needs the GitHub CLI, logged in).
+Exit codes are diagnostic:
 
-Platform notes:
-
-- **macOS:** clear quarantine with `sudo xattr -d com.apple.quarantine /usr/local/bin/clawd`.
-- **Linux:** install `libsqlite3-0`.
-
-**Option B (build from source).**
-
-1. `swift build -c release` → `sudo install -m755 .build/release/clawd /usr/local/bin/clawd`.
-2. `cp .env.example ~/.swift-claw/clawd.env`, fill in the token + allowlist, `chmod 600 ~/.swift-claw/clawd.env`.
-3. Verify: `clawd doctor` (config first, then DB/allowlist/connectivity).
-
-## macOS (launchd)
-
-- `sudo install -m755 deploy/run-clawd.sh /usr/local/bin/run-clawd.sh`
-- `mkdir -p ~/Library/LaunchAgents && cp deploy/com.ivanmagda.swift-claw.plist ~/Library/LaunchAgents/`
-- `launchctl load ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist`
-
-## Linux (systemd, user service)
-
-- `mkdir -p ~/.config/systemd/user && cp deploy/swift-claw.service ~/.config/systemd/user/`
-- `systemctl --user enable --now swift-claw.service`
-- `journalctl --user -u swift-claw -f`
-
-Both units are per-user: they start at login, not at boot, and stop at logout. On Linux, `sudo loginctl enable-linger $USER` keeps the service alive across logout and starts it at boot. On macOS, enable automatic login for the account. A `/Library/LaunchDaemons` service instead runs as root, where `$HOME` is `/var/root` and `run-clawd.sh` cannot find `~/.swift-claw/clawd.env`, so `clawd` exits 10. If you take that path, set `UserName`, `CLAW_ENV_FILE`, and `CLAW_STATE_ROOT` in the plist.
-
-A second `clawd` against the same state root refuses to boot (flock); a Telegram 409 is logged as critical. Distinct exit codes: 10 config, 11 secret, 12 already-running, 13 store.
+| Code | Meaning |
+|---|---|
+| 10 | invalid config |
+| 11 | secret loading failed |
+| 12 | another instance holds the state-root lock |
+| 13 | storage error |

--- a/deploy/run-clawd.sh
+++ b/deploy/run-clawd.sh
@@ -4,6 +4,7 @@ ENV_FILE="${CLAW_ENV_FILE:-$HOME/.swift-claw/clawd.env}"
 # set -a: plain VAR=value lines must be exported to reach the exec'd clawd's environment.
 if [ -f "$ENV_FILE" ]; then
   set -a
+  # shellcheck disable=SC1090  # env file path is runtime-configurable by design
   . "$ENV_FILE"
   set +a
 fi

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -152,7 +152,7 @@ Stop the daemon first; sealing takes the same state-root lock. Put **all** the s
 want back in the environment, not just the new one, since the reseal replaces the envelope:
 
 ```bash
-export CLAW_TELEGRAM_BOT_TOKEN=...   # the values you deleted after the first seal
+export CLAW_TELEGRAM_BOT_TOKEN=...   # the values the first seal blanked from clawd.env
 export CLAW_LLM_API_KEY=...
 export CLAW_SEARCH_API_KEY=...       # the one you are adding
 clawd secrets seal

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -11,8 +11,8 @@ From nothing to a running assistant that answers you in Telegram.
 - **LLM access.** Either an OpenAI-compatible endpoint with an API key (Anthropic,
   OpenAI, OpenRouter, or a local server), or a ChatGPT subscription.
 
-Install `clawd` first: release binary or source build, both covered in the
-[README](../README.md#install). The steps below assume `clawd` is on your `PATH`.
+Install `clawd` first: the install script, a manual release download, or a source build,
+all covered in [INSTALL.md](INSTALL.md). The steps below assume `clawd` is on your `PATH`.
 
 **On a ChatGPT subscription?** Do [step 8](#8-chatgpt-subscription-instead-of-an-api-key)
 right after step 2, before you start the daemon. Step 8 gives you the `CLAW_LLM_MODEL`
@@ -27,8 +27,11 @@ the identity of your bot, so treat it like a password.
 
 ## 2. Configure
 
-Your shell executes this file with `source`, so use the copy that ships with the release
-you verified rather than fetching one over the network:
+**Installed with the script?** `~/.swift-claw/clawd.env` is already in place — the
+script installed the verified template on first run. Skip to editing it below.
+
+**Manual install:** your shell executes this file with `source`, so use the copy that
+ships with the release you verified rather than fetching one over the network:
 
 ```bash
 mkdir -p -m 700 ~/.swift-claw
@@ -36,7 +39,7 @@ install -m 600 clawd.env.example ~/.swift-claw/clawd.env    # from your download
 ```
 
 `clawd.env.example` is a release asset covered by `SHA256SUMS`, so the checksum step from
-[Install](../README.md#install) already verified it. From a source checkout, use
+[INSTALL.md](INSTALL.md#2-manual-install) already verified it. From a source checkout, use
 `install -m 600 .env.example ~/.swift-claw/clawd.env` instead.
 
 Edit `~/.swift-claw/clawd.env` and set four values:
@@ -68,15 +71,15 @@ clawd secrets seal
 This encrypts the bot token and API keys into `~/.swift-claw/secrets.enc` with a key in
 `~/.swift-claw/secret.key` (mode 0600).
 
-Sealing copies the secrets out of your environment; it does not edit `clawd.env`. Delete
-or blank the `CLAW_TELEGRAM_BOT_TOKEN`, `CLAW_LLM_API_KEY`, and `CLAW_SEARCH_API_KEY`
-lines yourself. Until you do, the plaintext values stay on disk and in any backup of that
-directory. The daemon now reads them from the encrypted store, and refuses to fall back to
-plaintext if the store is present but broken.
+Sealing also blanks the plaintext `CLAW_TELEGRAM_BOT_TOKEN`, `CLAW_LLM_API_KEY`, and
+`CLAW_SEARCH_API_KEY` lines in `clawd.env` itself, and tells you what it changed
+(`--no-scrub` keeps them; before v0.2.0, blank them yourself). The daemon now reads the
+secrets from the encrypted store, and refuses to fall back to plaintext if the store is
+present but broken.
 
 Sourcing the file again does not undo the export: your current shell still holds the
-values it read before you edited them. Open a fresh shell and source the sanitized file
-there:
+values it read before sealing blanked them. Open a fresh shell and source the sanitized
+file there:
 
 ```bash
 set -a && source ~/.swift-claw/clawd.env && set +a
@@ -112,12 +115,17 @@ clawd run
 
 Send `/start` to your bot in Telegram. Because the allowlist is still empty, it answers:
 
-> This is a private bot. Your Telegram user ID is 12345678. Ask the owner to add it to the allowlist.
+> This is a private bot. Your Telegram user ID is 12345678. To authorize it, the owner
+> adds this line to clawd.env and restarts clawd:
+>
+> CLAW_ALLOWLIST=12345678
+
+(v0.2.0+; older releases print the ID in prose without the pasteable line.)
 
 Only `/start` gets that reply. Any other message from a non-allowlisted sender gets a
 bare "Sorry, this is a private bot." with no ID, so `/start` is how you learn the number.
 
-That number is you. Stop the daemon (Ctrl-C), set it in `clawd.env`:
+That number is you. Stop the daemon (Ctrl-C) and paste the shown line into `clawd.env`:
 
 ```bash
 CLAW_ALLOWLIST=12345678
@@ -151,38 +159,13 @@ locales, and the code sandbox.
 
 ## 7. Keep it running
 
-To restart `clawd` after a crash and start it on login, install it under launchd (macOS)
-or systemd (Linux). [deploy/README.md](../deploy/README.md) has the unit files and the
-three commands per platform.
+To restart `clawd` after a crash and start it on login, run it under launchd (macOS) or
+systemd (Linux). A healthy `clawd doctor` ends by printing the exact start command for
+your machine — run that.
 
-If you installed a release binary, download the unit files from that same release:
-`run-clawd.sh`, plus `swift-claw.service` (Linux) or `com.ivanmagda.swift-claw.plist`
-(macOS). `SHA256SUMS` covers them, so verify before use. You install `run-clawd.sh` as
-root and your machine runs it at every login, which is reason enough not to take it from
-an unverified source:
-
-```bash
-cd ~/Downloads
-UNIT=com.ivanmagda.swift-claw.plist    # Linux: swift-claw.service
-
-shasum -a 256 --ignore-missing -c SHA256SUMS &&    # Linux: sha256sum --ignore-missing -c SHA256SUMS
-  mkdir -p deploy && mv run-clawd.sh "$UNIT" deploy/
-```
-
-The deployment guide's commands read from `deploy/`, so run them from the directory that
-now holds it.
-
-Both units are **per-user**: they start when you log in, not at boot, and they stop when
-you log out. For a machine you administer and want always-on:
-
-- **Linux:** let the user manager run without a session with
-  `sudo loginctl enable-linger $USER`. Without it, a service you installed over SSH stops
-  when you disconnect and does not come back after a reboot.
-- **macOS:** enable automatic login for the account. That keeps the LaunchAgent, which is
-  the simple path. A system LaunchDaemon in `/Library/LaunchDaemons` runs as root, where
-  `$HOME` is `/var/root`, so the wrapper looks for its config in the wrong place and
-  `clawd` exits 10. If you go that route, pin the account and paths explicitly with
-  `UserName`, `CLAW_ENV_FILE`, and `CLAW_STATE_ROOT` in the plist.
+[INSTALL.md section 4](INSTALL.md#4-running-as-a-service) covers both layouts (script
+install and manual `/usr/local/bin`), plus the linger/auto-login notes for a machine
+that should stay on after you log out, log locations, and the exit codes.
 
 ## 8. ChatGPT subscription instead of an API key
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -117,7 +117,6 @@ Send `/start` to your bot in Telegram. Because the allowlist is still empty, it 
 
 > This is a private bot. Your Telegram user ID is 12345678. To authorize it, the owner
 > adds this line to clawd.env and restarts clawd:
->
 > CLAW_ALLOWLIST=12345678
 
 (v0.2.0+; older releases print the ID in prose without the pasteable line.)
@@ -174,7 +173,7 @@ logging in takes the same state-root lock the daemon holds, and while the daemon
 `clawd auth login` exits with "clawd is running for this state root."
 
 - Foreground: Ctrl-C.
-- macOS: `launchctl unload ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist`
+- macOS: `launchctl bootout gui/$(id -u)/com.ivanmagda.swift-claw`
 - Linux: `systemctl --user stop swift-claw.service`
 
 ```bash
@@ -200,7 +199,7 @@ fails config validation with exit 10. Then:
   through the guide. Do not start the daemon yet; the remaining steps need the state root
   to themselves.
 - **Already had clawd running?** Start it again: `clawd run`, or
-  `launchctl load ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist` /
+  `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist` /
   `systemctl --user start swift-claw.service`.
 
 This route is unofficial and vendor-dependent; details and caveats in

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,223 @@
+# Install, update, or uninstall
+
+Everything about getting the `clawd` binary on and off a machine. For first-run
+configuration (bot token, secrets, allowlist), continue with
+[GETTING_STARTED.md](GETTING_STARTED.md).
+
+## 1. Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ivan-magda/swift-claw/main/install.sh | sh
+```
+
+Pin a release instead of latest:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ivan-magda/swift-claw/main/install.sh | CLAWD_VERSION=v0.2.0 sh
+```
+
+What the script does:
+
+- Checks the platform: macOS 15+ on Apple Silicon, or Linux x86_64 with glibc 2.38+
+  (anything else gets a build-from-source pointer, and the script installs nothing).
+- Downloads the release binary, `SHA256SUMS`, the config template, `run-clawd.sh`, and
+  the service unit for your platform.
+- Verifies every download against `SHA256SUMS`; when the GitHub CLI is installed and
+  logged in, it also verifies the build provenance attestation and aborts on mismatch.
+- Installs under `~/.swift-claw` — no sudo. Re-running upgrades in place and never
+  touches `clawd.env`, sealed secrets, or the database.
+- Puts `~/.swift-claw/bin` on your `PATH` by writing `~/.swift-claw/env` and sourcing it
+  from your shell rc files. Set `CLAWD_NO_MODIFY_PATH=1` to skip the rc edits.
+- Stages the launchd/systemd service unit without starting it — you configure first,
+  then start it yourself (section 4).
+
+Prefer not to pipe to sh? Download it first
+(`curl -fsSLO https://raw.githubusercontent.com/ivan-magda/swift-claw/main/install.sh`),
+read it, then run `sh install.sh` — or follow the manual install below.
+
+> **Version skew:** pinned releases before v0.2.0 lack seal auto-scrub (blank the secret
+> lines yourself after sealing), the doctor start hint, and the copy-pasteable
+> `CLAW_ALLOWLIST=` line in the `/start` refusal (older releases print your numeric ID in
+> prose — copy it by hand).
+
+## 2. Manual install
+
+From the [latest release](https://github.com/ivan-magda/swift-claw/releases/latest),
+download the binary for your platform (`clawd-macos-arm64` or `clawd-linux-x86_64`),
+`SHA256SUMS`, and `clawd.env.example`. Then verify and install from your download
+directory:
+
+```bash
+cd ~/Downloads
+ASSET=clawd-macos-arm64                             # Linux: clawd-linux-x86_64
+
+shasum -a 256 --ignore-missing -c SHA256SUMS &&     # Linux: sha256sum --ignore-missing -c SHA256SUMS
+  sudo install -m755 "$ASSET" /usr/local/bin/clawd
+```
+
+Every downloaded file must print `OK`; the `&&` stops the install if verification fails.
+On a Mac without Homebrew, create the install directory first:
+`sudo mkdir -p /usr/local/bin`.
+
+- **macOS:** browser downloads carry the quarantine flag (curl downloads do not), so
+  Gatekeeper blocks the unsigned binary until you clear it:
+  `sudo xattr -d com.apple.quarantine /usr/local/bin/clawd`.
+- **Linux:** the binary links the system SQLite (`sudo apt-get install -y libsqlite3-0`)
+  and needs glibc 2.38 or newer (e.g. Ubuntu 24.04+); on older systems build from source.
+
+Install the verified config template — your shell runs this file with `source`, so take
+it from the checksummed release rather than an unverified copy:
+
+```bash
+mkdir -p -m 700 ~/.swift-claw
+install -m 600 clawd.env.example ~/.swift-claw/clawd.env
+```
+
+Or build from source with a Swift 6.3 toolchain. On Linux, install the SQLite headers
+first (`sudo apt-get install -y libsqlite3-dev`); the runtime package alone will not link:
+
+```bash
+git clone https://github.com/ivan-magda/swift-claw.git && cd swift-claw
+swift build -c release
+sudo install -m755 .build/release/clawd /usr/local/bin/clawd
+```
+
+From a source checkout the config template is `.env.example` in the repository root, and
+the service files are under `deploy/`.
+
+## 3. Verify downloads (optional)
+
+`SHA256SUMS` lists the SHA-256 of every release asset; `--ignore-missing` checks only the
+files present in your directory, and each one must print `OK`. The install script runs
+this check for you — this section is for manual installs and extra assurance.
+
+Every binary also carries a build provenance attestation. With the
+[GitHub CLI](https://cli.github.com) installed and logged in (`gh auth login`):
+
+```bash
+gh attestation verify clawd-<platform> -R ivan-magda/swift-claw
+gh attestation verify SHA256SUMS -R ivan-magda/swift-claw    # v0.2.0+
+```
+
+A verified `SHA256SUMS` covers every asset transitively: any file that matches a checksum
+in an attested manifest came from the release workflow. Releases before v0.2.0 attest
+only the binaries.
+
+## 4. Running as a service
+
+Both units are **per-user**: they start when you log in, not at boot, and stop when you
+log out. Configure and seal first ([GETTING_STARTED.md](GETTING_STARTED.md)) — a healthy
+`clawd doctor` ends by printing the exact start command for your machine.
+
+### Script install (`~/.swift-claw` layout)
+
+The install script already staged the unit, pointed at `~/.swift-claw/bin`. Start it:
+
+```bash
+# macOS
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist
+
+# Linux
+systemctl --user enable --now swift-claw.service
+```
+
+### Manual install (`/usr/local/bin` layout)
+
+Download `run-clawd.sh` plus your platform's unit (`com.ivanmagda.swift-claw.plist` or
+`swift-claw.service`) from the same release and verify them against `SHA256SUMS` as in
+section 3. You install `run-clawd.sh` as root and your machine runs it at every login,
+which is reason enough not to take it from an unverified source.
+
+macOS:
+
+```bash
+sudo install -m755 run-clawd.sh /usr/local/bin/run-clawd.sh
+mkdir -p ~/Library/LaunchAgents && cp com.ivanmagda.swift-claw.plist ~/Library/LaunchAgents/
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist
+```
+
+Linux:
+
+```bash
+mkdir -p ~/.config/systemd/user && cp swift-claw.service ~/.config/systemd/user/
+systemctl --user enable --now swift-claw.service
+```
+
+### Staying on after logout
+
+- **Linux:** `sudo loginctl enable-linger $USER` lets the user manager run without a
+  session. Without it, a service installed over SSH stops when you disconnect and does
+  not come back after a reboot.
+- **macOS:** enable automatic login for the account; that keeps the LaunchAgent, which is
+  the simple path. A system LaunchDaemon in `/Library/LaunchDaemons` runs as root, where
+  `$HOME` is `/var/root`, so the wrapper looks for its config in the wrong place and
+  `clawd` exits 10 — if you go that route, pin the account and paths explicitly with
+  `UserName`, `CLAW_ENV_FILE`, and `CLAW_STATE_ROOT` in the plist.
+
+### Logs and exit codes
+
+- **macOS:** `/tmp/clawd.out.log` and `/tmp/clawd.err.log`.
+- **Linux:** `journalctl --user -u swift-claw -f`.
+
+A second `clawd` against the same state root refuses to boot (file lock), and a Telegram
+409 conflict is logged as critical. Exit codes are diagnostic:
+
+| Code | Meaning |
+|---|---|
+| 10 | invalid config |
+| 11 | secret loading failed |
+| 12 | another instance holds the state-root lock |
+| 13 | storage error |
+
+## 5. Updating
+
+**Script layout:** re-run the one-liner from section 1. It upgrades the binary and
+service unit in place, preserves `clawd.env`, sealed secrets, and the database, and
+restarts the service if it was running.
+
+**Manual layout:** re-download the binary and `SHA256SUMS` from the new release, re-verify
+as in section 2, `sudo install` over the old binary, and restart the service
+(`launchctl kickstart -k gui/$(id -u)/com.ivanmagda.swift-claw` on macOS,
+`systemctl --user restart swift-claw.service` on Linux).
+
+The two layouts do not mix: re-running the script on a manual install creates the
+`~/.swift-claw/bin` layout alongside `/usr/local/bin/clawd`. The script notices the old
+binary, prints that the new install supersedes it, and shows the removal command.
+
+## 6. Uninstall
+
+**Script layout** — remove the binary and service, keep config, secrets, and data:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ivan-magda/swift-claw/main/install.sh | sh -s -- --uninstall
+```
+
+Also delete `~/.swift-claw` (config, secrets, database):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ivan-magda/swift-claw/main/install.sh | sh -s -- --uninstall --purge
+```
+
+A plain `--uninstall` keeps `~/.swift-claw/env` because your shell rc files still source
+it. After `--purge`, remove the `. "$HOME/.swift-claw/env"` line from your shell rc files
+by hand, or shells will report a missing file at startup. The script never touches a
+custom `CLAW_STATE_ROOT` outside `~/.swift-claw` — delete that directory yourself.
+
+**Manual layout, macOS:**
+
+```bash
+launchctl bootout gui/$(id -u)/com.ivanmagda.swift-claw
+rm ~/Library/LaunchAgents/com.ivanmagda.swift-claw.plist
+sudo rm /usr/local/bin/clawd /usr/local/bin/run-clawd.sh
+rm -rf ~/.swift-claw
+```
+
+**Manual layout, Linux:**
+
+```bash
+systemctl --user disable --now swift-claw.service
+rm ~/.config/systemd/user/swift-claw.service
+sudo rm /usr/local/bin/clawd
+rm -rf ~/.swift-claw
+systemctl --user daemon-reload
+```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -27,7 +27,8 @@ What the script does:
 - Installs under `~/.swift-claw` — no sudo. Re-running upgrades in place and never
   touches `clawd.env`, sealed secrets, or the database.
 - Puts `~/.swift-claw/bin` on your `PATH` by writing `~/.swift-claw/env` and sourcing it
-  from your shell rc files. Set `CLAWD_NO_MODIFY_PATH=1` to skip the rc edits.
+  from your shell rc files. `CLAWD_NO_MODIFY_PATH=1` skips the shell-profile edits;
+  `~/.swift-claw/env` is still written.
 - Stages the launchd/systemd service unit without starting it — you configure first,
   then start it yourself (section 4).
 

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -267,16 +267,11 @@ set -a && source ~/.swift-claw/clawd.env && set +a
 .build/debug/clawd secrets seal
 ```
 
-Sealing does not edit `clawd.env`. Remove the secret lines yourself:
-
-```
-# delete or blank these after sealing:
-CLAW_TELEGRAM_BOT_TOKEN=...
-CLAW_LLM_API_KEY=...
-CLAW_SEARCH_API_KEY=...
-```
-
-Keep the non-secret config (`CLAW_LLM_BASE_URL`, `CLAW_LLM_MODEL`, etc.).
+Sealing also blanks the three secret lines (`CLAW_TELEGRAM_BOT_TOKEN`,
+`CLAW_LLM_API_KEY`, `CLAW_SEARCH_API_KEY`) in the env file and prints what it changed.
+`--no-scrub` leaves them in place; `--env-file <path>` targets a file other than
+`$CLAW_ENV_FILE` / `~/.swift-claw/clawd.env`. The non-secret config
+(`CLAW_LLM_BASE_URL`, `CLAW_LLM_MODEL`, etc.) is untouched.
 
 ### How the daemon picks up secrets
 

--- a/install.sh
+++ b/install.sh
@@ -105,19 +105,29 @@ download_and_verify() {
   (cd "$workdir" && sha256_check) \
     || die "checksum verification FAILED — aborting; nothing was installed"
   ATTESTED="attestation not checked (optional; install+login the GitHub CLI and run:
-    gh attestation verify $ASSET -R $REPO)"
+    gh attestation verify \"$BIN_DIR/clawd\" -R $REPO)"
   if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    # An unpinned install still resolves to one concrete tag: the first redirect of
+    # the latest-release URL carries it, so the >= v0.2.0 fail-closed rule below can
+    # apply to "latest" exactly as it does to a pin. Empty on failure = unresolvable.
+    effective_tag="${CLAWD_VERSION:-}"
+    if [ -z "$effective_tag" ]; then
+      effective_tag="$(curl --proto '=https' --tlsv1.2 -fsSI -o /dev/null \
+        -w '%{redirect_url}' \
+        "https://github.com/${REPO}/releases/latest/download/SHA256SUMS" 2>/dev/null \
+        | sed -n 's|.*/download/\(v[^/]*\)/.*|\1|p')" || effective_tag=""
+    fi
     # The manifest attestation covers every asset transitively; releases before
     # v0.2.0 attest only the binaries.
     gh attestation verify "$workdir/$ASSET" -R "$REPO" >/dev/null 2>&1 \
       || die "GitHub attestation verification FAILED for $ASSET — aborting"
     if gh attestation verify "$workdir/SHA256SUMS" -R "$REPO" >/dev/null 2>&1; then
       ATTESTED="binary + manifest attestation OK"
-    elif [ -n "${CLAWD_VERSION:-}" ] && [ "$(printf '%s\n' "v0.2.0" "$CLAWD_VERSION" \
+    elif [ -n "$effective_tag" ] && [ "$(printf '%s\n' "v0.2.0" "$effective_tag" \
       | sort -V | head -n1)" = "v0.2.0" ]; then
-      # Every release from v0.2.0 attests its manifest, so a pinned modern release
-      # with an unverifiable SHA256SUMS is not trustworthy.
-      die "manifest attestation verification FAILED for SHA256SUMS ($CLAWD_VERSION) — aborting"
+      # Every release from v0.2.0 attests its manifest, so a modern release with an
+      # unverifiable SHA256SUMS is not trustworthy.
+      die "manifest attestation verification FAILED for SHA256SUMS ($effective_tag) — aborting"
     else
       ATTESTED="binary attestation OK, manifest unattested — if the installed release is
     v0.2.0 or newer, do NOT trust it; verify manually:
@@ -151,7 +161,6 @@ install_files() {
 }
 
 setup_path() {
-  [ "${CLAWD_NO_MODIFY_PATH:-0}" = "1" ] && return 0
   cat > "$CLAW_HOME/env" <<'EOF'
 #!/bin/sh
 # Adds ~/.swift-claw/bin to PATH. Written by install.sh; safe to source repeatedly.
@@ -160,6 +169,8 @@ case ":${PATH}:" in
   *) export PATH="$HOME/.swift-claw/bin:$PATH" ;;
 esac
 EOF
+  # The opt-out skips only the rc-file edits; the env helper above always exists.
+  [ "${CLAWD_NO_MODIFY_PATH:-0}" = "1" ] && return 0
   sourced_somewhere=0
   for rcfile in "$HOME/.zshrc" "$HOME/.zprofile" "$HOME/.bashrc" "$HOME/.profile"; do
     [ -f "$rcfile" ] || continue
@@ -216,7 +227,9 @@ stage_service() {
       # %h is systemd's home specifier, valid in ExecStart.
       sed 's|/usr/local/bin/clawd|%h/.swift-claw/bin/clawd|' \
         "$workdir/$UNIT_ASSET" > "$UNIT_DEST"
-      if command -v systemctl >/dev/null 2>&1; then
+      # A systemctl binary alone proves nothing (WSL ships one without a running
+      # systemd); a live user manager leaves this directory, the same probe doctor uses.
+      if [ -d /run/systemd/system ]; then
         START_CMD="systemctl --user enable --now swift-claw.service"
         systemctl --user daemon-reload 2>/dev/null || true
         if systemctl --user is-active --quiet swift-claw.service 2>/dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -113,8 +113,15 @@ download_and_verify() {
       || die "GitHub attestation verification FAILED for $ASSET — aborting"
     if gh attestation verify "$workdir/SHA256SUMS" -R "$REPO" >/dev/null 2>&1; then
       ATTESTED="binary + manifest attestation OK"
+    elif [ -n "${CLAWD_VERSION:-}" ] && [ "$(printf '%s\n' "v0.2.0" "$CLAWD_VERSION" \
+      | sort -V | head -n1)" = "v0.2.0" ]; then
+      # Every release from v0.2.0 attests its manifest, so a pinned modern release
+      # with an unverifiable SHA256SUMS is not trustworthy.
+      die "manifest attestation verification FAILED for SHA256SUMS ($CLAWD_VERSION) — aborting"
     else
-      ATTESTED="binary attestation OK (manifest unattested — release before v0.2.0?)"
+      ATTESTED="binary attestation OK, manifest unattested — if the installed release is
+    v0.2.0 or newer, do NOT trust it; verify manually:
+    gh attestation verify SHA256SUMS -R $REPO"
     fi
   fi
 }

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,303 @@
+#!/bin/sh
+# swift-claw installer.
+#
+#   curl -fsSL https://raw.githubusercontent.com/ivan-magda/swift-claw/main/install.sh | sh
+#
+# Everything is installed under ~/.swift-claw — no sudo. Re-running upgrades in
+# place and never touches clawd.env, sealed secrets, or the database.
+#
+#   ... | CLAWD_VERSION=v0.2.0 sh       pin a release (default: latest)
+#   ... | CLAWD_NO_MODIFY_PATH=1 sh     skip shell-profile PATH edits
+#   ... | sh -s -- --uninstall          remove binary + service, keep config/data
+#   ... | sh -s -- --uninstall --purge  also delete ~/.swift-claw
+#
+# main() on the last line: a truncated download can never execute a partial script.
+set -eu
+
+REPO="ivan-magda/swift-claw"
+SERVICE_LABEL="com.ivanmagda.swift-claw"
+CLAW_HOME="${HOME}/.swift-claw"
+BIN_DIR="${CLAW_HOME}/bin"
+# The Linux binary is built in the swift:6.3-noble container and links its glibc.
+# Bump in lockstep with the builder image in .github/workflows/release.yml.
+GLIBC_FLOOR="2.38"
+
+say() { printf '%s\n' "$*"; }
+die() { printf 'install.sh: %s\n' "$*" >&2; exit 1; }
+
+fetch() {
+  # $1 url, $2 dest. TLS floor pinned; --retry rides out transient CDN failures.
+  curl --proto '=https' --tlsv1.2 -fsSL --retry 3 -o "$2" "$1" \
+    || die "download failed: $1"
+}
+
+sha256_check() {
+  # A function, not a command string: zsh would not word-split "shasum -a 256".
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 --ignore-missing -c SHA256SUMS >/dev/null
+  else
+    sha256sum --ignore-missing -c SHA256SUMS >/dev/null
+  fi
+}
+
+detect_platform() {
+  host_os="$(uname -s)"
+  host_arch="$(uname -m)"
+  case "$host_os" in
+    Darwin)
+      if [ "$host_arch" != "arm64" ] \
+        || [ "$(sysctl -n sysctl.proc_translated 2>/dev/null || echo 0)" = "1" ]; then
+        die "no release binary for Intel Macs (or Rosetta shells) — build from source:
+  https://github.com/${REPO}#install"
+      fi
+      macos_major="$(sw_vers -productVersion | cut -d. -f1)"
+      [ "$macos_major" -ge 15 ] \
+        || die "macOS 15 or newer required (found $(sw_vers -productVersion))"
+      ASSET="clawd-macos-arm64"
+      UNIT_ASSET="${SERVICE_LABEL}.plist"
+      ;;
+    Linux)
+      [ "$host_arch" = "x86_64" ] || die "no release binary for Linux/$host_arch — build from source:
+  https://github.com/${REPO}#install"
+      glibc_version="$(ldd --version 2>/dev/null | sed -n '1s/.* //p')"
+      if [ -n "$glibc_version" ] && [ "$(printf '%s\n' "$GLIBC_FLOOR" "$glibc_version" \
+        | sort -V | head -n1)" != "$GLIBC_FLOOR" ]; then
+        die "glibc $glibc_version is too old (the release binary needs >= $GLIBC_FLOOR,
+  e.g. Ubuntu 24.04+). Build from source instead: https://github.com/${REPO}#install"
+      fi
+      ASSET="clawd-linux-x86_64"
+      UNIT_ASSET="swift-claw.service"
+      ;;
+    *)
+      die "unsupported OS: $host_os (macOS arm64 and Linux x86_64 have release binaries)"
+      ;;
+  esac
+}
+
+preflight() {
+  command -v curl >/dev/null 2>&1 || die "curl is required"
+  command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1 \
+    || die "shasum or sha256sum is required"
+  if [ "$(uname -s)" = "Linux" ] && command -v ldconfig >/dev/null 2>&1 \
+    && ! ldconfig -p | grep -q 'libsqlite3\.so\.0'; then
+    die "libsqlite3 is missing. Install it first:
+  sudo apt-get install -y libsqlite3-0    # Debian/Ubuntu"
+  fi
+}
+
+release_url() {
+  # $1 asset name
+  if [ -n "${CLAWD_VERSION:-}" ]; then
+    printf 'https://github.com/%s/releases/download/%s/%s' "$REPO" "$CLAWD_VERSION" "$1"
+  else
+    printf 'https://github.com/%s/releases/latest/download/%s' "$REPO" "$1"
+  fi
+}
+
+download_and_verify() {
+  workdir="$(mktemp -d)"
+  trap 'rm -rf "$workdir"' EXIT
+  say "Downloading ${CLAWD_VERSION:-latest} release assets..."
+  for asset_name in "$ASSET" SHA256SUMS clawd.env.example run-clawd.sh "$UNIT_ASSET"; do
+    fetch "$(release_url "$asset_name")" "$workdir/$asset_name"
+  done
+  say "Verifying checksums..."
+  (cd "$workdir" && sha256_check) \
+    || die "checksum verification FAILED — aborting; nothing was installed"
+  ATTESTED="attestation not checked (optional; install+login the GitHub CLI and run:
+    gh attestation verify $ASSET -R $REPO)"
+  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    # The manifest attestation covers every asset transitively; releases before
+    # v0.2.0 attest only the binaries.
+    gh attestation verify "$workdir/$ASSET" -R "$REPO" >/dev/null 2>&1 \
+      || die "GitHub attestation verification FAILED for $ASSET — aborting"
+    if gh attestation verify "$workdir/SHA256SUMS" -R "$REPO" >/dev/null 2>&1; then
+      ATTESTED="binary + manifest attestation OK"
+    else
+      ATTESTED="binary attestation OK (manifest unattested — release before v0.2.0?)"
+    fi
+  fi
+}
+
+install_files() {
+  umask 077
+  mkdir -p "$BIN_DIR"
+  chmod 700 "$CLAW_HOME"
+  # Two-phase move: never leave a half-written binary at the final path.
+  install -m 755 "$workdir/$ASSET" "$BIN_DIR/.clawd.new"
+  mv -f "$BIN_DIR/.clawd.new" "$BIN_DIR/clawd"
+  INSTALLED_VERSION="$("$BIN_DIR/clawd" --version 2>/dev/null)" \
+    || die "the installed binary failed to run on this machine.
+  On Linux this usually means glibc is older than $GLIBC_FLOOR. Build from source:
+  https://github.com/${REPO}#install"
+  # run-clawd.sh defaults to /usr/local/bin/clawd; point the default here instead.
+  sed 's|/usr/local/bin/clawd|'"$BIN_DIR"'/clawd|' "$workdir/run-clawd.sh" \
+    > "$BIN_DIR/run-clawd.sh"
+  chmod 755 "$BIN_DIR/run-clawd.sh"
+  install -m 600 "$workdir/clawd.env.example" "$CLAW_HOME/clawd.env.example"
+  if [ ! -f "$CLAW_HOME/clawd.env" ]; then
+    install -m 600 "$workdir/clawd.env.example" "$CLAW_HOME/clawd.env"
+    ENV_CREATED=1
+  else
+    ENV_CREATED=0
+  fi
+}
+
+setup_path() {
+  [ "${CLAWD_NO_MODIFY_PATH:-0}" = "1" ] && return 0
+  cat > "$CLAW_HOME/env" <<'EOF'
+#!/bin/sh
+# Adds ~/.swift-claw/bin to PATH. Written by install.sh; safe to source repeatedly.
+case ":${PATH}:" in
+  *:"$HOME/.swift-claw/bin":*) ;;
+  *) export PATH="$HOME/.swift-claw/bin:$PATH" ;;
+esac
+EOF
+  sourced_somewhere=0
+  for rcfile in "$HOME/.zshrc" "$HOME/.zprofile" "$HOME/.bashrc" "$HOME/.profile"; do
+    [ -f "$rcfile" ] || continue
+    # shellcheck disable=SC2016  # literal $HOME: the rc line must expand at shell startup
+    grep -qs '\.swift-claw/env' "$rcfile" \
+      || printf '\n. "$HOME/.swift-claw/env"\n' >> "$rcfile"
+    sourced_somewhere=1
+  done
+  if [ "$sourced_somewhere" = "0" ]; then
+    # A fresh account may have no rc files at all; create the platform's login default.
+    case "$(uname -s)" in
+      Darwin) default_rc="$HOME/.zprofile" ;;
+      *) default_rc="$HOME/.profile" ;;
+    esac
+    # shellcheck disable=SC2016  # literal $HOME, as above
+    printf '\n. "$HOME/.swift-claw/env"\n' >> "$default_rc"
+  fi
+}
+
+stage_service() {
+  case "$(uname -s)" in
+    Darwin)
+      UNIT_DEST="$HOME/Library/LaunchAgents/${SERVICE_LABEL}.plist"
+      mkdir -p "$HOME/Library/LaunchAgents"
+      was_loaded=0
+      launchctl print "gui/$(id -u)/${SERVICE_LABEL}" >/dev/null 2>&1 && was_loaded=1
+      # The shipped plist points at /usr/local/bin; retarget it to this install.
+      sed 's|/usr/local/bin/run-clawd.sh|'"$BIN_DIR"'/run-clawd.sh|' \
+        "$workdir/$UNIT_ASSET" > "$UNIT_DEST"
+      START_CMD="launchctl bootstrap gui/$(id -u) $UNIT_DEST"
+      if [ "$was_loaded" = "1" ]; then
+        # A loaded agent runs launchd's cached definition; only bootout+bootstrap
+        # picks up the rewritten plist. bootout returns before the job finishes
+        # draining, so wait for the label to disappear before re-bootstrapping.
+        launchctl bootout "gui/$(id -u)/${SERVICE_LABEL}" 2>/dev/null || true
+        drain_wait=0
+        while launchctl print "gui/$(id -u)/${SERVICE_LABEL}" >/dev/null 2>&1; do
+          drain_wait=$((drain_wait + 1))
+          [ "$drain_wait" -ge 20 ] && break
+          sleep 1
+        done
+        if launchctl bootstrap "gui/$(id -u)" "$UNIT_DEST"; then
+          SERVICE_STATE="reloaded and restarted"
+        else
+          SERVICE_STATE="updated on disk; reload failed — start it manually: $START_CMD"
+        fi
+      else
+        SERVICE_STATE="staged (not started — configure first)"
+      fi
+      ;;
+    Linux)
+      UNIT_DEST="$HOME/.config/systemd/user/swift-claw.service"
+      mkdir -p "$HOME/.config/systemd/user"
+      # %h is systemd's home specifier, valid in ExecStart.
+      sed 's|/usr/local/bin/clawd|%h/.swift-claw/bin/clawd|' \
+        "$workdir/$UNIT_ASSET" > "$UNIT_DEST"
+      if command -v systemctl >/dev/null 2>&1; then
+        START_CMD="systemctl --user enable --now swift-claw.service"
+        systemctl --user daemon-reload 2>/dev/null || true
+        if systemctl --user is-active --quiet swift-claw.service 2>/dev/null; then
+          systemctl --user restart swift-claw.service
+          SERVICE_STATE="restarted"
+        else
+          SERVICE_STATE="staged (not started — configure first)"
+        fi
+      else
+        START_CMD="clawd run"
+        SERVICE_STATE="staged (no systemd detected; run the daemon with: clawd run)"
+      fi
+      ;;
+  esac
+}
+
+print_next_steps() {
+  say ""
+  say "clawd $INSTALLED_VERSION installed to $BIN_DIR (checksum OK, $ATTESTED)"
+  say "Service unit: $UNIT_DEST — $SERVICE_STATE"
+  if [ -x /usr/local/bin/clawd ]; then
+    say "Note: an older /usr/local/bin/clawd exists; this install supersedes it."
+    say "      Remove it with: sudo rm /usr/local/bin/clawd /usr/local/bin/run-clawd.sh"
+  fi
+  if [ "$ENV_CREATED" = "1" ]; then
+    say ""
+    say "Next steps (new shell first, or run: . \"\$HOME/.swift-claw/env\"):"
+    say "  1. Get a bot token from @BotFather (https://t.me/BotFather, send /newbot)"
+    say "  2. Edit ~/.swift-claw/clawd.env — set the token and your LLM provider"
+    say "  3. Load it and seal the secrets:"
+    say "       set -a && . ~/.swift-claw/clawd.env && set +a && clawd secrets seal"
+    say "  4. Say hello once in the foreground: clawd run"
+    say "     (send /start to your bot — the refusal shows your numeric ID; set it as"
+    say "      CLAW_ALLOWLIST=<id> in clawd.env, then Ctrl-C)"
+    say "  5. Re-source the env file, check health, and start the service:"
+    say "       clawd doctor && $START_CMD"
+    say ""
+    say "Full guide: https://github.com/${REPO}/blob/main/docs/GETTING_STARTED.md"
+  else
+    say "Existing config kept: $CLAW_HOME/clawd.env"
+  fi
+}
+
+uninstall() {
+  purge_data="$1"
+  case "$(uname -s)" in
+    Darwin)
+      launchctl bootout "gui/$(id -u)/${SERVICE_LABEL}" 2>/dev/null || true
+      rm -f "$HOME/Library/LaunchAgents/${SERVICE_LABEL}.plist"
+      ;;
+    Linux)
+      systemctl --user disable --now swift-claw.service 2>/dev/null || true
+      rm -f "$HOME/.config/systemd/user/swift-claw.service"
+      systemctl --user daemon-reload 2>/dev/null || true
+      ;;
+  esac
+  # $CLAW_HOME/env stays on plain uninstall: rc lines still source it, and a missing
+  # file would error on every shell startup (rustup keeps its env file for the same reason).
+  rm -rf "$BIN_DIR" "$CLAW_HOME/clawd.env.example"
+  if [ "$purge_data" = "1" ]; then
+    rm -rf "$CLAW_HOME"
+    say "Removed $CLAW_HOME."
+    if [ -n "${CLAW_STATE_ROOT:-}" ] && [ "$CLAW_STATE_ROOT" != "$CLAW_HOME" ]; then
+      say "Note: your custom CLAW_STATE_ROOT at $CLAW_STATE_ROOT was NOT touched."
+    fi
+    say "Your shell profile may still source \$HOME/.swift-claw/env — remove that line"
+    say "by hand, or shells will report a missing file at startup."
+  else
+    say "Removed the binary and service. Config, secrets, and data remain in $CLAW_HOME"
+    say "(delete them with: rm -rf $CLAW_HOME)"
+  fi
+}
+
+main() {
+  if [ "${1:-}" = "--uninstall" ]; then
+    purge_flag=0
+    [ "${2:-}" = "--purge" ] && purge_flag=1
+    uninstall "$purge_flag"
+    exit 0
+  fi
+  [ -z "${1:-}" ] || die "unknown argument: $1 (supported: --uninstall [--purge])"
+  detect_platform
+  preflight
+  download_and_verify
+  install_files
+  setup_path
+  stage_service
+  print_next_steps
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -140,13 +140,17 @@ install_files() {
   umask 077
   mkdir -p "$BIN_DIR"
   chmod 700 "$CLAW_HOME"
-  # Two-phase move: never leave a half-written binary at the final path.
+  # Two-phase move: smoke-test the candidate first, so a binary that cannot run
+  # here never replaces a working install and no half-written file lands at the
+  # final path.
   install -m 755 "$workdir/$ASSET" "$BIN_DIR/.clawd.new"
-  mv -f "$BIN_DIR/.clawd.new" "$BIN_DIR/clawd"
-  INSTALLED_VERSION="$("$BIN_DIR/clawd" --version 2>/dev/null)" \
-    || die "the installed binary failed to run on this machine.
+  if ! INSTALLED_VERSION="$("$BIN_DIR/.clawd.new" --version 2>/dev/null)"; then
+    rm -f "$BIN_DIR/.clawd.new"
+    die "the installed binary failed to run on this machine.
   On Linux this usually means glibc is older than $GLIBC_FLOOR. Build from source:
   https://github.com/${REPO}#install"
+  fi
+  mv -f "$BIN_DIR/.clawd.new" "$BIN_DIR/clawd"
   # run-clawd.sh defaults to /usr/local/bin/clawd; point the default here instead.
   sed 's|/usr/local/bin/clawd|'"$BIN_DIR"'/clawd|' "$workdir/run-clawd.sh" \
     > "$BIN_DIR/run-clawd.sh"
@@ -172,7 +176,8 @@ EOF
   # The opt-out skips only the rc-file edits; the env helper above always exists.
   [ "${CLAWD_NO_MODIFY_PATH:-0}" = "1" ] && return 0
   sourced_somewhere=0
-  for rcfile in "$HOME/.zshrc" "$HOME/.zprofile" "$HOME/.bashrc" "$HOME/.profile"; do
+  for rcfile in "$HOME/.zshrc" "$HOME/.zprofile" "$HOME/.bashrc" "$HOME/.bash_profile" \
+    "$HOME/.profile"; do
     [ -f "$rcfile" ] || continue
     # shellcheck disable=SC2016  # literal $HOME: the rc line must expand at shell startup
     grep -qs '\.swift-claw/env' "$rcfile" \
@@ -264,8 +269,8 @@ print_next_steps() {
     say "  4. Say hello once in the foreground: clawd run"
     say "     (send /start to your bot — the refusal shows your numeric ID; set it as"
     say "      CLAW_ALLOWLIST=<id> in clawd.env, then Ctrl-C)"
-    say "  5. Re-source the env file, check health, and start the service:"
-    say "       clawd doctor && $START_CMD"
+    say "  5. Check health and start the service:"
+    say "       set -a && . ~/.swift-claw/clawd.env && set +a && clawd doctor && $START_CMD"
     say ""
     say "Full guide: https://github.com/${REPO}/blob/main/docs/GETTING_STARTED.md"
   else


### PR DESCRIPTION
## What this changes

Installing clawd used to take a dozen manual steps across two docs pages: click through Releases, verify checksums by hand, sudo install, clear quarantine, copy and edit the template, seal, delete plaintext lines, then fetch service units from a page the README never mentions. This PR replaces that with one command:

```bash
curl -fsSL https://raw.githubusercontent.com/ivan-magda/swift-claw/main/install.sh | sh
```

**install.sh** installs everything under `~/.swift-claw` with no sudo. It detects the platform (with a clear refusal on Intel Macs and pre-2.38 glibc), downloads the release assets, verifies each one against `SHA256SUMS` inside the script, runs `gh attestation verify` when the GitHub CLI is available, retargets and stages the launchd/systemd units without starting an unconfigured daemon, sets up PATH through `~/.swift-claw/env`, and prints five next steps that end at `clawd doctor`. Re-running it upgrades in place and leaves config, secrets, and the database alone. `sh -s -- --uninstall` removes the binary and service; `--purge` removes data too. The curl path also removes the `xattr` step entirely: quarantine flags come from browsers, not curl.

**Three first-run fixes in the binary:**
- `clawd secrets seal` now blanks the plaintext secret lines in the env file after sealing (atomic write, mode preserved, `--no-scrub` and `--env-file` to override). Hand-deleting lines from a working config was the most error-prone step in the old flow.
- The `/start` refusal ends with a pasteable `CLAW_ALLOWLIST=<id>` line.
- A healthy full `clawd doctor` ends by printing the exact service-start command for the platform, including an "start the daemon, then send /start" variant when only the empty allowlist blocks it.

**Docs:** new `docs/INSTALL.md` covers the whole lifecycle (install, manual install, verification, service, update, uninstall) on one page. The README install section shrinks to the one-liner plus links. GETTING_STARTED trims to first-run configuration. deploy/README points at INSTALL.md. LOCAL_DEV, CUSTOMIZATION, and `.env.example` updated in lockstep.

**Release/CI:** the publish job now attests `SHA256SUMS` itself, so the units and env template the installer executes are covered transitively; install.sh ships as a checksummed release asset; new shellcheck and installer end-to-end CI jobs (ubuntu + macos, real release assets).

## Notes for review

- `.env.example` now ships `# CLAW_STATE_ROOT=` commented out. Sourcing the template under `set -a` exported the empty value and clobbered any externally set override, which redirected a rehearsal seal at the real state root during testing. Blank and unset behave identically in `StateRootResolver`, so default users see no change.
- The installer fails closed when a pinned v0.2.0+ release lacks a manifest attestation; older pins and `latest` get an instruction to verify manually rather than a reassurance.
- `launchctl kickstart -k` in INSTALL.md §5 (manual-layout update) is verified by reasoning, not execution: no manual-layout service existed to run it against.

## Verification

Full test suite: 2191 tests in 282 suites, green. Lint gate clean, shellcheck clean on both scripts. The complete documented flow (install pinned v0.1.1 → configure → seal → doctor → update → uninstall → purge) was rehearsed in an isolated environment against the live release and matched the docs as written with zero corrections needed. TDD evidence (red/green) exists for all three Swift changes.

## After merging

Tag the release: the docs on main describe v0.2.0 behavior, so `git tag v0.2.0 && git push origin v0.2.0` should follow the merge without much delay. The release workflow builds, attests both binaries plus the manifest, and publishes all nine assets.