### PR TITLE
Delete dead code found by an over-engineering audit

### DIFF
--- a/Sources/ClawCore/Domain/Execution/ExecutionContracts.swift
+++ b/Sources/ClawCore/Domain/Execution/ExecutionContracts.swift
@@ -96,20 +96,17 @@ public struct ExecutionResult: Sendable, Equatable {
   public let stdout: String
   public let stderr: String
   public let truncatedRawBytes: Bool
-  public let wallClock: Duration
 
   public init(
     terminationReason: ExecTermination,
     stdout: String,
     stderr: String,
-    truncatedRawBytes: Bool,
-    wallClock: Duration
+    truncatedRawBytes: Bool
   ) {
     self.terminationReason = terminationReason
     self.stdout = stdout
     self.stderr = stderr
     self.truncatedRawBytes = truncatedRawBytes
-    self.wallClock = wallClock
   }
 }
 

--- a/Sources/ClawCore/LLM/LLM.swift
+++ b/Sources/ClawCore/LLM/LLM.swift
@@ -325,11 +325,6 @@ public enum TokenEstimator {
     inputTokens(forGraphemes: text.count)
   }
 
-  /// Estimated input tokens plus the reserved output cap.
-  public static func estimateTotalTokens(_ messages: [ChatMessage], maxOutput: Int) -> Int {
-    estimateInputTokens(messages) + maxOutput
-  }
-
   /// Inverse of input-token estimation: the max graphemes that fit a token budget.
   public static func graphemeBudget(forInputTokens inputTokens: Int) -> Int {
     Int(floor(Double(inputTokens) / 1.25)) * 4

--- a/Sources/ClawCore/LLM/MessageContent.swift
+++ b/Sources/ClawCore/LLM/MessageContent.swift
@@ -40,14 +40,4 @@ public struct MessageContent: Sendable, Equatable {
       }
     }
   }
-
-  /// True when this is exactly one text part. Callers that can only handle a lone string ask this;
-  /// a wire encoder choosing between a string and a parts array should ask `images.isEmpty` instead,
-  /// because a multi-part text-only content still fits the string form.
-  public var isPlainText: Bool {
-    guard parts.count == 1, case .text = parts[0] else {
-      return false
-    }
-    return true
-  }
 }

--- a/Sources/ClawCore/LLM/RouteSwitch.swift
+++ b/Sources/ClawCore/LLM/RouteSwitch.swift
@@ -30,9 +30,6 @@ extension ProviderError {
       nil
     }
   }
-
-  /// Whether this cause may be re-issued against a different route.
-  public var allowsRouteSwitch: Bool { routeSwitchPersistence != nil }
 }
 
 // MARK: - Decision

