### PR TITLE
Freeze dependency prioritization ranking policy

### DIFF
--- a/experiments/scheduled-task-learning/dependency-prioritization/contracts/ranking-policy.json
+++ b/experiments/scheduled-task-learning/dependency-prioritization/contracts/ranking-policy.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "grade_scope": "frozen_gold_remediation_queue",
+  "grade": {
+    "non_queue": 0,
+    "queue": {
+      "calculation": "base_plus_one_term_per_factor",
+      "base": 1,
+      "terms": {
+        "reachability": {
+          "unreachable": 0,
+          "unknown": 16,
+          "reachable": 32
+        },
+        "runtime_scope": {
+          "development_only": 0,
+          "production": 8
+        },
+        "compatible_remediation": {
+          "absent": 0,
+          "available": 4
+        },
+        "severity": {
+          "low": 0,
+          "moderate": 1,
+          "high": 2,
+          "critical": 3
+        }
+      }
+    }
+  },
+  "normalization": {
+    "reachability": "frozen_canonical_finding_value",
+    "runtime_scope": "production_if_any_canonical_path_is_runtime_otherwise_development_only",
+    "compatible_remediation": "available_if_any_option_is_available_unaffected_and_compatible_otherwise_absent",
+    "severity": "maximum_frozen_normalized_band_across_alias_cluster",
+    "missing_or_unmapped_severity": "fixture_ineligible"
+  },
+  "ndcg_gain": "linear_grade"
+}


### PR DESCRIPTION
## Summary

Freeze the D5 dependency-remediation queue grades before dependency fixtures, labels, or scorer implementation exist.

The policy gives reachability the highest weight, followed by runtime scope and compatible remediation; severity is the final tie-breaker. Linear grades are reserved for the deterministic nDCG calculation.

## Frozen artifact

- path: `experiments/scheduled-task-learning/dependency-prioritization/contracts/ranking-policy.json`
- SHA-256: `9b779a8156ac3aa675457d010efa0c82185ea8ea6b30b967cb9031e24f648c69`
- signed source commit: `768eaeb149c9eb1b79afafde9906e37af8bd34e6`

## Scope

This PR adds one data file. It does not change the page experiment, executable, protected D6 closure, runtime, or tests. Dependency fixtures and scorer work starts only after the hash-bound D5 approval is recorded.

Independent policy review found no P0/P1 issue.
