### PR TITLE
Remove legacy budget section DTO

### DIFF
--- a/Sources/ClawAgent/Context/BudgetFitter.swift
+++ b/Sources/ClawAgent/Context/BudgetFitter.swift
@@ -70,17 +70,6 @@ public struct FittedSection: Sendable, Equatable, Identifiable {
     renderUnits(units)
   }
 
-  public var section: Section {
-    Section(
-      id: id,
-      tier: tier,
-      priority: priority,
-      truncatable: truncatable,
-      cap: cap,
-      content: content
-    )
-  }
-
   fileprivate init(source: FittableSection, units: [SectionUnit], droppedUnitIDs: [String] = []) {
     self.id = source.id
     self.tier = source.tier
@@ -99,13 +88,6 @@ public enum BudgetFitterError: Error, Equatable {
 public enum BudgetFitter {
   public static let truncationMarker = TextTruncation.marker
   public static let dropMarkerUnitID = "drop-marker"
-
-  public static func fit(
-    _ sections: [FittableSection],
-    budget: ContextBudget
-  ) throws -> [Section] {
-    try fitWithUnits(sections, budget: budget).map(\.section)
-  }
 
   public static func fitWithUnits(
     _ sections: [FittableSection],

--- a/Sources/ClawCore/Domain/Context/ContextContracts.swift
+++ b/Sources/ClawCore/Domain/Context/ContextContracts.swift
@@ -45,31 +45,6 @@ public struct ContextPriority: Sendable, Equatable, Comparable, Hashable {
   }
 }
 
-public struct Section: Sendable, Equatable, Identifiable {
-  public let id: ContextRowID
-  public let tier: ContextTier
-  public let priority: ContextPriority
-  public let truncatable: Bool
-  public let cap: Int?
-  public let content: String
-
-  public init(
-    id: ContextRowID,
-    tier: ContextTier,
-    priority: ContextPriority,
-    truncatable: Bool,
-    cap: Int?,
-    content: String
-  ) {
-    self.id = id
-    self.tier = tier
-    self.priority = priority
-    self.truncatable = truncatable
-    self.cap = cap
-    self.content = content
-  }
-}
-
 public struct ContextBudget: Sendable, Equatable {
   public let inputCapGraphemes: Int
   public let userFileCap: Int

--- a/Tests/ClawAgentTests/Context/BudgetFitterTests.swift
+++ b/Tests/ClawAgentTests/Context/BudgetFitterTests.swift
@@ -13,7 +13,7 @@ import Testing
     let budget = testBudget(inputCap: 7)
 
     // when
-    let fitted = try BudgetFitter.fit(sections, budget: budget)
+    let fitted = try BudgetFitter.fitWithUnits(sections, budget: budget)
 
     // then
     #expect(fitted.map(\.id) == [.policy])
@@ -30,7 +30,7 @@ import Testing
 
     // when / then
     #expect(throws: BudgetFitterError.nonTruncatableRowsExceedInputCap(required: 11, cap: 5)) {
-      try BudgetFitter.fit(sections, budget: budget)
+      try BudgetFitter.fitWithUnits(sections, budget: budget)
     }
   }
 
@@ -44,7 +44,7 @@ import Testing
     let budget = testBudget(inputCap: 50)
 
     // when
-    let fitted = try BudgetFitter.fit(sections, budget: budget)
+    let fitted = try BudgetFitter.fitWithUnits(sections, budget: budget)
 
     // then
     #expect(fitted.map(\.id) == [.policy, .memoryItems, .history])
@@ -64,7 +64,7 @@ import Testing
     let budget = testBudget(inputCap: 32)
 
     // when
-    let fitted = try BudgetFitter.fit(sections, budget: budget)
+    let fitted = try BudgetFitter.fitWithUnits(sections, budget: budget)
 
     // then
     #expect(fitted.map(\.id) == [.policy, .memoryItems, .history, .recall])
@@ -108,7 +108,7 @@ import Testing
     ]
 
     // when
-    let fitted = try BudgetFitter.fit(sections, budget: budget)
+    let fitted = try BudgetFitter.fitWithUnits(sections, budget: budget)
 
     // then
     #expect(fitted.map(\.id) == [.memoryItems, .history, .recall, .skills])
@@ -132,7 +132,7 @@ import Testing
     let budget = testBudget(inputCap: 9)
 
     // when
-    let fitted = try BudgetFitter.fit(sections, budget: budget)
+    let fitted = try BudgetFitter.fitWithUnits(sections, budget: budget)
 
     // then
     #expect(fitted.map(\.id) == [.memoryItems])
@@ -173,7 +173,7 @@ import Testing
     #expect(history.content == "newest")
   }
 
-  @Test func existingFitStillReturnsSectionsWithSameContent() throws {
+  @Test func fittedSectionsPreserveUnitIdentityAndRowMetadata() throws {
     // given
     let section = FittableSection(
       id: .memoryItems,
@@ -198,21 +198,18 @@ import Testing
     )
 
     // when
-    let sections = try BudgetFitter.fit([section], budget: budget)
+    let fitted = try BudgetFitter.fitWithUnits([section], budget: budget)
 
     // then
-    #expect(
-      sections == [
-        Section(
-          id: .memoryItems,
-          tier: .untrustedLabeled,
-          priority: ContextPriority(60),
-          truncatable: true,
-          cap: 20,
-          content: "alpha\nbravo"
-        )
-      ]
-    )
+    let memoryItems = try #require(fitted.first)
+    #expect(memoryItems.id == .memoryItems)
+    #expect(memoryItems.tier == .untrustedLabeled)
+    #expect(memoryItems.priority == ContextPriority(60))
+    #expect(memoryItems.truncatable)
+    #expect(memoryItems.cap == 20)
+    #expect(memoryItems.content == "alpha\nbravo")
+    #expect(memoryItems.units == section.units)
+    #expect(memoryItems.droppedUnitIDs.isEmpty)
   }
 
   @Test func truncatesUnitWithMarkerWhenUnitAllowsCharacterTruncation() throws {
@@ -230,7 +227,7 @@ import Testing
     let budget = testBudget(inputCap: 13)
 
     // when
-    let fitted = try BudgetFitter.fit(sections, budget: budget)
+    let fitted = try BudgetFitter.fitWithUnits(sections, budget: budget)
 
     // then
     #expect(fitted.first?.content == "a…[truncated]")


### PR DESCRIPTION
## What

`BudgetFitter` now exposes `fitWithUnits` as its sole fitting API. The update removes `Section` and the `FittedSection.section` conversion. Tests inspect fitted content, retained units, and dropped IDs through the production result.

## Why

`ContextBuilder` consumes `FittedSection`, and no production caller used the lossy `Section` form. Keeping both APIs duplicated row metadata and made tests cover an unused adapter.

## Impact

Callers retain unit identities and dropped-unit IDs in one result type. Budget ordering, caps, truncation, and drop-marker behavior stay unchanged.

## Checks

- `timeout 180 swift test --skip-build --filter BudgetFitterTests`
- `timeout 240 swift test --skip-build --filter ContextBuilderTests`
- `timeout -k 10 300 swift test --skip-build` (2,670 tests passed)
- `scripts/lint.sh --fix`
- `scripts/lint.sh`

Closes #88