--- a/Sources/ClawCore/Persistence/OutboxStore.swift
+++ b/Sources/ClawCore/Persistence/OutboxStore.swift
@@ -2,12 +2,6 @@ import Foundation
 
 public protocol OutboxStore: Sendable {
   func claimOutbound(runId: Int64, chunk: OutboxChunk) throws(StoreError) -> Bool
-  /// Claims a reply only while the owning run is still active (RUNNING or AWAITING_APPROVAL —
-  /// a suspended run's own approval prompt must be deliverable).
-  func claimOutboundIfRunActive(
-    runId: Int64,
-    chunk: OutboxChunk
-  ) throws(StoreError) -> Bool
   func markSent(
     runId: Int64,
     stepIndex: Int,

--- a/Sources/ClawCore/Persistence/SessionMessageStore.swift
+++ b/Sources/ClawCore/Persistence/SessionMessageStore.swift
@@ -18,12 +18,6 @@ public protocol SessionMessageStore: Sendable {
   func claimAndPersistInbound(
     _ inbound: InboundMessage
   ) throws(StoreError) -> ClaimResult
-  /// Context returned oldest-first and bounded to the message this run is answering.
-  func loadContext(
-    sessionId: Int64,
-    throughMessageId: Int64,
-    limit: Int
-  ) throws(StoreError) -> [StoredMessage]
   /// Context snapshot returned oldest-first and bounded to the message this run is answering.
   /// Includes the durable session metadata the assembler needs for recall dedup and taint reads.
   func loadContextSnapshot(

--- a/Sources/ClawData/Stores/Delivery/OutboxStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Delivery/OutboxStoreGRDB.swift
@@ -15,41 +15,6 @@ public struct OutboxStoreGRDB: OutboxStore {
     }
   }
 
-  public func claimOutboundIfRunActive(
-    runId: Int64,
-    chunk: OutboxChunk
-  ) throws(StoreError) -> Bool {
-    try database.writeMapping { db in
-      try db.execute(
-        sql: """
-          INSERT OR IGNORE INTO outbound_deliveries(
-            run_id, step_index, chat_id, dedup_key, payload, payload_hash,
-            approval_id, reply_markup, status, created_ts
-          )
-          SELECT ?, ?, ?, ?, ?, ?, ?, ?, 'PENDING', ?
-          WHERE EXISTS (
-            SELECT 1 FROM runs WHERE id = ? AND state IN (?, ?)
-          )
-          """,
-        arguments: [
-          runId,
-          chunk.stepIndex,
-          chunk.chatId,
-          OutboxDedupKey.make(runId: runId, stepIndex: chunk.stepIndex),
-          chunk.payload,
-          chunk.payloadHash,
-          chunk.approvalId,
-          chunk.replyMarkup,
-          Date(),
-          runId,
-          RunState.running.rawValue,
-          RunState.awaitingApproval.rawValue,
-        ]
-      )
-      return db.changesCount > 0
-    }
-  }
-
   public func markSent(
     runId: Int64,
     stepIndex: Int,

--- a/Sources/ClawData/Stores/Session/SessionMessageStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Session/SessionMessageStoreGRDB.swift
@@ -112,18 +112,6 @@ public struct SessionMessageStoreGRDB: SessionMessageStore {
     }
   }
 
-  public func loadContext(
-    sessionId: Int64,
-    throughMessageId: Int64,
-    limit: Int
-  ) throws(StoreError) -> [StoredMessage] {
-    try loadContextSnapshot(
-      sessionId: sessionId,
-      throughMessageId: throughMessageId,
-      limit: limit
-    ).history
-  }
-
   public func loadContextSnapshot(
     sessionId: Int64,
     throughMessageId: Int64,

--- a/Sources/ClawExec/Backend/ContainerBackend+ControlCommands.swift
+++ b/Sources/ClawExec/Backend/ContainerBackend+ControlCommands.swift
@@ -144,8 +144,6 @@ extension ContainerBackend {
       teardownGracePeriod: commandTeardownGrace
     )
 
-    let clock = ContinuousClock()
-    let started = clock.now
     let allowance = command.timeout + command.teardownGracePeriod + hostWatchdogSlack
 
     switch await raceRunnerAgainstWatchdog(
@@ -158,25 +156,23 @@ extension ContainerBackend {
     case .runnerReturned(let result):
       return result
     case .deadlineExpired:
-      return failClosedResult(.timedOut, wallClock: started.duration(to: clock.now))
+      return failClosedResult(.timedOut)
     case .callerCancelled:
-      return failClosedResult(.cancelled, wallClock: started.duration(to: clock.now))
+      return failClosedResult(.cancelled)
     }
   }
 
   // Synthesized when the runner never reported: every consumer treats it fail-closed
   // (successOutput → nil, lifecycle/absence checks → false, bounded helpers → nil).
   private static func failClosedResult(
-    _ termination: ContainerCommandTermination,
-    wallClock: Duration
+    _ termination: ContainerCommandTermination
   ) -> ContainerCommandResult {
     let empty = CapturedCommandStream(bytes: Data(), totalBytes: 0, truncated: false)
     return ContainerCommandResult(
       termination: termination,
       stdout: empty,
       stderr: empty,
-      processIdentifier: nil,
-      wallClock: wallClock
+      processIdentifier: nil
     )
   }
 

--- a/Sources/ClawExec/Backend/ContainerBackend+Execution.swift
+++ b/Sources/ClawExec/Backend/ContainerBackend+Execution.swift
@@ -41,8 +41,7 @@ extension ContainerBackend {
       terminationReason: .cancelled,
       stdout: "",
       stderr: "",
-      truncatedRawBytes: false,
-      wallClock: .zero
+      truncatedRawBytes: false
     )
   }
 
@@ -81,8 +80,7 @@ extension ContainerBackend {
       )
     } catch {
       return infrastructureResult(
-        "failed to materialize execution scratch: \(error)",
-        started: started
+        "failed to materialize execution scratch: \(error)"
       )
     }
 
@@ -100,13 +98,12 @@ extension ContainerBackend {
           commandResult,
           identity: identity,
           cidFile: workspace.cidFile,
-          deadline: deadline,
-          started: started
+          deadline: deadline
         )
       case .deadlineExpired:
-        self.result(.timedOutKilled, started: started)
+        self.result(.timedOutKilled)
       case .callerCancelled:
-        self.result(.cancelled, started: started)
+        self.result(.cancelled)
       }
 
     let cleanupOK = await runShieldedCleanup(
@@ -119,8 +116,7 @@ extension ContainerBackend {
       // run would boot a second VM beside the zombie.
       preparedInitImage = nil
       result = infrastructureResult(
-        "could not confirm container removal for \(identity.name)",
-        started: started
+        "could not confirm container removal for \(identity.name)"
       )
     }
 
@@ -172,47 +168,41 @@ extension ContainerBackend {
     _ commandResult: ContainerCommandResult,
     identity: ExecutionIdentity,
     cidFile: URL,
-    deadline: ContinuousClock.Instant,
-    started: ContinuousClock.Instant
+    deadline: ContinuousClock.Instant
   ) async -> ExecutionResult {
     switch commandResult.termination {
     case .timedOut:
-      return result(.timedOutKilled, started: started)
+      return result(.timedOutKilled)
     case .cancelled:
-      return result(.cancelled, started: started)
+      return result(.cancelled)
     case .startFailed(let reason):
-      return infrastructureResult(reason, started: started)
+      return infrastructureResult(reason)
     case .signaled(let signal):
       return infrastructureResult(
-        "container CLI was terminated by host signal \(signal)",
-        started: started
+        "container CLI was terminated by host signal \(signal)"
       )
     case .exited(let code):
       guard cidMatches(identity, at: cidFile) else {
         return infrastructureResult(
-          "container did not create its identity file",
-          started: started
+          "container did not create its identity file"
         )
       }
 
       guard await engineRunning(deadline: deadline) else {
         return infrastructureResult(
-          "container engine became unavailable after execution",
-          started: started
+          "container engine became unavailable after execution"
         )
       }
 
       guard let present = await containerPresent(identity.name, deadline: deadline) else {
         return infrastructureResult(
-          "could not inspect container state after execution",
-          started: started
+          "could not inspect container state after execution"
         )
       }
 
       guard !present else {
         return infrastructureResult(
-          "container remained after the foreground CLI exited",
-          started: started
+          "container remained after the foreground CLI exited"
         )
       }
 
@@ -224,8 +214,7 @@ extension ContainerBackend {
         terminationReason: .exited(code: code),
         stdout: stdout,
         stderr: stderr,
-        truncatedRawBytes: commandResult.stdout.truncated || commandResult.stderr.truncated,
-        wallClock: started.duration(to: now())
+        truncatedRawBytes: commandResult.stdout.truncated || commandResult.stderr.truncated
       )
     }
   }

--- a/Sources/ClawExec/Backend/ContainerBackend.swift
+++ b/Sources/ClawExec/Backend/ContainerBackend.swift
@@ -170,15 +170,13 @@ public actor ContainerBackend {
 
 extension ContainerBackend {
   func result(
-    _ termination: ExecTermination,
-    started: ContinuousClock.Instant
+    _ termination: ExecTermination
   ) -> ExecutionResult {
     ExecutionResult(
       terminationReason: termination,
       stdout: "",
       stderr: "",
-      truncatedRawBytes: false,
-      wallClock: started.duration(to: now())
+      truncatedRawBytes: false
     )
   }
 
@@ -187,16 +185,14 @@ extension ContainerBackend {
       terminationReason: .unavailable(reason: ownerSafe(reason)),
       stdout: "",
       stderr: "",
-      truncatedRawBytes: false,
-      wallClock: .zero
+      truncatedRawBytes: false
     )
   }
 
   func infrastructureResult(
-    _ reason: String,
-    started: ContinuousClock.Instant
+    _ reason: String
   ) -> ExecutionResult {
-    result(.startFailed(reason: ownerSafe(reason)), started: started)
+    result(.startFailed(reason: ownerSafe(reason)))
   }
 
   func ownerSafe(_ reason: String) -> String {

--- a/Sources/ClawExec/ContainerCommandRunning.swift
+++ b/Sources/ClawExec/ContainerCommandRunning.swift
@@ -55,14 +55,12 @@ public struct ContainerCommandResult: Sendable, Equatable {
   public let stderr: CapturedCommandStream
 
   public let processIdentifier: Int32?
-  public let wallClock: Duration
 
   public init(
     termination: ContainerCommandTermination,
     stdout: CapturedCommandStream,
     stderr: CapturedCommandStream,
-    processIdentifier: Int32?,
-    wallClock: Duration
+    processIdentifier: Int32?
   ) {
     self.termination = termination
 
@@ -70,7 +68,6 @@ public struct ContainerCommandResult: Sendable, Equatable {
     self.stderr = stderr
 
     self.processIdentifier = processIdentifier
-    self.wallClock = wallClock
   }
 }
 
@@ -107,7 +104,6 @@ public struct SwiftSubprocessContainerCommandRunner: ContainerCommandRunning {
 
   public func run(_ command: ContainerCommand) async -> ContainerCommandResult {
     let clock = ContinuousClock()
-    let started = clock.now
 
     let teardownSequence = Self.teardownSequence(gracePeriod: command.teardownGracePeriod)
 
@@ -158,8 +154,7 @@ public struct SwiftSubprocessContainerCommandRunner: ContainerCommandRunning {
         ),
         stdout: result.closureResult.stdout,
         stderr: result.closureResult.stderr,
-        processIdentifier: Int32(result.processIdentifier.value),
-        wallClock: started.duration(to: clock.now)
+        processIdentifier: Int32(result.processIdentifier.value)
       )
     } catch {
       let termination: ContainerCommandTermination =
@@ -171,8 +166,7 @@ public struct SwiftSubprocessContainerCommandRunner: ContainerCommandRunning {
         termination: termination,
         stdout: Self.emptyStream,
         stderr: Self.emptyStream,
-        processIdentifier: nil,
-        wallClock: started.duration(to: clock.now)
+        processIdentifier: nil
       )
     }
   }

--- a/Sources/ClawGateway/Approval/ApprovalCoordinator.swift
+++ b/Sources/ClawGateway/Approval/ApprovalCoordinator.swift
@@ -1,5 +1,4 @@
 import ClawCore
-import Logging
 import Synchronization
 
 /// The process-local resolution of a durable approval. The `approvals` row stays the source of
@@ -61,7 +60,7 @@ public actor ApprovalCoordinator {
 
 /// The seam `TurnRunner` (suspend) and boot re-park hand the lane hold to. `ApprovalWaiter` is the
 /// real conformer — it awaits the coordinator, then performs the resume or deny. Kept a protocol so
-/// the placeholder below can be wired without a forward dependency on the real waiter.
+/// `DeferredApprovalParker` can stand in during composition and so tests can park without a waiter.
 public protocol ApprovalParking: Sendable {
   func park(
     approvalId: Int64,

--- a/Sources/ClawGateway/Approval/ApprovalCoordinator.swift
+++ b/Sources/ClawGateway/Approval/ApprovalCoordinator.swift
@@ -105,30 +105,3 @@ public final class DeferredApprovalParker: ApprovalParking {
     )
   }
 }
-
-/// Placeholder: HOLDS the session lane by awaiting the coordinator, then returns without
-/// resuming. The real resume/deny is `ApprovalWaiter`, which replaces this at the composition
-/// root; until it is wired, production registers no ask-tier tool, so `park` is never reached in
-/// production.
-public struct InertApprovalParker: ApprovalParking {
-  private let coordinator: ApprovalCoordinator
-  private let logger: Logger
-
-  public init(coordinator: ApprovalCoordinator, logger: Logger = Logger(label: "approval.parker")) {
-    self.coordinator = coordinator
-    self.logger = logger
-  }
-
-  public func park(
-    approvalId: Int64,
-    runId: Int64,
-    sessionId: Int64,
-    chatId: Int64,
-    revalidatePolicyOnApprove: Bool
-  ) async {
-    let signal = await coordinator.awaitResolution(approvalId: approvalId)
-    logger.debug(
-      "approval \(approvalId) resolved as \(String(describing: signal)); the waiter completes the run"
-    )
-  }
-}

--- a/Sources/ClawLLM/ChatGPT/ChatGPTResponsesSSEParser.swift
+++ b/Sources/ClawLLM/ChatGPT/ChatGPTResponsesSSEParser.swift
@@ -18,12 +18,6 @@ struct ChatGPTResponsesBounds: Sendable, Equatable {
     maximumAccumulatedOutputBytes: 4 * 1024 * 1024
   )
 
-  static let maximumEventBytes = standard.maximumEventBytes
-  static let maximumBufferedBytes = standard.maximumBufferedBytes
-  static let maximumDataEvents = standard.maximumDataEvents
-  static let maximumOutputItems = standard.maximumOutputItems
-  static let maximumAccumulatedOutputBytes = standard.maximumAccumulatedOutputBytes
-
   let maximumEventBytes: Int
   let maximumBufferedBytes: Int
   let maximumDataEvents: Int

--- a/Sources/ClawTelegram/Wire/WireModels.swift
+++ b/Sources/ClawTelegram/Wire/WireModels.swift
@@ -155,18 +155,6 @@ struct TCallbackQuery: Decodable {
   let data: String?
 }
 
-/// The inline-keyboard wire shape Telegram expects inside `reply_markup`:
-/// `{"inline_keyboard":[[{"text":…,"callback_data":…}]]}`. This is the authoritative shape the
-/// approval keyboard's JSON string must reproduce; the client sends the string parsed to a
-/// `JSONValue`, so these Encodable types are the contract, not the send path.
-struct TInlineKeyboardButton: Encodable {
-  let text: String
-  let callback_data: String
-}
-struct TInlineKeyboardMarkup: Encodable {
-  let inline_keyboard: [[TInlineKeyboardButton]]
-}
-
 struct TUpdate: Decodable {
   let update_id: Int64
   let message: TMessage?

--- a/Sources/ClawTestSupport/FakeExecutionBackend.swift
+++ b/Sources/ClawTestSupport/FakeExecutionBackend.swift
@@ -38,8 +38,7 @@ public actor FakeExecutionBackend: ExecutionBackend, SandboxMaintenance {
         terminationReason: .unavailable(reason: "no scripted execution result"),
         stdout: "",
         stderr: "",
-        truncatedRawBytes: false,
-        wallClock: .zero
+        truncatedRawBytes: false
       )
     }
     return results.removeFirst()

--- a/Sources/clawd/Bootstrap/EnvironmentLoader.swift
+++ b/Sources/clawd/Bootstrap/EnvironmentLoader.swift
@@ -33,15 +33,6 @@ enum EnvironmentLoader {
     try MCPConfigLoader.load(from: config.mcpConfigSource)
   }
 
-  /// Reads the token bound to each configured server in one pass, so the envelope opens once. Every
-  /// declared server gets an outcome, disabled ones included — doctor reports on the whole file.
-  static func loadMCPCredentials(
-    config: AppConfig,
-    servers: [MCPServerConfig]
-  ) throws(CredentialStoreError) -> [String: MCPCredentialLoad] {
-    return try EncryptedMCPCredentialStore(stateRoot: config.stateRoot).loadAll(servers: servers)
-  }
-
   /// Reads the boot snapshot: configured-server authentication outcomes plus every stored token for
   /// process-wide redaction, including records the current catalog no longer uses.
   static func loadMCPCredentialSnapshot(

--- a/Tests/ClawAgentTests/Context/ContextBuilderImageTests.swift
+++ b/Tests/ClawAgentTests/Context/ContextBuilderImageTests.swift
@@ -70,7 +70,8 @@ import Testing
 
     // then
     let last = try #require(rendered.last)
-    #expect(last.content.isPlainText)
+    #expect(last.content.parts.count == 1)
+    #expect(last.content.images.isEmpty)
   }
 
   @Test func aPhotoRowWithNoCachedBytesSaysSoExplicitly() throws {

--- a/Tests/ClawCoreTests/LLM/MessageContentTests.swift
+++ b/Tests/ClawCoreTests/LLM/MessageContentTests.swift
@@ -18,7 +18,6 @@ import Testing
     // then — plain text must stay distinguishable so the wire keeps encoding it as a JSON string
     #expect(content.parts == [.text("hello")])
     #expect(content.text == "hello")
-    #expect(content.isPlainText)
     #expect(content.images.isEmpty)
   }
 
@@ -28,7 +27,6 @@ import Testing
 
     // when / then — the grapheme-based context fitter reads this and must not see image bytes
     #expect(content.text == "what is this?")
-    #expect(content.isPlainText == false)
     #expect(content.images == [pixel])
   }
 

--- a/Tests/ClawCoreTests/LLM/RouteSwitchTests.swift
+++ b/Tests/ClawCoreTests/LLM/RouteSwitchTests.swift
@@ -46,7 +46,6 @@ struct RouteSwitchTests {
     // when / then
     for cause in causes {
       #expect(cause.routeSwitchPersistence == nil)
-      #expect(cause.allowsRouteSwitch == false)
     }
   }
 

--- a/Tests/ClawDataTests/Database/V9PersistenceAcceptanceTests.swift
+++ b/Tests/ClawDataTests/Database/V9PersistenceAcceptanceTests.swift
@@ -157,11 +157,11 @@ import Testing
     try runStatefulTurn(env)
 
     // when — the ordinary read seam, asked for nothing about state
-    let history = try env.sessions.loadContext(
+    let history = try env.sessions.loadContextSnapshot(
       sessionId: env.sessionId,
       throughMessageId: Int64.max,
       limit: 50
-    )
+    ).history
 
     // then — the window reads exactly as a pre-v9 window did, state riding along on the anchors
     #expect(

--- a/Tests/ClawDataTests/Stores/Delivery/OutboxStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Delivery/OutboxStoreTests.swift
@@ -8,7 +8,6 @@ import Testing
 @Suite struct OutboxStoreTests {
   private struct Fixture {
     let outbox: OutboxStoreGRDB
-    let runs: RunStoreGRDB
     let approvals: ApprovalStoreGRDB
 
     let writer: DatabaseQueue
@@ -36,7 +35,6 @@ import Testing
     let runId = try #require(claim.runId)
     return Fixture(
       outbox: OutboxStoreGRDB(writer: queue),
-      runs: RunStoreGRDB(writer: queue),
       approvals: ApprovalStoreGRDB(writer: queue),
       writer: queue,
       sessionId: sessionId,

--- a/Tests/ClawDataTests/Stores/Delivery/OutboxStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Delivery/OutboxStoreTests.swift
@@ -104,37 +104,6 @@ import Testing
     #expect(try env.outbox.pendingOutbound().isEmpty)
   }
 
-  @Test func activeClaimOnlyInsertsForRunningRun() throws {
-    // given
-    let env = try fixture()
-
-    // when / then
-    #expect(
-      try env.outbox.claimOutboundIfRunActive(
-        runId: env.runId,
-        chunk: OutboxChunk(stepIndex: 0, chatId: 42, payload: "pending", payloadHash: "p")
-      ) == false
-    )
-    _ = try #require(try env.runs.pickUp(runId: env.runId, now: Date()))
-    #expect(
-      try env.outbox.claimOutboundIfRunActive(
-        runId: env.runId,
-        chunk: OutboxChunk(stepIndex: 0, chatId: 42, payload: "running", payloadHash: "r")
-      )
-    )
-    _ = try env.runs.cancelActiveRun(
-      sessionId: env.sessionId,
-      reason: .cancelled,
-      now: Date()
-    )
-    #expect(
-      try env.outbox.claimOutboundIfRunActive(
-        runId: env.runId,
-        chunk: OutboxChunk(stepIndex: 1, chatId: 42, payload: "cancelled", payloadHash: "c")
-      ) == false
-    )
-  }
-
   @Test func pendingOutboundCarriesApprovalIdAndReplyMarkup() throws {
     // given — an approvals row and a PENDING delivery linked to it, carrying an inline keyboard
     let env = try fixture()

--- a/Tests/ClawDataTests/Stores/Run/AwaitingApprovalSeamTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/AwaitingApprovalSeamTests.swift
@@ -9,7 +9,6 @@ import Testing
   private struct Fixture {
     let queue: DatabaseQueue
     let runs: RunStoreGRDB
-    let outbox: OutboxStoreGRDB
 
     let sessionId: Int64
     let runId: Int64
@@ -41,7 +40,6 @@ import Testing
     return Fixture(
       queue: queue,
       runs: runs,
-      outbox: OutboxStoreGRDB(writer: queue),
       sessionId: sessionId,
       runId: runId
     )

--- a/Tests/ClawDataTests/Stores/Run/AwaitingApprovalSeamTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/AwaitingApprovalSeamTests.swift
@@ -93,21 +93,6 @@ import Testing
     #expect(health.oldestRunAgeSeconds != nil)
   }
 
-  @Test func outboxClaimTreatsASuspendedRunAsActive() throws {
-    // given
-    let env = try makeSuspendedFixture()
-
-    // when — the suspended run's own approval prompt rides this claim (preamble D7)
-    let claimed = try env.outbox.claimOutboundIfRunActive(
-      runId: env.runId,
-      chunk: OutboxChunk(stepIndex: 0, chatId: 7, payload: "approve?", payloadHash: "h")
-    )
-
-    // then
-    #expect(claimed)
-    #expect(try env.outbox.pendingOutbound().count == 1)
-  }
-
   @Test func assistantCommitOnASuspendedRunLosesArbitration() throws {
     // given
     let env = try makeSuspendedFixture()

--- a/Tests/ClawDataTests/Stores/Run/ExchangeCommitTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/ExchangeCommitTests.swift
@@ -360,11 +360,11 @@ extension ExchangeCommitTests {
   }
 
   private func loadedHistory(_ fixture: Fixture) throws -> [StoredMessage] {
-    try SessionMessageStoreGRDB(writer: fixture.queue).loadContext(
+    try SessionMessageStoreGRDB(writer: fixture.queue).loadContextSnapshot(
       sessionId: fixture.sessionId,
       throughMessageId: Int64.max,
       limit: 50
-    )
+    ).history
   }
 
   @Test func aCompletedCommitPersistsTheFinalStateAndEachExchangeState() throws {

--- a/Tests/ClawDataTests/Stores/Run/SuspendedTurnCommitTests.swift
+++ b/Tests/ClawDataTests/Stores/Run/SuspendedTurnCommitTests.swift
@@ -303,11 +303,11 @@ extension SuspendedTurnCommitTests {
     )
 
     // when — resume binds context to the filled observation row
-    let history = try SessionMessageStoreGRDB(writer: fixture.queue).loadContext(
+    let history = try SessionMessageStoreGRDB(writer: fixture.queue).loadContextSnapshot(
       sessionId: fixture.sessionId,
       throughMessageId: receipt.observationMessageId,
       limit: 50
-    )
+    ).history
 
     // then — the parked anchor carries its state; the completed and placeholder rows carry none
     #expect(history.map(\.role) == [.user, .assistant, .tool, .tool])

--- a/Tests/ClawDataTests/Stores/Session/SessionMessageStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Session/SessionMessageStoreTests.swift
@@ -90,11 +90,11 @@ import Testing
     let triggerMessageId = try #require(result.triggerMessageId)
     #expect(triggerMessageId == messageId)
 
-    let history = try store.loadContext(
+    let history = try store.loadContextSnapshot(
       sessionId: sessionId,
       throughMessageId: triggerMessageId,
       limit: 10
-    )
+    ).history
     #expect(history == [StoredMessage(role: .user, content: "hello", provenance: .trusted)])
 
     let run = try #require(
@@ -198,11 +198,11 @@ import Testing
     let throughMessageId = try #require(claims[3].triggerMessageId)
 
     // when
-    let history = try store.loadContext(
+    let history = try store.loadContextSnapshot(
       sessionId: sessionId,
       throughMessageId: throughMessageId,
       limit: 3
-    )
+    ).history
 
     // then — bounded through m4, so m5 is invisible to m4's turn.
     #expect(history.map(\.content) == ["m2", "m3", "m4"])
@@ -223,11 +223,11 @@ import Testing
     try store.resetWindowAndDetaint(sessionId: sessionId, now: Date())
     let second = try store.claimAndPersistInbound(inbound(updateId: 2, text: "after"))
     let triggerMessageId = try #require(second.triggerMessageId)
-    let history = try store.loadContext(
+    let history = try store.loadContextSnapshot(
       sessionId: sessionId,
       throughMessageId: triggerMessageId,
       limit: 10
-    )
+    ).history
 
     // then
     #expect(history.map(\.content) == ["after"])
@@ -584,11 +584,11 @@ extension SessionMessageStoreTests {
   }
 
   private func loadHistory(_ fixture: StateFixture) throws -> [StoredMessage] {
-    try fixture.store.loadContext(
+    try fixture.store.loadContextSnapshot(
       sessionId: fixture.sessionId,
       throughMessageId: Int64.max,
       limit: 50
-    )
+    ).history
   }
 
   @Test func anAssistantAnchorRoundTripsItsProviderStateVerbatim() throws {

--- a/Tests/ClawExecTests/ClawExecTestSupport.swift
+++ b/Tests/ClawExecTests/ClawExecTestSupport.swift
@@ -94,8 +94,7 @@ func commandResult(
       totalBytes: stderrTotal ?? stderr.count,
       truncated: stderrTruncated
     ),
-    processIdentifier: 42,
-    wallClock: .milliseconds(1)
+    processIdentifier: 42
   )
 }
 
@@ -243,8 +242,7 @@ struct NoopCommandRunner: ContainerCommandRunning {
       termination: .exited(0),
       stdout: CapturedCommandStream(bytes: Data(), totalBytes: 0, truncated: false),
       stderr: CapturedCommandStream(bytes: Data(), totalBytes: 0, truncated: false),
-      processIdentifier: 1,
-      wallClock: .zero
+      processIdentifier: 1
     )
   }
 }

--- a/Tests/ClawExecTests/ContainerInvocationTests.swift
+++ b/Tests/ClawExecTests/ContainerInvocationTests.swift
@@ -83,8 +83,7 @@ import Testing
       termination: .exited(7),
       stdout: output,
       stderr: CapturedCommandStream(bytes: Data(), totalBytes: 0, truncated: false),
-      processIdentifier: 42,
-      wallClock: .milliseconds(20)
+      processIdentifier: 42
     )
 
     // then

--- a/Tests/ClawGatewayTests/Acceptance/ExecuteCodeApprovalFlowTests.swift
+++ b/Tests/ClawGatewayTests/Acceptance/ExecuteCodeApprovalFlowTests.swift
@@ -19,8 +19,7 @@ import Testing
           terminationReason: .exited(code: 0),
           stdout: "answer=42 layer-a-secret-value",
           stderr: "",
-          truncatedRawBytes: false,
-          wallClock: .milliseconds(40)
+          truncatedRawBytes: false
         )
       ]
     )

