### PR TITLE
Map page gate outcomes to terminal decisions

### DIFF
--- a/Sources/ClawEvaluation/Page/EvaluationPagePipeline.swift
+++ b/Sources/ClawEvaluation/Page/EvaluationPagePipeline.swift
@@ -207,6 +207,9 @@ enum EvaluationPagePipelineError: Error, Sendable, Equatable {
 }
 
 enum EvaluationPageTerminalClassification: String, Codable, Sendable, Equatable {
+  case pageValidated = "page_validated"
+  case insufficientDevelopmentHeadroom = "insufficient_development_headroom"
+  case insufficientSealedHeadroom = "insufficient_sealed_headroom"
   case invalidBatch = "invalid_batch"
   case carrierFailure = "carrier_failure"
   case safetyFailure = "safety_failure"

--- a/Sources/ClawEvaluation/Page/Experiment/EvaluationPageExperiment.swift
+++ b/Sources/ClawEvaluation/Page/Experiment/EvaluationPageExperiment.swift
@@ -191,9 +191,9 @@ private extension EvaluationPageExperiment {
       context: context,
       accumulator: &page
     )
-    guard developmentGate.passed else {
+    if case .finish(let outcome) = developmentGate.decision {
       return try finish(
-        outcome: developmentGate.outcome,
+        outcome: outcome,
         canary: canary,
         page: page,
         journal: journal,
@@ -224,9 +224,9 @@ private extension EvaluationPageExperiment {
       lesson: promoted.binding,
       accumulator: &page
     )
-    guard regressionGate.passed else {
+    if case .finish(let outcome) = regressionGate.decision {
       return try finish(
-        outcome: regressionGate.outcome,
+        outcome: outcome,
         canary: canary,
         page: page,
         journal: journal,
@@ -611,8 +611,14 @@ private extension EvaluationPageExperiment {
       paths: context.paths
     )
 
+    guard case .finish(let outcome) = gate.decision else {
+      throw EvaluationPagePipelineError.stageGateReceiptInvalid(
+        EvaluationPageSplit.sealed.rawValue
+      )
+    }
+
     return try finish(
-      outcome: gate.outcome,
+      outcome: outcome,
       canary: canary,
       page: page,
       journal: context.journal,

--- a/Sources/ClawEvaluation/Page/Experiment/EvaluationPageGateAggregation.swift
+++ b/Sources/ClawEvaluation/Page/Experiment/EvaluationPageGateAggregation.swift
@@ -2,8 +2,62 @@ import ClawCore
 import Foundation
 
 struct EvaluationPageGateStatus {
-  let outcome: EvaluationPageTerminalClassification
-  let passed: Bool
+  let decision: EvaluationPageGateDecision
+}
+
+enum EvaluationPageGateDecision: Sendable, Equatable {
+  case proceed
+  case finish(EvaluationPageTerminalClassification)
+}
+
+enum EvaluationPageGateOutcome: String, Sendable, Equatable {
+  case carrierFailure = "carrier_failure"
+  case developmentReady = "development_ready"
+  case incompleteBatch = "incomplete_batch"
+  case insufficientDevelopmentHeadroom = "insufficient_development_headroom"
+  case insufficientSealedHeadroom = "insufficient_sealed_headroom"
+  case invalidBatch = "invalid_batch"
+  case pageTaskSpecificFailure = "page_task_specific_failure"
+  case pageValidated = "page_validated"
+  case regressionPromoted = "regression_promoted"
+  case regressionPromotedNotTestable = "regression_promoted_not_testable"
+  case safetyFailure = "safety_failure"
+
+  var passed: Bool {
+    switch self {
+    case .developmentReady, .regressionPromoted, .regressionPromotedNotTestable, .pageValidated:
+      true
+    default:
+      false
+    }
+  }
+
+  func decision(for stage: EvaluationPageSplit) -> EvaluationPageGateDecision? {
+    switch (stage, self) {
+    case (.development, .developmentReady),
+      (.regression, .regressionPromoted),
+      (.regression, .regressionPromotedNotTestable):
+      .proceed
+    case (.development, .insufficientDevelopmentHeadroom):
+      .finish(.insufficientDevelopmentHeadroom)
+    case (.sealed, .insufficientSealedHeadroom):
+      .finish(.insufficientSealedHeadroom)
+    case (.sealed, .pageValidated):
+      .finish(.pageValidated)
+    case (_, .invalidBatch):
+      .finish(.invalidBatch)
+    case (_, .carrierFailure):
+      .finish(.carrierFailure)
+    case (_, .safetyFailure):
+      .finish(.safetyFailure)
+    case (_, .pageTaskSpecificFailure):
+      .finish(.pageTaskSpecificFailure)
+    case (_, .incompleteBatch):
+      .finish(.incompleteBatch)
+    default:
+      nil
+    }
+  }
 }
 
 extension EvaluationPageExperiment {
@@ -62,12 +116,14 @@ extension EvaluationPageExperiment {
       receipt["stage"] as? String == stage.rawValue,
       let result = receipt["result"] as? [String: Any],
       let outcomeValue = result["outcome"] as? String,
-      let outcome = EvaluationPageTerminalClassification(rawValue: outcomeValue),
-      let passed = CanonicalJSON.boolean(result["passed"])
+      let outcome = EvaluationPageGateOutcome(rawValue: outcomeValue),
+      let passed = CanonicalJSON.boolean(result["passed"]),
+      passed == outcome.passed,
+      let decision = outcome.decision(for: stage)
     else {
       throw EvaluationPagePipelineError.stageGateReceiptInvalid(stage.rawValue)
     }
 
-    return EvaluationPageGateStatus(outcome: outcome, passed: passed)
+    return EvaluationPageGateStatus(decision: decision)
   }
 }

--- a/Sources/ClawEvaluation/Runtime/EvaluationWorkerFailureEvidence.swift
+++ b/Sources/ClawEvaluation/Runtime/EvaluationWorkerFailureEvidence.swift
@@ -187,7 +187,8 @@ struct EvaluationWorkerFailureEvidence: Codable, Sendable, Equatable {
       return .carrierFailure(terminal.reason.rawValue)
     case .invalidBatch:
       return .invalidBatch(terminal.reason.rawValue)
-    case .safetyFailure, .pageTaskSpecificFailure, .incompleteBatch:
+    case .pageValidated, .insufficientDevelopmentHeadroom, .insufficientSealedHeadroom,
+      .safetyFailure, .pageTaskSpecificFailure, .incompleteBatch:
       throw EvaluationPagePipelineError.invalidBatch("worker_failure_evidence_classification")
     }
   }

--- a/Tests/ClawEvaluationTests/Page/EvaluationPageGateAggregationTests.swift
+++ b/Tests/ClawEvaluationTests/Page/EvaluationPageGateAggregationTests.swift
@@ -1,0 +1,126 @@
+import ClawSubprocess
+import Foundation
+import Testing
+
+@testable import ClawEvaluation
+
+@Suite struct EvaluationPageGateAggregationTests {
+  private struct GateOutcomeCase: Sendable {
+    let stage: EvaluationPageSplit
+    let outcome: String
+    let passed: Bool
+    let expectedDecision: EvaluationPageGateDecision
+  }
+
+  private static let gateOutcomeCases = [
+    GateOutcomeCase(
+      stage: .development,
+      outcome: "development_ready",
+      passed: true,
+      expectedDecision: .proceed
+    ),
+    GateOutcomeCase(
+      stage: .regression,
+      outcome: "regression_promoted",
+      passed: true,
+      expectedDecision: .proceed
+    ),
+    GateOutcomeCase(
+      stage: .regression,
+      outcome: "regression_promoted_not_testable",
+      passed: true,
+      expectedDecision: .proceed
+    ),
+    GateOutcomeCase(
+      stage: .sealed,
+      outcome: "page_validated",
+      passed: true,
+      expectedDecision: .finish(.pageValidated)
+    ),
+    GateOutcomeCase(
+      stage: .development,
+      outcome: "insufficient_development_headroom",
+      passed: false,
+      expectedDecision: .finish(.insufficientDevelopmentHeadroom)
+    ),
+    GateOutcomeCase(
+      stage: .sealed,
+      outcome: "insufficient_sealed_headroom",
+      passed: false,
+      expectedDecision: .finish(.insufficientSealedHeadroom)
+    ),
+    GateOutcomeCase(
+      stage: .development,
+      outcome: "invalid_batch",
+      passed: false,
+      expectedDecision: .finish(.invalidBatch)
+    ),
+    GateOutcomeCase(
+      stage: .regression,
+      outcome: "carrier_failure",
+      passed: false,
+      expectedDecision: .finish(.carrierFailure)
+    ),
+    GateOutcomeCase(
+      stage: .sealed,
+      outcome: "safety_failure",
+      passed: false,
+      expectedDecision: .finish(.safetyFailure)
+    ),
+    GateOutcomeCase(
+      stage: .development,
+      outcome: "page_task_specific_failure",
+      passed: false,
+      expectedDecision: .finish(.pageTaskSpecificFailure)
+    ),
+    GateOutcomeCase(
+      stage: .sealed,
+      outcome: "incomplete_batch",
+      passed: false,
+      expectedDecision: .finish(.incompleteBatch)
+    ),
+  ]
+
+  @Test(arguments: gateOutcomeCases)
+  private func gateReceiptVocabularyMapsToTheStageDecision(testCase: GateOutcomeCase) async throws {
+    // given
+    let root = try makeEvaluationTestRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let configured = try makeEvaluationConfiguration(root: root)
+    let frozen = try makeEvaluationFreeze(root: root, configurations: [configured.configuration])
+    let receipt = try EvaluationCanonicalJSON.data(fromJSONObject: [
+      "result": [
+        "outcome": testCase.outcome,
+        "passed": testCase.passed,
+      ],
+      "stage": testCase.stage.rawValue,
+    ])
+    let artifacts = ScriptedEvaluationProtectedArtifactRunner(output: receipt)
+    let launcher = ScriptedEvaluationWorkerLauncher { _, _, _ in
+      EvaluationWorkerLaunchResult(termination: .rejected, processID: nil)
+    }
+    let experiment = EvaluationPageExperiment(
+      freezeVerifier: StaticEvaluationFreezeVerifier(context: frozen.context),
+      artifacts: artifacts,
+      launcher: launcher
+    )
+    let paths = EvaluationController.PagePipelinePaths(
+      evaluationRoot: configured.configuration.evaluationRootURL
+    )
+    let output = root.appendingPathComponent("gate-\(testCase.outcome).json")
+
+    // when
+    let status = try await experiment.aggregate(
+      stage: testCase.stage,
+      records: root.appendingPathComponent("records.json"),
+      output: output,
+      inputs: frozen.inputs,
+      freeze: frozen.context,
+      paths: paths
+    )
+
+    // then
+    #expect(status.decision == testCase.expectedDecision)
+    #expect(await launcher.observations.isEmpty)
+  }
+}


### PR DESCRIPTION
## Summary

- decode the complete frozen page gate outcome vocabulary in Swift
- continue only on stage-valid intermediate outcomes
- publish validated, insufficient-headroom, and failure outcomes through the existing terminal path
- fail closed when the Python `passed` flag or stage does not match the outcome

## Why

The previous failure-only decoder rejected a valid `development_ready` receipt after the first 18 development attempts, so the approved experiment could never reach lesson synthesis, regression, or sealed evaluation.

## Test intent

The parameterized boundary test exercises all 11 outcomes through the real receipt aggregation seam. It catches a return to the failure-only decoder, an omitted frozen outcome, an inverted `passed` classification, or incorrect headroom terminal mapping; the nearest existing tests cover only the Python producer.

## Verification

- `swift test --filter EvaluationPageGateAggregationTests` (11/11)
- `scripts/lint.sh`
- `git diff --check`
- independent P0/P1 production review: clear
- independent test-value and redundancy review: clear

The prior D6 snapshot is intentionally superseded and will be regenerated only after this fix lands.
