### PR TITLE
Define the dependency fixture policy

### DIFF
--- a/experiments/scheduled-task-learning/dependency-prioritization/README.md
+++ b/experiments/scheduled-task-learning/dependency-prioritization/README.md
@@ -11,9 +11,12 @@ benchmark reads its grades directly rather than re-encoding them in Python.
 
 ## Layout
 
-- `contracts/` fixes D5 ranking, target ownership, error taxonomy, feedback, and coverage.
+- `contracts/` fixes D5 ranking, fixture decisions, target ownership, error taxonomy, feedback, and
+  coverage.
 - `schemas/` closes the normalized source, canonical task, model input/output, gold, and score shapes.
 - `dependency_benchmark/normalization.py` maps author-only source keys to opaque canonical IDs.
+- `dependency_benchmark/fixture_policy.py` derives actionability, remediation, evidence, ranking
+  opportunities, and unrelated-family decisions from the frozen fixture contract.
 - `dependency_benchmark/scorer.py` validates one attempt and coordinates pure component/safety checks.
 - `dependency_benchmark/oracle.py` applies only frozen target-owned field transforms and computes headroom.
 - `conformance/cases.json` embeds three normalized fixtures and exactly 24 byte-distinct attempts.
@@ -58,3 +61,11 @@ A model output is semantically valid only when its remediation queue contains ex
 findings labeled `actionable`. This keeps the frozen D5 ranking component as pure linear-grade nDCG:
 an aligned but wrong actionability decision remains lesson-addressable, while a contradictory queue
 cannot receive an accidental perfect score from a trailing zero-grade entry.
+
+The embedded 24-case conformance corpus tests scorer behavior and deliberately exercises independent
+target-class ownership combinations. Fixture-policy derivation has its own pure tests; the scorer
+corpus is not evidence that future 10/4/6 project fixtures follow `contracts/fixture-policy.json`.
+That policy treats valid advisory fixed events as available releases and unions them with the frozen
+release inventory. It selects a pre-materialization source key by ecosystem version, origin, and source
+key; the later source-derivation layer owns parsing, version ordering, and the authoritative binding
+from that source key to a canonical option ID while materializing normalized facts.

--- a/experiments/scheduled-task-learning/dependency-prioritization/contracts/fixture-policy.json
+++ b/experiments/scheduled-task-learning/dependency-prioritization/contracts/fixture-policy.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": 1,
+  "runtime_scope": {
+    "precedence": ["production", "development_only"],
+    "empty": "invalid"
+  },
+  "reachability": {
+    "precedence": ["reachable", "unknown", "unreachable"],
+    "empty": "invalid"
+  },
+  "actionability": {
+    "unaffected": {
+      "value": "no_action",
+      "target_class": "policy.abstention"
+    },
+    "affected": {
+      "development_only": {
+        "unreachable": {
+          "value": "no_action",
+          "target_class": "policy.reachability"
+        },
+        "unknown": {
+          "value": "no_action",
+          "target_class": "policy.runtime_scope"
+        },
+        "reachable": {
+          "value": "actionable",
+          "target_class": "policy.reachability"
+        }
+      },
+      "production": {
+        "unreachable": {
+          "value": "no_action",
+          "target_class": "policy.reachability"
+        },
+        "unknown": {
+          "value": "actionable",
+          "target_class": "policy.runtime_scope"
+        },
+        "reachable": {
+          "value": "actionable",
+          "target_class": "policy.reachability"
+        }
+      }
+    }
+  },
+  "remediation": {
+    "candidate_versions": {
+      "sources": ["advisory_fixed_events", "frozen_release_inventory"],
+      "combination": "union",
+      "advisory_fixed_event_availability": "available",
+      "invalid_fixed_version": "fixture_invalid"
+    },
+    "candidate_identity": {
+      "required_fields": [
+        "target_version",
+        "origin_id",
+        "source_key",
+        "availability",
+        "affected_status",
+        "compatibility"
+      ],
+      "stage": "pre_materialization",
+      "origin_id": "advisory_record_id_or_reserved_release_inventory_origin",
+      "source_key": "unique_per_finding",
+      "equivalent_version_resolution": "origin_id_then_source_key",
+      "materialization_binding": "source_key_to_canonical_option_id_from_authoritative_normalization_binding",
+      "duplicate_selection_key": "fixture_invalid"
+    },
+    "safe_option": {
+      "availability": "available",
+      "affected_status": "unaffected",
+      "compatibility": "compatible",
+      "version_relation": "greater_than_installed"
+    },
+    "selection_order": [
+      "ecosystem_version_ascending",
+      "origin_id_ascending",
+      "source_key_ascending"
+    ],
+    "dispositions": {
+      "actionable_with_safe_option": "upgrade",
+      "actionable_without_safe_option": "no_safe_fix",
+      "no_action": "no_action"
+    },
+    "target_classes": {
+      "actionable": "policy.remediation",
+      "no_action": "policy.abstention"
+    }
+  },
+  "queue": {
+    "membership": "exactly_actionable_findings",
+    "target_class": "actionability_target_class"
+  },
+  "evidence": {
+    "gold_reference_set": "all_model_visible_references_owned_by_finding"
+  },
+  "ranking_opportunity": {
+    "minimum_actionable_findings": 2,
+    "requires_unequal_grades": true
+  },
+  "unrelated_family": {
+    "family_id": "different",
+    "disjoint_dimensions": [
+      "normalized_packages",
+      "record_alias_components",
+      "root_helper_nodes",
+      "graph_template_ids",
+      "generator_seeds",
+      "manifest_digests"
+    ],
+    "record_alias_identity": "transitive_component",
+    "manifest_digest": "canonical_semantic_json"
+  }
+}