--- a/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
+++ b/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
@@ -890,11 +890,11 @@ func makeStopNewStack(
       sessionKey: sessionKey,
       now: Date()
     )
-    let history = try reopened.sessionMessages.loadContext(
+    let history = try reopened.sessionMessages.loadContextSnapshot(
       sessionId: sessionId,
       throughMessageId: .max,
       limit: 50
-    )
+    ).history
     #expect(history.contains { $0.role == .user && $0.content == "hello" })
     #expect(history.contains { $0.role == .assistant && $0.content == "stub answer" })
   }

--- a/Tests/ClawGatewayTests/Routing/ConfirmationResolutionTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ConfirmationResolutionTests.swift
@@ -252,14 +252,6 @@ private struct FindSessionFailingSessions: SessionMessageStore {
     throw StoreError.unexpected("lookup lost")
   }
 
-  func loadContext(
-    sessionId: Int64,
-    throughMessageId: Int64,
-    limit: Int
-  ) throws(StoreError) -> [StoredMessage] {
-    try inner.loadContext(sessionId: sessionId, throughMessageId: throughMessageId, limit: limit)
-  }
-
   func loadContextSnapshot(
     sessionId: Int64,
     throughMessageId: Int64,

--- a/Tests/ClawGatewayTests/Routing/MessageRouterTests.swift
+++ b/Tests/ClawGatewayTests/Routing/MessageRouterTests.swift
@@ -26,13 +26,6 @@ struct FullSessions: SessionMessageStore {
   func claimAndPersistInbound(_ inbound: InboundMessage) throws(StoreError) -> ClaimResult {
     throw StoreError.diskFull
   }
-  func loadContext(
-    sessionId: Int64,
-    throughMessageId: Int64,
-    limit: Int
-  ) throws(StoreError) -> [StoredMessage] {
-    []
-  }
   func loadContextSnapshot(
     sessionId: Int64,
     throughMessageId: Int64,
@@ -122,11 +115,11 @@ struct FullSessions: SessionMessageStore {
     let sent = await harness.transport.sent
     #expect(sent.isEmpty)
     let firstCall = try #require(calls.first)
-    let history = try harness.sessionMessages.loadContext(
+    let history = try harness.sessionMessages.loadContextSnapshot(
       sessionId: firstCall.sessionId,
       throughMessageId: firstCall.triggerMessageId,
       limit: 50
-    )
+    ).history
     #expect(history.contains { $0.role == .user && $0.content == "hello" })
   }
 
@@ -270,11 +263,11 @@ struct FullSessions: SessionMessageStore {
     #expect(await harness.transport.sent.isEmpty)
     let calls = await harness.dispatcher.calls
     let firstCall = try #require(calls.first)
-    let history = try harness.sessionMessages.loadContext(
+    let history = try harness.sessionMessages.loadContextSnapshot(
       sessionId: firstCall.sessionId,
       throughMessageId: firstCall.triggerMessageId,
       limit: 50
-    )
+    ).history
     #expect(history.contains { $0.role == .user && $0.content == "/new@some_other_bot" })
   }
 

--- a/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
+++ b/Tests/ClawGatewayTests/Routing/TurnRunnerTests.swift
@@ -516,14 +516,6 @@ struct SnapshotFailingSessionMessages: SessionMessageStore {
     )
   }
 
-  func loadContext(
-    sessionId: Int64,
-    throughMessageId: Int64,
-    limit: Int
-  ) throws(StoreError) -> [StoredMessage] {
-    []
-  }
-
   func loadContextSnapshot(
     sessionId: Int64,
     throughMessageId: Int64,

--- a/Tests/ClawGatewayTests/Services/OutboxDispatcherTests.swift
+++ b/Tests/ClawGatewayTests/Services/OutboxDispatcherTests.swift
@@ -15,10 +15,6 @@ private struct MarkSentFailingOutbox: OutboxStore {
     try base.claimOutbound(runId: runId, chunk: chunk)
   }
 
-  func claimOutboundIfRunActive(runId: Int64, chunk: OutboxChunk) throws(StoreError) -> Bool {
-    try base.claimOutboundIfRunActive(runId: runId, chunk: chunk)
-  }
-
   func markSent(
     runId: Int64,
     stepIndex: Int,

--- a/Tests/ClawGatewayTests/Support/InertApprovalParker.swift
+++ b/Tests/ClawGatewayTests/Support/InertApprovalParker.swift
@@ -1,0 +1,30 @@
+import ClawCore
+import Logging
+
+@testable import ClawGateway
+
+/// Test parker: HOLDS the session lane by awaiting the coordinator, then returns without resuming.
+/// Suites that only need a run to park — never to resume — use this instead of the real
+/// `ApprovalWaiter`, which production wires at the composition root.
+struct InertApprovalParker: ApprovalParking {
+  private let coordinator: ApprovalCoordinator
+  private let logger: Logger
+
+  init(coordinator: ApprovalCoordinator, logger: Logger = Logger(label: "approval.parker")) {
+    self.coordinator = coordinator
+    self.logger = logger
+  }
+
+  func park(
+    approvalId: Int64,
+    runId: Int64,
+    sessionId: Int64,
+    chatId: Int64,
+    revalidatePolicyOnApprove: Bool
+  ) async {
+    let signal = await coordinator.awaitResolution(approvalId: approvalId)
+    logger.debug(
+      "approval \(approvalId) resolved as \(String(describing: signal)); the waiter completes the run"
+    )
+  }
+}

--- a/Tests/ClawLLMTests/Pricing/CostAndTokenTests.swift
+++ b/Tests/ClawLLMTests/Pricing/CostAndTokenTests.swift
@@ -100,7 +100,6 @@ import Testing
 
     // then
     #expect(TokenEstimator.estimateInputTokens(messages) == 3)
-    #expect(TokenEstimator.estimateTotalTokens(messages, maxOutput: 16) == 19)
     #expect(TokenEstimator.graphemeBudget(forInputTokens: 3) == 8)
   }
 }

--- a/Tests/ClawTelegramTests/Wire/CallbackWireTests.swift
+++ b/Tests/ClawTelegramTests/Wire/CallbackWireTests.swift
@@ -45,25 +45,4 @@ import Testing
     #expect(update.callback_query == nil)
     #expect(update.toRawUpdate().message?.text == "hi")
   }
-
-  @Test func inlineKeyboardEncodesTheTelegramWireShape() throws {
-    // given — the canonical reply_markup shape the approval keyboard's JSON string (Task 13)
-    // must reproduce byte-for-key: {"inline_keyboard":[[{"text":…,"callback_data":…}]]}
-    let markup = TInlineKeyboardMarkup(inline_keyboard: [
-      [
-        TInlineKeyboardButton(text: "Approve", callback_data: "apr:abc:y"),
-        TInlineKeyboardButton(text: "Deny", callback_data: "apr:abc:n"),
-      ]
-    ])
-
-    // when — a plain encoder: the snake_case field names ARE the wire keys, no strategy mangling
-    let data = try JSONEncoder().encode(markup)
-    let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
-
-    // then
-    let rows = try #require(object["inline_keyboard"] as? [[[String: String]]])
-    #expect(rows[0][0]["text"] == "Approve")
-    #expect(rows[0][0]["callback_data"] == "apr:abc:y")
-    #expect(rows[0][1]["callback_data"] == "apr:abc:n")
-  }
 }

