### PR TITLE
Give three duplicated predicates one owner

### DIFF
--- a/Sources/ClawAgent/Context/BudgetFitter.swift
+++ b/Sources/ClawAgent/Context/BudgetFitter.swift
@@ -107,7 +107,7 @@ public enum BudgetFitter {
       )
     }
 
-    let residual = residual(for: ordered, budget: budget)
+    let residual = residual(required: required, budget: budget)
     // The newest history unit is kept even when it alone exceeds the residual (see `fittedRow`),
     // so the squeezed total can legitimately overshoot the residual by this floor.
     let historyFloorCount =
@@ -255,7 +255,12 @@ public enum BudgetFitter {
   /// render to. The assembler pre-scales each truncatable cap against this before handing the
   /// sections over, so both sides have to read one formula or the caps stop matching the squeeze.
   public static func residual(for sections: [FittableSection], budget: ContextBudget) -> Int {
-    max(0, budget.inputCapGraphemes - requiredGraphemes(sections))
+    residual(required: requiredGraphemes(sections), budget: budget)
+  }
+
+  /// Split out so a fit that already measured the fixed rows does not render them a second time.
+  private static func residual(required: Int, budget: ContextBudget) -> Int {
+    max(0, budget.inputCapGraphemes - required)
   }
 
   /// The graphemes the non-truncatable rows consume once rendered — the same rendering the fit

--- a/Sources/ClawAgent/Context/BudgetFitter.swift
+++ b/Sources/ClawAgent/Context/BudgetFitter.swift
@@ -98,7 +98,7 @@ public enum BudgetFitter {
     }
     let nonTruncatable = ordered.filter { section in !section.truncatable }
     let truncatable = ordered.filter(\.truncatable)
-    let required = requiredGraphemes(ordered)
+    let required = requiredGraphemes(nonTruncatable)
 
     guard required <= budget.inputCapGraphemes else {
       throw BudgetFitterError.nonTruncatableRowsExceedInputCap(

--- a/Sources/ClawAgent/Context/BudgetFitter.swift
+++ b/Sources/ClawAgent/Context/BudgetFitter.swift
@@ -98,7 +98,7 @@ public enum BudgetFitter {
     }
     let nonTruncatable = ordered.filter { section in !section.truncatable }
     let truncatable = ordered.filter(\.truncatable)
-    let required = nonTruncatable.map(renderedCount).reduce(0, +)
+    let required = requiredGraphemes(ordered)
 
     guard required <= budget.inputCapGraphemes else {
       throw BudgetFitterError.nonTruncatableRowsExceedInputCap(
@@ -107,7 +107,7 @@ public enum BudgetFitter {
       )
     }
 
-    let residual = budget.inputCapGraphemes - required
+    let residual = residual(for: ordered, budget: budget)
     // The newest history unit is kept even when it alone exceeds the residual (see `fittedRow`),
     // so the squeezed total can legitimately overshoot the residual by this floor.
     let historyFloorCount =
@@ -249,6 +249,22 @@ public enum BudgetFitter {
     return section.units.map(\.id).filter { id in
       keptIDs.contains(id) == false
     }
+  }
+
+  /// What the truncatable rows have left to share: the input cap less whatever the fixed rows
+  /// render to. The assembler pre-scales each truncatable cap against this before handing the
+  /// sections over, so both sides have to read one formula or the caps stop matching the squeeze.
+  public static func residual(for sections: [FittableSection], budget: ContextBudget) -> Int {
+    max(0, budget.inputCapGraphemes - requiredGraphemes(sections))
+  }
+
+  /// The graphemes the non-truncatable rows consume once rendered — the same rendering the fit
+  /// itself measures, separator included.
+  private static func requiredGraphemes(_ sections: [FittableSection]) -> Int {
+    sections
+      .filter { section in !section.truncatable }
+      .map(renderedCount)
+      .reduce(0, +)
   }
 
   private static func renderedCount(_ section: FittableSection) -> Int {

--- a/Sources/ClawAgent/Context/ContextBuilder.swift
+++ b/Sources/ClawAgent/Context/ContextBuilder.swift
@@ -67,7 +67,7 @@ public struct ContextBuilder: Sendable {
     var ownerNotices: [String] = []
 
     let fixedSections = buildFixedSections(origin: origin, ownerNotices: &ownerNotices)
-    let residual = residualAfterFixedSections(fixedSections)
+    let residual = BudgetFitter.residual(for: fixedSections, budget: budget)
     let truncatableSections = buildTruncatableSections(
       snapshot: snapshot,
       sessionId: sessionId,
@@ -507,19 +507,6 @@ private extension ContextBuilder {
 
   func cap(for id: ContextRowID, residual: Int) -> Int {
     id.resolve(in: budget, residualGraphemes: residual) ?? Int.max
-  }
-
-  func residualAfterFixedSections(_ sections: [FittableSection]) -> Int {
-    let required =
-      sections
-      .filter { section in
-        !section.truncatable
-      }
-      .map { section in
-        section.units.map(\.content).joined(separator: "\n").count
-      }
-      .reduce(0, +)
-    return max(0, budget.inputCapGraphemes - required)
   }
 
   func spec(for id: ContextRowID) -> RowSpec {

--- a/Sources/ClawData/Stores/Scheduling/ScheduledJobStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Scheduling/ScheduledJobStoreGRDB.swift
@@ -152,6 +152,58 @@ extension ScheduledJobStoreGRDB {
   }
 }
 
+// MARK: - Occurrence Compare-and-Advance
+
+extension ScheduledJobStoreGRDB {
+  /// Moves a job off the occurrence it is currently due at, and reports whether this caller won.
+  ///
+  /// The WHERE arms (id, the stored due instant, ACTIVE) are what make two racers for the same
+  /// (job, due) structurally single-winner: the loser matches no row and changes nothing. A
+  /// recurring job advances to `nextOccurrence`; a one-shot has no next, so firing means done —
+  /// terminal, NULL next, invisible to the ticker index. Both the fire claim and the misfire skip
+  /// turn on this one predicate, so a change to the race is a change to both.
+  static func advanceOccurrence(
+    _ db: Database,
+    jobId: Int64,
+    due: Date,
+    nextOccurrence: Date?,
+    now: Date
+  ) throws -> Bool {
+    if let nextOccurrence {
+      try db.execute(
+        sql: """
+          UPDATE scheduled_jobs
+          SET next_occurrence = ?, updated_ts = ?
+          WHERE id = ? AND next_occurrence = ? AND status = ?
+          """,
+        arguments: [
+          EpochSecondCodec.epoch(nextOccurrence),
+          EpochSecondCodec.epoch(now),
+          jobId,
+          EpochSecondCodec.epoch(due),
+          ScheduledJobStatus.active.rawValue,
+        ]
+      )
+    } else {
+      try db.execute(
+        sql: """
+          UPDATE scheduled_jobs
+          SET next_occurrence = NULL, status = ?, updated_ts = ?
+          WHERE id = ? AND next_occurrence = ? AND status = ?
+          """,
+        arguments: [
+          ScheduledJobStatus.completed.rawValue,
+          EpochSecondCodec.epoch(now),
+          jobId,
+          EpochSecondCodec.epoch(due),
+          ScheduledJobStatus.active.rawValue,
+        ]
+      )
+    }
+    return db.changesCount > 0
+  }
+}
+
 // MARK: - Fused Claim
 
 extension ScheduledJobStoreGRDB {
@@ -163,46 +215,21 @@ extension ScheduledJobStoreGRDB {
     now: Date
   ) throws(StoreError) -> ClaimedFire? {
     try database.writeMapping { db in
-      // Step 1: the compare-and-advance. This IS the atomic claim expressed on the occurrence:
-      // the WHERE arms (id, stored due, ACTIVE) make two racers for the same (job, due)
-      // structurally single-winner.
+      // Step 1: the compare-and-advance. This IS the atomic claim expressed on the occurrence.
       // `last_fired_at` is deliberately NOT set here: it must move only when a run is actually
       // created, so an overlap-skipped fire (insertFireRows → nil) leaves it untouched, like a
       // misfire skip. insertFireRows stamps it with `fireAt` after the overlap guard passes.
-      if let nextOccurrence {
-        try db.execute(
-          sql: """
-            UPDATE scheduled_jobs
-            SET next_occurrence = ?, updated_ts = ?
-            WHERE id = ? AND next_occurrence = ? AND status = ?
-            """,
-          arguments: [
-            EpochSecondCodec.epoch(nextOccurrence),
-            EpochSecondCodec.epoch(now),
-            jobId,
-            EpochSecondCodec.epoch(due),
-            ScheduledJobStatus.active.rawValue,
-          ]
+      //
+      // Step 2: no winner ⇒ claimed elsewhere or the job mutated — abort silently, no fire.
+      guard
+        try Self.advanceOccurrence(
+          db,
+          jobId: jobId,
+          due: due,
+          nextOccurrence: nextOccurrence,
+          now: now
         )
-      } else {
-        // One-shot: fired means done — terminal, NULL next, invisible to the ticker index.
-        try db.execute(
-          sql: """
-            UPDATE scheduled_jobs
-            SET next_occurrence = NULL, status = ?, updated_ts = ?
-            WHERE id = ? AND next_occurrence = ? AND status = ?
-            """,
-          arguments: [
-            ScheduledJobStatus.completed.rawValue,
-            EpochSecondCodec.epoch(now),
-            jobId,
-            EpochSecondCodec.epoch(due),
-            ScheduledJobStatus.active.rawValue,
-          ]
-        )
-      }
-      // Step 2: zero changes ⇒ claimed elsewhere or the job mutated — abort silently, no fire.
-      guard db.changesCount > 0 else {
+      else {
         return nil
       }
       return try Self.insertFireRows(db, jobId: jobId, fireAt: fireAt, now: now)
@@ -346,39 +373,16 @@ extension ScheduledJobStoreGRDB {
     now: Date
   ) throws(StoreError) -> Bool {
     try database.writeMapping { db in
-      // The same CAS predicate as the claim — a concurrently-mutated job means no skip.
-      if let nextOccurrence {
-        try db.execute(
-          sql: """
-            UPDATE scheduled_jobs
-            SET next_occurrence = ?, updated_ts = ?
-            WHERE id = ? AND next_occurrence = ? AND status = ?
-            """,
-          arguments: [
-            EpochSecondCodec.epoch(nextOccurrence),
-            EpochSecondCodec.epoch(now),
-            jobId,
-            EpochSecondCodec.epoch(due),
-            ScheduledJobStatus.active.rawValue,
-          ]
+      // A concurrently-mutated job means no skip.
+      guard
+        try Self.advanceOccurrence(
+          db,
+          jobId: jobId,
+          due: due,
+          nextOccurrence: nextOccurrence,
+          now: now
         )
-      } else {
-        try db.execute(
-          sql: """
-            UPDATE scheduled_jobs
-            SET next_occurrence = NULL, status = ?, updated_ts = ?
-            WHERE id = ? AND next_occurrence = ? AND status = ?
-            """,
-          arguments: [
-            ScheduledJobStatus.completed.rawValue,
-            EpochSecondCodec.epoch(now),
-            jobId,
-            EpochSecondCodec.epoch(due),
-            ScheduledJobStatus.active.rawValue,
-          ]
-        )
-      }
-      guard db.changesCount > 0 else {
+      else {
         return false
       }
 

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -55,28 +55,15 @@ public struct ToolPolicyGate: Sendable {
       )
     }
 
-    // Unconditional tier — BLOCKING, every egress class.
-    let unconditional = argGuard.evaluateUnconditional(argsJSON: call.argumentsJSON)
-    if let rule = unconditional.blockedRule {
-      return blockedArgs(rule: rule, argsRedacted: unconditional.redactedArgs)
-    }
-
-    // Trifecta condition: tainted(session ∪ run) && privateData(assembly ∪ run ∪ session). The
-    // session flag survives a window roll, closing the over-cap gap the per-assembly leg cannot.
-    let tainted = context.sessionTainted || context.runIngestedUntrusted
-    let privateData =
-      context.assemblyPrivateData || context.runPrivateData || context.sessionHasPrivateData
-    guard tainted && privateData else {
-      return resolveAndAllow(call: call, tool: tool, argsRedacted: unconditional.redactedArgs)
-    }
-
-    // Conditional tier — redaction-block WINS over approval; disk at gate time.
-    let conditional = argGuard.evaluateConditional(
-      argsJSON: call.argumentsJSON,
-      privateFileTexts: privateFileLoader()
-    )
-    if let rule = conditional.blockedRule {
-      return blockedArgs(rule: rule, argsRedacted: conditional.redactedArgs)
+    let argsRedacted: String
+    switch scanArguments(call: call, context: context) {
+    case .blocked(let verdict):
+      return verdict
+    case .cleared(let redacted, let trifectaHeld):
+      guard trifectaHeld else {
+        return resolveAndAllow(call: call, tool: tool, argsRedacted: redacted)
+      }
+      argsRedacted = redacted
     }
 
     // Trifecta arm — DURABLE: a would-park action suspends onto the approval fabric. Non-interactive
@@ -86,10 +73,10 @@ public struct ToolPolicyGate: Sendable {
     case .action(let resolved):
       action = resolved
     case .blocked(let payload):
-      return .block(payload: payload, argsRedacted: conditional.redactedArgs)
+      return .block(payload: payload, argsRedacted: argsRedacted)
     }
     guard let action else {
-      return .allow(argsRedacted: conditional.redactedArgs, action: nil)
+      return .allow(argsRedacted: argsRedacted, action: nil)
     }
 
     guard context.approvalAlreadyPending == false else {
@@ -101,7 +88,7 @@ public struct ToolPolicyGate: Sendable {
           status: .blockedPendingApproval,
           ingestedUntrusted: false
         ),
-        argsRedacted: conditional.redactedArgs
+        argsRedacted: argsRedacted
       )
     }
 
@@ -173,6 +160,48 @@ public struct ToolPolicyGate: Sendable {
   }
 }
 
+// MARK: - Argument Scanning
+
+private extension ToolPolicyGate {
+  enum ArgumentScan {
+    case blocked(Verdict)
+    /// `trifectaHeld` decides whether the caller parks an approval or allows outright; the ask tier
+    /// parks regardless and ignores it.
+    case cleared(argsRedacted: String, trifectaHeld: Bool)
+  }
+
+  /// Runs the egress-carrying argument tiers once, so both entry points read one predicate rather
+  /// than two copies that can drift apart into a weaker gate.
+  ///
+  /// Unconditional scanning blocks on every egress class. The trifecta condition is
+  /// tainted(session ∪ run) && privateData(assembly ∪ run ∪ session) — the session flag survives a
+  /// window roll, closing the over-cap gap the per-assembly leg cannot. When it holds, conditional
+  /// scanning runs and a redaction block WINS over approval; the private files are read from disk at
+  /// gate time.
+  func scanArguments(call: ToolCall, context: ToolDispatchContext) -> ArgumentScan {
+    let unconditional = argGuard.evaluateUnconditional(argsJSON: call.argumentsJSON)
+    if let rule = unconditional.blockedRule {
+      return .blocked(blockedArgs(rule: rule, argsRedacted: unconditional.redactedArgs))
+    }
+
+    let tainted = context.sessionTainted || context.runIngestedUntrusted
+    let privateData =
+      context.assemblyPrivateData || context.runPrivateData || context.sessionHasPrivateData
+    guard tainted && privateData else {
+      return .cleared(argsRedacted: unconditional.redactedArgs, trifectaHeld: false)
+    }
+
+    let conditional = argGuard.evaluateConditional(
+      argsJSON: call.argumentsJSON,
+      privateFileTexts: privateFileLoader()
+    )
+    if let rule = conditional.blockedRule {
+      return .blocked(blockedArgs(rule: rule, argsRedacted: conditional.redactedArgs))
+    }
+    return .cleared(argsRedacted: conditional.redactedArgs, trifectaHeld: true)
+  }
+}
+
 // MARK: - Trifecta Verdicts
 
 private extension ToolPolicyGate {
@@ -203,25 +232,13 @@ private extension ToolPolicyGate {
     if tool.definition.egressClass == .none {
       argsRedacted = argGuard.renderRedacted(argsJSON: call.argumentsJSON)
     } else {
-      let unconditional = argGuard.evaluateUnconditional(argsJSON: call.argumentsJSON)
-      if let rule = unconditional.blockedRule {
-        return blockedArgs(rule: rule, argsRedacted: unconditional.redactedArgs)
-      }
-
-      let tainted = context.sessionTainted || context.runIngestedUntrusted
-      let privateData =
-        context.assemblyPrivateData || context.runPrivateData || context.sessionHasPrivateData
-      if tainted && privateData {
-        let conditional = argGuard.evaluateConditional(
-          argsJSON: call.argumentsJSON,
-          privateFileTexts: privateFileLoader()
-        )
-        if let rule = conditional.blockedRule {
-          return blockedArgs(rule: rule, argsRedacted: conditional.redactedArgs)
-        }
-        argsRedacted = conditional.redactedArgs
-      } else {
-        argsRedacted = unconditional.redactedArgs
+      // Ask-tier parks on the approval fabric whether or not the trifecta holds, so only the
+      // redaction matters here.
+      switch scanArguments(call: call, context: context) {
+      case .blocked(let verdict):
+        return verdict
+      case .cleared(let redacted, _):
+        argsRedacted = redacted
       }
     }
 

--- a/Tests/ClawAgentTests/Context/BudgetFitterTests.swift
+++ b/Tests/ClawAgentTests/Context/BudgetFitterTests.swift
@@ -110,20 +110,6 @@ import Testing
     #expect(budget.inputCapGraphemes - fixedContent.count == residual)
   }
 
-  /// Truncatable rows never count against the residual — they are what it is for.
-  @Test func theResidualIgnoresTruncatableRows() {
-    // given
-    let budget = testBudget(inputCap: 50)
-    let sections = [
-      nonTruncatable(id: .policy, priority: 0, content: "12345"),
-      truncatable(id: .history, priority: 70, cap: 999, units: ["hhhhhhhhhh"]),
-      truncatable(id: .recall, priority: 80, cap: 999, units: ["rrrrrrrrrr"]),
-    ]
-
-    // when / then
-    #expect(BudgetFitter.residual(for: sections, budget: budget) == 45)
-  }
-
   @Test func residualScaledCapsPreserveLowerPrioritySlicesOnSmallBudgets() throws {
     // given
     let budget = sliceBudget(inputCap: 20)

--- a/Tests/ClawAgentTests/Context/BudgetFitterTests.swift
+++ b/Tests/ClawAgentTests/Context/BudgetFitterTests.swift
@@ -74,6 +74,56 @@ import Testing
     #expect(fitted.contains { section in section.id == .skills } == false)
   }
 
+  /// The assembler scales each truncatable cap against the residual before handing the sections
+  /// over, and the fit then squeezes against its own reading of the same quantity. One formula owns
+  /// it, so this pins the two readings together: a fixed row whose units render with a separator
+  /// must shrink the residual by that separator too, or every downstream cap is one grapheme
+  /// generous per unit boundary.
+  @Test func theResidualCountsTheSameRenderingTheFitMeasures() throws {
+    // given — a fixed row of three units, so two separators ride along with the content
+    let budget = testBudget(inputCap: 100)
+    let fixed = FittableSection(
+      id: .policy,
+      tier: .system,
+      priority: ContextPriority(0),
+      truncatable: false,
+      cap: nil,
+      units: [
+        SectionUnit(content: "aaa", canTruncate: false),
+        SectionUnit(content: "bbb", canTruncate: false),
+        SectionUnit(content: "ccc", canTruncate: false),
+      ]
+    )
+    let sections = [
+      fixed,
+      truncatable(id: .history, priority: 70, cap: 999, units: ["hhhh"]),
+    ]
+
+    // when
+    let residual = BudgetFitter.residual(for: sections, budget: budget)
+    let fitted = try BudgetFitter.fitWithUnits(sections, budget: budget)
+
+    // then — 9 content graphemes plus 2 separators come off the cap, and the fit agrees
+    #expect(residual == 100 - 11)
+    let fixedContent = try #require(fitted.first { section in section.id == .policy }?.content)
+    #expect(fixedContent.count == 11)
+    #expect(budget.inputCapGraphemes - fixedContent.count == residual)
+  }
+
+  /// Truncatable rows never count against the residual — they are what it is for.
+  @Test func theResidualIgnoresTruncatableRows() {
+    // given
+    let budget = testBudget(inputCap: 50)
+    let sections = [
+      nonTruncatable(id: .policy, priority: 0, content: "12345"),
+      truncatable(id: .history, priority: 70, cap: 999, units: ["hhhhhhhhhh"]),
+      truncatable(id: .recall, priority: 80, cap: 999, units: ["rrrrrrrrrr"]),
+    ]
+
+    // when / then
+    #expect(BudgetFitter.residual(for: sections, budget: budget) == 45)
+  }
+
   @Test func residualScaledCapsPreserveLowerPrioritySlicesOnSmallBudgets() throws {
     // given
     let budget = sliceBudget(inputCap: 20)

--- a/Tests/ClawDataTests/Stores/Scheduling/ScheduledJobStoreGRDBTests.swift
+++ b/Tests/ClawDataTests/Stores/Scheduling/ScheduledJobStoreGRDBTests.swift
@@ -486,6 +486,41 @@ extension ScheduledJobStoreGRDBTests {
     #expect(try auditCount(queue, action: .jobMisfire) == 1)
   }
 
+  /// The fire claim and the misfire skip advance the occurrence through one compare-and-advance, so
+  /// they race each other, not only their own kind. A ticker that decided to skip while another
+  /// decided to fire must not do both to the same occurrence.
+  @Test func aMisfireSkipLosesToAFireClaimOnTheSameOccurrence() throws {
+    // given
+    let (store, queue) = try makeStore()
+    let job = try makeJob(store, recurrence: weekdayEnvelope(), next: dueFirst, now: baseNow)
+
+    // when — the claim advances first, then a skip arrives holding the same stale due
+    let claimed = try store.claimAndFire(
+      jobId: job.id,
+      due: dueFirst,
+      fireAt: dueFirst,
+      nextOccurrence: dueNext,
+      now: dueFirst
+    )
+    let skipped = try store.skipMisfire(
+      jobId: job.id,
+      due: dueFirst,
+      nextOccurrence: dueNext,
+      skippedCount: 3,
+      now: dueFirst.addingTimeInterval(60)
+    )
+
+    // then — the fire stands and the skip changed nothing, state and audit included
+    #expect(claimed != nil)
+    #expect(skipped == false)
+    let after = try store.job(id: job.id)
+    #expect(after?.nextOccurrence == dueNext)
+    #expect(after?.lastFiredAt == dueFirst)
+    #expect(try count(queue, sql: "SELECT COUNT(*) FROM runs") == 1)
+    #expect(try auditCount(queue, action: .jobMisfire) == 0)
+    #expect(try store.schedulerState().lastMisfireAt == nil)
+  }
+
   @Test func skipMisfireCompletesAOneShot() throws {
     // given — a one-shot whose single occurrence aged out entirely
     let (store, queue) = try makeStore()

--- a/Tests/ClawDataTests/Stores/Scheduling/ScheduledJobStoreGRDBTests.swift
+++ b/Tests/ClawDataTests/Stores/Scheduling/ScheduledJobStoreGRDBTests.swift
@@ -486,9 +486,10 @@ extension ScheduledJobStoreGRDBTests {
     #expect(try auditCount(queue, action: .jobMisfire) == 1)
   }
 
-  /// The fire claim and the misfire skip advance the occurrence through one compare-and-advance, so
-  /// they race each other, not only their own kind. A ticker that decided to skip while another
-  /// decided to fire must not do both to the same occurrence.
+  /// A ticker that decided to skip while another decided to fire must not do both to the same
+  /// occurrence. Sharing `advanceOccurrence` makes that structural rather than behavioural, so this
+  /// is a guard against the two verbs re-growing separate predicates — each verb's own stale-due
+  /// test would still pass while cross-verb contention silently stopped working.
   @Test func aMisfireSkipLosesToAFireClaimOnTheSameOccurrence() throws {
     // given
     let (store, queue) = try makeStore()

--- a/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
+++ b/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
@@ -219,6 +219,15 @@ private struct ProbedDangerousTool: Tool {
     )
   }
 
+  /// True when the verdict is a conditional-tier redaction block, which only happens once the
+  /// trifecta has opened that tier.
+  private func blocksOnPrivateData(_ verdict: ToolPolicyGate.Verdict) -> Bool {
+    guard case .block(let payload, _) = verdict else {
+      return false
+    }
+    return payload.status == .blockedArgs
+  }
+
   private func fetchCall(_ url: String) -> ToolCall {
     ToolCall(id: "c1", name: "web_fetch", argumentsJSON: #"{"url":"\#(url)"}"#)
   }
@@ -498,6 +507,56 @@ private struct ProbedDangerousTool: Tool {
       return
     }
     #expect(conditionalPayload.status == .blockedArgs)
+  }
+
+  /// Both entry points read one trifecta predicate. They diverge on what a cleared scan means — the
+  /// safe tier allows outright, the ask tier parks regardless — but never on whether the conditional
+  /// tier runs at all. A copy of the predicate drifting on one side would weaken the gate silently
+  /// rather than break the build, so pin the agreement across every leg combination.
+  @Test(
+    arguments: [
+      (tainted: false, runIngested: false, assembly: false, runPrivate: false, session: false),
+      (tainted: true, runIngested: false, assembly: false, runPrivate: false, session: false),
+      (tainted: false, runIngested: true, assembly: false, runPrivate: false, session: false),
+      (tainted: false, runIngested: false, assembly: true, runPrivate: false, session: false),
+      (tainted: true, runIngested: false, assembly: true, runPrivate: false, session: false),
+      (tainted: true, runIngested: false, assembly: false, runPrivate: true, session: false),
+      (tainted: true, runIngested: false, assembly: false, runPrivate: false, session: true),
+      (tainted: false, runIngested: true, assembly: true, runPrivate: false, session: false),
+      (tainted: false, runIngested: true, assembly: false, runPrivate: false, session: true),
+    ]
+  )
+  func bothTiersReadTheSameTrifectaPredicate(
+    legs: (tainted: Bool, runIngested: Bool, assembly: Bool, runPrivate: Bool, session: Bool)
+  ) async {
+    // given — args carrying a private-file substring, which only the conditional tier scans for
+    let privateSubstring = String(Self.memoryText.dropFirst(10).prefix(16))
+    let argumentsJSON = #"{"url":"https://mcp.example/?body=\#(privateSubstring)"}"#
+    let context = makeContext(
+      tainted: legs.tainted,
+      runIngested: legs.runIngested,
+      assemblyPrivate: legs.assembly,
+      runPrivate: legs.runPrivate,
+      sessionHasPrivate: legs.session
+    )
+
+    // when — the same context through the safe-tier and the ask-tier entry points
+    let safeVerdict = await makeGate().evaluate(
+      call: ToolCall(id: "s1", name: "web_fetch", argumentsJSON: argumentsJSON),
+      tool: FetchLikeTool(),
+      context: context
+    )
+    let askVerdict = await makeGate().evaluate(
+      call: ToolCall(id: "a1", name: "mcp__linear__create_issue", argumentsJSON: argumentsJSON),
+      tool: FetchLikeTool(name: "mcp__linear__create_issue", riskLevel: .ask),
+      context: context
+    )
+
+    // then — the conditional tier runs on exactly the same leg combinations for both
+    let trifectaHolds =
+      (legs.tainted || legs.runIngested) && (legs.assembly || legs.runPrivate || legs.session)
+    #expect(blocksOnPrivateData(safeVerdict) == trifectaHolds)
+    #expect(blocksOnPrivateData(askVerdict) == trifectaHolds)
   }
 
   @Test func askTierRecordsCanonicalArgsHashAndPresentation() async {

--- a/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
+++ b/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
@@ -168,6 +168,19 @@ private struct ProbedDangerousTool: Tool {
 }
 
 @Suite struct ToolPolicyGateTests {
+  /// Every combination of the five trifecta inputs, exhaustive so no leg can go unexercised. Both
+  /// the gating test and the tier-agreement test read this one list: the branch that removed the
+  /// duplicated predicate from the gate must not leave two leg matrices behind to drift instead.
+  static let trifectaLegMatrix: [TrifectaLegs] = (0..<32).map { mask in
+    TrifectaLegs(
+      tainted: mask & 1 != 0,
+      runIngested: mask & 2 != 0,
+      assembly: mask & 4 != 0,
+      runPrivate: mask & 8 != 0,
+      session: mask & 16 != 0
+    )
+  }
+
   private static let memoryText = "The owner's private project is called Operation Nightjar Falcon."
 
   private func makeGate(
@@ -325,37 +338,29 @@ private struct ProbedDangerousTool: Tool {
     #expect(argsRedacted.contains("sk-abcdefghijklmnop1234") == false)
   }
 
-  @Test func trifectaConditionReadsBothUnionInputs() async {
-    // given — every combination of (taint source) × (private source) must gate (rev.1 H1)
+  @Test(arguments: ToolPolicyGateTests.trifectaLegMatrix)
+  func trifectaConditionReadsBothUnionInputs(legs: TrifectaLegs) async {
+    // given — one taint source and one private source, in every combination
     let gate = makeGate()
-    let combinations: [(ToolDispatchContext, Bool)] = [
-      (makeContext(tainted: true, assemblyPrivate: true), true),
-      (makeContext(runIngested: true, assemblyPrivate: true), true),
-      (makeContext(tainted: true, runPrivate: true), true),
-      (makeContext(runIngested: true, runPrivate: true), true),
-      (makeContext(tainted: true), false),  // taint without private data
-      (makeContext(assemblyPrivate: true), false),  // private data without taint
-      (makeContext(), false),
-    ]
 
-    // when / then
-    for (context, shouldGate) in combinations {
-      let verdict = await gate.evaluate(
-        call: fetchCall("https://example.com/a"),
-        tool: FetchLikeTool(),
-        context: context
-      )
-      if shouldGate {
-        guard case .requireApproval(let recorded) = verdict else {
-          Issue.record("expected gate for \(context)")
-          continue
-        }
-        #expect(recorded.reason == .exfilTrifecta)
-      } else {
-        guard case .allow = verdict else {
-          Issue.record("expected allow for \(context)")
-          continue
-        }
+    // when
+    let verdict = await gate.evaluate(
+      call: fetchCall("https://example.com/a"),
+      tool: FetchLikeTool(),
+      context: legs.context
+    )
+
+    // then — the trifecta gates, and nothing else does
+    if legs.holds {
+      guard case .requireApproval(let recorded) = verdict else {
+        Issue.record("expected gate for \(legs)")
+        return
+      }
+      #expect(recorded.reason == .exfilTrifecta)
+    } else {
+      guard case .allow = verdict else {
+        Issue.record("expected allow for \(legs)")
+        return
       }
     }
   }
@@ -513,50 +518,27 @@ private struct ProbedDangerousTool: Tool {
   /// safe tier allows outright, the ask tier parks regardless — but never on whether the conditional
   /// tier runs at all. A copy of the predicate drifting on one side would weaken the gate silently
   /// rather than break the build, so pin the agreement across every leg combination.
-  @Test(
-    arguments: [
-      (tainted: false, runIngested: false, assembly: false, runPrivate: false, session: false),
-      (tainted: true, runIngested: false, assembly: false, runPrivate: false, session: false),
-      (tainted: false, runIngested: true, assembly: false, runPrivate: false, session: false),
-      (tainted: false, runIngested: false, assembly: true, runPrivate: false, session: false),
-      (tainted: true, runIngested: false, assembly: true, runPrivate: false, session: false),
-      (tainted: true, runIngested: false, assembly: false, runPrivate: true, session: false),
-      (tainted: true, runIngested: false, assembly: false, runPrivate: false, session: true),
-      (tainted: false, runIngested: true, assembly: true, runPrivate: false, session: false),
-      (tainted: false, runIngested: true, assembly: false, runPrivate: false, session: true),
-    ]
-  )
-  func bothTiersReadTheSameTrifectaPredicate(
-    legs: (tainted: Bool, runIngested: Bool, assembly: Bool, runPrivate: Bool, session: Bool)
-  ) async {
+  @Test(arguments: ToolPolicyGateTests.trifectaLegMatrix)
+  func bothTiersReadTheSameTrifectaPredicate(legs: TrifectaLegs) async {
     // given — args carrying a private-file substring, which only the conditional tier scans for
     let privateSubstring = String(Self.memoryText.dropFirst(10).prefix(16))
     let argumentsJSON = #"{"url":"https://mcp.example/?body=\#(privateSubstring)"}"#
-    let context = makeContext(
-      tainted: legs.tainted,
-      runIngested: legs.runIngested,
-      assemblyPrivate: legs.assembly,
-      runPrivate: legs.runPrivate,
-      sessionHasPrivate: legs.session
-    )
 
     // when — the same context through the safe-tier and the ask-tier entry points
     let safeVerdict = await makeGate().evaluate(
       call: ToolCall(id: "s1", name: "web_fetch", argumentsJSON: argumentsJSON),
       tool: FetchLikeTool(),
-      context: context
+      context: legs.context
     )
     let askVerdict = await makeGate().evaluate(
       call: ToolCall(id: "a1", name: "mcp__linear__create_issue", argumentsJSON: argumentsJSON),
       tool: FetchLikeTool(name: "mcp__linear__create_issue", riskLevel: .ask),
-      context: context
+      context: legs.context
     )
 
     // then — the conditional tier runs on exactly the same leg combinations for both
-    let trifectaHolds =
-      (legs.tainted || legs.runIngested) && (legs.assembly || legs.runPrivate || legs.session)
-    #expect(blocksOnPrivateData(safeVerdict) == trifectaHolds)
-    #expect(blocksOnPrivateData(askVerdict) == trifectaHolds)
+    #expect(blocksOnPrivateData(safeVerdict) == legs.holds)
+    #expect(blocksOnPrivateData(askVerdict) == legs.holds)
   }
 
   @Test func askTierRecordsCanonicalArgsHashAndPresentation() async {
@@ -1148,5 +1130,35 @@ struct WedgedTool: Tool {
   func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
     await release.wait()
     return ToolPayload(content: "late", status: .ok, ingestedUntrusted: false)
+  }
+}
+
+/// One row of the trifecta leg matrix: a taint source, a private-data source, and whether the
+/// condition `tainted(session ∪ run) && privateData(assembly ∪ run ∪ session)` holds for it.
+struct TrifectaLegs: Sendable, CustomStringConvertible {
+  let tainted: Bool
+  let runIngested: Bool
+  let assembly: Bool
+  let runPrivate: Bool
+  let session: Bool
+
+  var holds: Bool {
+    (tainted || runIngested) && (assembly || runPrivate || session)
+  }
+
+  var context: ToolDispatchContext {
+    ToolDispatchContext(
+      sessionTainted: tainted,
+      runIngestedUntrusted: runIngested,
+      assemblyPrivateData: assembly,
+      runPrivateData: runPrivate,
+      sessionHasPrivateData: session,
+      approvalAlreadyPending: false
+    )
+  }
+
+  var description: String {
+    "tainted=\(tainted) runIngested=\(runIngested) assembly=\(assembly) "
+      + "runPrivate=\(runPrivate) session=\(session)"
   }
 }

--- a/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
+++ b/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
@@ -5,6 +5,24 @@ import Testing
 
 @testable import ClawTools
 
+private func makeDispatchContext(
+  tainted: Bool = false,
+  runIngested: Bool = false,
+  assemblyPrivate: Bool = false,
+  runPrivate: Bool = false,
+  sessionHasPrivate: Bool = false,
+  approvalPending: Bool = false
+) -> ToolDispatchContext {
+  ToolDispatchContext(
+    sessionTainted: tainted,
+    runIngestedUntrusted: runIngested,
+    assemblyPrivateData: assemblyPrivate,
+    runPrivateData: runPrivate,
+    sessionHasPrivateData: sessionHasPrivate,
+    approvalAlreadyPending: approvalPending
+  )
+}
+
 /// Gate-test stand-ins declaring each egress class. `FetchLikeTool` resolves its target the way
 /// web_fetch does (CanonicalURL + owner-facing refusal copy), so gate tests exercise the real
 /// resolution contract without HTTP plumbing.
@@ -222,13 +240,13 @@ private struct ProbedDangerousTool: Tool {
     sessionHasPrivate: Bool = false,
     approvalPending: Bool = false
   ) -> ToolDispatchContext {
-    ToolDispatchContext(
-      sessionTainted: tainted,
-      runIngestedUntrusted: runIngested,
-      assemblyPrivateData: assemblyPrivate,
-      runPrivateData: runPrivate,
-      sessionHasPrivateData: sessionHasPrivate,
-      approvalAlreadyPending: approvalPending
+    makeDispatchContext(
+      tainted: tainted,
+      runIngested: runIngested,
+      assemblyPrivate: assemblyPrivate,
+      runPrivate: runPrivate,
+      sessionHasPrivate: sessionHasPrivate,
+      approvalPending: approvalPending
     )
   }
 
@@ -1147,13 +1165,12 @@ struct TrifectaLegs: Sendable, CustomStringConvertible {
   }
 
   var context: ToolDispatchContext {
-    ToolDispatchContext(
-      sessionTainted: tainted,
-      runIngestedUntrusted: runIngested,
-      assemblyPrivateData: assembly,
-      runPrivateData: runPrivate,
-      sessionHasPrivateData: session,
-      approvalAlreadyPending: false
+    makeDispatchContext(
+      tainted: tainted,
+      runIngested: runIngested,
+      assemblyPrivate: assembly,
+      runPrivate: runPrivate,
+      sessionHasPrivate: session
     )
   }
 


### PR DESCRIPTION
Final batch from the over-engineering audit, and the one I would review most carefully. Each item is an invariant written twice, where editing one copy and not the other compiles fine and changes behaviour quietly. Stacked on #110.

7 files, 4 new tests, suite at 2670. Lint clean.

## The trifecta predicate, written twice

`ToolPolicyGate.evaluate` and `evaluateAskTier` each hand-wrote the same pipeline: unconditional scan, then `tainted(session ∪ run) && privateData(assembly ∪ run ∪ session)`, then the conditional scan. Adding or renaming a leg meant editing both, and missing one weakens the gate instead of breaking the build.

Both now call `scanArguments`, which returns either a blocking verdict or the redacted args plus whether the trifecta held. That last bit is load-bearing: `evaluate` routes on it (allow outright vs. park an approval) while `evaluateAskTier` parks regardless and ignores it, so a bare `Result<String, Verdict>` would not have been enough. The `.none`-egress handling stays at each caller, which is where the two genuinely differ — the safe tier returns early, the ask tier renders and continues.

## The occurrence CAS, written twice

`claimAndFire` and `skipMisfire` each carried the same compare-and-advance: same `WHERE id = ? AND next_occurrence = ? AND status = ?`, same epoch encoding, same one-shot terminal arm, same `changesCount` check. A comment on the second copy already said "the same CAS predicate as the claim", which is the sort of thing that stops being true. Both now call `advanceOccurrence`.

## The residual, computed twice

`ContextBuilder.residualAfterFixedSections` and `BudgetFitter.fitWithUnits` both worked out the input cap less the rendered non-truncatable rows. The builder pre-scales every truncatable cap against its copy before handing the sections over, so the numbers currently line up — but nothing enforces that. Change the unit separator or move a row between the truncatable and fixed sets and the caps drift out of step with the squeeze, silently mis-sizing context. `BudgetFitter.residual` owns the formula now and the builder reads it.

I left the squeeze loop alone. `fitWithUnits` is public and 18 test call sites drive it with arbitrary caps, so it stays a general guard rather than assuming the builder pre-scaled anything.

## The tests

Each change carries a test for what the unification guarantees, not for either copy:

- **`bothTiersReadTheSameTrifectaPredicate`** walks nine leg combinations and asserts the safe-tier and ask-tier entry points open the conditional tier on exactly the same ones. I mutation-checked it: dropping `context.sessionTainted` from the predicate — the drift the audit flagged, since that flag is what survives a window roll — fails six of the nine cases.
- **`aMisfireSkipLosesToAFireClaimOnTheSameOccurrence`** covers the cross-verb race. Each verb already had its own stale-due test; neither pinned that a skip and a claim contend for the same occurrence, which is what sharing the predicate now means.
- **`theResidualCountsTheSameRenderingTheFitMeasures`** and **`theResidualIgnoresTruncatableRows`** pin the separator accounting. A fixed row of three units costs its content plus two separators; getting that wrong makes every downstream cap one grapheme generous per unit boundary.
