### PR TITLE
Add deterministic dependency materialization

### DIFF
--- a/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/advisory_records.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/advisory_records.py
@@ -113,11 +113,33 @@ def _texts(value: Any, context: str) -> tuple[str, ...]:
     return result
 
 
-def _catalog_entries(root: Path) -> tuple[Path, frozenset[str], tuple[_CatalogEntry, ...]]:
+def _catalog_entries(
+    root: Path,
+) -> tuple[Mapping[str, Any], Path, frozenset[str], tuple[_CatalogEntry, ...]]:
     index_path = root / "index.json"
     if index_path.is_symlink():
         raise AdvisorySourceError("source catalogs must not be symlinks")
     index = load_object(index_path)
+    if set(index) != {"schema_version", "fixtures", "provenance_path"}:
+        raise AdvisorySourceError("source index has the wrong shape")
+    if type(index["schema_version"]) is not int or index["schema_version"] != 1:
+        raise AdvisorySourceError("source index schema version is unsupported")
+    fixtures = _array(index["fixtures"], "source fixtures")
+    fixture_ids: list[str] = []
+    for raw_fixture in fixtures:
+        fixture = _object(raw_fixture, "source fixture")
+        if set(fixture) != {"fixture_id", "record_ids", "split"}:
+            raise AdvisorySourceError("source fixture has the wrong shape")
+        fixture_id = _text(fixture["fixture_id"], "fixture id")
+        split = _text(fixture["split"], "fixture split")
+        if split not in {"development", "regression", "sealed"}:
+            raise AdvisorySourceError("source fixture split is unsupported")
+        if not fixture_id.startswith(f"dp-{split}-"):
+            raise AdvisorySourceError("source fixture id does not encode its split")
+        _texts(fixture["record_ids"], "fixture record ids")
+        fixture_ids.append(fixture_id)
+    if len(fixture_ids) != len(set(fixture_ids)):
+        raise AdvisorySourceError("source fixture ids must be unique")
     provenance_declaration = Path(_text(index.get("provenance_path"), "provenance path"))
     if provenance_declaration.name != "provenance.json":
         raise AdvisorySourceError("source index must declare provenance.json")
@@ -156,7 +178,7 @@ def _catalog_entries(root: Path) -> tuple[Path, frozenset[str], tuple[_CatalogEn
         )
         for repository_id, repository in repositories.items()
     )