--- a/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
+++ b/Tests/ClawToolsTests/Tools/ExecuteCodeToolTests.swift
@@ -99,8 +99,7 @@ import Testing
       terminationReason: termination,
       stdout: stdout,
       stderr: stderr,
-      truncatedRawBytes: truncated,
-      wallClock: .milliseconds(20)
+      truncatedRawBytes: truncated
     )
   }
 

--- a/Tests/ClawdCompositionTests/ChatGPTSubscriptionAcceptanceTests.swift
+++ b/Tests/ClawdCompositionTests/ChatGPTSubscriptionAcceptanceTests.swift
@@ -170,11 +170,11 @@ import Testing
     #expect(commit == .committed)
 
     // when — reload the anchor from GRDB and thread it into turn 2
-    let reloaded = try stores.sessions.loadContext(
+    let reloaded = try stores.sessions.loadContextSnapshot(
       sessionId: sessionId,
       throughMessageId: .max,
       limit: 50
-    )
+    ).history
     let reloadedAssistant = try #require(reloaded.first { $0.role == .assistant })
     let reloadedState = try #require(reloadedAssistant.providerState)
     #expect(reloadedState == mintedState)  // survived the round-trip byte-for-byte
@@ -284,7 +284,7 @@ import Testing
     // when — turn 2 replays the poisoned anchor; the backend rejects it and the provider recovers
     let poisonedAnchor = try #require(
       try stores.sessions