--- a/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/fixture_policy.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/fixture_policy.py
@@ -1,0 +1,418 @@
+"""Frozen dependency fixture-policy interpretation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from functools import cmp_to_key
+from itertools import pairwise
+from typing import Any, TypedDict, cast
+
+from .policy import is_safe_remediation_option
+
+VersionComparator = Callable[[str, str], int]
+
+_ACTIONABILITY_VALUES = {"actionable", "no_action"}
+_ACTIONABILITY_TARGETS = {
+    "policy.abstention",
+    "policy.reachability",
+    "policy.runtime_scope",
+}
+_FINGERPRINT_DIMENSIONS = {
+    "normalized_packages",
+    "record_alias_components",
+    "root_helper_nodes",
+    "graph_template_ids",
+    "generator_seeds",
+    "manifest_digests",
+}
+_CANDIDATE_FIELDS = {
+    "target_version",
+    "origin_id",
+    "source_key",
+    "availability",
+    "affected_status",
+    "compatibility",
+}
+
+
+class RemediationCandidate(TypedDict):
+    """Pre-materialization release with stable provenance and canonical safety facts."""
+
+    target_version: str
+    origin_id: str
+    source_key: str
+    availability: str
+    affected_status: str
+    compatibility: str
+
+
+@dataclass(frozen=True, slots=True)
+class FixtureFamilyFingerprint:
+    """Semantic identities that must not overlap between unrelated fixture families."""
+
+    family_id: str
+    normalized_packages: frozenset[str]
+    record_alias_components: frozenset[str]
+    root_helper_nodes: frozenset[str]
+    graph_template_ids: frozenset[str]
+    generator_seeds: frozenset[str]
+    manifest_digests: frozenset[str]
+
+
+def validate_fixture_policy(value: Any) -> None:
+    policy = _object(
+        value,
+        {
+            "schema_version",
+            "runtime_scope",
+            "reachability",
+            "actionability",
+            "remediation",
+            "queue",
+            "evidence",
+            "ranking_opportunity",
+            "unrelated_family",
+        },
+        "fixture policy",
+    )
+    if type(policy["schema_version"]) is not int or policy["schema_version"] != 1:
+        raise ValueError("fixture policy schema version is unsupported")
+    _validate_aggregation(
+        policy["runtime_scope"],
+        ["production", "development_only"],
+        "runtime-scope policy",
+    )
+    _validate_aggregation(
+        policy["reachability"],
+        ["reachable", "unknown", "unreachable"],
+        "reachability policy",
+    )
+    _validate_actionability(policy["actionability"])
+    _validate_remediation(policy["remediation"])
+    if policy["queue"] != {
+        "membership": "exactly_actionable_findings",
+        "target_class": "actionability_target_class",
+    }:
+        raise ValueError("queue policy is unsupported")
+    if policy["evidence"] != {
+        "gold_reference_set": "all_model_visible_references_owned_by_finding"
+    }:
+        raise ValueError("evidence policy is unsupported")
+    ranking = _object(
+        policy["ranking_opportunity"],
+        {"minimum_actionable_findings", "requires_unequal_grades"},
+        "ranking-opportunity policy",
+    )
+    minimum = ranking["minimum_actionable_findings"]
+    if type(minimum) is not int or minimum <= 1:
+        raise ValueError("ranking-opportunity minimum is unsupported")
+    if not isinstance(ranking["requires_unequal_grades"], bool):
+        raise ValueError("ranking-opportunity grade rule is malformed")
+    unrelated = _object(
+        policy["unrelated_family"],
+        {
+            "family_id",
+            "disjoint_dimensions",
+            "record_alias_identity",
+            "manifest_digest",
+        },
+        "unrelated-family policy",
+    )
+    if (
+        unrelated["family_id"] != "different"
+        or unrelated["record_alias_identity"] != "transitive_component"
+        or unrelated["manifest_digest"] != "canonical_semantic_json"
+        or not _exact_string_list(
+            unrelated["disjoint_dimensions"],
+            _FINGERPRINT_DIMENSIONS,
+        )
+    ):
+        raise ValueError("unrelated-family policy is unsupported")
+
+
+def aggregate_runtime_scope(values: Iterable[str], policy: dict[str, Any]) -> str:
+    """Return production when any frozen path is production-scoped."""
+
+    validate_fixture_policy(policy)
+    return _aggregate(values, policy["runtime_scope"], "runtime scope")
+
+
+def aggregate_reachability(values: Iterable[str], policy: dict[str, Any]) -> str:
+    """Return the strongest frozen reachability observation."""
+
+    validate_fixture_policy(policy)
+    return _aggregate(values, policy["reachability"], "reachability")
+
+
+def derive_actionability(
+    affected_status: str,
+    runtime_scope: str,
+    reachability: str,
+    policy: dict[str, Any],
+) -> dict[str, str]:
+    validate_fixture_policy(policy)
+    affected = policy["actionability"]["affected"]
+    if runtime_scope not in affected or reachability not in affected[runtime_scope]:
+        raise ValueError("actionability inputs are outside the frozen fixture policy")
+    if affected_status == "unaffected":
+        return dict(policy["actionability"]["unaffected"])
+    if affected_status != "affected":
+        raise ValueError("affected status is outside the frozen fixture policy")
+    return dict(affected[runtime_scope][reachability])
+
+
+def derive_remediation(
+    actionability: str,
+    installed_version: str,
+    candidates: list[RemediationCandidate],
+    compare_versions: VersionComparator,
+    policy: dict[str, Any],
+) -> dict[str, str | None]:
+    validate_fixture_policy(policy)
+    if not installed_version:
+        raise ValueError("installed version must be non-empty")
+    for candidate in candidates:
+        _validate_candidate(candidate)
+    ordered_candidates = _ordered_candidates(candidates, compare_versions)
+    if any(
+        _compare_candidates(left, right, compare_versions) == 0
+        for left, right in pairwise(ordered_candidates)
+    ):
+        raise ValueError("remediation candidates have a duplicate selection key")
+    source_keys = [candidate["source_key"] for candidate in candidates]
+    if len(source_keys) != len(set(source_keys)):
+        raise ValueError("remediation candidate source keys must be unique")
+    remediation = policy["remediation"]
+    if actionability == "no_action":
+        return {
+            "disposition": remediation["dispositions"]["no_action"],
+            "selected_source_key": None,
+            "target_class": remediation["target_classes"]["no_action"],
+        }
+    if actionability != "actionable":
+        raise ValueError("actionability is outside the frozen remediation policy")
+    safe_candidates = [
+        candidate
+        for candidate in candidates
+        if is_safe_remediation_option(candidate)
+        and _compare_versions(candidate["target_version"], installed_version, compare_versions) > 0
+    ]
+    if not safe_candidates:
+        return {
+            "disposition": remediation["dispositions"]["actionable_without_safe_option"],
+            "selected_source_key": None,
+            "target_class": remediation["target_classes"]["actionable"],
+        }
+
+    ordered = _ordered_candidates(safe_candidates, compare_versions)
+    return {
+        "disposition": remediation["dispositions"]["actionable_with_safe_option"],
+        "selected_source_key": ordered[0]["source_key"],
+        "target_class": remediation["target_classes"]["actionable"],
+    }
+
+
+def expected_evidence_reference_ids(
+    finding_id: str,
+    references: list[dict[str, Any]],
+    policy: dict[str, Any],
+) -> list[str]:
+    validate_fixture_policy(policy)
+    return sorted(
+        str(reference["evidence_reference_id"])
+        for reference in references
+        if reference["finding_id"] == finding_id
+    )
+
+
+def is_ranking_opportunity(grades: list[int], policy: dict[str, Any]) -> bool:
+    validate_fixture_policy(policy)
+    if any(type(grade) is not int or grade < 0 for grade in grades):
+        raise ValueError("ranking grades must be non-negative integers")
+    ranking = policy["ranking_opportunity"]
+    if len(grades) < ranking["minimum_actionable_findings"]:
+        return False
+    return not ranking["requires_unequal_grades"] or len(set(grades)) > 1
+
+
+def are_unrelated_families(
+    left: FixtureFamilyFingerprint,
+    right: FixtureFamilyFingerprint,
+    policy: dict[str, Any],
+) -> bool:
+    validate_fixture_policy(policy)
+    if left.family_id == right.family_id:
+        return False
+    dimensions = policy["unrelated_family"]["disjoint_dimensions"]
+    return all(
+        getattr(left, dimension).isdisjoint(getattr(right, dimension)) for dimension in dimensions
+    )
+
+
+def _object(value: Any, keys: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise ValueError(f"{label} has the wrong shape")
+    return value
+
+
+def _validate_aggregation(value: Any, precedence: list[str], label: str) -> None:
+    contract = _object(value, {"precedence", "empty"}, label)
+    if contract["precedence"] != precedence or contract["empty"] != "invalid":
+        raise ValueError(f"{label} is unsupported")
+
+
+def _validate_actionability(value: Any) -> None:
+    contract = _object(value, {"unaffected", "affected"}, "actionability policy")
+    _validate_decision(contract["unaffected"])
+    affected = _object(
+        contract["affected"],
+        {"production", "development_only"},
+        "affected actionability policy",
+    )
+    for scope in affected.values():
+        by_reachability = _object(
+            scope,
+            {"reachable", "unknown", "unreachable"},
+            "affected reachability policy",
+        )
+        for decision in by_reachability.values():
+            _validate_decision(decision)
+
+
+def _validate_decision(value: Any) -> None:
+    decision = _object(value, {"value", "target_class"}, "actionability decision")
+    if (
+        decision["value"] not in _ACTIONABILITY_VALUES
+        or decision["target_class"] not in _ACTIONABILITY_TARGETS
+    ):
+        raise ValueError("actionability decision is unsupported")
+
+
+def _validate_remediation(value: Any) -> None:
+    contract = _object(
+        value,
+        {
+            "candidate_versions",
+            "candidate_identity",
+            "safe_option",
+            "selection_order",
+            "dispositions",
+            "target_classes",
+        },
+        "remediation policy",
+    )
+    if contract["candidate_versions"] != {
+        "sources": ["advisory_fixed_events", "frozen_release_inventory"],
+        "combination": "union",
+        "advisory_fixed_event_availability": "available",
+        "invalid_fixed_version": "fixture_invalid",
+    }:
+        raise ValueError("remediation candidate sources are unsupported")
+    if contract["candidate_identity"] != {
+        "required_fields": [
+            "target_version",
+            "origin_id",
+            "source_key",
+            "availability",
+            "affected_status",
+            "compatibility",
+        ],
+        "stage": "pre_materialization",
+        "origin_id": "advisory_record_id_or_reserved_release_inventory_origin",
+        "source_key": "unique_per_finding",
+        "equivalent_version_resolution": "origin_id_then_source_key",
+        "materialization_binding": (
+            "source_key_to_canonical_option_id_from_authoritative_normalization_binding"
+        ),
+        "duplicate_selection_key": "fixture_invalid",
+    }:
+        raise ValueError("remediation candidate identity is unsupported")
+    if contract["safe_option"] != {
+        "availability": "available",
+        "affected_status": "unaffected",
+        "compatibility": "compatible",
+        "version_relation": "greater_than_installed",
+    }:
+        raise ValueError("safe-option policy is unsupported")
+    if contract["selection_order"] != [
+        "ecosystem_version_ascending",
+        "origin_id_ascending",
+        "source_key_ascending",
+    ]:
+        raise ValueError("remediation selection order is unsupported")
+    if contract["dispositions"] != {
+        "actionable_with_safe_option": "upgrade",
+        "actionable_without_safe_option": "no_safe_fix",
+        "no_action": "no_action",
+    }:
+        raise ValueError("remediation dispositions are unsupported")
+    if contract["target_classes"] != {
+        "actionable": "policy.remediation",
+        "no_action": "policy.abstention",
+    }:
+        raise ValueError("remediation target classes are unsupported")
+
+
+def _exact_string_list(value: Any, expected: set[str]) -> bool:
+    return (
+        isinstance(value, list)
+        and all(isinstance(item, str) for item in value)
+        and len(value) == len(expected)
+        and set(value) == expected
+    )
+
+
+def _aggregate(values: Iterable[str], contract: dict[str, Any], label: str) -> str:
+    observed = set(values)
+    precedence = cast(list[str], contract["precedence"])
+    if not observed or not observed.issubset(precedence):
+        raise ValueError(f"{label} observations are empty or unsupported")
+    return next(value for value in precedence if value in observed)
+
+
+def _compare_candidates(
+    left: RemediationCandidate,
+    right: RemediationCandidate,
+    compare_versions: VersionComparator,
+) -> int:
+    version_order = _compare_versions(
+        left["target_version"],
+        right["target_version"],
+        compare_versions,
+    )
+    if version_order != 0:
+        return version_order
+    left_tie = (left["origin_id"], left["source_key"])
+    right_tie = (right["origin_id"], right["source_key"])
+    return (left_tie > right_tie) - (left_tie < right_tie)
+
+
+def _ordered_candidates(
+    candidates: list[RemediationCandidate],
+    compare_versions: VersionComparator,
+) -> list[RemediationCandidate]:
+    def candidate_order(left: RemediationCandidate, right: RemediationCandidate) -> int:
+        return _compare_candidates(left, right, compare_versions)
+
+    return sorted(candidates, key=cmp_to_key(candidate_order))
+
+
+def _compare_versions(left: str, right: str, compare_versions: VersionComparator) -> int:
+    result = compare_versions(left, right)
+    if type(result) is not int:
+        raise ValueError("version comparator must return an integer")
+    return (result > 0) - (result < 0)
+
+
+def _validate_candidate(value: Any) -> None:
+    candidate = _object(value, _CANDIDATE_FIELDS, "remediation candidate")
+    for field in ("target_version", "origin_id", "source_key"):
+        if not isinstance(candidate[field], str) or not candidate[field]:
+            raise ValueError(f"remediation candidate {field} must be non-empty text")
+    if candidate["availability"] not in {"available", "unavailable"}:
+        raise ValueError("remediation candidate availability is unsupported")
+    if candidate["affected_status"] not in {"affected", "unaffected"}:
+        raise ValueError("remediation candidate affected status is unsupported")
+    if candidate["compatibility"] not in {"compatible", "incompatible"}:
+        raise ValueError("remediation candidate compatibility is unsupported")

--- a/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/fixtures.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/fixtures.py
@@ -7,7 +7,7 @@ from typing import Any
 from benchmark_core.contract_validation import ContractError, ValidationIssue, require_valid
 
 from .normalization import materialize_task
-from .policy import finding_grade, validate_ranking_policy
+from .policy import finding_grade, is_safe_remediation_option, validate_ranking_policy
 from .validation import validate_gold, validate_source
 
 
@@ -48,11 +48,7 @@ def validate_fixture(
         remediation = label["remediation"]
         selected_option_id = remediation["selected_option_id"]
         safe_options = {
-            option_id
-            for option_id, option in options.items()
-            if option["availability"] == "available"
-            and option["affected_status"] == "unaffected"
-            and option["compatibility"] == "compatible"
+            option_id for option_id, option in options.items() if is_safe_remediation_option(option)
         }
         if remediation["disposition"] == "upgrade" and selected_option_id not in safe_options:
             _fail("gold upgrade must select a safe option")

--- a/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/policy.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/policy.py
@@ -1,8 +1,19 @@
-"""Frozen D5 ranking-policy interpretation."""
+"""Frozen dependency policy primitives and D5 ranking interpretation."""
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
+
+
+def is_safe_remediation_option(option: Mapping[str, Any]) -> bool:
+    """Return whether canonical option facts permit selection."""
+
+    return bool(
+        option["availability"] == "available"
+        and option["affected_status"] == "unaffected"
+        and option["compatibility"] == "compatible"
+    )
 
 
 def validate_ranking_policy(value: Any) -> None:
@@ -82,12 +93,7 @@ def finding_grade(
     )
     compatible = (
         "available"
-        if any(
-            option["availability"] == "available"
-            and option["affected_status"] == "unaffected"
-            and option["compatibility"] == "compatible"
-            for option in finding["remediation_options"]
-        )
+        if any(is_safe_remediation_option(option) for option in finding["remediation_options"])
         else "absent"
     )
     return int(

--- a/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/score_safety.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/score_safety.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from benchmark_core.attempt import SUCCESSFUL_FILE_READ_EVENT
 
+from .policy import is_safe_remediation_option
 from .score_ledger import entry
 
 
@@ -102,7 +103,7 @@ def remediation_safety(
             continue
         result["selected"] += 1
         owner = options_by_id.get(option_id)
-        safe = owner is not None and owner[0] == finding_id and _is_safe_option(owner[1])
+        safe = owner is not None and owner[0] == finding_id and is_safe_remediation_option(owner[1])
         if safe:
             result["safe"] += 1
         elif owner is not None and owner[0] == finding_id:
@@ -150,14 +151,6 @@ def critical_recall(
             )
             result["hits"].add("critical.critical_reachable_production")
     return result
-
-
-def _is_safe_option(option: dict[str, Any]) -> bool:
-    return bool(
-        option["availability"] == "available"
-        and option["affected_status"] == "unaffected"
-        and option["compatibility"] == "compatible"
-    )
 
 
 def _is_critical_reachable_production(finding: dict[str, Any]) -> bool:

--- a/experiments/scheduled-task-learning/dependency-prioritization/pyproject.toml
+++ b/experiments/scheduled-task-learning/dependency-prioritization/pyproject.toml
@@ -38,6 +38,7 @@ explicit_package_bases = true
 module = [
     "test_conformance",
     "test_feedback",
+    "test_fixture_policy",
     "test_normalization",
     "test_oracle",
     "test_validation",

--- a/experiments/scheduled-task-learning/dependency-prioritization/tests/test_fixture_policy.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/tests/test_fixture_policy.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+from typing import Any
+
+from benchmark_core.canonical import load_object
+from dependency_benchmark.fixture_policy import (
+    FixtureFamilyFingerprint,
+    RemediationCandidate,
+    aggregate_reachability,
+    aggregate_runtime_scope,
+    are_unrelated_families,
+    derive_actionability,
+    derive_remediation,
+    expected_evidence_reference_ids,
+    is_ranking_opportunity,
+)
+
+from support import ROOT
+
+
+def _policy() -> dict[str, Any]:
+    return load_object(ROOT / "contracts/fixture-policy.json")
+
+
+def _compare_versions(left: str, right: str) -> int:
+    left_parts = tuple(int(part) for part in left.split("."))
+    right_parts = tuple(int(part) for part in right.split("."))
+    width = max(len(left_parts), len(right_parts))
+    normalized_left = left_parts + (0,) * (width - len(left_parts))
+    normalized_right = right_parts + (0,) * (width - len(right_parts))
+    return (normalized_left > normalized_right) - (normalized_left < normalized_right)
+
+
+def _candidate(
+    target_version: str,
+    origin_id: str,
+    source_key: str,
+    *,
+    availability: str = "available",
+    affected_status: str = "unaffected",
+    compatibility: str = "compatible",
+) -> RemediationCandidate:
+    return {
+        "target_version": target_version,
+        "origin_id": origin_id,
+        "source_key": source_key,
+        "availability": availability,
+        "affected_status": affected_status,
+        "compatibility": compatibility,
+    }
+
+
+class DependencyFixturePolicyTests(unittest.TestCase):
+    def test_actionability_uses_the_frozen_scope_and_reachability_truth_table(self) -> None:
+        # Given
+        policy = _policy()
+        cases = (
+            ("unaffected", "production", "reachable", "no_action", "policy.abstention"),
+            ("affected", "development_only", "unreachable", "no_action", "policy.reachability"),
+            ("affected", "development_only", "unknown", "no_action", "policy.runtime_scope"),
+            ("affected", "development_only", "reachable", "actionable", "policy.reachability"),
+            ("affected", "production", "unreachable", "no_action", "policy.reachability"),
+            ("affected", "production", "unknown", "actionable", "policy.runtime_scope"),
+            ("affected", "production", "reachable", "actionable", "policy.reachability"),
+        )
+
+        # When / Then
+        self.assertEqual(
+            aggregate_runtime_scope(["development_only", "production"], policy),
+            "production",
+        )
+        self.assertEqual(
+            aggregate_reachability(["unreachable", "unknown"], policy),
+            "unknown",
+        )
+        self.assertEqual(
+            aggregate_reachability(["unreachable", "unknown", "reachable"], policy),
+            "reachable",
+        )
+        for affected, scope, reachability, value, target_class in cases:
+            with self.subTest(
+                affected_status=affected,
+                runtime_scope=scope,
+                reachability=reachability,
+            ):
+                self.assertEqual(
+                    derive_actionability(affected, scope, reachability, policy),
+                    {"value": value, "target_class": target_class},
+                )
+
+    def test_remediation_filters_and_orders_safe_upgrades(self) -> None:
+        # Given
+        policy = _policy()
+        candidates = [
+            _candidate("1.9", "record-a", "older"),
+            _candidate(
+                "2.1",
+                "record-a",
+                "affected",
+                affected_status="affected",
+            ),
+            _candidate(
+                "2.2",
+                "record-a",
+                "incompatible",
+                compatibility="incompatible",
+            ),
+            _candidate(
+                "2.3",
+                "record-a",
+                "unavailable",
+                availability="unavailable",
+            ),
+            _candidate("2.4.0", "record-z", "candidate-z"),
+            _candidate("2.4", "record-a", "candidate-a-z"),
+            _candidate("2.4.00", "record-a", "candidate-a-a"),
+            _candidate("3.0", "record-a", "later"),
+        ]
+
+        # When
+        upgrade = derive_remediation(
+            "actionable",
+            "2.0",
+            candidates,
+            _compare_versions,
+            policy,
+        )
+        no_safe_fix = derive_remediation(
+            "actionable",
+            "2.0",
+            candidates[:4],
+            _compare_versions,
+            policy,
+        )
+        no_action = derive_remediation(
+            "no_action",
+            "2.0",
+            candidates,
+            _compare_versions,
+            policy,
+        )
+
+        # Then
+        self.assertEqual(
+            upgrade,
+            {
+                "disposition": "upgrade",
+                "selected_source_key": "candidate-a-a",
+                "target_class": "policy.remediation",
+            },
+        )
+        self.assertEqual(
+            no_safe_fix,
+            {
+                "disposition": "no_safe_fix",
+                "selected_source_key": None,
+                "target_class": "policy.remediation",
+            },
+        )
+        self.assertEqual(
+            no_action,
+            {
+                "disposition": "no_action",
+                "selected_source_key": None,
+                "target_class": "policy.abstention",
+            },
+        )
+        with self.assertRaisesRegex(ValueError, "duplicate selection key"):
+            derive_remediation(
+                "actionable",
+                "2.0",
+                [
+                    _candidate("2.4", "record-a", "candidate-a"),
+                    _candidate("2.4.0", "record-a", "candidate-a"),
+                ],
+                _compare_versions,
+                policy,
+            )
+        with self.assertRaisesRegex(ValueError, "source keys must be unique"):
+            derive_remediation(
+                "actionable",
+                "2.0",
+                [
+                    _candidate("2.4", "record-a", "candidate-a"),
+                    _candidate("2.5", "record-b", "candidate-a"),
+                ],
+                _compare_versions,
+                policy,
+            )
+
+    def test_ranking_opportunity_requires_two_unequal_actionable_grades(self) -> None:
+        # Given
+        policy = _policy()
+
+        # When / Then
+        self.assertFalse(is_ranking_opportunity([24], policy))
+        self.assertFalse(is_ranking_opportunity([24, 24], policy))
+        self.assertTrue(is_ranking_opportunity([24, 32], policy))
+
+    def test_unrelated_families_require_every_semantic_dimension_to_be_disjoint(self) -> None:
+        # Given
+        policy = _policy()
+        left = FixtureFamilyFingerprint(
+            family_id="family-left",
+            normalized_packages=frozenset({"npm:left"}),
+            record_alias_components=frozenset({"alias:left"}),
+            root_helper_nodes=frozenset({"node:left"}),
+            graph_template_ids=frozenset({"graph:left"}),
+            generator_seeds=frozenset({"seed:left"}),
+            manifest_digests=frozenset({"manifest:left"}),
+        )
+        right = FixtureFamilyFingerprint(
+            family_id="family-right",
+            normalized_packages=frozenset({"npm:right"}),
+            record_alias_components=frozenset({"alias:right"}),
+            root_helper_nodes=frozenset({"node:right"}),
+            graph_template_ids=frozenset({"graph:right"}),
+            generator_seeds=frozenset({"seed:right"}),
+            manifest_digests=frozenset({"manifest:right"}),
+        )
+        dimensions = policy["unrelated_family"]["disjoint_dimensions"]
+
+        # When / Then
+        self.assertTrue(are_unrelated_families(left, right, policy))
+        self.assertFalse(
+            are_unrelated_families(left, replace(right, family_id=left.family_id), policy)
+        )
+        for dimension in dimensions:
+            with self.subTest(dimension=dimension):
+                overlapping = replace(right, **{dimension: getattr(left, dimension)})
+                self.assertFalse(are_unrelated_families(left, overlapping, policy))
+
+    def test_evidence_gold_contains_every_visible_reference_owned_by_the_finding(self) -> None:
+        # Given
+        policy = _policy()
+        references = [
+            {"finding_id": "finding-a", "evidence_reference_id": "evidence-z"},
+            {"finding_id": "finding-b", "evidence_reference_id": "evidence-b"},
+            {"finding_id": "finding-a", "evidence_reference_id": "evidence-a"},
+        ]
+
+        # When
+        evidence_ids = expected_evidence_reference_ids("finding-a", references, policy)
+
+        # Then
+        self.assertEqual(evidence_ids, ["evidence-a", "evidence-z"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of #118. This PR is the fixture-policy layer in the dependency benchmark stack.

## Scope

- Freeze one canonical policy for runtime-scope and reachability aggregation, actionability, remediation, evidence ownership, ranking opportunities, and unrelated fixture families.
- Keep affected reachable development dependencies actionable while assigning them the lower D5 queue grade; unknown findings are actionable only when a production path exists.
- Select remediation before canonical materialization from fixed-event and frozen-inventory candidates, with exact safety and tie-break rules.
- Centralize the canonical safe-option predicate and remove duplicate checks from gold validation and scorer safety.

This layer does not add advisory parsers, project fixtures, package-manager execution, D7 artifacts, network access, or model calls.

## Test-intent map

| Risk | Production seam | Nearest existing test | Unique reachable mutant | Primary test |
|---|---|---|---|---|
| Scope, reachability, actionability, or target ownership drifts | fixture-policy aggregation and truth table | Existing fixture tests score supplied gold; they do not derive this table | Reverse precedence or treat reachable dev / unknown production incorrectly | `test_actionability_uses_the_frozen_scope_and_reachability_truth_table` |
| An unsafe, old, nonminimal, or ambiguous fix becomes gold | pre-materialization remediation selection | Existing validation checks only whether an already-selected canonical option has three safe flags | Admit an older candidate, omit a safety predicate, choose the highest version, or ignore origin/source tie-breaks | `test_remediation_filters_and_orders_safe_upgrades` |
| A fixture with no possible ordering error counts toward ranking coverage | ranking-opportunity predicate | Scorer tests evaluate queues but do not decide fixture eligibility | Accept one actionable item or two equal-grade items | `test_ranking_opportunity_requires_two_unequal_actionable_grades` |
| Related fixtures satisfy cross-family transfer | unrelated-family predicate | Oracle currently trusts distinct family IDs | Remove any overlap dimension or use any-overlap instead of all-disjoint | `test_unrelated_families_require_every_semantic_dimension_to_be_disjoint` |
| Gold silently omits visible evidence owned by a finding | evidence-set derivation | Existing validation rejects cross-finding IDs but permits an incomplete owned subset | Select only the first owned reference | `test_evidence_gold_contains_every_visible_reference_owned_by_the_finding` |

The pre-commit redundancy pass and an independent P0/P1 review found five distinct seams and no redundant test.

## Verification

- `scripts/lint.sh`
- `scripts/test.sh` (24/24)
- contract SHA-256: `dbc98c96822ef1cf58208797dc3f69260c48214d4ea3e288622ca3e19693c2d1`
- `git diff --check`
- signed commit verification

Stack base: `feature/issue-118-scenario-validation`
