### PR TITLE
Fix macOS temporary-path containment identity

### DIFF
--- a/Sources/ClawEvaluation/Infrastructure/EvaluationPathSecurity.swift
+++ b/Sources/ClawEvaluation/Infrastructure/EvaluationPathSecurity.swift
@@ -9,26 +9,31 @@ import Foundation
 
 enum EvaluationPathSecurity {
   static func isStrictlyContained(_ candidate: URL, under root: URL) -> Bool {
-    let candidatePath = candidate.standardizedFileURL.path
-    let rootPath = root.standardizedFileURL.path
+    let candidatePath = normalizedContainmentPath(for: candidate)
+    let rootPath = normalizedContainmentPath(for: root)
     return candidatePath != rootPath
       && WorkspacePathContainment.isContained(target: candidatePath, root: rootPath)
   }
 
   static func isContainedOrEqual(_ candidate: URL, under root: URL) -> Bool {
     WorkspacePathContainment.isContained(
-      target: candidate.standardizedFileURL.path,
-      root: root.standardizedFileURL.path
+      target: normalizedContainmentPath(for: candidate),
+      root: normalizedContainmentPath(for: root)
     )
   }
 
   static func relativePath(of candidate: URL, under root: URL) -> String? {
-    let candidate = candidate.standardizedFileURL
-    let root = root.standardizedFileURL
-    guard isStrictlyContained(candidate, under: root) else {
+    let candidatePath = normalizedContainmentPath(for: candidate)
+    let rootPath = normalizedContainmentPath(for: root)
+    guard
+      candidatePath != rootPath,
+      WorkspacePathContainment.isContained(target: candidatePath, root: rootPath)
+    else {
       return nil
     }
-    return candidate.pathComponents.dropFirst(root.pathComponents.count).joined(separator: "/")
+    let candidateComponents = URL(fileURLWithPath: candidatePath).pathComponents
+    let rootComponents = URL(fileURLWithPath: rootPath).pathComponents
+    return candidateComponents.dropFirst(rootComponents.count).joined(separator: "/")
   }
 
   package static func ensurePrivateDirectory(at directory: URL) throws {
@@ -235,21 +240,30 @@ private extension EvaluationPathSecurity {
   }
 
   static func symlinkInspectionPath(for path: URL) -> URL {
+    let normalizedPath = normalizedSystemTemporaryAlias(path.path)
+    guard normalizedPath != path.path else {
+      return path
+    }
+    return URL(fileURLWithPath: normalizedPath, isDirectory: path.hasDirectoryPath)
+  }
+
+  static func normalizedContainmentPath(for path: URL) -> String {
+    normalizedSystemTemporaryAlias(path.standardizedFileURL.path)
+  }
+
+  static func normalizedSystemTemporaryAlias(_ path: String) -> String {
     #if os(macOS)
       let temporaryAliasPath = "/tmp"
       let canonicalTemporaryPath = "/private/tmp"
       guard
         WorkspacePathContainment.canonicalPath(temporaryAliasPath) == canonicalTemporaryPath,
-        WorkspacePathContainment.isContained(target: path.path, root: temporaryAliasPath)
+        WorkspacePathContainment.isContained(target: path, root: temporaryAliasPath)
       else {
         return path
       }
 
-      let suffix = String(path.path.dropFirst(temporaryAliasPath.count))
-      return URL(
-        fileURLWithPath: canonicalTemporaryPath + suffix,
-        isDirectory: path.hasDirectoryPath
-      )
+      let suffix = String(path.dropFirst(temporaryAliasPath.count))
+      return canonicalTemporaryPath + suffix
     #else
       return path
     #endif

--- a/Tests/ClawEvaluationTests/Page/EvaluationPagePipelineTests.swift
+++ b/Tests/ClawEvaluationTests/Page/EvaluationPagePipelineTests.swift
@@ -235,6 +235,8 @@ import Testing
     defer { try? FileManager.default.removeItem(at: root) }
     let configured = try makeEvaluationConfiguration(root: root, attemptID: "record-safety")
     let frozen = try makeEvaluationFreeze(root: root, configurations: [configured.configuration])
+    let manifestURL = root.appendingPathComponent("config/manifest.json")
+    try Data("{}".utf8).write(to: manifestURL)
     let workspace = try EvaluationWorkspaceMaterializer.reset(
       configuration: configured.configuration
     )
@@ -330,10 +332,14 @@ import Testing
     #expect(toolEvents[1]["name"] as? String == EvaluationToolContract.requiredToolName)
     #expect(toolEvents[1]["path"] is NSNull)
     let manifestFlag = try #require(invocation.arguments.firstIndex(of: "--manifest"))
-    #expect(
-      invocation.arguments[manifestFlag + 1]
-        == root.appendingPathComponent("config/manifest.json").standardizedFileURL.path
+    let manifestPath = invocation.arguments[manifestFlag + 1]
+    let canonicalManifestPath = try #require(
+      WorkspacePathContainment.canonicalPath(manifestPath)
     )
-    #expect(invocation.arguments[manifestFlag + 1].hasPrefix("/"))
+    let expectedManifestPath = try #require(
+      WorkspacePathContainment.canonicalPath(manifestURL.path)
+    )
+    #expect(canonicalManifestPath == expectedManifestPath)
+    #expect(manifestPath.hasPrefix("/"))
   }
 }

--- a/Tests/ClawEvaluationTests/Security/EvaluationPathSecurityTests.swift
+++ b/Tests/ClawEvaluationTests/Security/EvaluationPathSecurityTests.swift
@@ -99,6 +99,26 @@ extension EvaluationFilesystemSecurityTests {
         try EvaluationPathSecurity.ensurePrivateDirectory(at: aliasLink)
       }
     }
+
+    @Test func containmentUsesOneIdentityForAnExistingTemporaryRootAndMissingChild() throws {
+      // given
+      let directoryName = "swift-claw-evaluation-path-\(UUID().uuidString)"
+      let root = URL(fileURLWithPath: "/private/tmp", isDirectory: true)
+        .appendingPathComponent(directoryName, isDirectory: true)
+      let child = root.appendingPathComponent("results/output.json")
+      try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+      defer { try? FileManager.default.removeItem(at: root) }
+
+      // when
+      let isStrictlyContained = EvaluationPathSecurity.isStrictlyContained(child, under: root)
+      let isContainedOrEqual = EvaluationPathSecurity.isContainedOrEqual(child, under: root)
+      let relativePath = EvaluationPathSecurity.relativePath(of: child, under: root)
+
+      // then
+      #expect(isStrictlyContained)
+      #expect(isContainedOrEqual)
+      #expect(relativePath == "results/output.json")
+    }
   #endif
 
   @Test func workerConfigurationSnapshotRejectsDotComponentsBeforeNormalization() throws {


### PR DESCRIPTION
## Summary
- normalize only the verified macOS system `/tmp` alias to `/private/tmp` before lexical containment comparisons
- keep traversal, component-prefix, symlink, hardlink, and Linux behavior unchanged
- cover an existing temporary root with a missing descendant and require concrete manifest file identity

## Verification
- `swift test --skip-build --filter Evaluation`: 98/98
- security tests: 17/17
- `scripts/lint.sh`: pass
- independent security review: no P0/P1
- independent test-value/redundancy review: GO after fixing a caught nil-identity P1
- signed commit: `c6c949ccfa9cffc6defe240df95f60c7104d9e70`

This corrects the pre-call failure that invalidated the original D6 canary with zero model sends. A new D6 snapshot and exact approval are still required before rerun.