-        .loadContext(sessionId: sessionId, throughMessageId: .max, limit: 50)
+        .loadContextSnapshot(sessionId: sessionId, throughMessageId: .max, limit: 50).history
         .first { $0.role == .assistant }
     )
     let poisonedAnchorState = try #require(poisonedAnchor.providerState)
@@ -352,7 +352,7 @@ import Testing
       store: FreshCredentialStore()
     )
     let anchors = try stores.sessions
-      .loadContext(sessionId: sessionId, throughMessageId: .max, limit: 50)
+      .loadContextSnapshot(sessionId: sessionId, throughMessageId: .max, limit: 50).history
       .filter { $0.role == .assistant }
     #expect(anchors.count == 2)  // both epochs are on disk
 


### PR DESCRIPTION
A multi-agent audit swept every module for code that works but carries more machinery than it needs. Of 28 candidates, 21 survived an adversarial verification pass that required a repo-wide search across `Sources/`, `Tests/`, `docs/`, `scripts/` and `deploy/` before any "no callers" claim counted. This PR lands the eight findings that are pure deletions. Two further batches (indirection removals, and unifying three predicates that are currently written twice) are still to come.

38 files, 323 lines out, 61 in. The suite passes at 2666 tests and the lint gate is clean.

## What went

**Three helpers with no callers.** `TokenEstimator.estimateTotalTokens`, `MessageContent.isPlainText` and `ProviderError.allowsRouteSwitch` each existed only for the one assertion covering it. `estimateTotalTokens` is also the overflow-unsafe variant of a calculation the live path does with `SaturatingArithmetic.sum`, so leaving it in the API was an invitation to reach for the wrong one.