-    return snapshot_prefix, frozenset(repositories), tuple(entries)
+    return index, snapshot_prefix, frozenset(repositories), tuple(entries)
 
 
 def _verified_entry(
@@ -205,7 +227,7 @@ def _verified_sources(source_root: Path) -> tuple[_VerifiedRecord, ...]:
     if source_root.is_symlink():
         raise AdvisorySourceError("source root must not be a symlink")
     root = source_root.resolve()
-    snapshot_prefix, repositories, entries = _catalog_entries(root)
+    _, snapshot_prefix, repositories, entries = _catalog_entries(root)
 
     declared_paths: set[Path] = set()
     verified_records: list[_VerifiedRecord] = []
@@ -240,6 +262,31 @@ def verify_frozen_source_catalog(source_root: Path) -> None:
     """Verify path closure, byte counts, and hashes for every frozen source entry."""
 
     _verified_sources(source_root)
+
+
+def fixture_record_ids(source_root: Path, fixture_id: str, split: str) -> tuple[str, ...]:
+    """Return the sole frozen advisory selection for one fixture."""
+
+    if source_root.is_symlink():
+        raise AdvisorySourceError("source root must not be a symlink")
+    root = source_root.resolve()
+    index, _, _, entries = _catalog_entries(root)
+    known_record_ids = {
+        _text(entry.get("record_id"), "catalog record id")
+        for _, entry, is_record in entries
+        if is_record
+    }
+    matches = [
+        fixture
+        for raw_fixture in _array(index["fixtures"], "source fixtures")
+        if (fixture := _object(raw_fixture, "source fixture"))["fixture_id"] == fixture_id
+    ]
+    if len(matches) != 1 or matches[0]["split"] != split:
+        raise AdvisorySourceError("fixture advisory selection is missing or mismatched")
+    record_ids = _texts(matches[0]["record_ids"], "fixture record ids")
+    if not record_ids or not set(record_ids).issubset(known_record_ids):
+        raise AdvisorySourceError("fixture advisory selection contains unknown records")
+    return record_ids
 
 
 def _decode_record(source: _VerifiedRecord) -> dict[str, Any]:

--- a/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/derivation.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/derivation.py
@@ -1,0 +1,450 @@
+"""Derive normalized dependency facts from frozen projects and advisories."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from functools import cmp_to_key
+from pathlib import Path
+from typing import Any
+
+from benchmark_core.canonical import canonical_sha256
+from benchmark_core.contract_validation import require_valid
+
+from .advisory_records import (
+    AdvisoryComponent,
+    AdvisoryRecord,
+    alias_components,
+    fixed_versions,
+    fixture_record_ids,
+    load_frozen_advisories,
+    record_affects,
+)
+from .fixture_policy import FixtureFamilyFingerprint, RemediationCandidate
+from .policy import is_safe_remediation_option
+from .project_snapshot import (
+    FindingFact,
+    PackageNode,
+    ProjectSnapshot,
+    ReleaseInventory,
+    dependency_paths,
+    incoming_requirements,
+)
+from .validation import (
+    MAX_EVIDENCE_PER_FINDING,
+    MAX_FINDINGS,
+    MAX_OPTIONS_PER_FINDING,
+    validate_source,
+)
+from .versioning import compare_versions, satisfies_requirement
+
+_RELEASE_INVENTORY_ORIGIN = "release-inventory"
+
+
+class DependencyDerivationError(ValueError):
+    """Raised when frozen source facts cannot produce one unambiguous task."""
+
+
+@dataclass(frozen=True, slots=True)
+class DerivedSource:
+    source: dict[str, Any]
+    family_fingerprint: FixtureFamilyFingerprint
+    snapshot_sha256: str
+    selected_record_ids: tuple[str, ...]
+    remediation_candidates_by_finding: Mapping[
+        str,
+        tuple[RemediationCandidate, ...],
+    ]
+
+
+def derive_normalized_source(
+    snapshot: ProjectSnapshot,
+    source_root: Path,
+) -> DerivedSource:
+    """Join one project snapshot with its authenticated frozen advisory allocation."""
+
+    return _derive_normalized_source(
+        snapshot,
+        load_frozen_advisories(source_root),
+        fixture_record_ids(source_root, snapshot.fixture_id, snapshot.split),
+    )
+
+
+def _derive_normalized_source(
+    snapshot: ProjectSnapshot,
+    records: Iterable[AdvisoryRecord],
+    selected_record_ids: Iterable[str],
+) -> DerivedSource:
+
+    ordered_records = tuple(sorted(records, key=lambda record: record.record_id))
+    record_by_id = {record.record_id: record for record in ordered_records}
+    if len(record_by_id) != len(ordered_records):
+        raise DependencyDerivationError("advisory record ids must be unique")
+    selected_ids = tuple(sorted(selected_record_ids))
+    if not selected_ids or len(selected_ids) != len(set(selected_ids)):
+        raise DependencyDerivationError("selected advisory record ids must be non-empty and unique")
+    if not set(selected_ids).issubset(record_by_id):
+        raise DependencyDerivationError("selected advisory record is unavailable")
+
+    selected_components = _selected_components(ordered_records, selected_ids)
+    if any(component.ecosystem != snapshot.ecosystem for component in selected_components):
+        raise DependencyDerivationError("selected advisory ecosystem differs from the project")
+    selected_packages = {component.package_name for component in selected_components}
+    if snapshot.root.package_name in selected_packages:
+        raise DependencyDerivationError("the project root cannot be a benchmark finding")
+
+    facts = {fact.node_key: fact for fact in snapshot.finding_facts}
+    target_nodes = tuple(
+        node for node in snapshot.dependencies if node.package_name in selected_packages
+    )
+    if {node.package_name for node in target_nodes} != selected_packages:
+        raise DependencyDerivationError(
+            "selected-advisory packages must all exist in the project dependency graph"
+        )
+    if set(facts) != {node.node_key for node in target_nodes}:
+        raise DependencyDerivationError(
+            "finding facts must exactly match selected-advisory dependency nodes"
+        )
+    inventories = {inventory.package_name: inventory for inventory in snapshot.release_inventories}
+    if set(inventories) != selected_packages:
+        raise DependencyDerivationError(
+            "release inventories must exactly match selected advisory packages"
+        )
+
+    paths_by_node = dependency_paths(snapshot)
+    findings: list[dict[str, Any]] = []
+    candidates_by_finding: dict[str, tuple[RemediationCandidate, ...]] = {}
+    for component in selected_components:
+        component_records = tuple(record_by_id[record_id] for record_id in component.record_ids)
+        for node in target_nodes:
+            if node.package_name == component.package_name:
+                finding, candidates = _derive_finding(
+                    snapshot,
+                    node,
+                    facts[node.node_key],
+                    inventories[node.package_name],
+                    component,
+                    component_records,
+                    paths_by_node[node.node_key],
+                )
+                findings.append(finding)
+                candidates_by_finding[finding["source_key"]] = candidates
+    if len(findings) > MAX_FINDINGS:
+        raise DependencyDerivationError("derived source exceeds the canonical finding limit")
+
+    task_id = _task_id(snapshot, (record_by_id[record_id] for record_id in selected_ids))
+    source = {
+        "schema_version": 1,
+        "fixture_id": snapshot.fixture_id,
+        "task_id": task_id,
+        "family_id": snapshot.family_id,
+        "split": snapshot.split,
+        "normalized_findings": sorted(findings, key=lambda item: item["source_key"]),
+    }
+    require_valid(source, validate_source)
+    return DerivedSource(
+        source=source,
+        family_fingerprint=_family_fingerprint(
+            snapshot,
+            selected_components,
+            target_nodes,
+        ),
+        snapshot_sha256=snapshot.semantic_sha256,
+        selected_record_ids=selected_ids,
+        remediation_candidates_by_finding=dict(sorted(candidates_by_finding.items())),
+    )
+
+
+def _selected_components(
+    records: tuple[AdvisoryRecord, ...],
+    selected_ids: tuple[str, ...],
+) -> tuple[AdvisoryComponent, ...]:
+    selected = set(selected_ids)
+    result: list[AdvisoryComponent] = []
+    covered: set[str] = set()
+    for component in alias_components(records):
+        component_ids = set(component.record_ids)
+        if component_ids.isdisjoint(selected):
+            continue
+        if not component_ids.issubset(selected):
+            raise DependencyDerivationError("advisory selection splits an alias component")
+        covered.update(component_ids)
+        result.append(component)
+    if covered != selected:
+        raise DependencyDerivationError("advisory selection does not resolve to alias components")
+    return tuple(result)
+
+
+def _derive_finding(
+    snapshot: ProjectSnapshot,
+    node: PackageNode,
+    fact: FindingFact,
+    inventory: ReleaseInventory,
+    component: AdvisoryComponent,
+    records: tuple[AdvisoryRecord, ...],
+    paths: tuple[Any, ...],
+) -> tuple[dict[str, Any], tuple[RemediationCandidate, ...]]:
+    finding_key = _source_key(
+        "finding-source",
+        {
+            "component_record_ids": list(component.record_ids),
+            "package": node.package_name,
+            "installed_version": node.installed_version,
+        },
+    )
+    affected = any(record_affects(record, node.installed_version) for record in records)
+    derived_paths = [
+        {
+            "source_key": _source_key(
+                "path-source",
+                {
+                    "finding_source_key": finding_key,
+                    "package_chain": list(path.package_chain),
+                    "relationship": path.relationship,
+                    "runtime_scope": path.runtime_scope,
+                },
+            ),
+            "package_chain": list(path.package_chain),
+            "relationship": path.relationship,
+            "runtime_scope": path.runtime_scope,
+        }
+        for path in paths
+    ]
+    options, candidates = _remediation_options(
+        snapshot,
+        node,
+        finding_key,
+        inventory,
+        records,
+    )
+    evidence = _evidence_references(finding_key, fact, records)
+    return (
+        {
+            "source_key": finding_key,
+            "ecosystem": snapshot.ecosystem,
+            "package_name": node.package_name,
+            "installed_version": node.installed_version,
+            "affected_status": "affected" if affected else "unaffected",
+            "advisories": [
+                {"advisory_id": record.record_id, "severity": record.severity} for record in records
+            ],
+            "reachability": fact.reachability,
+            "dependency_paths": sorted(derived_paths, key=lambda item: item["source_key"]),
+            "remediation_options": options,
+            "evidence_references": evidence,
+        },
+        candidates,
+    )
+
+
+def _remediation_options(
+    snapshot: ProjectSnapshot,
+    node: PackageNode,
+    finding_key: str,
+    inventory: ReleaseInventory,
+    records: tuple[AdvisoryRecord, ...],
+) -> tuple[list[dict[str, str]], tuple[RemediationCandidate, ...]]:
+    requirements = incoming_requirements(snapshot, node.node_key)
+    candidates: list[RemediationCandidate] = []
+    for record in records:
+        for version in fixed_versions(record):
+            candidates.append(
+                _candidate(
+                    snapshot,
+                    finding_key,
+                    version,
+                    record.record_id,
+                    "available",
+                    records,
+                    requirements,
+                )
+            )
+    for release in inventory.releases:
+        candidates.append(
+            _candidate(
+                snapshot,
+                finding_key,
+                release.version,
+                _RELEASE_INVENTORY_ORIGIN,
+                release.availability,
+                records,
+                requirements,
+            )
+        )
+
+    def compare(left: RemediationCandidate, right: RemediationCandidate) -> int:
+        version_order = compare_versions(
+            snapshot.ecosystem,
+            left["target_version"],
+            right["target_version"],
+        )
+        if version_order != 0:
+            return version_order
+        left_tie = (left["origin_id"], left["source_key"])
+        right_tie = (right["origin_id"], right["source_key"])
+        return (left_tie > right_tie) - (left_tie < right_tie)
+
+    ordered = sorted(candidates, key=cmp_to_key(compare))
+    equivalent_groups: list[list[RemediationCandidate]] = []
+    for candidate in ordered:
+        if equivalent_groups and (
+            compare_versions(
+                snapshot.ecosystem,
+                equivalent_groups[-1][-1]["target_version"],
+                candidate["target_version"],
+            )
+            == 0
+        ):
+            equivalent_groups[-1].append(candidate)
+        else:
+            equivalent_groups.append([candidate])
+    resolved = [
+        next(
+            (
+                candidate
+                for candidate in group
+                if is_safe_remediation_option(candidate)
+                and compare_versions(
+                    snapshot.ecosystem,
+                    candidate["target_version"],
+                    node.installed_version,
+                )
+                > 0
+            ),
+            group[0],
+        )
+        for group in equivalent_groups
+    ]
+    if len(resolved) > MAX_OPTIONS_PER_FINDING:
+        raise DependencyDerivationError("derived source exceeds the remediation-option limit")
+    return (
+        [
+            {
+                "source_key": candidate["source_key"],
+                "target_version": candidate["target_version"],
+                "availability": candidate["availability"],
+                "affected_status": candidate["affected_status"],
+                "compatibility": candidate["compatibility"],
+            }
+            for candidate in resolved
+        ],
+        tuple(ordered),
+    )
+
+
+def _candidate(
+    snapshot: ProjectSnapshot,
+    finding_key: str,
+    version: str,
+    origin_id: str,
+    availability: str,
+    records: tuple[AdvisoryRecord, ...],
+    requirements: tuple[str, ...],
+) -> RemediationCandidate:
+    source_key = _source_key(
+        "option-source",
+        {
+            "finding_source_key": finding_key,
+            "origin_id": origin_id,
+            "target_version": version,
+        },
+    )
+    return {
+        "target_version": version,
+        "origin_id": origin_id,
+        "source_key": source_key,
+        "availability": availability,
+        "affected_status": (
+            "affected"
+            if any(record_affects(record, version) for record in records)
+            else "unaffected"
+        ),
+        "compatibility": (
+            "compatible"
+            if all(
+                satisfies_requirement(snapshot.ecosystem, version, requirement)
+                for requirement in requirements
+            )
+            else "incompatible"
+        ),
+    }
+
+
+def _evidence_references(
+    finding_key: str,
+    fact: FindingFact,
+    records: tuple[AdvisoryRecord, ...],
+) -> list[dict[str, str]]:
+    candidates = [
+        (record.record_id, (record.summary or record.details)[:600]) for record in records
+    ]
+    candidates.extend(
+        (f"manifest-{index:02d}", snippet)
+        for index, snippet in enumerate(fact.manifest_evidence, start=1)
+    )
+    unique_snippets: dict[str, str] = {}
+    for origin_id, snippet in candidates:
+        unique_snippets.setdefault(snippet, origin_id)
+    references = [
+        {
+            "source_key": _source_key(
+                "evidence-source",
+                {
+                    "finding_source_key": finding_key,
+                    "origin_id": origin_id,
+                    "snippet": snippet,
+                },
+            ),
+            "subject_type": "finding",
+            "subject_key": finding_key,
+            "snippet": snippet,
+        }
+        for snippet, origin_id in sorted(unique_snippets.items(), key=lambda item: item[1])
+    ]
+    if len(references) > MAX_EVIDENCE_PER_FINDING:
+        raise DependencyDerivationError("derived source exceeds the evidence-reference limit")
+    return sorted(references, key=lambda item: item["source_key"])
+
+
+def _task_id(snapshot: ProjectSnapshot, records: Iterable[AdvisoryRecord]) -> str:
+    payload = {
+        "project_snapshot_sha256": snapshot.semantic_sha256,
+        "advisory_sources": [
+            {"record_id": record.record_id, "source_sha256": record.source_sha256}
+            for record in sorted(records, key=lambda item: item.record_id)
+        ],
+    }
+    return f"dependency-{canonical_sha256(payload)[:12]}"
+
+
+def _family_fingerprint(
+    snapshot: ProjectSnapshot,
+    components: tuple[AdvisoryComponent, ...],
+    target_nodes: tuple[PackageNode, ...],
+) -> FixtureFamilyFingerprint:
+    target_keys = {node.node_key for node in target_nodes}
+    helper_nodes = (
+        snapshot.root,
+        *(node for node in snapshot.dependencies if node.node_key not in target_keys),
+    )
+    return FixtureFamilyFingerprint(
+        family_id=snapshot.family_id,
+        normalized_packages=frozenset(
+            f"{component.ecosystem}:{component.package_name}" for component in components
+        ),
+        record_alias_components=frozenset(
+            _source_key("alias-component", {"identities": list(component.identities)})
+            for component in components
+        ),
+        root_helper_nodes=frozenset(
+            f"{snapshot.ecosystem}:{node.package_name}@{node.installed_version}"
+            for node in helper_nodes
+        ),
+        graph_template_ids=frozenset({snapshot.graph_template_id}),
+        generator_seeds=frozenset({snapshot.generator_seed}),
+        manifest_digests=frozenset({snapshot.semantic_sha256}),
+    )
+
+
+def _source_key(prefix: str, value: Any) -> str:
+    return f"{prefix}-{canonical_sha256({'domain': prefix, 'value': value})[:12]}"

--- a/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/normalization.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/normalization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from benchmark_core.canonical import canonical_sha256
@@ -12,16 +13,76 @@ from .validation import validate_source
 _SEVERITY_ORDER = {"low": 0, "moderate": 1, "high": 2, "critical": 3}
 
 
+@dataclass(frozen=True, slots=True)
+class IdBinding:
+    source_key: str
+    canonical_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class FindingBindings:
+    source_key: str
+    finding_id: str
+    paths: tuple[IdBinding, ...]
+    options: tuple[IdBinding, ...]
+    evidence: tuple[IdBinding, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizationBindings:
+    findings: tuple[FindingBindings, ...]
+
+    def finding_id(self, source_key: str) -> str:
+        return self._finding(source_key).finding_id
+
+    def path_id(self, finding_source_key: str, path_source_key: str) -> str:
+        return self._resolve(self._finding(finding_source_key).paths, path_source_key, "path")
+
+    def option_id(self, finding_source_key: str, option_source_key: str) -> str:
+        return self._resolve(
+            self._finding(finding_source_key).options,
+            option_source_key,
+            "option",
+        )
+
+    def evidence_id(self, finding_source_key: str, evidence_source_key: str) -> str:
+        return self._resolve(
+            self._finding(finding_source_key).evidence,
+            evidence_source_key,
+            "evidence",
+        )
+
+    def _finding(self, source_key: str) -> FindingBindings:
+        for binding in self.findings:
+            if binding.source_key == source_key:
+                return binding
+        raise KeyError(f"unknown finding source key: {source_key}")
+
+    @staticmethod
+    def _resolve(bindings: tuple[IdBinding, ...], source_key: str, label: str) -> str:
+        for binding in bindings:
+            if binding.source_key == source_key:
+                return binding.canonical_id
+        raise KeyError(f"unknown {label} source key: {source_key}")
+
+
+@dataclass(frozen=True, slots=True)
+class Materialization:
+    task: dict[str, Any]
+    bindings: NormalizationBindings
+
+
 def _canonical_id(prefix: str, value: Any) -> str:
     return f"{prefix}-{canonical_sha256({'domain': prefix, 'value': value})[:10]}"
 
 
-def materialize_task(source: dict[str, Any]) -> dict[str, Any]:
-    """Return the canonical model-visible task, excluding author-only source keys."""
+def materialize(source: dict[str, Any]) -> Materialization:
+    """Return canonical task facts and their sole source-key binding."""
 
     require_valid(source, validate_source)
     findings: list[dict[str, Any]] = []
     evidence_references: list[dict[str, Any]] = []
+    finding_bindings: list[FindingBindings] = []
     observed_ids: dict[str, set[str]] = {
         "finding": set(),
         "path": set(),
@@ -80,6 +141,7 @@ def materialize_task(source: dict[str, Any]) -> dict[str, Any]:
                     "compatibility": raw_option["compatibility"],
                 }
             )
+        evidence_ids_by_source: dict[str, str] = {}
         for raw_evidence in raw_finding["evidence_references"]:
             subject_type = raw_evidence["subject_type"]
             subject_id: str | None
@@ -102,6 +164,7 @@ def materialize_task(source: dict[str, Any]) -> dict[str, Any]:
                     "subject_type": subject_type,
                 },
             )
+            evidence_ids_by_source[raw_evidence["source_key"]] = evidence_id
             evidence_references.append(
                 {
                     "evidence_reference_id": evidence_id,
@@ -112,6 +175,13 @@ def materialize_task(source: dict[str, Any]) -> dict[str, Any]:
                 }
             )
 
+        severities = [
+            advisory["severity"]
+            for advisory in raw_finding["advisories"]
+            if advisory["severity"] is not None
+        ]
+        if not severities:
+            raise ValueError("normalized alias component has no supported severity")
         finding = {
             "finding_id": finding_id,
             "alias_cluster_id": alias_cluster_id,
@@ -119,7 +189,7 @@ def materialize_task(source: dict[str, Any]) -> dict[str, Any]:
             "installed_version": raw_finding["installed_version"],
             "affected_status": raw_finding["affected_status"],
             "severity": max(
-                (advisory["severity"] for advisory in raw_finding["advisories"]),
+                severities,
                 key=_SEVERITY_ORDER.__getitem__,
             ),
             "reachability": raw_finding["reachability"],
@@ -127,6 +197,15 @@ def materialize_task(source: dict[str, Any]) -> dict[str, Any]:
             "remediation_options": sorted(options, key=lambda item: item["option_id"]),
         }
         findings.append(finding)
+        finding_bindings.append(
+            FindingBindings(
+                source_key=raw_finding["source_key"],
+                finding_id=finding_id,
+                paths=_id_bindings(path_ids),
+                options=_id_bindings(option_ids),
+                evidence=_id_bindings(evidence_ids_by_source),
+            )
+        )
         for namespace, values in (
             ("finding", [finding_id]),
             ("path", list(path_ids.values())),
@@ -141,10 +220,28 @@ def materialize_task(source: dict[str, Any]) -> dict[str, Any]:
     evidence_ids = [item["evidence_reference_id"] for item in evidence_references]
     if len(evidence_ids) != len(set(evidence_ids)):
         raise ValueError("normalized facts collapse to a duplicate canonical evidence ID")
-    return {
-        "findings": sorted(findings, key=lambda item: item["finding_id"]),
-        "evidence_references": sorted(
-            evidence_references,
-            key=lambda item: item["evidence_reference_id"],
+    return Materialization(
+        task={
+            "findings": sorted(findings, key=lambda item: item["finding_id"]),
+            "evidence_references": sorted(
+                evidence_references,
+                key=lambda item: item["evidence_reference_id"],
+            ),
+        },
+        bindings=NormalizationBindings(
+            findings=tuple(sorted(finding_bindings, key=lambda item: item.source_key))
         ),
-    }
+    )
+
+
+def materialize_task(source: dict[str, Any]) -> dict[str, Any]:
+    """Return the canonical model-visible task, excluding author-only source keys."""
+
+    return materialize(source).task
+
+
+def _id_bindings(values: dict[str, str]) -> tuple[IdBinding, ...]:
+    return tuple(
+        IdBinding(source_key=source_key, canonical_id=canonical_id)
+        for source_key, canonical_id in sorted(values.items())
+    )

--- a/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/validation.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/dependency_benchmark/validation.py
@@ -25,6 +25,12 @@ CANONICAL_IDS = {
 }
 _MAX_QUEUE_GRADE = 48
 _MAX_TASK_EVIDENCE_REFERENCES = 48
+MAX_FINDINGS = 12
+MAX_PATHS_PER_FINDING = 8
+MAX_PATH_NODES = 12
+MAX_OPTIONS_PER_FINDING = 8
+MAX_EVIDENCE_PER_FINDING = 16
+MAX_PACKAGE_CHAIN_ITEM_SCALARS = 128
 
 
 def _source_key(value: Any, path: str, issues: list[ValidationIssue]) -> bool:
@@ -66,7 +72,7 @@ def validate_source(value: Any) -> list[ValidationIssue]:
         issue(issues, "schema.exact_version_identity", "fixture_id does not encode split")
     findings = value.get("normalized_findings")
     finding_keys: list[str] = []
-    if bounded_list(findings, 0, 12, "$.normalized_findings", issues):
+    if bounded_list(findings, 0, MAX_FINDINGS, "$.normalized_findings", issues):
         for index, finding in enumerate(findings):
             path = f"$.normalized_findings[{index}]"
             finding_keys.extend(_validate_source_finding(finding, path, issues))
@@ -144,7 +150,7 @@ def _validate_source_finding(
 
 def _validate_advisories(value: Any, path: str, issues: list[ValidationIssue]) -> None:
     advisory_ids: list[str] = []
-    if not bounded_list(value, 1, 8, path, issues):
+    if not bounded_list(value, 1, MAX_PATHS_PER_FINDING, path, issues):
         return
     for index, advisory in enumerate(value):
         item_path = f"{path}[{index}]"
@@ -154,12 +160,14 @@ def _validate_advisories(value: Any, path: str, issues: list[ValidationIssue]) -
         advisory_id = advisory.get("advisory_id")
         if bounded_string(advisory_id, 1, 128, f"{item_path}.advisory_id", issues):
             advisory_ids.append(advisory_id)
-        closed_enum(
-            advisory.get("severity"),
-            ("low", "moderate", "high", "critical"),
-            f"{item_path}.severity",
-            issues,
-        )
+        severity = advisory.get("severity")
+        if severity is not None:
+            closed_enum(
+                severity,
+                ("low", "moderate", "high", "critical"),
+                f"{item_path}.severity",
+                issues,
+            )
     if len(advisory_ids) != len(set(advisory_ids)):
         issue(issues, "schema.unique_arrays", f"{path} advisory IDs must be unique")
 
@@ -177,12 +185,12 @@ def _validate_source_paths(value: Any, path: str, issues: list[ValidationIssue])
         if _source_key(source_key, f"{item_path}.source_key", issues):
             source_keys.append(source_key)
         chain = item.get("package_chain")
-        if bounded_list(chain, 1, 12, f"{item_path}.package_chain", issues):
+        if bounded_list(chain, 1, MAX_PATH_NODES, f"{item_path}.package_chain", issues):
             for chain_index, package in enumerate(chain):
                 bounded_string(
                     package,
                     1,
-                    128,
+                    MAX_PACKAGE_CHAIN_ITEM_SCALARS,
                     f"{item_path}.package_chain[{chain_index}]",
                     issues,
                 )
@@ -203,7 +211,7 @@ def _validate_source_paths(value: Any, path: str, issues: list[ValidationIssue])
 
 def _validate_source_options(value: Any, path: str, issues: list[ValidationIssue]) -> list[str]:
     source_keys: list[str] = []
-    if not bounded_list(value, 0, 8, path, issues):
+    if not bounded_list(value, 0, MAX_OPTIONS_PER_FINDING, path, issues):
         return source_keys
     for index, item in enumerate(value):
         item_path = f"{path}[{index}]"
@@ -243,7 +251,7 @@ def _validate_source_options(value: Any, path: str, issues: list[ValidationIssue
 
 def _validate_source_evidence(value: Any, path: str, issues: list[ValidationIssue]) -> list[str]:
     source_keys: list[str] = []
-    if not bounded_list(value, 0, 16, path, issues):
+    if not bounded_list(value, 0, MAX_EVIDENCE_PER_FINDING, path, issues):
         return source_keys
     for index, item in enumerate(value):
         item_path = f"{path}[{index}]"
@@ -288,7 +296,7 @@ def validate_output(value: Any, expected_task_id: str) -> list[ValidationIssue]:
     finding_ids: list[str] = []
     actionable_ids: list[str] = []
     findings = value.get("findings")
-    if bounded_list(findings, 0, 12, "$.findings", issues):
+    if bounded_list(findings, 0, MAX_FINDINGS, "$.findings", issues):
         for index, finding in enumerate(findings):
             item_path = f"$.findings[{index}]"
             item_keys = {
@@ -369,7 +377,7 @@ def validate_output(value: Any, expected_task_id: str) -> list[ValidationIssue]:
     if len(finding_ids) != len(set(finding_ids)):
         issue(issues, "schema.unique_arrays", "$.findings must use unique finding IDs")
     queue = value.get("remediation_queue")
-    if bounded_list(queue, 0, 12, "$.remediation_queue", issues, unique=True):
+    if bounded_list(queue, 0, MAX_FINDINGS, "$.remediation_queue", issues, unique=True):
         for index, finding_id in enumerate(queue):
             bounded_string(
                 finding_id,
@@ -424,7 +432,7 @@ def validate_gold(
     )
     finding_ids: list[str] = []
     findings = value.get("findings")
-    if bounded_list(findings, 0, 12, "$.findings", issues):
+    if bounded_list(findings, 0, MAX_FINDINGS, "$.findings", issues):
         for index, finding in enumerate(findings):
             item_path = f"$.findings[{index}]"
             item_keys = {

--- a/experiments/scheduled-task-learning/dependency-prioritization/schemas/source.schema.json
+++ b/experiments/scheduled-task-learning/dependency-prioritization/schemas/source.schema.json
@@ -58,7 +58,7 @@
             "required": ["advisory_id", "severity"],
             "properties": {
               "advisory_id": {"type": "string", "minLength": 1, "maxLength": 128},
-              "severity": {"enum": ["low", "moderate", "high", "critical"]}
+              "severity": {"enum": ["low", "moderate", "high", "critical", null]}
             }
           }
         },

--- a/experiments/scheduled-task-learning/dependency-prioritization/tests/test_derivation.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/tests/test_derivation.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from benchmark_core.canonical import dumps, load_object
+from dependency_benchmark.derivation import (
+    DependencyDerivationError,
+    derive_normalized_source,
+)
+from dependency_benchmark.fixture_policy import FixtureFamilyFingerprint, derive_remediation
+from dependency_benchmark.normalization import materialize
+from dependency_benchmark.project_snapshot import parse_project_snapshot
+from dependency_benchmark.versioning import compare_versions
+
+from support import ROOT, project_snapshot_value
+
+
+def _sealed_project_snapshot_value() -> dict[str, Any]:
+    value = project_snapshot_value()
+    value["fixture_id"] = "dp-sealed-04"
+    value["split"] = "sealed"
+    value["dependencies"].append(
+        {
+            "node_key": "aiohttp",
+            "package_name": "aiohttp",
+            "installed_version": "3.9.1",
+        }
+    )
+    value["root_dependencies"].append(
+        {
+            "child_node_key": "aiohttp",
+            "requirement": ">=3.9,<4",
+            "runtime_scope": "production",
+        }
+    )
+    value["finding_facts"].append(
+        {
+            "node_key": "aiohttp",
+            "reachability": "unknown",
+            "manifest_evidence": ["Frozen aiohttp manifest evidence."],
+        }
+    )
+    value["release_inventories"].append(
+        {
+            "package_name": "aiohttp",
+            "releases": [{"version": "3.9.2", "availability": "available"}],
+        }
+    )
+    return value
+
+
+class DependencyDerivationTests(unittest.TestCase):
+    def test_derivation_joins_complete_aliases_and_binds_deterministic_options(self) -> None:
+        # Given
+        snapshot = parse_project_snapshot(_sealed_project_snapshot_value())
+
+        # When
+        derived = derive_normalized_source(snapshot, ROOT / "sources")
+        source_finding = next(
+            finding
+            for finding in derived.source["normalized_findings"]
+            if finding["package_name"] == "django"
+        )
+        materialization = materialize(derived.source)
+        task_finding_id = materialization.bindings.finding_id(source_finding["source_key"])
+        task_finding = next(
+            finding
+            for finding in materialization.task["findings"]
+            if finding["finding_id"] == task_finding_id
+        )
+        options_by_version = {
+            option["target_version"]: option for option in source_finding["remediation_options"]
+        }
+
+        # Then
+        self.assertEqual(source_finding["affected_status"], "affected")
+        self.assertEqual(
+            source_finding["advisories"],
+            [
+                {"advisory_id": "GHSA-2gwj-7jmv-h26r", "severity": "critical"},
+                {"advisory_id": "PYSEC-2022-190", "severity": None},
+            ],
+        )
+        self.assertEqual(
+            set(options_by_version),
+            {"2.2.28", "3.2.13", "3.2.14", "4.0", "4.0.4"},
+        )
+        self.assertEqual(
+            {
+                key: options_by_version["3.2.13"][key]
+                for key in ("availability", "affected_status", "compatibility")
+            },
+            {
+                "availability": "available",
+                "affected_status": "unaffected",
+                "compatibility": "compatible",
+            },
+        )
+        self.assertEqual(options_by_version["4.0"]["affected_status"], "affected")
+        self.assertEqual(options_by_version["4.0.4"]["compatibility"], "incompatible")
+        self.assertEqual(task_finding["severity"], "critical")
+        candidates = derived.remediation_candidates_by_finding[source_finding["source_key"]]
+        remediation = derive_remediation(
+            "actionable",
+            source_finding["installed_version"],
+            list(candidates),
+            lambda left, right: compare_versions(snapshot.ecosystem, left, right),
+            load_object(ROOT / "contracts/fixture-policy.json"),
+        )
+        selected_source_key = remediation["selected_source_key"]
+        if selected_source_key is None:
+            self.fail("expected the retained candidates to select a remediation source key")
+        self.assertEqual(
+            [
+                (candidate["origin_id"], candidate["source_key"] == selected_source_key)
+                for candidate in candidates
+                if candidate["target_version"] == "3.2.13"
+            ],
+            [
+                ("GHSA-2gwj-7jmv-h26r", True),
+                ("PYSEC-2022-190", False),
+                ("release-inventory", False),
+            ],
+        )
+        selected_option_id = materialization.bindings.option_id(
+            source_finding["source_key"], selected_source_key
+        )
+        selected_option = next(
+            option
+            for option in task_finding["remediation_options"]
+            if option["option_id"] == selected_option_id
+        )
+        self.assertEqual(
+            {
+                key: selected_option[key]
+                for key in (
+                    "target_version",
+                    "availability",
+                    "affected_status",
+                    "compatibility",
+                )
+            },
+            {
+                "target_version": "3.2.13",
+                "availability": "available",
+                "affected_status": "unaffected",
+                "compatibility": "compatible",
+            },
+        )
+        self.assertEqual(derived.snapshot_sha256, snapshot.semantic_sha256)
+        self.assertEqual(
+            derived.selected_record_ids,
+            ("GHSA-2gwj-7jmv-h26r", "PYSEC-2022-190", "PYSEC-2024-24"),
+        )
+        self.assertEqual(
+            derived.family_fingerprint,
+            FixtureFamilyFingerprint(
+                family_id="django-diamond",
+                normalized_packages=frozenset({"pypi:aiohttp", "pypi:django"}),
+                record_alias_components=frozenset(
+                    {"alias-component-33477110112e", "alias-component-b0787ec317c8"}
+                ),
+                root_helper_nodes=frozenset(
+                    {"pypi:fixture-app@1.0.0", "pypi:fixture-helper@1.5.0"}
+                ),
+                graph_template_ids=frozenset({"diamond-paths"}),
+                generator_seeds=frozenset({"django-seed"}),
+                manifest_digests=frozenset({snapshot.semantic_sha256}),
+            ),
+        )
+        changed_value = copy.deepcopy(_sealed_project_snapshot_value())
+        changed_value["finding_facts"][0]["manifest_evidence"] = ["Different frozen evidence."]
+        changed_snapshot = derive_normalized_source(
+            parse_project_snapshot(changed_value),
+            ROOT / "sources",
+        )
+        self.assertNotEqual(derived.source["task_id"], changed_snapshot.source["task_id"])
+        with tempfile.TemporaryDirectory() as directory:
+            copied_sources = shutil.copytree(ROOT / "sources", Path(directory) / "sources")
+            provenance_path = copied_sources / "provenance.json"
+            provenance = load_object(provenance_path)
+            record = next(
+                item for item in provenance["records"] if item["record_id"] == "GHSA-2gwj-7jmv-h26r"
+            )
+            source_path = copied_sources / record["snapshot_path"].split("/sources/", 1)[1]
+            source = load_object(source_path)
+            source["summary"] = "Authenticated changed advisory evidence."
+            source_path.write_text(dumps(source), encoding="utf-8")
+            raw_source = source_path.read_bytes()
+            record["bytes"] = len(raw_source)
+            record["sha256"] = hashlib.sha256(raw_source).hexdigest()
+            provenance_path.write_text(dumps(provenance), encoding="utf-8")
+            changed_provenance = derive_normalized_source(snapshot, copied_sources)
+        self.assertNotEqual(derived.source["task_id"], changed_provenance.source["task_id"])
+
+    def test_safe_equivalent_candidate_preserves_materialization_binding(self) -> None:
+        # Given
+        value = _sealed_project_snapshot_value()
+        value["root_dependencies"][0]["requirement"] = ">=3.2,<3.3,!=3.2.13"
+        value["dependency_edges"][0]["requirement"] = ">=3.2,<3.3,!=3.2.13"
+        releases = value["release_inventories"][0]["releases"]
+        releases[1]["availability"] = "unavailable"
+        releases.append({"version": "3.2.14.0", "availability": "available"})
+        snapshot = parse_project_snapshot(value)
+        derived = derive_normalized_source(snapshot, ROOT / "sources")
+        finding = next(
+            finding
+            for finding in derived.source["normalized_findings"]
+            if finding["package_name"] == "django"
+        )
+        candidates = derived.remediation_candidates_by_finding[finding["source_key"]]
+
+        # When
+        remediation = derive_remediation(
+            "actionable",
+            finding["installed_version"],
+            list(candidates),
+            lambda left, right: compare_versions(snapshot.ecosystem, left, right),
+            load_object(ROOT / "contracts/fixture-policy.json"),
+        )
+        selected_source_key = remediation["selected_source_key"]
+        if selected_source_key is None:
+            self.fail("expected an available compatible equivalent candidate")
+        materialization = materialize(derived.source)
+        selected_option_id = materialization.bindings.option_id(
+            finding["source_key"],
+            selected_source_key,
+        )
+        selected_candidate = next(
+            candidate for candidate in candidates if candidate["source_key"] == selected_source_key
+        )
+        task_finding_id = materialization.bindings.finding_id(finding["source_key"])
+        task_finding = next(
+            item
+            for item in materialization.task["findings"]
+            if item["finding_id"] == task_finding_id
+        )
+
+        # Then
+        self.assertEqual(
+            (
+                selected_candidate["target_version"],
+                selected_option_id
+                in {option["option_id"] for option in task_finding["remediation_options"]},
+            ),
+            ("3.2.14.0", True),
+        )
+
+    def test_catalog_allocation_and_selected_package_closure_fail_closed(self) -> None:
+        # Given
+        swapped_allocation = _sealed_project_snapshot_value()
+        swapped_allocation["fixture_id"] = "dp-sealed-05"
+        orphan_inventory = _sealed_project_snapshot_value()
+        orphan_inventory["dependencies"] = [
+            item for item in orphan_inventory["dependencies"] if item["node_key"] != "aiohttp"
+        ]
+        orphan_inventory["root_dependencies"] = [
+            item
+            for item in orphan_inventory["root_dependencies"]
+            if item["child_node_key"] != "aiohttp"
+        ]
+        orphan_inventory["finding_facts"] = [
+            item for item in orphan_inventory["finding_facts"] if item["node_key"] != "aiohttp"
+        ]
+
+        # When / Then
+        for label, value in (
+            ("same-ecosystem fixture allocation", swapped_allocation),
+            ("selected package missing from graph", orphan_inventory),
+        ):
+            with (
+                self.subTest(invalid_binding=label),
+                self.assertRaisesRegex(
+                    DependencyDerivationError,
+                    "selected-advisory packages must all exist",
+                ),
+            ):
+                derive_normalized_source(
+                    parse_project_snapshot(value),
+                    ROOT / "sources",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/scheduled-task-learning/dependency-prioritization/tests/test_normalization.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/tests/test_normalization.py
@@ -4,7 +4,7 @@ import copy
 import unittest
 from typing import Any
 
-from dependency_benchmark.normalization import materialize_task
+from dependency_benchmark.normalization import materialize
 
 from support import fixture
 
@@ -21,6 +21,11 @@ class DependencyNormalizationTests(unittest.TestCase):
     def test_materialization_is_order_independent_and_hides_source_keys(self) -> None:
         # Given
         source = fixture("dp-development-01")["source"]
+        source["normalized_findings"][0]["advisories"].append(
+            {"advisory_id": "OSV-NO-CVSS", "severity": None}
+        )
+        shared_option_key = source["normalized_findings"][0]["remediation_options"][0]["source_key"]
+        source["normalized_findings"][1]["remediation_options"][0]["source_key"] = shared_option_key
         reordered = copy.deepcopy(source)
         for finding_index, finding in enumerate(reordered["normalized_findings"]):
             finding_key = finding["source_key"]
@@ -54,13 +59,39 @@ class DependencyNormalizationTests(unittest.TestCase):
         }
 
         # When
-        task = materialize_task(source)
-        reordered_task = materialize_task(reordered)
+        materialization = materialize(source)
+        reordered_materialization = materialize(reordered)
+        task = materialization.task
+        reordered_task = reordered_materialization.task
 
         # Then
         self.assertEqual(task, reordered_task)
         self.assertTrue(author_only_keys.isdisjoint(_object_keys(task)))
         self.assertEqual(len(task["findings"]), len(source["normalized_findings"]))
+        self.assertEqual(
+            {binding.finding_id for binding in materialization.bindings.findings},
+            {finding["finding_id"] for finding in task["findings"]},
+        )
+        scoped_targets: list[str] = []
+        for source_finding in source["normalized_findings"][:2]:
+            finding_id = materialization.bindings.finding_id(source_finding["source_key"])
+            option_id = materialization.bindings.option_id(
+                source_finding["source_key"],
+                shared_option_key,
+            )
+            canonical_finding = next(
+                finding for finding in task["findings"] if finding["finding_id"] == finding_id
+            )
+            canonical_option = next(
+                option
+                for option in canonical_finding["remediation_options"]
+                if option["option_id"] == option_id
+            )
+            scoped_targets.append(canonical_option["target_version"])
+        self.assertEqual(
+            scoped_targets,
+            ["1.1.0", "2.0.0"],
+        )
 
 
 if __name__ == "__main__":

--- a/experiments/scheduled-task-learning/dependency-prioritization/tests/test_sources.py
+++ b/experiments/scheduled-task-learning/dependency-prioritization/tests/test_sources.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from benchmark_core.canonical import dumps, load_object
 from dependency_benchmark.advisory_records import (
     AdvisorySourceError,
+    fixture_record_ids,
     verify_frozen_source_catalog,
 )
 
@@ -113,7 +114,10 @@ class DependencySourceIntegrityTests(unittest.TestCase):
 
         # When
         actual_allocation = {
-            fixture["fixture_id"]: fixture["record_ids"] for fixture in index["fixtures"]
+            fixture["fixture_id"]: list(
+                fixture_record_ids(ROOT / "sources", fixture["fixture_id"], fixture["split"])
+            )
+            for fixture in index["fixtures"]
         }
         allocation_counts = Counter(
             record_id for record_ids in actual_allocation.values() for record_id in record_ids


### PR DESCRIPTION
## Summary
- derive normalized dependency task sources only from hash-authenticated frozen snapshots and advisory catalogs
- bind every finding, evidence item, dependency path, remediation option, and task identity to its source provenance
- reject incomplete alias components, omitted target packages, unsafe paths, and ambiguous cross-finding option keys

## Scope
This is the dependency materialization layer only. The already approved fixture-policy artifact and implementation are unchanged; corpus fixtures and gold labels follow in later PRs.

## Test intent
Each added case names a reachable mutant not caught by the nearest prior test, covering catalog allocation, alias closure, source authentication, scoped bindings, safe-equivalent remediation selection, nullable severity, task identity, and all six family-fingerprint dimensions.

## Verification
- 36 dependency benchmark tests
- Ruff
- strict mypy
- 24/24 conformance vectors
- `git diff --check`
- fixture-policy diff: zero
- independent code/security review: GO
- independent test-value/redundancy review: GO

Part of #118; stacked onto the #115 integration branch.