### PR TITLE
Stabilize the proactive-cap acceptance barrier

### DIFF
--- a/Tests/ClawGatewayTests/Acceptance/SC7AcceptanceTests.swift
+++ b/Tests/ClawGatewayTests/Acceptance/SC7AcceptanceTests.swift
@@ -713,6 +713,7 @@ import Testing
     // then — denied offline with the named cap; the owner is DMed exactly once; audited
     #expect(payloads.contains(Degradation.budget(cap: BudgetGate.proactivePerDayCap)))
     #expect(await harness.provider.completions == 0)
+    _ = try await harness.waitForAudit(action: AuditAction.budgetTripped.rawValue, atLeast: 1)
     let trips = await harness.transport.sent.map(\.text).filter { text in
       text == Degradation.proactiveCapTripped
     }


### PR DESCRIPTION
The SC7 acceptance test used the durable outbox row as a completion barrier even though the owner notification and audit are emitted afterward. Wait for the bounded budget-trip audit before asserting both effects, preserving the existing production assertions while removing the Linux CI race.\n\nVerification: exact test passed 10/10 locally; independent test-value review found no P0/P1.