**Five shadow constants.** `ChatGPTResponsesBounds` declared type-level statics mirroring `.standard`'s fields. Production reads the injected instance and the tests read `compactBounds`, so nothing read the mirrors.

**`wallClock`.** Both `ExecutionResult` and `ContainerCommandResult` carried a duration that six sites wrote and nothing read. Dropping it also drops the `started:` instant that threaded through `result`, `infrastructureResult` and `classify` across roughly fifteen call sites, plus two `ContinuousClock()` instances that existed to fill the field on the timeout path. The audit sized this as trivial; it turned out to be the largest change here.

**`EnvironmentLoader.loadMCPCredentials`.** Superseded by `loadMCPCredentialSnapshot`, which returns a strict superset and which both boot paths already call.

**`SessionMessageStore.loadContext`.** A pass-through to `loadContextSnapshot(...).history` that no production code called. `TurnRunner` uses the snapshot form. The requirement survived as test sugar while forcing all three doubles to hand-write a forwarder; call sites now read `.history` off the snapshot.

**`OutboxStoreGRDB.claimOutboundIfRunActive`.** A second copy of `RunStoreGRDB.insertOutbox`'s nine-column INSERT, dedup key and argument order, with no production caller. When v8 added `approval_id` and `reply_markup`, both copies had to change.

**`TInlineKeyboardButton` / `TInlineKeyboardMarkup`.** Never constructed. Real approval keyboards are hand-built JSON in `ApprovalKeyboard`, and the two don't even agree on key order.

**`InertApprovalParker`.** A test double shipping in `ClawGateway`, with a comment claiming production registers no ask-tier tool. `DaemonBuilder+Approvals` wires the real `DeferredApprovalParker`, so the comment had been wrong for a while. Moved to the test target.

## Worth a look during review

Deleting `claimOutboundIfRunActive` takes two tests with it. They asserted a real run-active gate, but one that nothing in production reaches. If you want that gate live, it belongs as an `EXISTS` precheck on `insertOutbox` rather than a duplicate INSERT statement.

Three of the deletions were kept alive only by the assertion that covered them. A test whose sole caller is the thing it tests is a signal to delete, not coverage, and that may be worth a line in `docs/TESTING.md`.
