### PR TITLE
Fix page evaluation under the macOS temporary alias

### DIFF
--- a/Sources/ClawEvaluation/Infrastructure/EvaluationPathSecurity.swift
+++ b/Sources/ClawEvaluation/Infrastructure/EvaluationPathSecurity.swift
@@ -42,7 +42,9 @@ enum EvaluationPathSecurity {
       if let dotComponent = path.pathComponents.first(where: { $0 == "." || $0 == ".." }) {
         throw EvaluationPathSecurityError.dotPathComponent(dotComponent)
       }
-      try rejectSymlinkComponents(of: path.standardizedFileURL)
+      try rejectSymlinkComponents(
+        of: symlinkInspectionPath(for: path.standardizedFileURL)
+      )
     }
   }
 
@@ -230,6 +232,27 @@ private extension EvaluationPathSecurity {
     return candidates.first { candidate in
       WorkspacePathContainment.isContained(target: path.path, root: candidate.path)
     } ?? URL(fileURLWithPath: "/", isDirectory: true)
+  }
+
+  static func symlinkInspectionPath(for path: URL) -> URL {
+    #if os(macOS)
+      let temporaryAliasPath = "/tmp"
+      let canonicalTemporaryPath = "/private/tmp"
+      guard
+        WorkspacePathContainment.canonicalPath(temporaryAliasPath) == canonicalTemporaryPath,
+        WorkspacePathContainment.isContained(target: path.path, root: temporaryAliasPath)
+      else {
+        return path
+      }
+
+      let suffix = String(path.path.dropFirst(temporaryAliasPath.count))
+      return URL(
+        fileURLWithPath: canonicalTemporaryPath + suffix,
+        isDirectory: path.hasDirectoryPath
+      )
+    #else
+      return path
+    #endif
   }
 
   static func rejectSymlink(at candidate: URL) throws {

--- a/Tests/ClawEvaluationTests/Security/EvaluationPathSecurityTests.swift
+++ b/Tests/ClawEvaluationTests/Security/EvaluationPathSecurityTests.swift
@@ -72,6 +72,35 @@ extension EvaluationFilesystemSecurityTests {
     #expect((attributes[.posixPermissions] as? NSNumber)?.uint16Value == 0o700)
   }
 
+  #if os(macOS)
+    @Test func privateDirectoryPreparationTrustsOnlyTheCanonicalSystemTemporaryAlias() throws {
+      // given
+      let directoryName = "swift-claw-evaluation-path-\(UUID().uuidString)"
+      let canonicalRoot = URL(fileURLWithPath: "/private/tmp", isDirectory: true)
+        .appendingPathComponent(directoryName, isDirectory: true)
+      let aliasRoot = URL(fileURLWithPath: "/tmp", isDirectory: true)
+        .appendingPathComponent(directoryName, isDirectory: true)
+      defer { try? FileManager.default.removeItem(at: canonicalRoot) }
+
+      // when
+      try EvaluationPathSecurity.ensurePrivateDirectory(at: canonicalRoot)
+      try EvaluationPathSecurity.ensurePrivateDirectory(at: aliasRoot)
+
+      let target = canonicalRoot.appendingPathComponent("target", isDirectory: true)
+      let link = canonicalRoot.appendingPathComponent("link", isDirectory: true)
+      try FileManager.default.createDirectory(at: target, withIntermediateDirectories: false)
+      try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+      let aliasLink = aliasRoot.appendingPathComponent("link", isDirectory: true)
+
+      // then
+      #expect(
+        throws: EvaluationPathSecurityError.symlinkedComponent(link.lastPathComponent)
+      ) {
+        try EvaluationPathSecurity.ensurePrivateDirectory(at: aliasLink)
+      }
+    }
+  #endif
+
   @Test func workerConfigurationSnapshotRejectsDotComponentsBeforeNormalization() throws {
     // given
     let root = try makeEvaluationTestRoot()


### PR DESCRIPTION
## Summary

- Map the verified macOS `/tmp` root alias to `/private/tmp` before component inspection.
- Keep `lstat` checks for each descendant and cover the alias branch with one regression test.

## Reason

Protocol 0.3 stores the page evaluation root under `/private/tmp`. Foundation rewrites an existing path to `/tmp`; `EvaluationPathSecurity` treated that OS alias as an unsafe symlink and stopped before canary execution.

## Test intent

| Risk | Production seam | Nearest existing test | Unique mutant | Primary test |
| --- | --- | --- | --- | --- |
| The frozen root cannot open, or the trusted root alias masks a descendant symlink. | `EvaluationPathSecurity.rejectSymlinkComponents` | The current temporary-root and symlink tests do not enter the macOS alias branch. | Remove the alias mapping, or trust the whole `/tmp` subtree. | Prepare one UUID root through both spellings, then reject a linked child through `/tmp`. |

## Verification

- `swift test --filter EvaluationFilesystemSecurityTests`: 16 tests passed.
- Exact alias regression: 1 test passed.
- Full Swift suite: 2,801 tests passed.
- `scripts/lint.sh`: passed with existing warnings outside this diff.
- Independent code, security, and test-redundancy reviews found no P0/P1 issues.
