### PR TITLE
Strengthen behavioral test coverage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -107,7 +107,13 @@ let package = Package(
       ]
     ),
     .target(name: "ClawAuth", dependencies: ["ClawCore"]),
-    .target(name: "ClawTestSupport", dependencies: ["ClawCore", "ClawTools"]),
+    .target(
+      name: "ClawTestSupport",
+      dependencies: [
+        "ClawCore", "ClawTools",
+        .product(name: "Logging", package: "swift-log"),
+      ]
+    ),
     .target(
       name: "ClawGateway",
       dependencies: [

--- a/Sources/ClawExec/Backend/ContainerBackend+Execution.swift
+++ b/Sources/ClawExec/Backend/ContainerBackend+Execution.swift
@@ -24,6 +24,7 @@ extension ContainerBackend {
     }
     executionTasks[taskIdentifier] = work
     executionTail = work
+    executionAdmitted()
 
     let result = await withTaskCancellationHandler {
       await work.value

--- a/Sources/ClawExec/Backend/ContainerBackend.swift
+++ b/Sources/ClawExec/Backend/ContainerBackend.swift
@@ -22,6 +22,7 @@ public actor ContainerBackend {
   let sanitizeReason: @Sendable (String) -> String
   let now: @Sendable () -> ContinuousClock.Instant
   let supportedHost: @Sendable () -> Bool
+  let executionAdmitted: @Sendable () -> Void
   // Drives the host-watchdog deadline sleeps; injectable so tests can fire a watchdog
   // without waiting out a real per-command allowance.
   let watchdogSleep: @Sendable (Duration) async throws -> Void
@@ -47,7 +48,8 @@ public actor ContainerBackend {
       commands: commands,
       sanitizeReason: sanitizeReason,
       now: now,
-      supportedHost: Self.defaultSupportedHost
+      supportedHost: Self.defaultSupportedHost,
+      executionAdmitted: {}
     )
   }
 
@@ -58,6 +60,7 @@ public actor ContainerBackend {
     sanitizeReason: @escaping @Sendable (String) -> String,
     now: @escaping @Sendable () -> ContinuousClock.Instant,
     supportedHost: @escaping @Sendable () -> Bool,
+    executionAdmitted: @escaping @Sendable () -> Void = {},
     watchdogSleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
       try await Task.sleep(for: duration)
     }
@@ -69,6 +72,7 @@ public actor ContainerBackend {
     self.sanitizeReason = sanitizeReason
     self.now = now
     self.supportedHost = supportedHost
+    self.executionAdmitted = executionAdmitted
     self.watchdogSleep = watchdogSleep
 
     self.sensitiveHostPaths = [
@@ -159,16 +163,6 @@ public actor ContainerBackend {
 
   func setPreparedInitImageForTesting(_ image: String?) {
     preparedInitImage = image
-  }
-
-  var queuedExecutionCountForTesting: Int {
-    executionTasks.count
-  }
-
-  func runSerializedForTesting(
-    operation: @escaping @Sendable () async -> ExecutionResult
-  ) async -> ExecutionResult {
-    await enqueueExecution(operation: operation)
   }
 }
 

--- a/Sources/ClawGateway/Services/TelegramPollerService.swift
+++ b/Sources/ClawGateway/Services/TelegramPollerService.swift
@@ -14,6 +14,7 @@ public struct TelegramPollerService: Service {
   private let pollTimeout: Int
 
   private let logger: Logger
+  private let clock: any Clock<Duration>
 
   /// Re-sent on every call: omitting it would reuse the previous server-side setting. Approval
   /// inline buttons are delivered as `callback_query`, so it joins direct messages and edits — the
@@ -33,7 +34,8 @@ public struct TelegramPollerService: Service {
     router: MessageRouter,
     cursor: any UpdateCursorStore,
     pollTimeout: Int,
-    logger: Logger
+    logger: Logger,
+    clock: any Clock<Duration> = ContinuousClock()
   ) {
     self.intake = intake
     self.router = router
@@ -43,6 +45,7 @@ public struct TelegramPollerService: Service {
     self.pollTimeout = pollTimeout
 
     self.logger = logger
+    self.clock = clock
   }
 
   public func run() async throws {
@@ -66,7 +69,7 @@ public struct TelegramPollerService: Service {
               logger.warning(
                 "transient failure on update \(rawUpdate.updateId); re-polling, not advancing"
               )
-              try? await Task.sleep(for: Backoff.transientFailure)
+              try? await clock.sleep(for: Backoff.transientFailure)
               break batch
             case .storageFull:
               // Disk full: the user already got the notice. Back off long and don't advance, so we
@@ -74,7 +77,7 @@ public struct TelegramPollerService: Service {
               logger.error(
                 "storage full on update \(rawUpdate.updateId); backing off, not advancing"
               )
-              try? await Task.sleep(for: Backoff.storageFull)
+              try? await clock.sleep(for: Backoff.storageFull)
               break batch
             }
           }
@@ -84,7 +87,7 @@ public struct TelegramPollerService: Service {
           try await react(to: error)
         } catch {
           logger.error("poll loop error: \(error)")
-          try? await Task.sleep(for: Backoff.otherError)
+          try? await clock.sleep(for: Backoff.otherError)
         }
       }
     }
@@ -96,13 +99,13 @@ public struct TelegramPollerService: Service {
     case .conflict409(let description):
       // The single-instance flock should prevent this locally; loud + bounded back-off otherwise.
       logger.critical("409 Conflict — another getUpdates consumer is active: \(description)")
-      try? await Task.sleep(for: Backoff.conflict)
+      try? await clock.sleep(for: Backoff.conflict)
     case .floodControl(let retryAfter):
       logger.warning("429 flood control; backing off \(retryAfter)s")
-      try? await Task.sleep(for: .seconds(retryAfter))
+      try? await clock.sleep(for: .seconds(retryAfter))
     case .apiError, .transport, .decoding:
       logger.error("telegram error: \(error)")
-      try? await Task.sleep(for: Backoff.otherError)
+      try? await clock.sleep(for: Backoff.otherError)
     }
   }
 }

--- a/Sources/ClawTestSupport/RecordingLogCapture.swift
+++ b/Sources/ClawTestSupport/RecordingLogCapture.swift
@@ -1,0 +1,54 @@
+import Logging
+import Synchronization
+
+/// A thread-safe swift-log sink for tests whose observable contract includes a developer log.
+public final class RecordingLogCapture: Sendable {
+  public struct Entry: Sendable {
+    public let level: Logger.Level
+    public let message: String
+    public let metadata: Logger.Metadata
+  }
+
+  private let storage = Mutex<[Entry]>([])
+
+  public init() {}
+
+  public var entries: [Entry] {
+    storage.withLock { current in
+      current
+    }
+  }
+
+  public func logger(label: String = "test.recording") -> Logger {
+    Logger(label: label) { _ in
+      RecordingLogHandler(capture: self)
+    }
+  }
+
+  fileprivate func append(_ event: LogEvent) {
+    storage.withLock { current in
+      current.append(
+        Entry(
+          level: event.level,
+          message: event.message.description,
+          metadata: event.metadata ?? [:]
+        )
+      )
+    }
+  }
+}
+
+private struct RecordingLogHandler: LogHandler {
+  let capture: RecordingLogCapture
+  var logLevel: Logger.Level = .trace
+  var metadata: Logger.Metadata = [:]
+
+  subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+    get { metadata[key] }
+    set { metadata[key] = newValue }
+  }
+
+  func log(event: LogEvent) {
+    capture.append(event)
+  }
+}

--- a/Sources/ClawTestSupport/ScriptedHTTPExecutor.swift
+++ b/Sources/ClawTestSupport/ScriptedHTTPExecutor.swift
@@ -12,11 +12,10 @@ public struct ScriptedTransportFailure: Error, CustomStringConvertible, Sendable
   public var description: String { message }
 }
 
-/// Parks a scripted stream's body producer inside the exchange: `started` opens on entry (so a test
-/// knows the consumer is live inside the transfer), and the producer then waits on `release` before
-/// it may send. Ignoring cancellation is deliberate — a held producer must outlive a cancel, which is
-/// what a shutdown-grace test is there to observe. Always pair it with a `defer { release.open() }`
-/// so teardown cannot strand the producer.
+/// Parks a scripted stream's body producer at a chosen boundary inside the exchange: `started` opens
+/// on entry, and the producer then waits on `release`. Ignoring cancellation is deliberate — a held
+/// producer must outlive a cancel, which is what shutdown and abandonment tests observe. Always pair
+/// it with a `defer { release.open() }` so teardown cannot strand the producer.
 public struct ScriptedStreamHold: Sendable {
   public let started: AsyncGate
   public let release: AsyncGate
@@ -53,6 +52,9 @@ public actor ScriptedHTTPExecutor: HTTPExecuting, HTTPStreaming {
     /// Chunks the producer may not send until the hold is released, so a test can keep a stream open
     /// and watch what its consumer does meanwhile.
     case blockedStream(HTTPStreamHead, [Data], ScriptedStreamHold)
+    /// Sends the chunks, then keeps the transfer open until released. A consumer can receive a real
+    /// event and abandon the stream while its producer is provably still live.
+    case streamThenBlock(HTTPStreamHead, [Data], ScriptedStreamHold)
   }
 
   public struct Recorded: Sendable {
@@ -87,7 +89,7 @@ public actor ScriptedHTTPExecutor: HTTPExecuting, HTTPStreaming {
     case .ok(let result): return result
     case .fail(let error): throw error
     case .transportFailure(let failure): throw failure
-    case .stream, .streamFailure, .respondingStream, .blockedStream:
+    case .stream, .streamFailure, .respondingStream, .blockedStream, .streamThenBlock:
       throw ScriptedTransportFailure(message: "expected buffered step, got streaming step")
     }
   }
@@ -107,7 +109,25 @@ public actor ScriptedHTTPExecutor: HTTPExecuting, HTTPStreaming {
         safeMessage: "scripted executor exhausted"
       )
     }
-    switch steps.removeFirst() {
+    return try Self.exchange(
+      for: steps.removeFirst(),
+      request: request,
+      maximumUnreadBytes: maximumUnreadBytes,
+      errorBytes: errorBytes
+    )
+  }
+}
+
+// MARK: - Streaming steps
+
+private extension ScriptedHTTPExecutor {
+  static func exchange(
+    for step: Step,
+    request: HTTPRequest,
+    maximumUnreadBytes: Int,
+    errorBytes: Int
+  ) throws -> HTTPStreamExchange {
+    switch step {
     case .transportFailure(let failure):
       throw failure
     case .stream(let head, let chunks):
@@ -142,7 +162,15 @@ public actor ScriptedHTTPExecutor: HTTPExecuting, HTTPStreaming {
         chunks: chunks,
         unread: maximumUnreadBytes,
         error: errorBytes,
-        hold: hold
+        leadingHold: hold
+      )
+    case .streamThenBlock(let head, let chunks, let hold):
+      return Self.exchange(
+        head: head,
+        chunks: chunks,
+        unread: maximumUnreadBytes,
+        error: errorBytes,
+        trailingHold: hold
       )
     case .ok, .fail:
       throw HTTPTransportFailure(
@@ -201,16 +229,18 @@ private extension ScriptedHTTPExecutor {
     unread: Int,
     error: Int,
     failure: HTTPTransportFailure? = nil,
-    hold: ScriptedStreamHold? = nil
+    leadingHold: ScriptedStreamHold? = nil,
+    trailingHold: ScriptedStreamHold? = nil
   ) -> HTTPStreamExchange {
     HTTPStreamExchange.make(
       head: head,
       maximumUnreadBodyBytes: HTTPResponseBodyPolicy.isSuccess(head.statusCode) ? unread : error
     ) { sink in
-      if let hold {
-        hold.started.open()
-        await hold.release.waitIgnoringCancellation()
+      if let leadingHold {
+        leadingHold.started.open()
+        await leadingHold.release.waitIgnoringCancellation()
       }
+
       do {
         for chunk in chunks {
           try await sink.send(chunk)
@@ -218,9 +248,16 @@ private extension ScriptedHTTPExecutor {
       } catch {
         return .cancelled(.mayHaveBeenSent)
       }
+
+      if let trailingHold {
+        trailingHold.started.open()
+        await trailingHold.release.waitIgnoringCancellation()
+      }
+
       if let failure {
         return .failed(failure)
       }
+
       return .completed
     }
   }

--- a/Sources/ClawTools/Tools/FileWriteTool.swift
+++ b/Sources/ClawTools/Tools/FileWriteTool.swift
@@ -197,7 +197,7 @@ public struct FileWriteTool: Tool {
 
 // MARK: - Atomic Write Steps
 
-extension FileWriteTool {
+private extension FileWriteTool {
   struct RenameFailed: Error {
     let code: Int32
   }
@@ -206,9 +206,6 @@ extension FileWriteTool {
   /// approved "create", so replacing is off the table — fail closed.
   struct CreateCollision: Error {}
 
-  /// Step 1 of the atomic write, split from step 2 so the crash-window invariant is
-  /// testable: the temp file lives NEXT TO the target (same directory ⇒ same volume ⇒
-  /// `rename(2)` is atomic), inside the workspace by construction.
   static func stageTemporary(content: Data, target: String) throws -> String {
     let parent = (target as NSString).deletingLastPathComponent
     let leaf = (target as NSString).lastPathComponent
@@ -217,8 +214,6 @@ extension FileWriteTool {
     return tempPath
   }
 
-  /// Step 2 for an OVERWRITE-approved write: `rename(2)` replaces the target atomically; the
-  /// pre-existing file survives any crash before this call returns.
   static func commitRename(tempPath: String, target: String) throws {
     guard rename(tempPath, target) == 0 else {
       let code = errno
@@ -227,10 +222,6 @@ extension FileWriteTool {
     }
   }
 
-  /// Step 2 for a CREATE-approved write: `link(2)` publishes the temp atomically and fails with
-  /// `EEXIST` if the target appeared while the approval was pending — the no-replace analog of
-  /// `rename(2)`, portable across Darwin and Glibc (no `renamex_np`/`renameat2` availability
-  /// dance). The temp's extra link is removed on success.
   static func commitCreate(tempPath: String, target: String) throws {
     guard link(tempPath, target) == 0 else {
       let code = errno

--- a/Sources/clawd/Composition/DaemonBuilder.swift
+++ b/Sources/clawd/Composition/DaemonBuilder.swift
@@ -9,6 +9,7 @@ import ClawWorkspace
 import Foundation
 import Logging
 import ServiceLifecycle
+import UnixSignals
 
 /// The composition root. Holds the cross-cutting inputs `run()` resolves before wiring — config,
 /// secrets, stores, the dedicated tool executor, the Telegram transport, and the logger — plus the
@@ -209,13 +210,16 @@ struct DaemonBuilder: Sendable {
     services: [any Service],
     coordination: TurnCoordination,
     credentialSources: [any LLMCredentialSource],
-    boot: @escaping @Sendable () async -> Void
+    boot: @escaping @Sendable () async -> Void,
+    laneDrainClock: any Clock<Duration> = ContinuousClock(),
+    gracefulShutdownSignals: [UnixSignal] = [.sigterm, .sigint]
   ) -> DaemonRuntimeBundle {
     let laneShutdownOutcome = LaneShutdownOutcome()
     let laneAdmission = LaneAdmissionShutdownService(
       lanes: coordination.lanes,
       outcome: laneShutdownOutcome,
       drainTimeout: .seconds(Self.gracefulShutdownSeconds),
+      clock: laneDrainClock,
       logger: logger
     )
 
@@ -223,6 +227,7 @@ struct DaemonBuilder: Sendable {
       services: Self.servicesWithLaneAdmissionLast(base: services, laneAdmission: laneAdmission),
       boot: boot,
       logger: logger,
+      gracefulShutdownSignals: gracefulShutdownSignals,
       gracefulShutdownSeconds: Self.gracefulShutdownSeconds
     )
 

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -24,8 +24,8 @@ struct RunCommand: AsyncParsableCommand {
     // Before the logger on purpose: the MCP tokens are part of the redaction set the log backend is
     // installed with, so they have to be in hand before anything can write a line.
     let mcp = try Self.loadMCPOrExit(config: config)
-    let redactionValues = mcp.redactionValues(with: secrets)
-    let logger = Self.bootstrapLogger(redactionValues: redactionValues)
+    let bootLogging = Self.makeBootLogging(secrets: secrets, mcp: mcp)
+    let logger = bootLogging.logger
 
     let stores = try Self.openStoresOrExit(config: config, logger: logger)
     try Self.ensureWorkspaceDirectoryOrExit(config: config)
@@ -51,7 +51,7 @@ struct RunCommand: AsyncParsableCommand {
     logger.info("clawd starting (owners allowlisted: \(config.allowlist.count))")
     try await Self.serveThenShutDown(
       composed: composed,
-      redactionValues: redactionValues,
+      redactionValues: bootLogging.redactionValues,
       logger: logger
     )
   }
@@ -59,14 +59,15 @@ struct RunCommand: AsyncParsableCommand {
 
 // MARK: - Serve & Shutdown
 
-private extension RunCommand {
+extension RunCommand {
   /// Runs the service graph, then sequences dependent-resource teardown in the mandated order. On a
   /// lane-drain timeout it terminates the process from here — before `run`'s `defer { lock.release()
   /// }` and any client teardown unwind — so the held instance-lock fd stays owned until termination.
   static func serveThenShutDown(
     composed: RunComposition.Composed,
     redactionValues: [String],
-    logger: Logger
+    logger: Logger,
+    terminator: FatalProcessTerminator = .production
   ) async throws {
     let bundle = composed.bundle
     let clients = composed.clients
@@ -113,7 +114,7 @@ private extension RunCommand {
     case .failed(let error):
       throw error
     case .fatalLaneTimeout(let activeRunIDs):
-      try FatalProcessTerminator.production.fatalLaneDrainTimeout(
+      try terminator.fatalLaneDrainTimeout(
         activeRunIDs: activeRunIDs,
         logger: logger
       )
@@ -141,6 +142,33 @@ private extension RunCommand {
 }
 
 // MARK: - Environment Bootstrap
+
+extension RunCommand {
+  typealias LoggerBootstrap = @Sendable ([String]) -> Logger
+
+  struct BootLogging {
+    let logger: Logger
+    let redactionValues: [String]
+  }
+
+  static func makeBootLogging(
+    secrets: Secrets,
+    mcp: MCPBootInputs,
+    bootstrap: LoggerBootstrap
+  ) -> BootLogging {
+    let redactionValues = mcp.redactionValues(with: secrets)
+    return BootLogging(
+      logger: bootstrap(redactionValues),
+      redactionValues: redactionValues
+    )
+  }
+
+  static func makeBootLogging(secrets: Secrets, mcp: MCPBootInputs) -> BootLogging {
+    makeBootLogging(secrets: secrets, mcp: mcp) { redactionValues in
+      bootstrapLogger(redactionValues: redactionValues)
+    }
+  }
+}
 
 private extension RunCommand {
   /// Installs the redacting swift-log backend (level from `CLAW_LOG_LEVEL`, default `.info`) over

--- a/Tests/ClawAgentTests/Runtime/LoopPersistenceContractTests.swift
+++ b/Tests/ClawAgentTests/Runtime/LoopPersistenceContractTests.swift
@@ -149,23 +149,34 @@ import Testing
   }
 
   @Test func auditWriteFailureLogsAndContinues() async throws {
-    // given — audit is observability, not a gate (§6)
+    // given — audit is observability, not a gate
     let provider = SequenceProvider([
       toolCallResponse([fetchProposal(id: "c1")]),
       okResponse(content: "finished anyway"),
     ])
     let auditLog = RecordingAuditLog(thrown: StoreError.unexpected("scripted"))
+    let logs = RecordingLogCapture()
     let runtime = makeRuntime(
       provider: provider,
       toolDispatcher: ScriptedDispatcher(respond: okOutcome()),
-      auditLog: auditLog
+      auditLog: auditLog,
+      logger: logs.logger()
     )
 
     // when
     let outcome = try await run(runtime)
 
-    // then — the run completed despite every audit write failing
+    // then — the failure is visible to the operator, but audit observability does not gate the run
     #expect(try requireCompleted(outcome.result).content == "finished anyway")
+    let warnings = logs.entries.filter { entry in
+      entry.level == .warning
+    }
+    let warning = try #require(warnings.first)
+    #expect(warnings.count == 1)
+    #expect(warning.message.contains("audit write failed"))
+    #expect(warning.message.contains("scripted"))
+    #expect(warning.metadata["run"]?.description == "1")
+    #expect(warning.metadata["session"]?.description == "1")
   }
 
   @Test func auditWriteDiskFullPropagates() async throws {

--- a/Tests/ClawAgentTests/Support/AgentTestSupport.swift
+++ b/Tests/ClawAgentTests/Support/AgentTestSupport.swift
@@ -1,5 +1,6 @@
 import ClawTestSupport
 import Foundation
+import Logging
 import Testing
 
 @testable import ClawAgent
@@ -148,6 +149,7 @@ func makeRuntime(
   usageStore: any UsageStore = RecordingUsageStore(),
   auditLog: any AuditLog = RecordingAuditLog(),
   providerCallIDGenerator: any ProviderCallIDGenerating = UUIDProviderCallIDGenerator(),
+  logger: Logger = Logger(label: "test.silent", factory: { _ in SwiftLogNoOpLogHandler() }),
   clock: any Clock<Duration> = ContinuousClock()
 ) -> AgentRuntime {
   AgentRuntime(
@@ -167,6 +169,7 @@ func makeRuntime(
     usageStore: usageStore,
     auditLog: auditLog,
     providerCallIDGenerator: providerCallIDGenerator,
+    logger: logger,
     clock: clock
   )
 }

--- a/Tests/ClawAuthTests/Commands/AuthLockingTests.swift
+++ b/Tests/ClawAuthTests/Commands/AuthLockingTests.swift
@@ -152,7 +152,7 @@ private func encryptedArtifacts(in world: AuthWorld) -> [Bool] {
       #expect(blocked.exit == .commandFailure)
       #expect(blocked.transcript.lowercased().contains("stop"))
       #expect(world.log.recorded.isEmpty)
-      #expect(world.storedCredential == AuthFixture.priorCredential)
+      #expect(try world.loadStoredCredential() == AuthFixture.priorCredential)
 
       // when — the daemon stops
       daemon.release()
@@ -160,7 +160,8 @@ private func encryptedArtifacts(in world: AuthWorld) -> [Bool] {
 
       // then
       #expect(allowed.exit == .success)
-      #expect(world.storedCredential == nil)
+      #expect(try world.loadStoredCredential() == nil)
+      #expect(FileManager.default.fileExists(atPath: world.paths.credentialEnvelope.path))
       #expect(world.log.recorded.contains(.credentialDeleted))
     }
   }

--- a/Tests/ClawAuthTests/Commands/AuthLoginWorkflowTests.swift
+++ b/Tests/ClawAuthTests/Commands/AuthLoginWorkflowTests.swift
@@ -104,7 +104,7 @@ import Testing
 
       // then
       #expect(result.exit == .success)
-      let stored = world.storedCredential
+      let stored = try world.loadStoredCredential()
       #expect(stored?.profileID == AuthFixture.freshProfileID)
       #expect(stored?.accessToken == AuthFixture.accessToken)
       #expect(stored?.refreshToken == AuthFixture.refreshToken)
@@ -116,7 +116,7 @@ import Testing
     try await withAuthWorld("auth-login-replace") { world in
       // given
       try world.seedPriorLogin()
-      #expect(world.storedCredential?.profileID == AuthFixture.priorProfileID)
+      #expect(try world.loadStoredCredential()?.profileID == AuthFixture.priorProfileID)
       let workflow = world.loginWorkflow()
 
       // when
@@ -124,8 +124,8 @@ import Testing
 
       // then
       #expect(result.exit == .success)
-      #expect(world.storedCredential?.profileID == AuthFixture.freshProfileID)
-      #expect(world.storedCredential?.accessToken == AuthFixture.accessToken)
+      #expect(try world.loadStoredCredential()?.profileID == AuthFixture.freshProfileID)
+      #expect(try world.loadStoredCredential()?.accessToken == AuthFixture.accessToken)
     }
   }
 
@@ -256,7 +256,7 @@ import Testing
 
       // then
       #expect(result.exit == .commandFailure)
-      #expect(world.storedCredential == AuthFixture.priorCredential)
+      #expect(try world.loadStoredCredential() == AuthFixture.priorCredential)
       #expect(world.log.recorded.contains(.credentialSaved) == false)
     }
   }
@@ -273,7 +273,7 @@ import Testing
 
       // then
       #expect(result.exit == .cancelled)
-      #expect(world.storedCredential == AuthFixture.priorCredential)
+      #expect(try world.loadStoredCredential() == AuthFixture.priorCredential)
       #expect(world.log.recorded.contains(.credentialSaved) == false)
     }
   }
@@ -298,7 +298,7 @@ import Testing
 
       // then
       #expect(result.exit == .commandFailure)
-      #expect(world.storedCredential == AuthFixture.priorCredential)
+      #expect(try world.loadStoredCredential() == AuthFixture.priorCredential)
     }
   }
 
@@ -410,7 +410,8 @@ import Testing
 
       // then
       #expect(result.exit == .success)
-      #expect(world.storedCredential?.profileID == AuthFixture.freshProfileID)
+      let stored = try world.loadStoredCredential()
+      #expect(stored?.profileID == AuthFixture.freshProfileID)
       #expect(world.terminal.transcript.contains("CLAW_LLM_MODEL=openai-chatgpt/<model>"))
     }
   }
@@ -426,7 +427,8 @@ import Testing
 
       // then
       #expect(result.exit == .success)
-      #expect(world.storedCredential?.profileID == AuthFixture.freshProfileID)
+      let stored = try world.loadStoredCredential()
+      #expect(stored?.profileID == AuthFixture.freshProfileID)
       #expect(world.terminal.transcript.contains("CLAW_LLM_MODEL=openai-chatgpt/<model>"))
     }
   }

--- a/Tests/ClawAuthTests/Commands/AuthLogoutWorkflowTests.swift
+++ b/Tests/ClawAuthTests/Commands/AuthLogoutWorkflowTests.swift
@@ -27,7 +27,8 @@ import Testing
           .lockReleased,
         ]
       )
-      #expect(world.storedCredential == nil)
+      #expect(try world.loadStoredCredential() == nil)
+      #expect(FileManager.default.fileExists(atPath: world.paths.credentialEnvelope.path))
     }
   }
 
@@ -93,7 +94,7 @@ import Testing
       #expect(result.transcript.lowercased().contains("stop"))
       #expect(world.log.recorded.isEmpty)
       // The credential the daemon is using is exactly as it was.
-      #expect(world.storedCredential == AuthFixture.priorCredential)
+      #expect(try world.loadStoredCredential() == AuthFixture.priorCredential)
     }
   }
 }

--- a/Tests/ClawAuthTests/Support/AuthWorld.swift
+++ b/Tests/ClawAuthTests/Support/AuthWorld.swift
@@ -309,10 +309,10 @@ struct AuthWorld: Sendable {
     builtCatalog.seenAuthorization
   }
 
-  /// The store as the owner's disk actually holds it, unrecorded — for assertions about what a
-  /// command left behind rather than about what it did.
-  var storedCredential: StoredOAuthCredential? {
-    try? EncryptedLLMCredentialStore(stateRoot: root).load(providerID: .openAIChatGPT)
+  /// Loads the store as the owner's disk actually holds it, unrecorded. Read failures remain test
+  /// failures rather than being mistaken for an absent credential.
+  func loadStoredCredential() throws(LLMCredentialStoreError) -> StoredOAuthCredential? {
+    try EncryptedLLMCredentialStore(stateRoot: root).load(providerID: .openAIChatGPT)
   }
 
   /// The store every command in this world opens, recording the open so a test can assert *when* it

--- a/Tests/ClawCoreTests/Domain/Execution/ExecutionContractsTests.swift
+++ b/Tests/ClawCoreTests/Domain/Execution/ExecutionContractsTests.swift
@@ -1,140 +1,92 @@
-import ClawTestSupport
-import Foundation
 import Testing
 
 @testable import ClawCore
 
 @Suite struct ExecutionContractsTests {
-  private let passingHealth = SandboxHealth(
-    available: true,
-    osOK: true,
-    engineVersion: "1.1.0",
-    versionOK: true,
-    imageDigestOK: true,
-    capsEmpty: true,
-    netIsolated: true,
-    capsMatch: true,
-    reaperOK: true,
-    rootfsRO: true,
-    stagingRO: true,
-    interpretersOK: true,
-    lastError: nil
-  )
-
-  @Test func requestCarriesOnlyApprovedGuestInputs() {
+  @Test func healthIsReadyWhenEveryGatePasses() {
     // given
-    let entrypoint = StagedFile(
-      name: ".clawd-entrypoint.py",
-      bytes: Data("print('ok')".utf8),
-      mode: .readExecute
-    )
-    let input = StagedFile(name: "notes.txt", bytes: Data("hello".utf8), mode: .readOnly)
+    let health = SandboxHealth.passingForTests
 
     // when
-    let request = ExecutionRequest(
-      language: .python,
-      entrypoint: entrypoint,
-      inputs: [input],
-      network: false,
-      timeout: .seconds(30)
-    )
+    let isReady = health.isReady
 
     // then
-    #expect(request.language == .python)
-    #expect(request.entrypoint == entrypoint)
-    #expect(request.inputs == [input])
-    #expect(request.network == false)
-    #expect(request.timeout == .seconds(30))
-    #expect(FileMode.readOnly.rawValue == 0o400)
-    #expect(FileMode.readExecute.rawValue == 0o500)
+    #expect(isReady)
   }
 
-  @Test func healthIsReadyOnlyWhenEveryGatePasses() {
-    // given / when / then
-    #expect(passingHealth.isReady)
-    #expect(SandboxHealth.passingForTests == passingHealth)
+  @Test func healthIsNotReadyWhenAnyGateFails() {
+    // given
+    let failedHealth = HealthGate.allCases.map(Self.health(failing:))
 
-    let failed = SandboxHealth(
-      available: true,
-      osOK: true,
+    // when
+    let readiness = failedHealth.map(\.isReady)
+
+    // then
+    #expect(readiness == Array(repeating: false, count: HealthGate.allCases.count))
+  }
+}
+
+// MARK: - Health Fixtures
+
+private extension ExecutionContractsTests {
+  enum HealthGate: CaseIterable {
+    case available
+    case operatingSystem
+    case version
+    case imageDigest
+    case emptyCapabilities
+    case networkIsolation
+    case matchingCapabilities
+    case reaper
+    case readOnlyRoot
+    case readOnlyStaging
+    case interpreters
+    case lastError
+  }
+
+  static func health(failing gate: HealthGate) -> SandboxHealth {
+    var available = true
+    var osOK = true
+    var versionOK = true
+    var imageDigestOK = true
+    var capsEmpty = true
+    var netIsolated = true
+    var capsMatch = true
+    var reaperOK = true
+    var rootfsRO = true
+    var stagingRO = true
+    var interpretersOK = true
+    var lastError: String?
+
+    switch gate {
+    case .available: available = false
+    case .operatingSystem: osOK = false
+    case .version: versionOK = false
+    case .imageDigest: imageDigestOK = false
+    case .emptyCapabilities: capsEmpty = false
+    case .networkIsolation: netIsolated = false
+    case .matchingCapabilities: capsMatch = false
+    case .reaper: reaperOK = false
+    case .readOnlyRoot: rootfsRO = false
+    case .readOnlyStaging: stagingRO = false
+    case .interpreters: interpretersOK = false
+    case .lastError: lastError = "probe failed"
+    }
+
+    return SandboxHealth(
+      available: available,
+      osOK: osOK,
       engineVersion: "1.1.0",
-      versionOK: true,
-      imageDigestOK: true,
-      capsEmpty: true,
-      netIsolated: false,
-      capsMatch: true,
-      reaperOK: true,
-      rootfsRO: true,
-      stagingRO: true,
-      interpretersOK: true,
-      lastError: "network escaped"
+      versionOK: versionOK,
+      imageDigestOK: imageDigestOK,
+      capsEmpty: capsEmpty,
+      netIsolated: netIsolated,
+      capsMatch: capsMatch,
+      reaperOK: reaperOK,
+      rootfsRO: rootfsRO,
+      stagingRO: stagingRO,
+      interpretersOK: interpretersOK,
+      lastError: lastError
     )
-    #expect(failed.isReady == false)
-  }
-
-  @Test func fakeRecordsRequestsAndNeverInventsSuccess() async {
-    // given
-    let scripted = ExecutionResult(
-      terminationReason: .exited(code: 0),
-      stdout: "ok\n",
-      stderr: "",
-      truncatedRawBytes: false,
-      wallClock: .milliseconds(8)
-    )
-    let backend = FakeExecutionBackend(results: [scripted])
-    let request = ExecutionRequest(
-      language: .sh,
-      entrypoint: StagedFile(
-        name: ".clawd-entrypoint.sh",
-        bytes: Data("printf ok".utf8),
-        mode: .readExecute
-      ),
-      inputs: [],
-      network: false,
-      timeout: .seconds(5)
-    )
-
-    // when
-    let first = await backend.run(request)
-    let second = await backend.run(request)
-    let health = await backend.prepare()
-    await backend.shutdown()
-
-    // then
-    #expect(first == scripted)
-    #expect(
-      second.terminationReason
-        == .unavailable(reason: "no scripted execution result")
-    )
-    #expect(await backend.recordedRequests() == [request, request])
-    #expect(await backend.probe() == .available(engineVersion: "1.1.0"))
-    #expect(health == .passingForTests)
-    #expect(await backend.prepareCallCount() == 1)
-    #expect(await backend.shutdownCallCount() == 1)
-  }
-
-  @Test func fakeCanBeReScriptedAfterConstruction() async {
-    // given
-    let backend = FakeExecutionBackend(results: [])
-    let result = ExecutionResult(
-      terminationReason: .timedOutKilled,
-      stdout: "",
-      stderr: "",
-      truncatedRawBytes: false,
-      wallClock: .seconds(2)
-    )
-    let request = ExecutionRequest(
-      language: .python,
-      entrypoint: StagedFile(name: "entry.py", bytes: Data(), mode: .readExecute),
-      inputs: [],
-      network: false,
-      timeout: .seconds(1)
-    )
-
-    // when
-    await backend.enqueue(result)
-
-    // then
-    #expect(await backend.run(request) == result)
   }
 }

--- a/Tests/ClawCoreTests/SmokeTests.swift
+++ b/Tests/ClawCoreTests/SmokeTests.swift
@@ -1,5 +1,0 @@
-import Testing
-
-@Test func packageBuildsAndTestsRun() {
-  #expect(Bool(true))
-}

--- a/Tests/ClawDataTests/Database/MemorySchemaMigrationTests.swift
+++ b/Tests/ClawDataTests/Database/MemorySchemaMigrationTests.swift
@@ -23,9 +23,9 @@ import Testing
     // then
     let names = Set(columns.map { row in row["name"] as String })
     #expect(
-      names == [
+      names.isSuperset(of: [
         "id", "text", "kind", "sensitivity", "importance", "source", "session_id", "created_at",
-      ]
+      ])
     )
     let importanceColumn = try #require(
       columns.first { row in (row["name"] as String) == "importance" }

--- a/Tests/ClawDataTests/Database/V9MigrationTests.swift
+++ b/Tests/ClawDataTests/Database/V9MigrationTests.swift
@@ -316,26 +316,6 @@ import Testing
 
   // MARK: - FTS Synchronization
 
-  @Test func theRebuiltMessagesTableKeepsItsFtsSynchronizationTriggers() throws {
-    // given
-    let queue = try ClawDatabase.makeInMemoryQueue()
-
-    // when
-    try ClawDatabase.migrate(queue)
-
-    // then — the external-content index is driven by triggers alone; without all three it
-    // silently drifts from the table it claims to index
-    let triggers = try queue.read { db in
-      Set(
-        try String.fetchAll(
-          db,
-          sql: "SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'messages'"
-        )
-      )
-    }
-    #expect(triggers == ["__messages_fts_ai", "__messages_fts_ad", "__messages_fts_au"])
-  }
-
   @Test func theFtsIndexCarriesNoProviderStateColumn() throws {
     // given — replay state is opaque bytes only its adapter may read; indexing it would both
     // corrupt the index and expose the payload to a content search
@@ -376,7 +356,7 @@ import Testing
     #expect(Set(matched) == [1, 3])
   }
 
-  @Test func aMessageWrittenAfterTheRebuildIsIndexedAndUnindexedByTheTriggers() throws {
+  @Test func aMessageWrittenAfterTheRebuildTracksInsertUpdateAndDelete() throws {
     // given
     let queue = try ClawDatabase.makeInMemoryQueue()
     try Self.seedVEight(queue)
@@ -397,14 +377,40 @@ import Testing
     }
     #expect(indexed == messageId)
 
-    // and the delete trigger unindexes it
+    // when
     try queue.write { db in
-      try db.execute(sql: "DELETE FROM messages WHERE id = ?", arguments: [messageId])
+      try db.execute(
+        sql: "UPDATE messages SET content = 'renamed needle' WHERE id = ?",
+        arguments: [messageId]
+      )
     }
-    let remaining = try queue.read { db in
+
+    // then
+    let oldContentCount = try queue.read { db in
       try Int.fetchOne(
         db,
         sql: "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'postmigration'"
+      )
+    }
+    let updated = try queue.read { db in
+      try Int64.fetchOne(
+        db,
+        sql: "SELECT rowid FROM messages_fts WHERE messages_fts MATCH 'renamed'"
+      )
+    }
+    #expect(oldContentCount == 0)
+    #expect(updated == messageId)
+
+    // when
+    try queue.write { db in
+      try db.execute(sql: "DELETE FROM messages WHERE id = ?", arguments: [messageId])
+    }
+
+    // then
+    let remaining = try queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'renamed'"
       )
     }
     #expect(remaining == 0)

--- a/Tests/ClawExecTests/ClawExecTestSupport.swift
+++ b/Tests/ClawExecTests/ClawExecTestSupport.swift
@@ -1,5 +1,6 @@
 import ClawCore
 import Foundation
+import Synchronization
 import Testing
 
 @testable import ClawExec
@@ -155,7 +156,10 @@ func pythonEntrypoint() -> StagedFile {
   StagedFile(name: ".clawd-entrypoint.py", bytes: Data("print('ok')".utf8), mode: .readExecute)
 }
 
-func executionRequest(input: StagedFile? = nil) -> ExecutionRequest {
+func executionRequest(
+  input: StagedFile? = nil,
+  timeout: Duration = .seconds(1)
+) -> ExecutionRequest {
   ExecutionRequest(
     language: .python,
     entrypoint: pythonEntrypoint(),
@@ -163,7 +167,7 @@ func executionRequest(input: StagedFile? = nil) -> ExecutionRequest {
       [staged]
     } ?? [],
     network: false,
-    timeout: .seconds(1)
+    timeout: timeout
   )
 }
 
@@ -196,6 +200,7 @@ struct BackendFixture {
     sanitizeReason: @escaping @Sendable (String) -> String = { $0 },
     now: @escaping @Sendable () -> ContinuousClock.Instant = { ContinuousClock.now },
     supportedHost: @escaping @Sendable () -> Bool = { true },
+    executionAdmitted: @escaping @Sendable () -> Void = {},
     watchdogSleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
       try await Task.sleep(for: duration)
     }
@@ -207,6 +212,7 @@ struct BackendFixture {
       sanitizeReason: sanitizeReason,
       now: now,
       supportedHost: supportedHost,
+      executionAdmitted: executionAdmitted,
       watchdogSleep: watchdogSleep
     )
   }
@@ -264,17 +270,20 @@ actor AsyncGate {
   }
 }
 
-actor ExecutionRecorder {
-  private var recorded: [Int] = []
-  private var waiters: [(Int, CheckedContinuation<Void, Never>)] = []
+final class ExecutionAdmissionRecorder: Sendable {
+  private struct State {
+    var count = 0
+    var waiters: [(Int, CheckedContinuation<Void, Never>)] = []
+  }
 
-  func record(_ value: Int) {
-    recorded.append(value)
-    let ready = waiters.filter { waiter in
-      recorded.count >= waiter.0
-    }
-    waiters.removeAll { waiter in
-      recorded.count >= waiter.0
+  private let state = Mutex(State())
+
+  func record() {
+    let ready = state.withLock { current in
+      current.count += 1
+      let ready = current.waiters.filter { current.count >= $0.0 }
+      current.waiters.removeAll { current.count >= $0.0 }
+      return ready
     }
     for waiter in ready {
       waiter.1.resume()
@@ -282,27 +291,17 @@ actor ExecutionRecorder {
   }
 
   func waitForCount(_ count: Int) async {
-    if recorded.count >= count { return }
     await withCheckedContinuation { continuation in
-      waiters.append((count, continuation))
+      let shouldResume = state.withLock { current in
+        guard current.count < count else {
+          return true
+        }
+        current.waiters.append((count, continuation))
+        return false
+      }
+      if shouldResume {
+        continuation.resume()
+      }
     }
   }
-
-  func values() -> [Int] { recorded }
-}
-
-func waitForQueuedCount(_ count: Int, backend: ContainerBackend) async {
-  while await backend.queuedExecutionCountForTesting < count {
-    await Task.yield()
-  }
-}
-
-func testExecutionResult(code: Int32) -> ExecutionResult {
-  ExecutionResult(
-    terminationReason: .exited(code: code),
-    stdout: "",
-    stderr: "",
-    truncatedRawBytes: false,
-    wallClock: .zero
-  )
 }

--- a/Tests/ClawExecTests/ContainerBackendCleanupTests.swift
+++ b/Tests/ClawExecTests/ContainerBackendCleanupTests.swift
@@ -38,11 +38,13 @@ import Testing
     #expect(await runner.recorded().count == commandsAfterFirst)
   }
 
-  @Test func failedCleanupAlsoRefusesRunsAlreadyQueuedBehindIt() async throws {
+  @Test(.timeLimit(.minutes(1)))
+  func failedCleanupAlsoRefusesRunsAlreadyQueuedBehindIt() async throws {
     // given
     let fixture = try BackendFixture()
     defer { fixture.remove() }
     let gate = AsyncGate()
+    let admissions = ExecutionAdmissionRecorder()
     let runner = ScriptedCommandRunner { command, history in
       if command.arguments.first == "run" {
         writeCidfile(from: command.arguments)
@@ -55,12 +57,13 @@ import Testing
       }
       return commandResult(.exited(0))
     }
-    let backend = fixture.backend(commands: runner)
+    let backend = fixture.backend(commands: runner, executionAdmitted: admissions.record)
     await backend.setPreparedInitImageForTesting("ghcr.io/apple/containerization/vminit:1.1.0")
     let first = Task { await backend.run(executionRequest()) }
+    await admissions.waitForCount(1)
     await runner.waitForCount(1)
     let second = Task { await backend.run(executionRequest()) }
-    await waitForQueuedCount(2, backend: backend)
+    await admissions.waitForCount(2)
 
     // when
     await gate.open()

--- a/Tests/ClawExecTests/ContainerBackendExecutionTests.swift
+++ b/Tests/ClawExecTests/ContainerBackendExecutionTests.swift
@@ -5,75 +5,60 @@ import Testing
 @testable import ClawExec
 
 @Suite struct ContainerBackendExecutionTests {
-  @Test func storedTaskChainPreventsActorReentrancyFromOverlappingExecutions() async throws {
+  @Test(.timeLimit(.minutes(1)))
+  func concurrentRunsStayNonOverlappingAndExecuteFIFO() async throws {
     // given
     let fixture = try BackendFixture()
     defer { fixture.remove() }
-    let backend = fixture.backend()
-    let gate = AsyncGate()
-    let recorder = ExecutionRecorder()
+    let firstRunGate = AsyncGate()
+    let admissions = ExecutionAdmissionRecorder()
+    let runner = ScriptedCommandRunner { command, history in
+      switch command.arguments.first {
+      case "run":
+        writeCidfile(from: command.arguments)
+        let runNumber = history.filter { $0.arguments.first == "run" }.count
+        if runNumber == 1 {
+          await firstRunGate.wait()
+        }
+        return commandResult(.exited(Int32(runNumber)))
+      case "system":
+        return jsonCommandResult(#"{"status":"running"}"#)
+      case "list":
+        return jsonCommandResult("[]")
+      default:
+        return commandResult(.exited(0))
+      }
+    }
+    let backend = fixture.backend(commands: runner, executionAdmitted: admissions.record)
+    await backend.setPreparedInitImageForTesting("ghcr.io/apple/containerization/vminit:1.1.0")
     let first = Task {
-      await backend.runSerializedForTesting {
-        await recorder.record(1)
-        await gate.wait()
-        return testExecutionResult(code: 1)
-      }
+      await backend.run(executionRequest(timeout: .seconds(1)))
     }
-    await recorder.waitForCount(1)
-
-    // when
+    await admissions.waitForCount(1)
+    await runner.waitForCount(1)
     let second = Task {
-      await backend.runSerializedForTesting {
-        await recorder.record(2)
-        return testExecutionResult(code: 2)
-      }
+      await backend.run(executionRequest(timeout: .seconds(2)))
     }
-    await waitForQueuedCount(2, backend: backend)
-
-    // then
-    #expect(await recorder.values() == [1])
-    await gate.open()
-    #expect(await first.value.terminationReason == .exited(code: 1))
-    #expect(await second.value.terminationReason == .exited(code: 2))
-    #expect(await recorder.values() == [1, 2])
-  }
-
-  @Test func storedTaskChainPreservesAdmissionFIFO() async throws {
-    // given
-    let fixture = try BackendFixture()
-    defer { fixture.remove() }
-    let backend = fixture.backend()
-    let gate = AsyncGate()
-    let recorder = ExecutionRecorder()
-    let first = Task {
-      await backend.runSerializedForTesting {
-        await recorder.record(1)
-        await gate.wait()
-        return testExecutionResult(code: 1)
-      }
-    }
-    await recorder.waitForCount(1)
-    let second = Task {
-      await backend.runSerializedForTesting {
-        await recorder.record(2)
-        return testExecutionResult(code: 2)
-      }
-    }
-    await waitForQueuedCount(2, backend: backend)
+    await admissions.waitForCount(2)
     let third = Task {
-      await backend.runSerializedForTesting {
-        await recorder.record(3)
-        return testExecutionResult(code: 3)
-      }
+      await backend.run(executionRequest(timeout: .seconds(3)))
     }
-    await waitForQueuedCount(3, backend: backend)
-
-    // when
-    await gate.open()
-    _ = await [first.value, second.value, third.value]
+    await admissions.waitForCount(3)
 
     // then
-    #expect(await recorder.values() == [1, 2, 3])
+    let blockedRunCommands = await runner.recorded().filter { $0.arguments.first == "run" }
+    #expect(blockedRunCommands.count == 1)
+
+    // when
+    await firstRunGate.open()
+    let results = await [first.value, second.value, third.value]
+
+    // then
+    #expect(
+      results.map(\.terminationReason) == [.exited(code: 1), .exited(code: 2), .exited(code: 3)]
+    )
+    let runCommands = await runner.recorded().filter { $0.arguments.first == "run" }
+    #expect(runCommands.map(\.timeout) == [.seconds(1), .seconds(2), .seconds(3)])
   }
 
   @Test func runRequiresPreparedRuntimeInitImageWithoutStartingACommand() async throws {
@@ -310,37 +295,51 @@ import Testing
     #expect(reason.contains("could not confirm container removal"))
   }
 
-  @Test func cancellationWhileQueuedReturnsCancelledWithoutStartingOperation() async throws {
+  @Test(.timeLimit(.minutes(1)))
+  func cancellationWhileQueuedReturnsCancelledWithoutStartingOperation() async throws {
     // given
     let fixture = try BackendFixture()
     defer { fixture.remove() }
-    let backend = fixture.backend()
-    let gate = AsyncGate()
-    let recorder = ExecutionRecorder()
+    let firstRunGate = AsyncGate()
+    let admissions = ExecutionAdmissionRecorder()
+    let runner = ScriptedCommandRunner { command, history in
+      switch command.arguments.first {
+      case "run":
+        writeCidfile(from: command.arguments)
+        let runNumber = history.filter { $0.arguments.first == "run" }.count
+        if runNumber == 1 {
+          await firstRunGate.wait()
+        }
+        return commandResult(.exited(Int32(runNumber)))
+      case "system":
+        return jsonCommandResult(#"{"status":"running"}"#)
+      case "list":
+        return jsonCommandResult("[]")
+      default:
+        return commandResult(.exited(0))
+      }
+    }
+    let backend = fixture.backend(commands: runner, executionAdmitted: admissions.record)
+    await backend.setPreparedInitImageForTesting("ghcr.io/apple/containerization/vminit:1.1.0")
     let first = Task {
-      await backend.runSerializedForTesting {
-        await recorder.record(1)
-        await gate.wait()
-        return testExecutionResult(code: 1)
-      }
+      await backend.run(executionRequest())
     }
-    await recorder.waitForCount(1)
+    await admissions.waitForCount(1)
+    await runner.waitForCount(1)
     let queued = Task {
-      await backend.runSerializedForTesting {
-        await recorder.record(2)
-        return testExecutionResult(code: 2)
-      }
+      await backend.run(executionRequest(timeout: .seconds(2)))
     }
-    await waitForQueuedCount(2, backend: backend)
+    await admissions.waitForCount(2)
 
     // when
     queued.cancel()
-    await gate.open()
+    await firstRunGate.open()
     _ = await first.value
     let result = await queued.value
 
     // then
     #expect(result.terminationReason == .cancelled)
-    #expect(await recorder.values() == [1])
+    let runCommands = await runner.recorded().filter { $0.arguments.first == "run" }
+    #expect(runCommands.count == 1)
   }
 }

--- a/Tests/ClawGatewayTests/Routing/ProviderSurfaceParityTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ProviderSurfaceParityTests.swift
@@ -340,7 +340,7 @@ import Testing
     #expect(copy == ScheduleReplies.quotaLimited(retryAfterSeconds: 42))
   }
 
-  @Test func bothSurfacesShareTheTraceFormatterAndSplitWireModelFromIdentity() async throws {
+  @Test func bothSurfacesSendCanonicalTraceIdentityAndSplitWireModelFromIdentity() async throws {
     // given — a recording provider that succeeds, so each surface's request and usage row are visible
     let wireModel = "wire-model"
     let identity = "identity-ref"
@@ -389,7 +389,7 @@ import Testing
     )
     let parseResult = await parser.parse(ownerText: "x", sessionId: parseSession)
 
-    // then — both requests stamp the one shared trace identity, keyed on the database session id
+    // then — both requests stamp the canonical wire identity, keyed on the database session id
     let turnRequest = try #require(await turnProvider.requests.first)
     let parseRequest = try #require(await parseProvider.requests.first)
     #expect(turnRequest.sessionId == SessionTraceID.format(sessionID: turnSession))
@@ -409,52 +409,5 @@ import Testing
       try String.fetchOne(db, sql: "SELECT model FROM provider_usage")
     }
     #expect(parseModel == identity)
-  }
-
-  @Test func noPrivateSessionTraceFormatterRemains() throws {
-    // given — the one legitimate home for the `clawd-session-` prefix
-    let sourcesRoot = Self.repoRoot().appendingPathComponent("Sources")
-
-    // when — every source file except the shared formatter is scanned for the raw prefix
-    let offenders = try Self.swiftFiles(under: sourcesRoot).filter { url in
-      guard url.lastPathComponent != "SessionTraceID.swift" else {
-        return false
-      }
-      let contents = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
-      return contents.contains("clawd-session-")
-    }
-
-    // then — no second, private formatter has re-opened the split trace identity
-    #expect(offenders.isEmpty, "private clawd-session- formatter(s): \(offenders.map(\.path))")
-  }
-}
-
-// MARK: - Source Guard Support
-
-private extension ProviderSurfaceParityTests {
-  /// The repository root, four directories up from this file
-  /// (`Tests/ClawGatewayTests/Routing/<file>`).
-  static func repoRoot() -> URL {
-    URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()  // Routing
-      .deletingLastPathComponent()  // ClawGatewayTests
-      .deletingLastPathComponent()  // Tests
-      .deletingLastPathComponent()  // repo root
-  }
-
-  static func swiftFiles(under root: URL) throws -> [URL] {
-    guard
-      let enumerator = FileManager.default.enumerator(
-        at: root,
-        includingPropertiesForKeys: nil
-      )
-    else {
-      return []
-    }
-    var files: [URL] = []
-    for case let url as URL in enumerator where url.pathExtension == "swift" {
-      files.append(url)
-    }
-    return files
   }
 }

--- a/Tests/ClawGatewayTests/Services/TelegramPollerServiceTests.swift
+++ b/Tests/ClawGatewayTests/Services/TelegramPollerServiceTests.swift
@@ -1,8 +1,10 @@
 import ClawAgent
 import ClawCore
 import ClawData
+import ClawTestSupport
 import Foundation
 import Logging
+import Synchronization
 import Testing
 
 @testable import ClawGateway
@@ -51,7 +53,9 @@ private actor BlockingTurnRunner: TurnDispatching {
     batches: [[RawUpdate]],
     allowed: [Int64],
     throwOnGetUpdates: TelegramError? = nil,
-    sendError: TelegramError? = nil
+    sendError: TelegramError? = nil,
+    logger: Logger = TestLog.silent,
+    clock: any Clock<Duration> = ContinuousClock()
   ) throws -> Stack {
     let queue = try ClawDatabase.makeInMemoryQueue()
     try ClawDatabase.migrate(queue)
@@ -90,7 +94,8 @@ private actor BlockingTurnRunner: TurnDispatching {
       router: router,
       cursor: cursor,
       pollTimeout: 0,
-      logger: TestLog.silent
+      logger: logger,
+      clock: clock
     )
 
     return Stack(poller: poller, transport: transport, cursor: cursor, dispatcher: dispatcher)
@@ -225,37 +230,109 @@ private actor BlockingTurnRunner: TurnDispatching {
     #expect(try stack.cursor.loadCursor() == nil)  // …but the offset did NOT advance
   }
 
-  @Test func conflict409IsHandledLoudlyWithoutHotSpin() async throws {
-    // given — getUpdates throws 409; react logs critical + backs off, the loop survives
+  @Test(.timeLimit(.minutes(1)))
+  func conflict409LogsCriticalBacksOffTenSecondsAndRepolls() async throws {
+    // given — getUpdates repeatedly throws 409 and the injected clock holds each backoff
+    let recovery = PollerRecoveryControl(expectedFirstDelay: .seconds(10))
+    defer { recovery.releaseAll() }
+    let logs = RecordingLogCapture()
     let stack = try makeStack(
       batches: [],
       allowed: [42],
-      throwOnGetUpdates: .conflict409(description: "terminated by other getUpdates")
+      throwOnGetUpdates: .conflict409(description: "terminated by other getUpdates"),
+      logger: logs.logger(),
+      clock: recovery.clock
     )
 
-    // when — wait until the 409 has been hit, then cancel mid-backoff
+    // when — observe the first backoff, release it, then hold the second one after the retry
     let task = Task { try await stack.poller.run() }
-    await stack.transport.waitForPolls(atLeast: 1)
+    await recovery.firstBackoffStarted.wait()
+    recovery.allowRetry()
+    await recovery.secondBackoffStarted.wait()
     task.cancel()
 
-    // then
-    try await task.value  // returns cleanly, no throw/crash
+    // then — the fault is loud, the requested delay is exact, and one release permits one re-poll
+    try await task.value
+    #expect(recovery.requestedDelays == [.seconds(10), .seconds(10)])
+    #expect(await stack.transport.pollCount == 2)
+    let critical = try #require(logs.entries.first { entry in entry.level == .critical })
+    #expect(critical.message.contains("409 Conflict"))
+    #expect(critical.message.contains("terminated by other getUpdates"))
   }
 
-  @Test func readTimeoutOnGetUpdatesBacksOffAndTheLoopSurvives() async throws {
-    // given — a socket read timeout surfaces from the client as TelegramError.transport (A3)
+  @Test(.timeLimit(.minutes(1)))
+  func readTimeoutLogsErrorBacksOffThreeSecondsAndRepolls() async throws {
+    // given — a socket read timeout surfaces as TelegramError.transport on every poll
+    let recovery = PollerRecoveryControl(expectedFirstDelay: .seconds(3))
+    defer { recovery.releaseAll() }
+    let logs = RecordingLogCapture()
     let stack = try makeStack(
       batches: [],
       allowed: [42],
-      throwOnGetUpdates: .transport("getUpdates: read timed out")
+      throwOnGetUpdates: .transport("getUpdates: read timed out"),
+      logger: logs.logger(),
+      clock: recovery.clock
     )
 
-    // when — the first poll throws; react() logs + backs off; cancel mid-backoff
+    // when — observe the first backoff, release it, then hold the second one after the retry
     let task = Task { try await stack.poller.run() }
-    await stack.transport.waitForPolls(atLeast: 1)
+    await recovery.firstBackoffStarted.wait()
+    recovery.allowRetry()
+    await recovery.secondBackoffStarted.wait()
     task.cancel()
 
-    // then — the loop absorbed the network error and exits cleanly, never crashing the daemon
+    // then — recovery reports the transport fault, requests its delay, and keeps polling
     try await task.value
+    #expect(recovery.requestedDelays == [.seconds(3), .seconds(3)])
+    #expect(await stack.transport.pollCount == 2)
+    let error = try #require(logs.entries.first { entry in entry.level == .error })
+    #expect(error.message.contains("telegram error"))
+    #expect(error.message.contains("getUpdates: read timed out"))
+  }
+}
+
+private final class PollerRecoveryControl: Sendable {
+  let firstBackoffStarted = AsyncGate()
+  let secondBackoffStarted = AsyncGate()
+
+  private let retryAllowed = AsyncGate()
+  private let subsequentBackoffHeld = AsyncGate()
+  private let delays = Mutex<[Duration]>([])
+  private let expectedFirstDelay: Duration
+
+  init(expectedFirstDelay: Duration) {
+    self.expectedFirstDelay = expectedFirstDelay
+  }
+
+  var clock: ScriptedClock {
+    ScriptedClock { [self] delay in
+      let sleepCount = delays.withLock { recorded in
+        recorded.append(delay)
+        return recorded.count
+      }
+      if sleepCount == 1 {
+        #expect(delay == expectedFirstDelay)
+        firstBackoffStarted.open()
+        await retryAllowed.wait()
+      } else {
+        secondBackoffStarted.open()
+        await subsequentBackoffHeld.wait()
+      }
+    }
+  }
+
+  var requestedDelays: [Duration] {
+    delays.withLock { recorded in
+      recorded
+    }
+  }
+
+  func allowRetry() {
+    retryAllowed.open()
+  }
+
+  func releaseAll() {
+    retryAllowed.open()
+    subsequentBackoffHeld.open()
   }
 }

--- a/Tests/ClawLLMTests/ChatGPT/ChatGPTResponsesProviderCancellationTests.swift
+++ b/Tests/ClawLLMTests/ChatGPT/ChatGPTResponsesProviderCancellationTests.swift
@@ -52,20 +52,27 @@ import Testing
   }
 
   @Test(.timeLimit(.minutes(1)))
-  func abandoningTheIteratorMidStreamIsConservative() async {
-    // given — a stream that publishes a delta the consumer then walks away from
-    let harness = ProviderHarness(steps: [.stream(okHead, Fixtures.slowSuccess())])
-
-    // when — the consumer breaks after the first delta, dropping the iterator
+  func abandoningAHeldOpenIteratorCancelsWithConservativeAccounting() async throws {
+    // given — the HTTP producer emits a delta, then remains live until the test releases it
+    let hold = ScriptedStreamHold()
+    defer { hold.release.open() }
+    let harness = ProviderHarness(
+      steps: [.streamThenBlock(okHead, Fixtures.slowSuccess(), hold)]
+    )
     let stream = harness.provider.stream(request: plainRequest)
-    var iterator = stream.makeAsyncIterator()
-    _ = try? await iterator.next()
 
-    // then — whether the abandonment lease stopped the work first or the finite body reached its
-    // ambiguous end first, the tokens the stream produced are never silently written off: the
-    // accounting stays conservative rather than resetting to notStarted
+    // when — the helper returns only after reading a real delta while the transfer is held open;
+    // returning releases the iterator before this test joins the owning stream
+    try await readOneDeltaAndAbandon(from: stream, onceProducerIsHeldBy: hold)
+    hold.release.open()
+
+    // then — iterator abandonment, rather than natural EOF, cancelled the live inference
     let terminal = await stream.awaitTermination()
-    #expect(Support.isConservative(Support.accounting(of: terminal)))
+    guard case .cancelled(let accounting) = terminal else {
+      Issue.record("expected iterator abandonment to cancel the stream, got \(terminal)")
+      return
+    }
+    #expect(Support.isConservative(accounting))
   }
 
   @Test(.timeLimit(.minutes(1)))
@@ -100,6 +107,15 @@ import Testing
     // then
     #expect(first == second)
   }
+}
+
+private func readOneDeltaAndAbandon(
+  from stream: LLMEventStream,
+  onceProducerIsHeldBy hold: ScriptedStreamHold
+) async throws {
+  var iterator = stream.makeAsyncIterator()
+  #expect(try await iterator.next() == .delta("Hello"))
+  await hold.started.wait()
 }
 
 // MARK: - Test doubles

--- a/Tests/ClawTelegramTests/Client/TelegramRichDraftStreamerTests.swift
+++ b/Tests/ClawTelegramTests/Client/TelegramRichDraftStreamerTests.swift
@@ -11,6 +11,7 @@ actor DraftTransport: TelegramTransport {
   }
 
   private(set) var drafts: [DraftRecord] = []
+  private(set) var draftAttempts: [DraftRecord] = []
   var throwDraft = false
 
   func getMe() async throws -> BotIdentity { BotIdentity(id: 1, username: "claw_bot") }
@@ -26,10 +27,12 @@ actor DraftTransport: TelegramTransport {
   func sendRichMessage(chatId: Int64, markdown: String) async throws -> Int64 { 1 }
 
   func sendRichMessageDraft(chatId: Int64, draftId: Int64, markdown: String) async throws -> Bool {
+    let record = DraftRecord(chatId: chatId, draftId: draftId, markdown: markdown)
+    draftAttempts.append(record)
     if throwDraft {
       throw TelegramError.transport("draft down")
     }
-    drafts.append(DraftRecord(chatId: chatId, draftId: draftId, markdown: markdown))
+    drafts.append(record)
     return true
   }
 
@@ -65,7 +68,7 @@ actor DraftTransport: TelegramTransport {
     #expect(await transport.drafts.isEmpty)
   }
 
-  @Test func sendErrorsAreSwallowed() async {
+  @Test func sendErrorsAreSwallowedAfterAttemptingTheDraft() async throws {
     // given
     let transport = DraftTransport()
     await transport.setThrowDraft(true)
@@ -75,6 +78,8 @@ actor DraftTransport: TelegramTransport {
     await streamer.sendDraft(chatId: 42, draftId: 9, markdown: "partial")
 
     // then
+    let attempt = try #require(await transport.draftAttempts.first)
+    #expect(attempt == DraftTransport.DraftRecord(chatId: 42, draftId: 9, markdown: "partial"))
     #expect(await transport.drafts.isEmpty)
   }
 }

--- a/Tests/ClawTelegramTests/Wire/RuntimeHTTPClientsTests.swift
+++ b/Tests/ClawTelegramTests/Wire/RuntimeHTTPClientsTests.swift
@@ -36,14 +36,4 @@ private struct RecordingClient: Sendable {
     #expect(RuntimeHTTPClientRole.llm.egressProfile == .protectedEgress)
     #expect(RuntimeHTTPClientRole.tool.egressProfile == .protectedEgress)
   }
-
-  @Test func liveBuildsThreeIndependentClosableClients() async throws {
-    // given / when — the production bundle over real AsyncHTTPClient-backed clients
-    let clients = RuntimeHTTPClients.live()
-
-    // then — three distinct closers, each shutting its own client down cleanly
-    try await clients.llm.close()
-    try await clients.telegram.close()
-    try await clients.tool.close()
-  }
 }

--- a/Tests/ClawToolsTests/Tools/FileWriteToolTests.swift
+++ b/Tests/ClawToolsTests/Tools/FileWriteToolTests.swift
@@ -161,33 +161,6 @@ import Testing
     #expect(try String(contentsOfFile: target, encoding: .utf8) == "new")
   }
 
-  @Test func crashBetweenTempWriteAndRenameLeavesTheOriginalIntact() throws {
-    // given — an original file, and the staged-but-not-committed state a crash would leave.
-    // The target is built on the CANONICAL root (macOS: /var → /private/var), matching the only
-    // form stage/commit ever receive in production — the gate's canonical resolution.
-    let root = try makeWorkspace()
-    let canonicalRoot = try #require(WorkspacePathContainment.canonicalPath(root.path))
-    let target = canonicalRoot + "/plan.md"
-    try Data("original".utf8).write(to: URL(fileURLWithPath: target))
-
-    // when — step 1 only (the crash window of §6.3/§6.6)
-    let tempPath = try FileWriteTool.stageTemporary(
-      content: Data("replacement".utf8),
-      target: target
-    )
-
-    // then — the original is untouched and the temp lives INSIDE the workspace (same volume)
-    #expect(try String(contentsOfFile: target, encoding: .utf8) == "original")
-    #expect(WorkspacePathContainment.isContained(target: tempPath, root: canonicalRoot))
-
-    // when — step 2 commits
-    try FileWriteTool.commitRename(tempPath: tempPath, target: target)
-
-    // then — atomic replacement, temp gone
-    #expect(try String(contentsOfFile: target, encoding: .utf8) == "replacement")
-    #expect(FileManager.default.fileExists(atPath: tempPath) == false)
-  }
-
   @Test func createApprovedWriteFailsClosedWhenTheTargetAppearsAfterApproval() async throws {
     // given — gate time: plan.md does not exist, so the approval binds to a CREATE
     let root = try makeWorkspace()

--- a/Tests/ClawWorkspaceTests/MCPConfigLoaderTests.swift
+++ b/Tests/ClawWorkspaceTests/MCPConfigLoaderTests.swift
@@ -225,9 +225,15 @@ import Testing
     // given
     let yaml = "servers:\n  - name: docs\n   url: [unclosed\n"
 
-    // when / then
-    #expect(throws: MCPConfigError.self) {
+    // when
+    let error = #expect(throws: MCPConfigError.self) {
       try MCPConfigLoader.parse(yaml: yaml)
+    }
+
+    // then
+    guard case .malformed = error else {
+      Issue.record("expected malformed, got \(String(describing: error))")
+      return
     }
   }
 

--- a/Tests/ClawdCompositionTests/MCPBootWiringTests.swift
+++ b/Tests/ClawdCompositionTests/MCPBootWiringTests.swift
@@ -3,6 +3,7 @@ import ClawGateway
 import ClawMCP
 import ClawSecrets
 import Foundation
+import Logging
 import Testing
 
 @testable import clawd
@@ -46,31 +47,61 @@ import Testing
     #expect(inputs.token(for: "linear") == nil)
   }
 
-  @Test("a token quoted by a log line is scrubbed by the redactor the union builds")
-  func tokenIsUnprintableThroughTheBootRedactor() throws {
-    // given — the union exactly as `RunCommand.bootstrapLogger` consumes it.
+  @Test("the run command hands every loaded secret to the logging bootstrap")
+  func runCommandBootstrapsLoggingWithTheCompleteRedactionSet() throws {
+    // given
     let inputs = MCPBootInputs(
       config: try MCPConfig(servers: [try server(named: "linear")]),
       credentials: ["linear": .token("mcp-linear-secret-token")],
       credentialRedactionValues: ["mcp-linear-secret-token"]
     )
-    let values = inputs.redactionValues(
-      with: Secrets(telegramBotToken: "tg-token", llmApiKey: nil, searchApiKey: nil)
+    let secrets = Secrets(
+      telegramBotToken: "tg-token",
+      llmApiKey: "llm-secret-token",
+      searchApiKey: "search-secret-token"
     )
-    let redactor = SecretRedactor(secretValues: values)
+    let capture = BootLoggingCapture()
 
-    // when — the shape a transport failure takes when a server echoes the header back.
-    let line = redactor.redact(
-      "mcp send failed: 401 {\"error\":\"bad Bearer mcp-linear-secret-token\"}"
+    // when
+    let logging = RunCommand.makeBootLogging(
+      secrets: secrets,
+      mcp: inputs,
+      bootstrap: { values in
+        capture.record(values)
+        return Logger(label: "test", factory: { _ in SwiftLogNoOpLogHandler() })
+      }
     )
 
     // then
-    #expect(line.contains("mcp-linear-secret-token") == false)
-    #expect(line.contains(SecretRedactor.replacement))
+    let expected = Set([
+      "tg-token",
+      "llm-secret-token",
+      "search-secret-token",
+      "mcp-linear-secret-token",
+    ])
+    #expect(Set(capture.values) == expected)
+    #expect(Set(logging.redactionValues) == expected)
   }
 
   private func server(named name: String) throws -> MCPServerConfig {
     try MCPServerConfig(name: name, url: "https://\(name).test.invalid/mcp")
+  }
+}
+
+private final class BootLoggingCapture: @unchecked Sendable {
+  private let lock = NSLock()
+  private var recorded: [String] = []
+
+  var values: [String] {
+    lock.lock()
+    defer { lock.unlock() }
+    return recorded
+  }
+
+  func record(_ values: [String]) {
+    lock.lock()
+    defer { lock.unlock() }
+    recorded = values
   }
 }
 

--- a/Tests/ClawdCompositionTests/MCPCompositionAcceptanceTests.swift
+++ b/Tests/ClawdCompositionTests/MCPCompositionAcceptanceTests.swift
@@ -396,16 +396,11 @@ private extension MCPCompositionAcceptanceTests {
     )
     let secrets = Secrets(telegramBotToken: "tg-token", llmApiKey: nil, searchApiKey: nil)
 
-    return DaemonBuilder(
+    return try CompositionAcceptance.makeBuilder(
+      http: http,
       config: config,
       secrets: secrets,
-      stores: try EnvironmentLoader.openStores(config: config),
-      toolExecutor: http,
-      transport: TelegramClient(token: "tg-token", http: http),
-      botUsername: nil,
-      mcp: inputs,
-      logger: Self.silentLogger,
-      makeManagedStore: { FreshCredentialStore(present: false) }
+      mcp: inputs
     )
   }
 

--- a/Tests/ClawdCompositionTests/RuntimeShutdownAcceptanceTests.swift
+++ b/Tests/ClawdCompositionTests/RuntimeShutdownAcceptanceTests.swift
@@ -3,6 +3,7 @@ import ClawCore
 import ClawData
 import ClawGateway
 import ClawLLM
+import ClawTelegram
 import ClawTestSupport
 import Foundation
 import GRDB
@@ -11,22 +12,13 @@ import Testing
 
 @testable import clawd
 
-/// Shutdown acceptance driven through the real `DaemonRuntimeBundle`: a lane held **live inside a
-/// composed ChatGPT provider's SSE and its nested HTTP exchange**, carried by a bundle whose real
-/// service graph (the production-ordered `LaneAdmissionShutdownService`) closes admission, joins the
-/// producer, and records the drain result the bundle exposes — which is then handed to the real
-/// `RuntimeShutdownCoordinator` exactly as `RunCommand` sequences it. Proves the clean-drain ordering
-/// (bundle drain → credential → llm → telegram → tool) and the grace-timeout path: active run IDs
-/// surface through the bundle, no dependent resource closes, a recording fatal terminator fires
-/// (never the production `_exit`), and a real `RUNNING` row is left for boot reconciliation.
+/// Shutdown acceptance through the production builder and command orchestration.
 @Suite struct RuntimeShutdownAcceptanceTests {
-  /// A held lane whose work runs a composed provider stream to termination, so joining the lane joins
-  /// the LLM producer and its nested HTTP exchange.
   private struct HeldLane: Sendable {
-    let registry: SessionLaneRegistry
+    let coordination: DaemonBuilder.TurnCoordination
     let hold: ScriptedStreamHold
     let join: TerminationBox
-    let stack: ProviderStack
+    let credentialSource: any LLMCredentialSource
   }
 
   private func startHeldLane(
@@ -42,10 +34,10 @@ import Testing
       )
     ])
     let stack = try CompositionAcceptance.makeStack(http: http, store: FreshCredentialStore())
-    let registry = SessionLaneRegistry()
+    let coordination = DaemonBuilder.TurnCoordination()
     let join = TerminationBox()
 
-    let admission = await registry.enqueue(sessionID: sessionId, runID: runId) {
+    let admission = await coordination.lanes.enqueue(sessionID: sessionId, runID: runId) {
       let session = stack.binding.provider.stream(
         request: ChatRequest(
           model: stack.binding.wireModel,
@@ -60,166 +52,136 @@ import Testing
 
     // The lane is now live inside the provider's SSE producer and its nested HTTP exchange.
     await hold.started.wait()
-    return HeldLane(registry: registry, hold: hold, join: join, stack: stack)
+    return HeldLane(
+      coordination: coordination,
+      hold: hold,
+      join: join,
+      credentialSource: stack.credentialSource
+    )
   }
 
   // MARK: - Clean drain
 
   @Test func cleanDrainThroughTheBundleJoinsTheProducerThenRunsCleanupInOrder() async throws {
-    // given — a lane held live inside composed provider SSE, carried by a real runtime bundle
+    // given
     let lane = try await startHeldLane(sessionId: 1, runId: 10)
     let booted = AsyncGate()
-    let bundle = Self.makeBundle(lane: lane, clock: ContinuousClock(), boot: { booted.open() })
     let recorder = StepRecorder()
+    let composed = try Self.makeComposed(
+      lane: lane,
+      clock: ContinuousClock(),
+      boot: { booted.open() },
+      recorder: recorder
+    )
 
-    // when — run the real service graph, release the SSE, then stop the graph. Its lane-admission
-    // service closes admission, joins the producer, and records the drain result on the bundle.
-    let daemonTask = Task { try await bundle.daemon.run() }
+    // when
+    let commandTask = Task {
+      try await RunCommand.serveThenShutDown(
+        composed: composed,
+        redactionValues: [],
+        logger: Self.silent
+      )
+    }
     await booted.wait()
     lane.hold.release.open()
-    daemonTask.cancel()
-    try await daemonTask.value
+    commandTask.cancel()
+    try await commandTask.value
 
-    // then — the producer/exchange actually joined and the bundle carries a clean drain
+    // then
     #expect(await lane.join.isCompleted)
-    let laneDrain = await bundle.laneShutdownOutcome.value() ?? .drained
-    #expect(laneDrain == .drained)
-
-    // when — the coordinator runs the dependent cleanup after the bundle's clean drain, exactly as
-    // `RunCommand` sequences it
-    let coordinator = RuntimeShutdownCoordinator(
-      logger: Self.silent,
-      redactor: SecretRedactor(secretValues: [])
-    )
-    let outcome = await coordinator.shutDown(
-      daemonError: nil,
-      laneDrain: laneDrain,
-      dependent: Self.recordingCleanup(recorder)
-    )
-
-    // then — credential shutdown, then the three client closes, in the mandated order
     #expect(await recorder.events == ["credential", "llm", "telegram", "tool"])
-    if case .clean = outcome {
-    } else {
-      Issue.record("expected clean outcome, got \(outcome)")
-    }
   }
 
   // MARK: - Grace timeout
 
   @Test(.timeLimit(.minutes(1)))
   func graceTimeoutThroughTheBundleSkipsCleanupReportsRunIDsAndLeavesARunningRow() async throws {
-    // given — a real RUNNING run row and a lane held live inside composed SSE that will not finish,
-    // carried by a real runtime bundle whose drain deadline fires at once on a manual clock
+    // given
     let (writer, sessionId, runId) = try Self.makeRunningRun()
     let lane = try await startHeldLane(sessionId: sessionId, runId: runId)
     let booted = AsyncGate()
-    let bundle = Self.makeBundle(lane: lane, clock: ScriptedClock { _ in }, boot: { booted.open() })
     let recorder = StepRecorder()
-
-    // when — run and then stop the service graph; the held producer outlives cancellation and the
-    // grace window expires immediately, so the bundle records a timeout, not a drain
-    let daemonTask = Task { try await bundle.daemon.run() }
-    await booted.wait()
-    daemonTask.cancel()
-    try await daemonTask.value
-
-    // then — the still-active run is reported through the bundle, not drained
-    let laneDrain = await bundle.laneShutdownOutcome.value() ?? .drained
-    guard case .timedOut(let activeRunIDs) = laneDrain else {
-      Issue.record("expected timedOut, got \(laneDrain)")
-      lane.hold.release.open()
-      _ = await lane.registry.drain(timeout: .seconds(5), clock: ContinuousClock())
-      return
-    }
-    #expect(activeRunIDs == [runId])
-
-    // when — the coordinator refuses every dependent close on a fatal lane timeout
-    let coordinator = RuntimeShutdownCoordinator(
-      logger: Self.silent,
-      redactor: SecretRedactor(secretValues: [])
+    let logs = RecordingLogCapture()
+    let composed = try Self.makeComposed(
+      lane: lane,
+      clock: ScriptedClock { _ in },
+      boot: { booted.open() },
+      recorder: recorder
     )
-    let outcome = await coordinator.shutDown(
-      daemonError: nil,
-      laneDrain: laneDrain,
-      dependent: Self.recordingCleanup(recorder)
-    )
-
-    // then — no credential or client cleanup ran, and the run IDs pass through untouched
-    #expect(await recorder.events == [])
-    guard case .fatalLaneTimeout(let fatalRunIDs) = outcome else {
-      Issue.record("expected fatalLaneTimeout, got \(outcome)")
-      lane.hold.release.open()
-      return
-    }
-    #expect(fatalRunIDs == [runId])
-
-    // when — the fatal path terminates through a recording terminator, never production `_exit`
     let recordedCode = ExitCodeBox()
     let terminator = FatalProcessTerminator { code in
       recordedCode.set(code)
       throw FatalExitSentinel()
     }
-    #expect(throws: FatalExitSentinel.self) {
-      try terminator.fatalLaneDrainTimeout(activeRunIDs: fatalRunIDs, logger: Self.silent)
-    }
-    #expect(recordedCode.value == 1)
 
-    // then — the run is still RUNNING on disk for the boot reconciler to sweep
+    // when
+    let commandTask = Task {
+      try await RunCommand.serveThenShutDown(
+        composed: composed,
+        redactionValues: [],
+        logger: logs.logger(),
+        terminator: terminator
+      )
+    }
+    await booted.wait()
+    commandTask.cancel()
+    await #expect(throws: FatalExitSentinel.self) {
+      try await commandTask.value
+    }
+
+    // then
+    #expect(await recorder.events == [])
+    #expect(recordedCode.value == 1)
+    #expect(logs.entries.contains { $0.message.contains(String(runId)) })
     let state = try Self.runState(writer, runId: runId)
     #expect(state == RunState.running.rawValue)
 
-    // cleanup — release the held producer so no task is left parked past the test
     lane.hold.release.open()
-    _ = await lane.registry.drain(timeout: .seconds(5), clock: ContinuousClock())
+    _ = await lane.coordination.lanes.drain(
+      timeout: .seconds(5),
+      clock: ContinuousClock()
+    )
   }
 
   // MARK: - Helpers
 
   private static let silent = Logger(label: "test", factory: { _ in SwiftLogNoOpLogHandler() })
 
-  /// A real `DaemonRuntimeBundle` over the held lane's registry and the composed credential source,
-  /// built with the production service-ordering helper so its daemon carries the same lane-admission
-  /// service the composition root wires. Cancelling `daemon.run()` stops the graph, driving that
-  /// service through close-admission → cancel → drain → record on `laneShutdownOutcome` — the exact
-  /// handoff `RunCommand` reads. `boot` fires once the graph is running, so a test can stop it after.
-  private static func makeBundle(
+  private static func makeComposed(
     lane: HeldLane,
     clock: any Clock<Duration>,
-    boot: @escaping @Sendable () async -> Void
-  ) -> DaemonRuntimeBundle {
-    let outcome = LaneShutdownOutcome()
-    let laneAdmission = LaneAdmissionShutdownService(
-      lanes: lane.registry,
-      outcome: outcome,
-      drainTimeout: .seconds(5),
-      clock: clock,
-      logger: silent
-    )
-    let daemon = Daemon(
-      services: DaemonBuilder.servicesWithLaneAdmissionLast(base: [], laneAdmission: laneAdmission),
+    boot: @escaping @Sendable () async -> Void,
+    recorder: StepRecorder
+  ) throws -> RunComposition.Composed {
+    let http = ScriptedHTTPExecutor([])
+    let builder = try CompositionAcceptance.makeBuilder(http: http)
+    let bundle = builder.runtimeBundle(
+      services: [],
+      coordination: lane.coordination,
+      credentialSources: [
+        RecordingCredentialSource(base: lane.credentialSource, recorder: recorder)
+      ],
       boot: boot,
-      logger: silent,
-      gracefulShutdownSignals: [],
-      gracefulShutdownSeconds: 30
+      laneDrainClock: clock,
+      gracefulShutdownSignals: []
     )
-    return DaemonRuntimeBundle(
-      daemon: daemon,
-      lanes: lane.registry,
-      credentialSources: [lane.stack.credentialSource],
-      laneShutdownOutcome: outcome
+    return RunComposition.Composed(
+      bundle: bundle,
+      clients: RuntimeHTTPClients { role in
+        RuntimeHTTPClient(
+          executor: AsyncHTTPExecutor(client: .shared),
+          close: { await recorder.record(Self.event(for: role)) }
+        )
+      }
     )
   }
 
-  private static func recordingCleanup(
-    _ recorder: StepRecorder
-  ) -> RuntimeShutdownCoordinator.DependentCleanup {
-    RuntimeShutdownCoordinator.DependentCleanup(
-      commitCredentials: { await recorder.record("credential") },
-      closeLLMClient: { await recorder.record("llm") },
-      closeTelegramClient: { await recorder.record("telegram") },
-      closeToolClient: { await recorder.record("tool") }
-    )
+  private static func event(for role: RuntimeHTTPClientRole) -> String {
+    switch role {
+    case .telegram: return "telegram"
+    case .llm: return "llm"
+    case .tool: return "tool"
+    }
   }
 
   private static func makeRunningRun() throws -> (
@@ -277,5 +239,26 @@ private actor StepRecorder {
 
   func record(_ name: String) {
     events.append(name)
+  }
+}
+
+private struct RecordingCredentialSource: LLMCredentialSource {
+  let base: any LLMCredentialSource
+  let recorder: StepRecorder
+
+  func authorization() async throws -> LLMRequestAuthorization {
+    try await base.authorization()
+  }
+
+  func reject(
+    generation: LLMCredentialGeneration,
+    disposition: LLMCredentialRejection
+  ) async {
+    await base.reject(generation: generation, disposition: disposition)
+  }
+
+  func shutdown() async throws {
+    await recorder.record("credential")
+    try await base.shutdown()
   }
 }

--- a/Tests/ClawdCompositionTests/Support/CompositionAcceptanceHarness.swift
+++ b/Tests/ClawdCompositionTests/Support/CompositionAcceptanceHarness.swift
@@ -98,6 +98,30 @@ enum CompositionAcceptance {
     )
   }
 
+  static func makeBuilder(
+    http: any HTTPExecuting & HTTPStreaming,
+    config: AppConfig? = nil,
+    secrets: Secrets = Secrets(
+      telegramBotToken: "tg-token",
+      llmApiKey: nil,
+      searchApiKey: nil
+    ),
+    mcp: MCPBootInputs = .empty
+  ) throws -> DaemonBuilder {
+    let config = try config ?? chatGPTConfig()
+    return DaemonBuilder(
+      config: config,
+      secrets: secrets,
+      stores: try EnvironmentLoader.openStores(config: config),
+      toolExecutor: http,
+      transport: TelegramClient(token: secrets.telegramBotToken, http: http),
+      botUsername: nil,
+      mcp: mcp,
+      logger: Logger(label: "test", factory: { _ in SwiftLogNoOpLogHandler() }),
+      makeManagedStore: { FreshCredentialStore(present: false) }
+    )
+  }
+
   // MARK: SSE fixtures (one `data:` frame per event)
 
   static func event(_ json: String) -> Data { Data("data: \(json)\n\n".utf8) }


### PR DESCRIPTION
## Summary

This PR replaces tests that asserted fixtures, source text, and private helper mechanics with tests that drive public behavior. It removes smoke cases whose success path made no observable claim.

Deterministic clocks, held-open streams, admission recorders, and shared log capture let the suite observe retry delays, cancellation, FIFO ordering, shutdown, redaction, and log metadata without wall-clock sleeps.

## Root cause

Some tests stayed green when production skipped the behavior named by the test. Others bypassed `DaemonBuilder`, `RunCommand`, or public backend entry points, so wiring regressions escaped the suite.

## Changes

- Drive container serialization, runtime shutdown, boot redaction, retry recovery, and stream cancellation through production entry points with deterministic control seams.
- Require observable network attempts, log records, decryptable auth state, and FTS mutations; remove assertion-free and implementation-coupled cases.

## Impact

The patch preserves runtime defaults and user-visible behavior. The revised tests fail when production breaks the contracts named in their test names.

## Validation

- `swift build --build-tests`
- `scripts/lint.sh`
- `swift test --skip-build`: 2,669 tests in 332 suites
- `git diff --check`
