### PR TITLE
feat: derive frozen dependency advisory facts

### DIFF
--- a/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/advisory_records.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/advisory_records.py
@@ -1,0 +1,570 @@
+"""Verified, deterministic decoding of the frozen OSV advisory snapshots."""
+
+from __future__ import annotations
+
+import hashlib
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from functools import cmp_to_key
+from pathlib import Path
+from typing import Any, Literal
+
+from benchmark_core.canonical import SHA256_HEX, canonical_sha256, load_object, loads_object
+from cvss.cvss3 import CVSS3
+from cvss.cvss4 import CVSS4
+from cvss.exceptions import CVSS3Error, CVSS4Error
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
+
+from dependency_benchmark.versioning import (
+    AffectedInterval,
+    Ecosystem,
+    VersioningError,
+    canonical_package_name,
+    canonical_version,
+    compare_versions,
+    is_version_affected,
+    normalize_ecosystem,
+    parse_osv_intervals,
+    sort_versions,
+)
+
+SeverityBand = Literal["low", "moderate", "high", "critical"]
+
+_LOW_MAX = 3.9
+_MODERATE_MAX = 6.9
+_HIGH_MAX = 8.9
+_CRITICAL_MAX = 10.0
+
+
+class AdvisorySourceError(ValueError):
+    """Raised when a frozen source cannot produce unambiguous advisory facts."""
+
+
+@dataclass(frozen=True, slots=True)
+class CVSSVector:
+    kind: Literal["CVSS_V3", "CVSS_V4"]
+    vector: str
+    base_score: float
+    band: SeverityBand
+
+
+@dataclass(frozen=True, slots=True)
+class AdvisoryRecord:
+    repository_id: str
+    source_sha256: str
+    source_bytes: int
+    record_id: str
+    aliases: tuple[str, ...]
+    summary: str | None
+    details: str
+    ecosystem: Ecosystem
+    package_name: str
+    affected_entry_count: int
+    intervals: tuple[AffectedInterval, ...]
+    explicit_versions: tuple[str, ...]
+    explicit_version_raw_count: int
+    ignored_git_range_count: int
+    cvss_vectors: tuple[CVSSVector, ...]
+    severity: SeverityBand | None
+
+
+@dataclass(frozen=True, slots=True)
+class AdvisoryComponent:
+    record_ids: tuple[str, ...]
+    identities: tuple[str, ...]
+    ecosystem: Ecosystem
+    package_name: str
+    severity: SeverityBand
+
+
+@dataclass(frozen=True, slots=True)
+class _VerifiedRecord:
+    metadata: Mapping[str, Any]
+    raw_text: str
+
+
+_CatalogEntry = tuple[str, Mapping[str, Any], bool]
+
+
+def _object(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise AdvisorySourceError(f"{context} must be an object")
+    return value
+
+
+def _array(value: Any, context: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise AdvisorySourceError(f"{context} must be an array")
+    return value
+
+
+def _text(value: Any, context: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise AdvisorySourceError(f"{context} must be a non-empty string")
+    return value
+
+
+def _texts(value: Any, context: str) -> tuple[str, ...]:
+    result = tuple(_text(item, f"{context} item") for item in _array(value, context))
+    if len(result) != len(set(result)):
+        raise AdvisorySourceError(f"{context} must not contain duplicates")
+    return result
+
+
+def _catalog_entries(root: Path) -> tuple[Path, frozenset[str], tuple[_CatalogEntry, ...]]:
+    index_path = root / "index.json"
+    if index_path.is_symlink():
+        raise AdvisorySourceError("source catalogs must not be symlinks")
+    index = load_object(index_path)
+    provenance_declaration = Path(_text(index.get("provenance_path"), "provenance path"))
+    if provenance_declaration.name != "provenance.json":
+        raise AdvisorySourceError("source index must declare provenance.json")
+    snapshot_prefix = provenance_declaration.parent / "snapshots"
+    provenance_path = root / provenance_declaration.name
+    if provenance_path.is_symlink():
+        raise AdvisorySourceError("source catalogs must not be symlinks")
+    provenance = load_object(provenance_path)
+    repositories = {
+        _text(repository.get("repository_id"), "repository id"): repository
+        for repository in _array(provenance.get("repositories"), "repositories")
+        if isinstance(repository, dict)
+    }
+    if len(repositories) != len(_array(provenance.get("repositories"), "repositories")):
+        raise AdvisorySourceError("repository catalog contains an invalid or duplicate entry")
+    records = _array(provenance.get("records"), "records")
+    record_ids = [
+        _text(_object(record, "record").get("record_id"), "record id") for record in records
+    ]
+    if len(record_ids) != len(set(record_ids)):
+        raise AdvisorySourceError("record catalog contains duplicate record ids")
+
+    entries: list[_CatalogEntry] = [
+        (
+            _text(_object(record, "record").get("repository_id"), "record repository id"),
+            _object(record, "record"),
+            True,
+        )
+        for record in records
+    ]
+    entries.extend(
+        (
+            repository_id,
+            _object(repository.get("license"), "repository license"),
+            False,
+        )
+        for repository_id, repository in repositories.items()
+    )
+    return snapshot_prefix, frozenset(repositories), tuple(entries)
+
+
+def _verified_entry(
+    root: Path,
+    snapshot_prefix: Path,
+    repositories: frozenset[str],
+    repository_id: str,
+    entry: Mapping[str, Any],
+) -> tuple[Path, bytes]:
+    if repository_id not in repositories:
+        raise AdvisorySourceError(f"unknown source repository: {repository_id}")
+    snapshot_path = Path(_text(entry.get("snapshot_path"), "snapshot path"))
+    repository_path = Path(_text(entry.get("repository_path"), "repository path"))
+    try:
+        relative_path = snapshot_path.relative_to(snapshot_prefix)
+    except ValueError as error:
+        raise AdvisorySourceError("snapshot path escapes the declared source prefix") from error
+    expected_path = Path(repository_id) / repository_path
+    if relative_path != expected_path or ".." in relative_path.parts:
+        raise AdvisorySourceError("snapshot path does not match repository provenance")
+    local_path = root / "snapshots" / relative_path
+    for candidate in (local_path, *local_path.parents):
+        if candidate == root:
+            break
+        if candidate.is_symlink():
+            raise AdvisorySourceError("source snapshot paths must not contain symlinks")
+    try:
+        resolved_path = local_path.resolve(strict=True)
+    except OSError as error:
+        raise AdvisorySourceError(f"source snapshot is unavailable: {snapshot_path}") from error
+    if not resolved_path.is_relative_to(root / "snapshots"):
+        raise AdvisorySourceError("source snapshot resolves outside the source root")
+    raw = resolved_path.read_bytes()
+    declared_bytes = entry.get("bytes")
+    declared_sha256 = entry.get("sha256")
+    if type(declared_bytes) is not int or declared_bytes < 0:
+        raise AdvisorySourceError("source byte count must be a non-negative integer")
+    if not isinstance(declared_sha256, str) or SHA256_HEX.fullmatch(declared_sha256) is None:
+        raise AdvisorySourceError("source SHA-256 must be canonical lowercase hex")
+    if len(raw) != declared_bytes or hashlib.sha256(raw).hexdigest() != declared_sha256:
+        raise AdvisorySourceError(f"source snapshot does not match provenance: {snapshot_path}")
+    return local_path, raw
+
+
+def _verified_sources(source_root: Path) -> tuple[_VerifiedRecord, ...]:
+    if source_root.is_symlink():
+        raise AdvisorySourceError("source root must not be a symlink")
+    root = source_root.resolve()
+    snapshot_prefix, repositories, entries = _catalog_entries(root)
+
+    declared_paths: set[Path] = set()
+    verified_records: list[_VerifiedRecord] = []
+    for repository_id, entry, is_record in entries:
+        resolved_path, raw = _verified_entry(
+            root,
+            snapshot_prefix,
+            repositories,
+            repository_id,
+            entry,
+        )
+        declared_paths.add(resolved_path)
+        if is_record:
+            try:
+                raw_text = raw.decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise AdvisorySourceError("advisory snapshots must be UTF-8") from error
+            verified_records.append(_VerifiedRecord(metadata=entry, raw_text=raw_text))
+
+    actual_paths: set[Path] = set()
+    for path in (root / "snapshots").rglob("*"):
+        if path.is_symlink():
+            raise AdvisorySourceError("source snapshot tree must not contain symlinks")
+        if path.is_file():
+            actual_paths.add(path)
+    if actual_paths != declared_paths:
+        raise AdvisorySourceError("source snapshot tree does not match the provenance catalog")
+    return tuple(verified_records)
+
+
+def verify_frozen_source_catalog(source_root: Path) -> None:
+    """Verify path closure, byte counts, and hashes for every frozen source entry."""
+
+    _verified_sources(source_root)
+
+
+def _decode_record(source: _VerifiedRecord) -> dict[str, Any]:
+    repository_id = _text(source.metadata.get("repository_id"), "record repository id")
+    try:
+        if repository_id == "github-advisory-database":
+            return loads_object(source.raw_text)
+        if repository_id == "pypa-advisory-database":
+            yaml = YAML(typ="base", pure=True)
+            yaml.version = (1, 2)
+            yaml.allow_duplicate_keys = False
+            yaml.max_depth = 64
+            return _object(yaml.load(source.raw_text), "YAML advisory")
+    except (ValueError, YAMLError) as error:
+        raise AdvisorySourceError("advisory snapshot could not be decoded strictly") from error
+    raise AdvisorySourceError(f"unsupported advisory repository: {repository_id}")
+
+
+def _severity_vectors(value: Any) -> tuple[CVSSVector, ...]:
+    items = [] if value is None else _array(value, "severity")
+    vectors: list[CVSSVector] = []
+    for raw_item in items:
+        item = _object(raw_item, "severity item")
+        raw_kind = _text(item.get("type"), "severity type")
+        vector = _text(item.get("score"), "severity vector")
+        try:
+            if raw_kind == "CVSS_V3" and vector.startswith(("CVSS:3.0/", "CVSS:3.1/")):
+                kind: Literal["CVSS_V3", "CVSS_V4"] = "CVSS_V3"
+                parsed_v3 = CVSS3(vector)
+                clean_vector = parsed_v3.clean_vector()
+                score = float(parsed_v3.scores()[0])
+            elif raw_kind == "CVSS_V4" and vector.startswith("CVSS:4.0/"):
+                kind = "CVSS_V4"
+                parsed_v4 = CVSS4(vector)
+                clean_vector = parsed_v4.clean_vector()
+                score = float(parsed_v4.scores()[0])
+            else:
+                raise AdvisorySourceError("severity type and vector version do not match")
+            if clean_vector != vector:
+                raise AdvisorySourceError("CVSS vector is not in canonical form")
+        except (CVSS3Error, CVSS4Error) as error:
+            raise AdvisorySourceError("invalid CVSS vector") from error
+        if score <= 0:
+            raise AdvisorySourceError("CVSS base score has no benchmark severity band")
+        if score <= _LOW_MAX:
+            band: SeverityBand = "low"
+        elif score <= _MODERATE_MAX:
+            band = "moderate"
+        elif score <= _HIGH_MAX:
+            band = "high"
+        elif score <= _CRITICAL_MAX:
+            band = "critical"
+        else:
+            raise AdvisorySourceError("CVSS base score has no benchmark severity band")
+        vectors.append(CVSSVector(kind=kind, vector=vector, base_score=score, band=band))
+    return tuple(sorted(vectors, key=lambda item: (item.kind, item.vector)))
+
+
+def _compare_intervals(
+    ecosystem: Ecosystem, left: AffectedInterval, right: AffectedInterval
+) -> int:
+    if left.introduced is None:
+        return 0 if right.introduced is None else -1
+    if right.introduced is None:
+        return 1
+    result = compare_versions(ecosystem, left.introduced, right.introduced)
+    if result != 0:
+        return result
+    if left.fixed is None:
+        return 0 if right.fixed is None else 1
+    if right.fixed is None:
+        return -1
+    return compare_versions(ecosystem, left.fixed, right.fixed)
+
+
+def _record_from_source(source: _VerifiedRecord) -> AdvisoryRecord:
+    raw = _decode_record(source)
+    metadata = source.metadata
+    record_id = _text(raw.get("id"), "advisory id")
+    if record_id != _text(metadata.get("record_id"), "catalog record id"):
+        raise AdvisorySourceError("raw advisory id does not match provenance")
+    aliases = tuple(sorted(_texts(raw.get("aliases"), "advisory aliases")))
+    if aliases != tuple(sorted(_texts(metadata.get("aliases"), "catalog aliases"))):
+        raise AdvisorySourceError("raw advisory aliases do not match provenance")
+    raw_summary = raw.get("summary")
+    summary = None if raw_summary is None else _text(raw_summary, "advisory summary")
+    details = _text(raw.get("details"), "advisory details")
+
+    catalog_package = _object(metadata.get("package"), "catalog package")
+    ecosystem = normalize_ecosystem(_text(catalog_package.get("ecosystem"), "ecosystem"))
+    package_name = canonical_package_name(
+        ecosystem,
+        _text(catalog_package.get("name"), "package name"),
+    )
+    affected_entries = _array(raw.get("affected"), "affected")
+    if not affected_entries:
+        raise AdvisorySourceError("advisory must contain an affected package")
+    intervals: list[AffectedInterval] = []
+    explicit_versions: list[str] = []
+    ignored_git_ranges = 0
+    raw_version_count = 0
+    for raw_affected in affected_entries:
+        affected = _object(raw_affected, "affected item")
+        raw_package = _object(affected.get("package"), "affected package")
+        raw_ecosystem = normalize_ecosystem(_text(raw_package.get("ecosystem"), "ecosystem"))
+        raw_package_name = canonical_package_name(
+            raw_ecosystem,
+            _text(raw_package.get("name"), "package name"),
+        )
+        if (raw_ecosystem, raw_package_name) != (ecosystem, package_name):
+            raise AdvisorySourceError("raw affected package does not match provenance")
+
+        raw_versions = _array(affected.get("versions", []), "affected versions")
+        raw_version_count += len(raw_versions)
+        explicit_versions.extend(
+            canonical_version(ecosystem, _text(version, "affected version"))
+            for version in raw_versions
+        )
+        for raw_range in _array(affected.get("ranges", []), "affected ranges"):
+            affected_range = _object(raw_range, "affected range")
+            range_type = _text(affected_range.get("type"), "affected range type")
+            if range_type == "GIT":
+                ignored_git_ranges += 1
+                continue
+            if range_type != "ECOSYSTEM":
+                raise AdvisorySourceError(f"unsupported affected range type: {range_type}")
+            raw_events = _array(affected_range.get("events"), "affected range events")
+            events = [_object(event, "affected range event") for event in raw_events]
+            intervals.extend(parse_osv_intervals(ecosystem, events))
+    if not intervals and not explicit_versions:
+        raise AdvisorySourceError("advisory has no supported affected-version facts")
+
+    def compare_intervals(left: AffectedInterval, right: AffectedInterval) -> int:
+        return _compare_intervals(ecosystem, left, right)
+
+    ordered_intervals = tuple(sorted(set(intervals), key=cmp_to_key(compare_intervals)))
+    vectors = _severity_vectors(raw.get("severity"))
+    severity = max((vector.band for vector in vectors), key=_severity_rank, default=None)
+    return AdvisoryRecord(
+        repository_id=_text(metadata.get("repository_id"), "repository id"),
+        source_sha256=_text(metadata.get("sha256"), "source SHA-256"),
+        source_bytes=int(metadata["bytes"]),
+        record_id=record_id,
+        aliases=aliases,
+        summary=summary,
+        details=details,
+        ecosystem=ecosystem,
+        package_name=package_name,
+        affected_entry_count=len(affected_entries),
+        intervals=ordered_intervals,
+        explicit_versions=sort_versions(ecosystem, explicit_versions),
+        explicit_version_raw_count=raw_version_count,
+        ignored_git_range_count=ignored_git_ranges,
+        cvss_vectors=vectors,
+        severity=severity,
+    )
+
+
+def _severity_rank(value: SeverityBand) -> int:
+    return {"low": 0, "moderate": 1, "high": 2, "critical": 3}[value]
+
+
+def load_frozen_advisories(source_root: Path) -> tuple[AdvisoryRecord, ...]:
+    """Decode all verified frozen advisory records into canonical source facts."""
+
+    try:
+        return tuple(
+            sorted(
+                map(_record_from_source, _verified_sources(source_root)),
+                key=lambda record: record.record_id,
+            )
+        )
+    except VersioningError as error:
+        raise AdvisorySourceError("advisory contains invalid package version facts") from error
+
+
+def alias_components(records: Iterable[AdvisoryRecord]) -> tuple[AdvisoryComponent, ...]:
+    """Compute transitive OSV alias closure and aggregate component severity."""
+
+    ordered = tuple(sorted(records, key=lambda record: record.record_id))
+    if len({record.record_id for record in ordered}) != len(ordered):
+        raise AdvisorySourceError("advisory record ids must be unique")
+    parent = list(range(len(ordered)))
+
+    def find(index: int) -> int:
+        while parent[index] != index:
+            parent[index] = parent[parent[index]]
+            index = parent[index]
+        return index
+
+    def union(left: int, right: int) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root != right_root:
+            parent[right_root] = left_root
+
+    owner: dict[str, int] = {}
+    for index, record in enumerate(ordered):
+        for identity in (record.record_id, *record.aliases):
+            previous = owner.setdefault(identity, index)
+            union(index, previous)
+
+    grouped: dict[int, list[AdvisoryRecord]] = {}
+    for index, record in enumerate(ordered):
+        grouped.setdefault(find(index), []).append(record)
+    components: list[AdvisoryComponent] = []
+    for grouped_records in grouped.values():
+        packages = {(record.ecosystem, record.package_name) for record in grouped_records}
+        if len(packages) != 1:
+            raise AdvisorySourceError("one alias component spans different packages")
+        severities = [record.severity for record in grouped_records if record.severity is not None]
+        if not severities:
+            raise AdvisorySourceError("alias component has no supported CVSS severity")
+        ecosystem, package_name = next(iter(packages))
+        components.append(
+            AdvisoryComponent(
+                record_ids=tuple(sorted(record.record_id for record in grouped_records)),
+                identities=tuple(
+                    sorted(
+                        {
+                            identity
+                            for record in grouped_records
+                            for identity in (record.record_id, *record.aliases)
+                        }
+                    )
+                ),
+                ecosystem=ecosystem,
+                package_name=package_name,
+                severity=max(severities, key=_severity_rank),
+            )
+        )
+    return tuple(sorted(components, key=lambda component: component.record_ids))
+
+
+def record_affects(record: AdvisoryRecord, version: str) -> bool:
+    return is_version_affected(
+        record.ecosystem,
+        version,
+        record.intervals,
+        record.explicit_versions,
+    )
+
+
+def fixed_versions(record: AdvisoryRecord) -> tuple[str, ...]:
+    return sort_versions(
+        record.ecosystem,
+        (interval.fixed for interval in record.intervals if interval.fixed is not None),
+    )
+
+
+def semantic_receipt(records: Iterable[AdvisoryRecord]) -> dict[str, Any]:
+    """Return a compact receipt for normalized parser semantics, distinct from byte provenance."""
+
+    ordered = tuple(sorted(records, key=lambda record: record.record_id))
+    components = alias_components(ordered)
+    record_payload = [
+        {
+            "repository_id": record.repository_id,
+            "source_sha256": record.source_sha256,
+            "record_id": record.record_id,
+            "aliases": list(record.aliases),
+            "summary_present": record.summary is not None,
+            "details_sha256": hashlib.sha256(record.details.encode("utf-8")).hexdigest(),
+            "package": {"ecosystem": record.ecosystem, "name": record.package_name},
+            "affected_entry_count": record.affected_entry_count,
+            "intervals": [
+                {"introduced": interval.introduced, "fixed": interval.fixed}
+                for interval in record.intervals
+            ],
+            "fixed_versions": list(fixed_versions(record)),
+            "explicit_version_raw_count": record.explicit_version_raw_count,
+            "explicit_versions_sha256": canonical_sha256(list(record.explicit_versions)),
+            "ignored_git_range_count": record.ignored_git_range_count,
+            "cvss": [
+                {
+                    "type": vector.kind,
+                    "vector": vector.vector,
+                    "base_score": vector.base_score,
+                    "band": vector.band,
+                }
+                for vector in record.cvss_vectors
+            ],
+            "severity": record.severity,
+        }
+        for record in ordered
+    ]
+    component_payload = [
+        {
+            "record_ids": list(component.record_ids),
+            "identities": list(component.identities),
+            "package": {"ecosystem": component.ecosystem, "name": component.package_name},
+            "severity": component.severity,
+        }
+        for component in components
+    ]
+    return {
+        "schema_version": 1,
+        "record_count": len(ordered),
+        "repository_counts": dict(
+            sorted(Counter(record.repository_id for record in ordered).items())
+        ),
+        "total_bytes": sum(record.source_bytes for record in ordered),
+        "normalized_package_count": len(
+            {(record.ecosystem, record.package_name) for record in ordered}
+        ),
+        "alias_component_count": len(components),
+        "affected_entry_count": sum(record.affected_entry_count for record in ordered),
+        "ecosystem_interval_count": sum(len(record.intervals) for record in ordered),
+        "git_range_count": sum(record.ignored_git_range_count for record in ordered),
+        "fixed_version_count": sum(len(fixed_versions(record)) for record in ordered),
+        "explicit_version_raw_count": sum(record.explicit_version_raw_count for record in ordered),
+        "explicit_version_canonical_count": sum(
+            len(record.explicit_versions) for record in ordered
+        ),
+        "cvss_type_counts": dict(
+            sorted(
+                Counter(vector.kind for record in ordered for vector in record.cvss_vectors).items()
+            )
+        ),
+        "record_band_counts": dict(
+            sorted(Counter(record.severity or "missing" for record in ordered).items())
+        ),
+        "component_band_counts": dict(
+            sorted(Counter(component.severity for component in components).items())
+        ),
+        "records_semantic_sha256": canonical_sha256(record_payload),
+        "alias_components_sha256": canonical_sha256(component_payload),
+    }

--- a/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/versioning.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/versioning.py
@@ -1,0 +1,245 @@
+"""Frozen npm and PyPI version semantics for dependency source derivation."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from functools import cmp_to_key
+from itertools import pairwise
+from typing import Literal
+
+import nodesemver
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.utils import InvalidName, canonicalize_name
+from packaging.version import InvalidVersion, Version
+
+Ecosystem = Literal["npm", "pypi"]
+
+_NUMERIC_IDENTIFIER = r"(?:0|[1-9][0-9]*)"
+_PRERELEASE_IDENTIFIER = rf"(?:{_NUMERIC_IDENTIFIER}|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
+_BUILD_IDENTIFIER = r"[0-9A-Za-z-]+"
+_NPM_VERSION_TEXT = (
+    rf"{_NUMERIC_IDENTIFIER}\.{_NUMERIC_IDENTIFIER}\.{_NUMERIC_IDENTIFIER}"
+    rf"(?:-{_PRERELEASE_IDENTIFIER}(?:\.{_PRERELEASE_IDENTIFIER})*)?"
+    rf"(?:\+{_BUILD_IDENTIFIER}(?:\.{_BUILD_IDENTIFIER})*)?"
+)
+_NPM_VERSION = re.compile(rf"^{_NPM_VERSION_TEXT}$")
+_NPM_COMPARATOR = rf"(?:<=|>=|<|>|=)?{_NPM_VERSION_TEXT}"
+_NPM_REQUIREMENT = re.compile(
+    rf"^(?:\*|(?:\^|~){_NPM_VERSION_TEXT}|{_NPM_COMPARATOR}(?: +{_NPM_COMPARATOR})*)$"
+)
+_NPM_PACKAGE = re.compile(r"^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$")
+
+
+class VersioningError(ValueError):
+    """Raised when frozen ecosystem version facts are invalid or unsupported."""
+
+
+@dataclass(frozen=True, slots=True)
+class AffectedInterval:
+    """One half-open affected interval; ``None`` denotes an unbounded endpoint."""
+
+    introduced: str | None
+    fixed: str | None
+
+
+def normalize_ecosystem(value: str) -> Ecosystem:
+    if value == "npm":
+        return "npm"
+    if value in {"PyPI", "pypi"}:
+        return "pypi"
+    raise VersioningError(f"unsupported package ecosystem: {value}")
+
+
+def canonical_package_name(ecosystem: Ecosystem, value: str) -> str:
+    if not value or value != value.strip():
+        raise VersioningError("package name must be non-empty and have no surrounding whitespace")
+    if ecosystem == "npm":
+        if _NPM_PACKAGE.fullmatch(value) is None:
+            raise VersioningError(f"invalid canonical npm package name: {value}")
+        return value
+    try:
+        return canonicalize_name(value, validate=True)
+    except InvalidName as error:
+        raise VersioningError(f"invalid PyPI package name: {value}") from error
+
+
+def canonical_version(ecosystem: Ecosystem, value: str) -> str:
+    if not value or value != value.strip():
+        raise VersioningError("version must be non-empty and have no surrounding whitespace")
+    if ecosystem == "npm":
+        if _NPM_VERSION.fullmatch(value) is None:
+            raise VersioningError(f"version is outside the frozen npm grammar: {value}")
+        try:
+            parsed = nodesemver.SemVer(value, loose=False, include_prerelease=False)
+        except (TypeError, ValueError) as error:
+            raise VersioningError(f"invalid npm version: {value}") from error
+        if parsed.raw != value:
+            raise VersioningError(f"invalid npm version: {value}")
+        return value
+    try:
+        return str(Version(value))
+    except InvalidVersion as error:
+        raise VersioningError(f"invalid PyPI version: {value}") from error
+
+
+def compare_versions(ecosystem: Ecosystem, left: str, right: str) -> int:
+    canonical_left = canonical_version(ecosystem, left)
+    canonical_right = canonical_version(ecosystem, right)
+    if ecosystem == "npm":
+        result = nodesemver.compare(canonical_left, canonical_right, False)
+        if not isinstance(result, int) or result not in {-1, 0, 1}:
+            raise VersioningError("npm comparator returned an unsupported result")
+        return result
+    left_version = Version(canonical_left)
+    right_version = Version(canonical_right)
+    return (left_version > right_version) - (left_version < right_version)
+
+
+def sort_versions(ecosystem: Ecosystem, values: Iterable[str]) -> tuple[str, ...]:
+    canonical = {canonical_version(ecosystem, value) for value in values}
+
+    def compare(left: str, right: str) -> int:
+        precedence = compare_versions(ecosystem, left, right)
+        if precedence != 0:
+            return precedence
+        return (left > right) - (left < right)
+
+    return tuple(sorted(canonical, key=cmp_to_key(compare)))
+
+
+def canonical_requirement(ecosystem: Ecosystem, value: str) -> str:
+    if not value or value != value.strip():
+        raise VersioningError("requirement must be non-empty and have no surrounding whitespace")
+    if ecosystem == "npm":
+        if _NPM_REQUIREMENT.fullmatch(value) is None:
+            raise VersioningError(f"requirement is outside the frozen npm grammar: {value}")
+        try:
+            parsed = nodesemver.Range(value, False)
+        except (TypeError, ValueError) as error:
+            raise VersioningError(f"invalid npm requirement: {value}") from error
+        return parsed.range or "*"
+    if "===" in value:
+        raise VersioningError("arbitrary PEP 440 equality is outside the frozen grammar")
+    try:
+        return str(SpecifierSet(value))
+    except InvalidSpecifier as error:
+        raise VersioningError(f"invalid PyPI requirement: {value}") from error
+
+
+def satisfies_requirement(ecosystem: Ecosystem, version: str, requirement: str) -> bool:
+    candidate = canonical_version(ecosystem, version)
+    normalized_requirement = canonical_requirement(ecosystem, requirement)
+    if ecosystem == "npm":
+        return bool(
+            nodesemver.satisfies(
+                candidate,
+                normalized_requirement,
+                loose=False,
+                include_prerelease=False,
+            )
+        )
+    candidate_version = Version(candidate)
+    specifiers = SpecifierSet(normalized_requirement)
+    if candidate_version.is_prerelease and specifiers.prereleases is not True:
+        return False
+    return specifiers.contains(candidate_version, prereleases=True)
+
+
+def parse_osv_intervals(
+    ecosystem: Ecosystem,
+    events: Iterable[Mapping[str, str]],
+) -> tuple[AffectedInterval, ...]:
+    boundaries: list[tuple[str, str | None]] = []
+    for event in events:
+        if len(event) != 1:
+            raise VersioningError("each OSV event must contain exactly one boundary")
+        kind, raw_version = next(iter(event.items()))
+        if kind not in {"introduced", "fixed"}:
+            raise VersioningError(f"unsupported OSV event type: {kind}")
+        if not isinstance(raw_version, str):
+            raise VersioningError("OSV event versions must be strings")
+        if kind == "introduced" and raw_version == "0":
+            boundaries.append((kind, None))
+        else:
+            boundaries.append((kind, canonical_version(ecosystem, raw_version)))
+    if not boundaries:
+        raise VersioningError("OSV event list must not be empty")
+
+    intervals: list[AffectedInterval] = []
+    index = 0
+    while index < len(boundaries):
+        kind, introduced = boundaries[index]
+        if kind != "introduced":
+            raise VersioningError("each OSV interval must begin with an introduced event")
+        index += 1
+        if index >= len(boundaries):
+            raise VersioningError("open OSV intervals are outside the frozen source grammar")
+        next_kind, fixed = boundaries[index]
+        if next_kind != "fixed":
+            raise VersioningError("each OSV introduction must be followed by a fix")
+        index += 1
+        if (
+            introduced is not None
+            and fixed is not None
+            and compare_versions(ecosystem, introduced, fixed) >= 0
+        ):
+            raise VersioningError("OSV fixed boundary must follow its introduction")
+        intervals.append(AffectedInterval(introduced=introduced, fixed=fixed))
+
+    def compare_intervals(left: AffectedInterval, right: AffectedInterval) -> int:
+        if left.introduced is None:
+            return 0 if right.introduced is None else -1
+        if right.introduced is None:
+            return 1
+        return compare_versions(ecosystem, left.introduced, right.introduced)
+
+    ordered = sorted(set(intervals), key=cmp_to_key(compare_intervals))
+    for previous, current in pairwise(ordered):
+        if previous.fixed is None:
+            raise VersioningError("an open OSV interval overlaps a later interval")
+        if (
+            current.introduced is None
+            or compare_versions(
+                ecosystem,
+                current.introduced,
+                previous.fixed,
+            )
+            < 0
+        ):
+            raise VersioningError("OSV affected intervals must not overlap")
+    return tuple(ordered)
+
+
+def is_version_affected(
+    ecosystem: Ecosystem,
+    version: str,
+    intervals: Iterable[AffectedInterval],
+    explicit_versions: Iterable[str] = (),
+) -> bool:
+    candidate = canonical_version(ecosystem, version)
+    if any(compare_versions(ecosystem, candidate, explicit) == 0 for explicit in explicit_versions):
+        return True
+    for interval in intervals:
+        at_or_after_introduction = (
+            interval.introduced is None
+            or compare_versions(
+                ecosystem,
+                candidate,
+                interval.introduced,
+            )
+            >= 0
+        )
+        before_fix = (
+            interval.fixed is None
+            or compare_versions(
+                ecosystem,
+                candidate,
+                interval.fixed,
+            )
+            < 0
+        )
+        if at_or_after_introduction and before_fix:
+            return True
+    return False

--- a/experiments/scheduled-task-learning/dependency-prioritization/pyproject.toml
+++ b/experiments/scheduled-task-learning/dependency-prioritization/pyproject.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 description = "Deterministic dependency-prioritization benchmark core."
 requires-python = ">=3.11"
 dependencies = [
+    "cvss==3.6",
+    "node-semver==0.9.1",
+    "packaging==26.3",
+    "ruamel.yaml==0.19.1",
     "swift-claw-benchmark-core",
 ]
 
@@ -33,6 +37,7 @@ strict = true
 mypy_path = "tests"
 files = ["dependency_benchmark", "tests"]
 explicit_package_bases = true
+untyped_calls_exclude = ["cvss", "nodesemver"]
 
 [[tool.mypy.overrides]]
 module = [
@@ -45,3 +50,8 @@ module = [
 ]
 disallow_any_generics = false
 disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = ["cvss", "cvss.*", "nodesemver", "nodesemver.*"]
+ignore_missing_imports = true
+follow_untyped_imports = true

--- a/experiments/scheduled-task-learning/dependency-prioritization/tests/test_advisory_records.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/tests/test_advisory_records.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, ClassVar
+
+from benchmark_core.canonical import dumps
+from dependency_benchmark.advisory_records import (
+    AdvisoryRecord,
+    AdvisorySourceError,
+    alias_components,
+    fixed_versions,
+    load_frozen_advisories,
+    record_affects,
+    semantic_receipt,
+)
+
+from support import ROOT
+
+
+def _write_synthetic_source(root: Path, advisory: dict[str, Any]) -> None:
+    repository_id = "github-advisory-database"
+    prefix = Path("synthetic/sources")
+    record_path = Path("advisories/GHSA-test.json")
+    license_path = Path("LICENSE.md")
+    record_bytes = dumps(advisory).encode("utf-8")
+    license_bytes = b"synthetic license\n"
+    record_snapshot = root / "snapshots" / repository_id / record_path
+    license_snapshot = root / "snapshots" / repository_id / license_path
+    record_snapshot.parent.mkdir(parents=True)
+    license_snapshot.parent.mkdir(parents=True, exist_ok=True)
+    record_snapshot.write_bytes(record_bytes)
+    license_snapshot.write_bytes(license_bytes)
+    provenance = {
+        "schema_version": 1,
+        "repositories": [
+            {
+                "repository_id": repository_id,
+                "url": "https://example.invalid/advisories",
+                "commit": "0" * 40,
+                "license": {
+                    "repository_path": str(license_path),
+                    "snapshot_path": str(prefix / "snapshots" / repository_id / license_path),
+                    "bytes": len(license_bytes),
+                    "sha256": hashlib.sha256(license_bytes).hexdigest(),
+                    "spdx_id": "CC-BY-4.0",
+                },
+            }
+        ],
+        "records": [
+            {
+                "record_id": "GHSA-test",
+                "aliases": ["CVE-test"],
+                "package": {"ecosystem": "npm", "name": "package"},
+                "repository_id": repository_id,
+                "repository_path": str(record_path),
+                "snapshot_path": str(prefix / "snapshots" / repository_id / record_path),
+                "bytes": len(record_bytes),
+                "sha256": hashlib.sha256(record_bytes).hexdigest(),
+            }
+        ],
+    }
+    index = {
+        "schema_version": 1,
+        "fixtures": [],
+        "provenance_path": str(prefix / "provenance.json"),
+    }
+    root.mkdir(exist_ok=True)
+    (root / "index.json").write_text(dumps(index), encoding="utf-8")
+    (root / "provenance.json").write_text(dumps(provenance), encoding="utf-8")
+
+
+def _synthetic_advisory() -> dict[str, Any]:
+    return {
+        "id": "GHSA-test",
+        "aliases": ["CVE-test"],
+        "summary": "Synthetic advisory",
+        "details": "Synthetic evidence",
+        "severity": [
+            {
+                "type": "CVSS_V3",
+                "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            }
+        ],
+        "affected": [
+            {
+                "package": {"ecosystem": "npm", "name": "package"},
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [{"introduced": "0"}, {"fixed": "1.2.3"}],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+class DependencyAdvisoryRecordTests(unittest.TestCase):
+    records: ClassVar[tuple[AdvisoryRecord, ...]]
+    by_id: ClassVar[dict[str, AdvisoryRecord]]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.records = load_frozen_advisories(ROOT / "sources")
+        cls.by_id = {record.record_id: record for record in cls.records}
+
+    def test_frozen_sources_have_the_registered_semantic_receipt(self) -> None:
+        # Given / When
+        receipt = semantic_receipt(self.records)
+        minimist = self.by_id["GHSA-xvch-5gv4-984h"]
+        django = self.by_id["PYSEC-2022-190"]
+        form_data = self.by_id["GHSA-fjxv-7rqg-78g4"]
+        aiohttp = self.by_id["PYSEC-2024-24"]
+
+        # Then
+        self.assertEqual(
+            receipt,
+            {
+                "schema_version": 1,
+                "record_count": 27,
+                "repository_counts": {
+                    "github-advisory-database": 14,
+                    "pypa-advisory-database": 13,
+                },
+                "total_bytes": 110253,
+                "normalized_package_count": 26,
+                "alias_component_count": 26,
+                "affected_entry_count": 39,
+                "ecosystem_interval_count": 42,
+                "git_range_count": 3,
+                "fixed_version_count": 42,
+                "explicit_version_raw_count": 1873,
+                "explicit_version_canonical_count": 1871,
+                "cvss_type_counts": {"CVSS_V3": 23, "CVSS_V4": 7},
+                "record_band_counts": {
+                    "critical": 10,
+                    "high": 10,
+                    "missing": 1,
+                    "moderate": 6,
+                },
+                "component_band_counts": {"critical": 10, "high": 10, "moderate": 6},
+                "records_semantic_sha256": (
+                    "d10a3f0e201a85815ad4e11137c6dec5cd76983ab43901899c1e50c745499b09"
+                ),
+                "alias_components_sha256": (
+                    "cab748d32f95569a5d9c32c54dc02c32be318e4acbadd6158384ffbfdfcf4075"
+                ),
+            },
+        )
+        self.assertEqual(fixed_versions(minimist), ("0.2.4", "1.2.6"))
+        self.assertEqual(minimist.summary, "Prototype Pollution in minimist")
+        self.assertIn("1.2.6", minimist.details)
+        self.assertTrue(record_affects(minimist, "1.2.5"))
+        self.assertFalse(record_affects(minimist, "1.2.6"))
+        self.assertEqual(django.package_name, "django")
+        self.assertEqual(django.severity, None)
+        self.assertEqual(len(django.explicit_versions), 45)
+        self.assertEqual(form_data.cvss_vectors[0].kind, "CVSS_V4")
+        self.assertEqual(form_data.severity, "critical")
+        self.assertEqual(aiohttp.ignored_git_range_count, 1)
+
+    def test_alias_closure_is_transitive_and_aggregates_component_severity(self) -> None:
+        # Given
+        base = self.by_id["GHSA-xvch-5gv4-984h"]
+        records = (
+            replace(base, record_id="A", aliases=("bridge-one",), severity="moderate"),
+            replace(
+                base,
+                record_id="B",
+                aliases=("A", "bridge-two"),
+                severity=None,
+            ),
+            replace(base, record_id="C", aliases=("bridge-two",), severity="critical"),
+        )
+
+        # When
+        components = alias_components(records)
+
+        # Then
+        self.assertEqual(len(components), 1)
+        self.assertEqual(components[0].record_ids, ("A", "B", "C"))
+        self.assertEqual(components[0].severity, "critical")
+        with self.assertRaises(AdvisorySourceError):
+            alias_components((*records[:2], replace(records[2], package_name="other")))
+        with self.assertRaises(AdvisorySourceError):
+            alias_components(tuple(replace(record, severity=None) for record in records))
+
+    def test_loader_rejects_raw_catalog_and_osv_ambiguity(self) -> None:
+        # Given
+        invalid_advisories = []
+        wrong_id = _synthetic_advisory()
+        wrong_id["id"] = "GHSA-other"
+        invalid_advisories.append(wrong_id)
+        wrong_alias = _synthetic_advisory()
+        wrong_alias["aliases"] = ["CVE-other"]
+        invalid_advisories.append(wrong_alias)
+        wrong_package = _synthetic_advisory()
+        wrong_package["affected"][0]["package"]["name"] = "other"
+        invalid_advisories.append(wrong_package)
+        wrong_cvss = _synthetic_advisory()
+        wrong_cvss["severity"][0]["score"] = (
+            "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+        )
+        invalid_advisories.append(wrong_cvss)
+        noncanonical_cvss = _synthetic_advisory()
+        noncanonical_cvss["severity"][0]["score"] = "CVSS:3.1/AC:L/AV:N/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        invalid_advisories.append(noncanonical_cvss)
+        zero_cvss = _synthetic_advisory()
+        zero_cvss["severity"][0]["score"] = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
+        invalid_advisories.append(zero_cvss)
+        wrong_event = _synthetic_advisory()
+        wrong_event["affected"][0]["ranges"][0]["events"][1] = {"last_affected": "1.2.2"}
+        invalid_advisories.append(wrong_event)
+
+        # When / Then
+        for index, advisory in enumerate(invalid_advisories):
+            with self.subTest(case=index), tempfile.TemporaryDirectory() as directory:
+                source_root = Path(directory) / "sources"
+                _write_synthetic_source(source_root, advisory)
+                with self.assertRaises(AdvisorySourceError):
+                    load_frozen_advisories(source_root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/scheduled-task-learning/dependency-prioritization/tests/test_sources.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/tests/test_sources.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-import hashlib
 import re
+import shutil
+import tempfile
 import unittest
 from collections import Counter
 from pathlib import Path
 
 from benchmark_core.canonical import dumps, load_object
+from dependency_benchmark.advisory_records import (
+    AdvisorySourceError,
+    verify_frozen_source_catalog,
+)
 
 from support import ROOT
 
@@ -46,42 +51,34 @@ class DependencySourceIntegrityTests(unittest.TestCase):
         provenance_path = ROOT / "sources/provenance.json"
         index = load_object(index_path)
         provenance = load_object(provenance_path)
-        snapshot_root = ROOT / "sources/snapshots"
-        snapshot_prefix = Path(index["provenance_path"]).parent / "snapshots"
-        repositories = {
-            repository["repository_id"]: repository for repository in provenance["repositories"]
-        }
-        records = {record["record_id"]: record for record in provenance["records"]}
-        entries = [(record["repository_id"], record) for record in provenance["records"]] + [
-            (repository["repository_id"], repository["license"])
-            for repository in provenance["repositories"]
-        ]
 
         # When
-        declared_paths: set[Path] = set()
-        for repository_id, entry in entries:
-            relative_path = Path(entry["snapshot_path"]).relative_to(snapshot_prefix)
-            snapshot_path = snapshot_root / relative_path
-            declared_paths.add(snapshot_path)
-            with self.subTest(snapshot_path=entry["snapshot_path"]):
-                self.assertIn(repository_id, repositories)
-                self.assertNotIn("..", relative_path.parts)
-                self.assertEqual(relative_path, Path(repository_id) / entry["repository_path"])
-                self.assertFalse(snapshot_path.is_symlink())
-                snapshot_bytes = snapshot_path.read_bytes()
-                self.assertEqual(len(snapshot_bytes), entry["bytes"])
-                self.assertEqual(hashlib.sha256(snapshot_bytes).hexdigest(), entry["sha256"])
-        actual_paths = {
-            path for path in snapshot_root.rglob("*") if path.is_file() or path.is_symlink()
-        }
+        verify_frozen_source_catalog(ROOT / "sources")
 
         # Then
-        self.assertEqual(len(repositories), len(provenance["repositories"]))
-        self.assertEqual(len(records), len(provenance["records"]))
-        self.assertEqual(actual_paths, declared_paths)
         for catalog_path, catalog in ((index_path, index), (provenance_path, provenance)):
             with self.subTest(catalog_path=catalog_path):
                 self.assertEqual(catalog_path.read_text(encoding="utf-8"), dumps(catalog))
+        for mutation in ("bytes", "sha256", "closure", "catalog_symlink"):
+            with self.subTest(mutation=mutation), tempfile.TemporaryDirectory() as directory:
+                copied_sources = shutil.copytree(ROOT / "sources", Path(directory) / "sources")
+                if mutation == "bytes":
+                    record = provenance["records"][0]
+                    snapshot = copied_sources / record["snapshot_path"].split("/sources/", 1)[1]
+                    snapshot.write_bytes(snapshot.read_bytes() + b"\n")
+                elif mutation == "sha256":
+                    record = provenance["records"][0]
+                    snapshot = copied_sources / record["snapshot_path"].split("/sources/", 1)[1]
+                    content = snapshot.read_bytes()
+                    snapshot.write_bytes(bytes([content[0] ^ 1]) + content[1:])
+                elif mutation == "closure":
+                    (copied_sources / "snapshots/orphan").write_text("orphan", encoding="utf-8")
+                else:
+                    index_copy = copied_sources / "index-copy.json"
+                    (copied_sources / "index.json").rename(index_copy)
+                    (copied_sources / "index.json").symlink_to(index_copy)
+                with self.assertRaises(AdvisorySourceError):
+                    verify_frozen_source_catalog(copied_sources)
 
     def test_source_index_preserves_the_exact_record_allocation(self) -> None:
         # Given

--- a/experiments/scheduled-task-learning/dependency-prioritization/tests/test_versioning.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/tests/test_versioning.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import unittest
+from collections.abc import Callable
+from typing import Any
+
+from dependency_benchmark.versioning import (
+    AffectedInterval,
+    Ecosystem,
+    VersioningError,
+    canonical_package_name,
+    canonical_requirement,
+    canonical_version,
+    compare_versions,
+    is_version_affected,
+    normalize_ecosystem,
+    parse_osv_intervals,
+    satisfies_requirement,
+    sort_versions,
+)
+
+
+class DependencyVersioningTests(unittest.TestCase):
+    def test_supported_ecosystems_follow_the_frozen_version_contract(self) -> None:
+        # Given
+        normalization_cases = [
+            (
+                "npm",
+                "@scope/package",
+                "@scope/package",
+                "1.2.3-alpha.1+build.7",
+                "1.2.3-alpha.1+build.7",
+            ),
+            ("PyPI", "Django", "django", "0.12.01", "0.12.1"),
+        ]
+        satisfaction_cases: list[tuple[Ecosystem, str, str, bool]] = [
+            ("npm", "1.5.0", "^1.2.3", True),
+            ("npm", "2.0.0", "^1.2.3", False),
+            ("npm", "1.2.3-alpha.1", ">=1.0.0 <2.0.0", False),
+            ("npm", "1.2.3-alpha.1", ">=1.2.3-alpha.0 <2.0.0", True),
+            ("pypi", "1.5a1", ">=1.0", False),
+            ("pypi", "1.5a1", ">=1.0a1", True),
+        ]
+
+        # When / Then
+        for raw_ecosystem, raw_name, name, raw_version, version in normalization_cases:
+            with self.subTest(ecosystem=raw_ecosystem, version=raw_version):
+                normalized_ecosystem = normalize_ecosystem(raw_ecosystem)
+                self.assertEqual(canonical_package_name(normalized_ecosystem, raw_name), name)
+                self.assertEqual(canonical_version(normalized_ecosystem, raw_version), version)
+        for ecosystem, version, requirement, expected in satisfaction_cases:
+            with self.subTest(ecosystem=ecosystem, version=version, requirement=requirement):
+                self.assertEqual(satisfies_requirement(ecosystem, version, requirement), expected)
+        self.assertEqual(canonical_requirement("npm", "^1.2.3"), ">=1.2.3 <2.0.0")
+        self.assertEqual(canonical_requirement("pypi", ">=1.0, <2"), "<2,>=1.0")
+        self.assertEqual(compare_versions("npm", "1.2.3+one", "1.2.3+two"), 0)
+        self.assertEqual(
+            sort_versions("npm", ["1.10.0", "1.2.10", "1.2.3+two", "1.2.3+one"]),
+            ("1.2.3+one", "1.2.3+two", "1.2.10", "1.10.0"),
+        )
+        self.assertEqual(
+            sort_versions("pypi", ["1.0.post1", "1.0", "1.0rc1"]),
+            ("1.0rc1", "1.0", "1.0.post1"),
+        )
+
+    def test_versioning_rejects_unsupported_or_ambiguous_syntax(self) -> None:
+        # Given
+        invalid_calls: list[tuple[Callable[..., Any], tuple[Any, ...]]] = [
+            (normalize_ecosystem, ("Maven",)),
+            (canonical_package_name, ("npm", "MixedCase")),
+            (canonical_package_name, ("pypi", "foo/bar")),
+            (canonical_version, ("npm", "1.2")),
+            (canonical_version, ("npm", "01.2.3")),
+            (canonical_version, ("npm", "1.2.3-01")),
+            (canonical_requirement, ("npm", "1.x")),
+            (canonical_requirement, ("npm", "^1.2.3 || ^2.0.0")),
+            (canonical_requirement, ("pypi", "===legacy")),
+        ]
+
+        # When / Then
+        for function, arguments in invalid_calls:
+            with (
+                self.subTest(function=function.__name__, arguments=arguments),
+                self.assertRaises(VersioningError),
+            ):
+                function(*arguments)
+
+    def test_osv_events_preserve_branch_pairs_and_fixed_exclusivity(self) -> None:
+        # Given
+        descending_branch_events = [
+            {"introduced": "4.0"},
+            {"fixed": "4.0.4"},
+            {"introduced": "3.2"},
+            {"fixed": "3.2.13"},
+            {"introduced": "2.2"},
+            {"fixed": "2.2.28"},
+            {"introduced": "2.2"},
+            {"fixed": "2.2.28"},
+        ]
+
+        # When
+        intervals = parse_osv_intervals("pypi", descending_branch_events)
+
+        # Then
+        self.assertEqual(
+            intervals,
+            (
+                AffectedInterval("2.2", "2.2.28"),
+                AffectedInterval("3.2", "3.2.13"),
+                AffectedInterval("4.0", "4.0.4"),
+            ),
+        )
+        self.assertTrue(is_version_affected("pypi", "3.2.12", intervals))
+        self.assertFalse(is_version_affected("pypi", "3.2.13", intervals))
+        self.assertTrue(is_version_affected("pypi", "3.1", intervals, ("3.1",)))
+        for invalid_events in (
+            [{"fixed": "1.0"}, {"introduced": "0"}],
+            [{"introduced": "0"}],
+            [{"introduced": "0"}, {"last_affected": "1.0"}],
+            [
+                {"introduced": "0"},
+                {"fixed": "2.0"},
+                {"introduced": "1.0"},
+                {"fixed": "3.0"},
+            ],
+        ):
+            with self.subTest(invalid_events=invalid_events), self.assertRaises(VersioningError):
+                parse_osv_intervals("pypi", invalid_events)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/scheduled-task-learning/dependency-prioritization/uv.lock
+++ b/experiments/scheduled-task-learning/dependency-prioritization/uv.lock
@@ -3,10 +3,23 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "cvss"
+version = "3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/f6/1f7d315de23f39bbc32b94bb6b33a1b6124856037bfaa3f8bdb1a49584fa/cvss-3.6.tar.gz", hash = "sha256:f21d18224efcd3c01b44ff1b37dec2e3208d29a6d0ce6c87a599c73c21ee1a99", size = 30047, upload-time = "2025-08-04T10:50:13.753Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/6d/fe2c65b94a28ae0481dc254e8cd664b82390069003bea945076d8a445f2b/cvss-3.6-py2.py3-none-any.whl", hash = "sha256:e342c6ad9c7eb69d2aebbbc2768a03cabd57eb947c806e145de5b936219833ea", size = 31154, upload-time = "2025-08-04T10:50:12.328Z" },
+]
+
+[[package]]
 name = "dependency-prioritization-benchmark"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "cvss" },
+    { name = "node-semver" },
+    { name = "packaging" },
+    { name = "ruamel-yaml" },
     { name = "swift-claw-benchmark-core" },
 ]
 
@@ -17,7 +30,13 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "swift-claw-benchmark-core", directory = "../benchmark-core" }]
+requires-dist = [
+    { name = "cvss", specifier = "==3.6" },
+    { name = "node-semver", specifier = "==0.9.1" },
+    { name = "packaging", specifier = "==26.3" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
+    { name = "swift-claw-benchmark-core", directory = "../benchmark-core" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -190,12 +209,39 @@ wheels = [
 ]
 
 [[package]]
+name = "node-semver"
+version = "0.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/46/83d4ff2e6ee95a2395c9695f92b83c7aec16a8341cf4b50be08d67f59deb/node_semver-0.9.1.tar.gz", hash = "sha256:f052dbdcbc42dd5a0c04b22829a3af98c1f29e4675cc6d88db24250a3f7f8ec7", size = 12828, upload-time = "2026-06-23T03:06:50.862Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/82/aee31be77e4539deb4b1305f2b42ed5f92a2ff7b8057ada67a0c3ba12187/node_semver-0.9.1-py3-none-any.whl", hash = "sha256:47669dc0f7e104cc482f69fda53c04fbe34ce9b7c9d6990e43c99a028d1628bd", size = 12051, upload-time = "2026-06-23T03:06:49.633Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of #118.

## Scope

- pin strict npm, PEP 440, YAML, and CVSS implementations;
- verify the frozen source catalog, snapshot closure, bytes, and hashes before decoding;
- normalize advisory records, OSV intervals, aliases, package identities, CVSS severity, and semantic receipts;
- reuse the production source-verification seam from the existing integrity test.

This PR intentionally excludes project snapshots, graph derivation, concrete 10/4/6 fixtures, runtime/model calls, and the D7 manifest.

## Test-intent map

| Risk | Production seam | Nearest existing test | Unique reachable mutant | Primary test |
|---|---|---|---|---|
| ecosystem version drift | `versioning` public functions | fixture policy uses only authored canonical facts | loose npm grammar, wrong prerelease admission, lexical ordering, or wrong PEP 440 canonicalization | `DependencyVersioningTests` supported/invalid vectors |
| OSV branch corruption | `parse_osv_intervals` / `is_version_affected` | no existing source-semantic parser | global event sorting, fixed-inclusive boundary, open/reversed/overlapping intervals | `test_osv_events_preserve_branch_pairs_and_fixed_exclusivity` |
| source semantic drift | `load_frozen_advisories` / `semantic_receipt` | source integrity previously checked bytes only | YAML coercion, GIT-as-version, missing V4, per-record missing severity rejection | `test_frozen_sources_have_the_registered_semantic_receipt` |
| alias closure drift | `alias_components` | no transitive component test | alias-only union, primary-ID omission, mixed-package aggregation, or all-missing severity | `test_alias_closure_is_transitive_and_aggregates_component_severity` |
| catalog/raw ambiguity | verified decoding boundary | exact source allocation does not decode records | ID/alias/package mismatch, noncanonical/zero CVSS, unsupported OSV event | `test_loader_rejects_raw_catalog_and_osv_ambiguity` |
| integrity seam regression | `verify_frozen_source_catalog` | former test duplicated the algorithm | same-length byte substitution, orphan entry, or catalog symlink | refactored `test_frozen_snapshot_bytes_match_the_registered_provenance` |

## Verification

- `scripts/lint.sh`
- `scripts/test.sh` — 30/30 passed
- `uv lock --check`
- `git diff --check`
- independent API/security/SOLID-KISS-YAGNI review: GO, no P0/P1
- independent test-value/redundancy review: GO, no P0/P1
- signed commit verified with `git verify-commit`
