### PR TITLE
build(deps): migrate to swift-subprocess 1.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4d333cace57af3566de647f80e4a666d249647d2a3c32d3fd25eeb0dc7ee1c5d",
+  "originHash" : "6a2f9344279dc8ce24e3d6d69cb9c5fe9dcb4f48ab7bb9c02ca5c8650b3a924f",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-subprocess.git",
       "state" : {
-        "revision" : "11633673a41f509f8945f23c96c7acd4adafd679",
-        "version" : "0.5.0"
+        "revision" : "b3937ab85dd32f6e9435914599c1519074769c1a",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-log.git", from: "1.14.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
     .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.11.0"),
-    .package(url: "https://github.com/swiftlang/swift-subprocess.git", exact: "0.5.0"),
+    .package(url: "https://github.com/swiftlang/swift-subprocess.git", exact: "1.0.0"),
     .package(url: "https://github.com/apple/swift-system.git", from: "1.7.4"),
   ],
   targets: [

--- a/Sources/ClawExec/ContainerCommandRunning.swift
+++ b/Sources/ClawExec/ContainerCommandRunning.swift
@@ -153,11 +153,11 @@ public struct SwiftSubprocessContainerCommandRunner: ContainerCommandRunning {
 
       return ContainerCommandResult(
         termination: Self.classifyTermination(
-          timedOut: result.closureOutput.timedOut,
+          timedOut: result.closureResult.timedOut,
           status: result.terminationStatus
         ),
-        stdout: result.closureOutput.stdout,
-        stderr: result.closureOutput.stderr,
+        stdout: result.closureResult.stdout,
+        stderr: result.closureResult.stderr,
         processIdentifier: Int32(result.processIdentifier.value),
         wallClock: started.duration(to: clock.now)
       )

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -752,7 +752,7 @@ A **state machine** persisted in `approvals` so it survives restart. See §7.1 c
   failed host, version, digest, capability, network, resource, reaper, rootfs, staging, or
   interpreter assertion keeps `execute_code` out of the registry. `shutdown()` cancels the
   execution chain and reaps again.
-- **swift-subprocess is only a launcher.** It provides no isolation. Pin exact release 0.5.0, use
+- **swift-subprocess is only a launcher.** It provides no isolation. Pin exact release 1.0.0, use
   streaming capture and an explicit teardown sequence, and keep the hardware VM as the boundary.
 - `sandbox-exec`/Seatbelt may wrap the launcher only as optional defense-in-depth; it is never the
   isolation boundary.


### PR DESCRIPTION
Bumps swift-subprocess from 0.5.0 to 1.0.0, replacing #106.

## The break

Dependabot's bump failed CI on one renamed member: `ExecutionResult.closureOutput` is now `closureResult`. That accounts for all three compiler errors, in `Sources/ClawExec/ContainerCommandRunning.swift`.

Nothing else moved. `Subprocess.run`'s closure overload, `Executable.path(FilePath)`, `Arguments([String])`, `Environment.inherit.updating`, `PlatformOptions.createSession`/`teardownSequence`, `TeardownStep.gracefulShutDown`, `Execution.teardown(using:)`, `SubprocessOutputSequence`, and the two-case `TerminationStatus` all carried over unchanged. `SwiftSubprocessContainerCommandRunner` is the only type in the repo that imports `Subprocess`, so the rest of the code and the tests sit behind the `ContainerCommandRunning` seam and needed no edits.

## Why this is worth more than a version bump

1.0.0 fixes the atexit deadlock that hung every real-sandbox test run at process exit.

In 0.5.0 the `WorkQueue` wait predicate checked only `queue.isEmpty`. A worker parked in `dequeue()` therefore slept through `shutdown()`'s `pthread_cond_signal`, and the `atexit` handler's `pthread_join` waited on it forever. 1.0.0 widens the predicate to `queue.isEmpty && !isShuttingDown` and sets that flag before signalling, so the worker wakes, `dequeue()` returns nil, and the join returns.

`clawd` links the same library, so SIGTERM arriving during subprocess activity could stall daemon shutdown the same way.

## Verification

- `swift build` clean.
- `swift test`: 2677 tests across 332 suites pass, exit 0.
- `scripts/lint.sh`: ok. The SwiftLint warnings it prints predate this branch.
- `CLAW_REAL_SANDBOX_TESTS=1 swift test --filter ContainerBackendRealAcceptanceTests` now returns exit 1 after 29s against a 600s ceiling, and leaves no orphaned `swiftpm-testing-helper`. On 0.5.0 that run hit the ceiling and returned 124 no matter how the tests went.

That suite reports 14 issues, all of them `could not pull sandbox images`. The `container` CLI 1.1.0 on the machine I ran this from cannot find its images plugin, which is a local install problem rather than anything in this diff. The suite is gated out of CI.

## On replacing #106

Dependabot branched from `8ebd4df`, which predates a06d480. Its diff therefore also rolls `actions/attest` back from v4.2.2 to v4.2.1 across all three release jobs. This branch starts from current `main` and carries the dependency bump alone.

Closes #106.
