### PR TITLE
Add closed evaluation scenario profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ docs/plans/
 docs/alt-solutions/
 docs/teleclaw-prompt.md
 docs/research/118-scenario-validation-progress.md
+docs/research/118-scenario-validation-audit-log.md

--- a/Sources/ClawEvaluation/Infrastructure/EvaluationFreezeVerification.swift
+++ b/Sources/ClawEvaluation/Infrastructure/EvaluationFreezeVerification.swift
@@ -91,8 +91,15 @@ struct EvaluationFreezeManifest: Codable, Sendable, Equatable {
     protectedArtifacts.first { $0.path == relativePath }
   }
 
-  func validateBudgetContract() throws {
-    guard categories["budget"]?.values == PageEvaluationContract.budgetManifestValues else {
+  func validateBudgetContract(for profile: EvaluationExperimentProfile) throws {
+    let expectedValues: JSONValue
+    switch profile.kind {
+    case .pageChange:
+      expectedValues = PageEvaluationContract.budgetManifestValues
+    case .dependencyPrioritization:
+      throw EvaluationFreezeError.unsupportedExperiment(profile.kind.rawValue)
+    }
+    guard categories["budget"]?.values == expectedValues else {
       throw EvaluationFreezeError.budgetContractMismatch
     }
   }
@@ -240,6 +247,11 @@ struct EvaluationFreezeContext: Sendable, Equatable {
       && receipt.comment == other.receipt.comment
       && receipt.executable == other.receipt.executable
   }
+
+  package func matches(_ profile: EvaluationExperimentProfile) -> Bool {
+    profile.matches(decision: manifest.decision, experiment: manifest.experiment)
+      && profile.matches(decision: receipt.decision, experiment: receipt.experiment)
+  }
 }
 
 protocol EvaluationFreezeVerifying: Sendable {
@@ -254,11 +266,14 @@ extension EvaluationFreezeVerifying {
 }
 
 struct EvaluationLiveFreezeVerifier: EvaluationFreezeVerifying {
+  private let profile: EvaluationExperimentProfile
   private let runningExecutablePath: @Sendable () -> String
 
   package init(
+    profile: EvaluationExperimentProfile = .pageChange,
     runningExecutablePath: @escaping @Sendable () -> String = { CommandLine.arguments[0] }
   ) {
+    self.profile = profile
     self.runningExecutablePath = runningExecutablePath
   }
 
@@ -274,6 +289,7 @@ struct EvaluationLiveFreezeVerifier: EvaluationFreezeVerifying {
     try Self.validate(
       receipt: receipt,
       inputs: inputs,
+      profile: profile,
       verifierModules: prepared.verifierModules,
       executable: prepared.executableRecord
     )
@@ -301,6 +317,7 @@ struct EvaluationLiveFreezeVerifier: EvaluationFreezeVerifying {
     try Self.validate(
       receipt: receipt,
       inputs: inputs,
+      profile: profile,
       verifierModules: prepared.verifierModules,
       executable: prepared.executableRecord
     )
@@ -419,7 +436,10 @@ private extension EvaluationLiveFreezeVerifier {
       throw EvaluationFreezeError.manifestDigestMismatch
     }
     let manifest = try JSONDecoder().decode(EvaluationFreezeManifest.self, from: manifestData)
-    try manifest.validateBudgetContract()
+    guard profile.matches(decision: manifest.decision, experiment: manifest.experiment) else {
+      throw EvaluationFreezeError.experimentProfileMismatch
+    }
+    try manifest.validateBudgetContract(for: profile)
     let runtimeURL = inputURLs[4].standardizedFileURL
     try EvaluationPathSecurity.requireRegularSingleLinkFile(at: runtimeURL)
     let runtime = try EvaluationRuntimeConfiguration.load(from: runtimeURL)
@@ -516,6 +536,7 @@ private extension EvaluationLiveFreezeVerifier {
   static func validate(
     receipt: EvaluationFreezeReceipt,
     inputs: EvaluationFreezeInputs,
+    profile: EvaluationExperimentProfile,
     verifierModules: [EvaluationManifestArtifact],
     executable: EvaluationManifestArtifact
   ) throws {
@@ -525,8 +546,7 @@ private extension EvaluationLiveFreezeVerifier {
     guard
       receipt.schemaVersion == 1,
       receipt.status == "verified",
-      receipt.decision == "D6",
-      receipt.experiment == "page-change",
+      profile.matches(decision: receipt.decision, experiment: receipt.experiment),
       receipt.manifest.sha256 == inputs.manifestSHA256,
       receipt.verifier.path == verifier.path,
       receipt.verifier.bytes == verifier.bytes,
@@ -717,6 +737,8 @@ private extension EvaluationLiveFreezeVerifier {
 
 enum EvaluationFreezeError: Error, Sendable, Equatable {
   case manifestDigestMismatch
+  case experimentProfileMismatch
+  case unsupportedExperiment(String)
   case budgetContractMismatch
   case missingProtectedBinding
   case runtimeConfigurationPathMismatch

--- a/Sources/ClawEvaluation/Page/EvaluationContract.swift
+++ b/Sources/ClawEvaluation/Page/EvaluationContract.swift
@@ -1,8 +1,11 @@
 import ClawCore
 import Foundation
 
-/// Frozen runtime values shared by the page-change controller, worker, and manifest generator.
+/// Frozen fixture, topology, and stage-budget values owned by the page-change experiment.
 enum PageEvaluationContract {
+  static let profile = EvaluationExperimentProfile.pageChange
+  static let runtime = profile.runtime
+
   struct StageLimits: Sendable, Equatable {
     let maximumAttempts: Int
     let maximumResponsesSends: Int
@@ -12,9 +15,9 @@ enum PageEvaluationContract {
   }
 
   package static let schemaVersion = 1
-  package static let providerReference = "openai-chatgpt/gpt-5.6-sol"
-  package static let wireModel = "gpt-5.6-sol"
-  package static let transportMode = EvaluationTransportMode.streamingSSE.rawValue
+  package static let providerReference = runtime.providerReference
+  package static let wireModel = runtime.wireModel
+  package static let transportMode = runtime.transportMode
   package static let inputFileName = "input.json"
   package static let synthesisInputFileName = "synthesis-input.json"
   package static let stateDirectoryName = "state"
@@ -22,14 +25,14 @@ enum PageEvaluationContract {
   package static let resultsDirectoryName = "results"
   package static let lessonSetsDirectoryName = "lesson-sets"
   package static let activeLessonFileName = "active.json"
-  package static let policyVersionHexCount = 16
-  package static let wholeAttemptReplacementMax = 1
+  package static let wholeAttemptReplacementMax = runtime.wholeAttemptReplacementMax
   // swiftlint:disable:next identifier_name
-  package static let maximumCompletedModelRoundTripsPerAttempt = 2
-  package static let responsesSendsPerLogicalRoundTrip = 1
-  package static let maximumResponsesSendsPerAttempt =
-    maximumCompletedModelRoundTripsPerAttempt * responsesSendsPerLogicalRoundTrip
-  package static let maximumInputGraphemes = 59_999
+  package static let maximumCompletedModelRoundTripsPerAttempt =
+    runtime.maximumCompletedModelRoundTripsPerAttempt
+  package static let responsesSendsPerLogicalRoundTrip =
+    runtime.responsesSendsPerLogicalRoundTrip
+  package static let maximumResponsesSendsPerAttempt = runtime.maximumResponsesSendsPerAttempt
+  package static let maximumInputGraphemes = runtime.maximumInputGraphemes
   package static let canaryProcessCount = 2
   package static let canaryAttemptsPerProcess = 2
   package static let canaryPlannedAttempts = canaryProcessCount * canaryAttemptsPerProcess
@@ -56,19 +59,18 @@ enum PageEvaluationContract {
   package static let pagePlannedAttempts = pageTaskPlannedAttempts + pageSynthesisPlannedAttempts
   package static let pageReplacementPool = 3
   package static let conformanceCaseCount = 24
-  package static let missingUsageTokenProxy = 132_768
-  package static let globalMaximumAttempts = 194
-  package static let globalMaximumResponsesSends =
-    globalMaximumAttempts * maximumResponsesSendsPerAttempt
-  package static let globalMaximumFileReads = 194
-  package static let globalAccountedTokenThreshold = 4_350_000
+  package static let missingUsageTokenProxy = runtime.missingUsageTokenProxy
+  package static let globalMaximumAttempts = runtime.globalMaximumAttempts
+  package static let globalMaximumResponsesSends = runtime.globalMaximumResponsesSends
+  package static let globalMaximumFileReads = runtime.globalMaximumFileReads
+  package static let globalAccountedTokenThreshold = runtime.globalAccountedTokenThreshold
   package static let feedbackGeneratorVersion = "page-feedback-v1"
   package static let targetClasses = Set([
     "noise.volatile_value",
     "noise.time_or_build_metadata",
     "noise.structure_or_order",
   ])
-  package static let terminalValidationPolicy = StreamingTerminalValidationPolicy.throughStreamEnd
+  package static let terminalValidationPolicy = runtime.terminalValidationPolicy
   static let canaryLimits = StageLimits(
     maximumAttempts: canaryPlannedAttempts,
     maximumResponsesSends: canaryPlannedAttempts * maximumResponsesSendsPerAttempt,
@@ -106,28 +108,12 @@ enum PageEvaluationContract {
     ])
   }
 
-  package static let outputLimits = AttemptOutputLimits(
-    maximumUTF8Bytes: 32_768,
-    maximumGraphemes: 16_384
-  )
+  package static let outputLimits = runtime.outputLimits
 
-  package static let runBudget = RunBudget(
-    maxInputTokens: 100_000,
-    maxOutputTokens: 4_096,
-    wallClockDeadlineSeconds: 180,
-    retryBudget: 1,
-    perRunUSD: RunBudget.default.perRunUSD,
-    perDayUSD: RunBudget.default.perDayUSD,
-    proactivePerDayUSD: RunBudget.default.proactivePerDayUSD,
-    referenceUSDPerToken: RunBudget.default.referenceUSDPerToken,
-    maxTurns: 2,
-    maxToolCalls: 1,
-    dayTokenCeilingOverride: RunBudget.default.dayTokenCeiling
-  )
+  package static let runBudget = runtime.runBudget
 
   static func isValidPolicyVersion(_ value: String) -> Bool {
-    value.count == policyVersionHexCount
-      && value.allSatisfy { "0123456789abcdef".contains($0) }
+    runtime.isValidPolicyVersion(value)
   }
 }
 

--- a/Sources/ClawEvaluation/Page/Experiment/EvaluationPageExperiment.swift
+++ b/Sources/ClawEvaluation/Page/Experiment/EvaluationPageExperiment.swift
@@ -10,7 +10,7 @@ package struct EvaluationPageExperiment: Sendable {
   let controller: EvaluationController
 
   package init() {
-    let verifier = EvaluationLiveFreezeVerifier()
+    let verifier = EvaluationLiveFreezeVerifier(profile: PageEvaluationContract.profile)
     freezeVerifier = verifier
     artifacts = EvaluationProtectedArtifactRunner()
     controller = EvaluationController(freezeVerifier: verifier)
@@ -35,8 +35,7 @@ package struct EvaluationPageExperiment: Sendable {
 
     guard
       freeze.manifest.schemaVersion == PageEvaluationContract.schemaVersion,
-      freeze.manifest.decision == "D6",
-      freeze.manifest.experiment == "page-change"
+      freeze.matches(PageEvaluationContract.profile)
     else {
       throw EvaluationPagePipelineError.invalidManifestContract
     }

--- a/Sources/ClawEvaluation/Runtime/EvaluationExperimentProfile.swift
+++ b/Sources/ClawEvaluation/Runtime/EvaluationExperimentProfile.swift
@@ -1,0 +1,97 @@
+import ClawCore
+
+package enum EvaluationExperimentKind: String, Sendable {
+  case pageChange = "page-change"
+  case dependencyPrioritization = "dependency-prioritization"
+
+  package var profile: EvaluationExperimentProfile {
+    switch self {
+    case .pageChange:
+      .pageChange
+    case .dependencyPrioritization:
+      .dependencyPrioritization
+    }
+  }
+}
+
+package struct EvaluationExperimentProfile: Sendable, Equatable {
+  package static let pageChange = Self(kind: .pageChange, approvalDecision: "D6")
+  package static let dependencyPrioritization = Self(
+    kind: .dependencyPrioritization,
+    approvalDecision: "D7"
+  )
+
+  package let kind: EvaluationExperimentKind
+  package let approvalDecision: String
+  package let runtime: EvaluationRuntimeContract
+
+  private init(kind: EvaluationExperimentKind, approvalDecision: String) {
+    self.kind = kind
+    self.approvalDecision = approvalDecision
+    runtime = .frozen
+  }
+
+  package static func matching(decision: String?, experiment: String?) -> Self? {
+    guard let experiment, let kind = EvaluationExperimentKind(rawValue: experiment) else {
+      return nil
+    }
+    let profile = kind.profile
+    guard decision == profile.approvalDecision else {
+      return nil
+    }
+    return profile
+  }
+
+  package func matches(decision: String?, experiment: String?) -> Bool {
+    Self.matching(decision: decision, experiment: experiment) == self
+  }
+}
+
+package struct EvaluationRuntimeContract: Sendable, Equatable {
+  package static let frozen = Self()
+
+  package let providerReference = "openai-chatgpt/gpt-5.6-sol"
+  package let wireModel = "gpt-5.6-sol"
+  package let transportMode = EvaluationTransportMode.streamingSSE.rawValue
+  package let wholeAttemptReplacementMax = 1
+  // swiftlint:disable:next identifier_name
+  package let maximumCompletedModelRoundTripsPerAttempt = 2
+  package let responsesSendsPerLogicalRoundTrip = 1
+  package let maximumInputGraphemes = 59_999
+  package let missingUsageTokenProxy = 132_768
+  package let globalMaximumAttempts = 194
+  package let globalMaximumFileReads = 194
+  package let globalAccountedTokenThreshold = 4_350_000
+  package let policyVersionHexCount = 16
+  package let terminalValidationPolicy = StreamingTerminalValidationPolicy.throughStreamEnd
+  package let outputLimits = AttemptOutputLimits(
+    maximumUTF8Bytes: 32_768,
+    maximumGraphemes: 16_384
+  )
+  package let runBudget = RunBudget(
+    maxInputTokens: 100_000,
+    maxOutputTokens: 4_096,
+    wallClockDeadlineSeconds: 180,
+    retryBudget: 1,
+    perRunUSD: RunBudget.default.perRunUSD,
+    perDayUSD: RunBudget.default.perDayUSD,
+    proactivePerDayUSD: RunBudget.default.proactivePerDayUSD,
+    referenceUSDPerToken: RunBudget.default.referenceUSDPerToken,
+    maxTurns: 2,
+    maxToolCalls: 1,
+    dayTokenCeilingOverride: RunBudget.default.dayTokenCeiling
+  )
+
+  package var maximumResponsesSendsPerAttempt: Int {
+    maximumCompletedModelRoundTripsPerAttempt * responsesSendsPerLogicalRoundTrip
+  }
+
+  package var globalMaximumResponsesSends: Int {
+    globalMaximumAttempts * maximumResponsesSendsPerAttempt
+  }
+
+  package func isValidPolicyVersion(_ value: String) -> Bool {
+    value.count == policyVersionHexCount
+      && value.allSatisfy { "0123456789abcdef".contains($0) }
+  }
+}

--- a/Sources/ClawEvaluation/Runtime/EvaluationRuntimeConfiguration.swift
+++ b/Sources/ClawEvaluation/Runtime/EvaluationRuntimeConfiguration.swift
@@ -94,15 +94,16 @@ package struct EvaluationRuntimeConfiguration: Codable, Sendable, Equatable {
   }
 
   package func validate() throws {
+    let contract = EvaluationRuntimeContract.frozen
     guard
       schemaVersion == PageEvaluationContract.schemaVersion,
       evaluationRoot.hasPrefix("/"),
       ISO8601DateFormatter().date(from: fixedTimestamp) != nil,
-      providerReference == PageEvaluationContract.providerReference,
-      wireModel == PageEvaluationContract.wireModel,
-      transportMode.rawValue == PageEvaluationContract.transportMode,
+      providerReference == contract.providerReference,
+      wireModel == contract.wireModel,
+      transportMode.rawValue == contract.transportMode,
       fallbackReference == nil,
-      PageEvaluationContract.isValidPolicyVersion(expectedPolicyVersion),
+      contract.isValidPolicyVersion(expectedPolicyVersion),
       Self.isSafeRepositoryRelativePath(taskPromptPath),
       Self.isSafeRepositoryRelativePath(executablePath),
       Self.isSafeRepositoryRelativePath(freezeVerifierPath),
@@ -110,21 +111,21 @@ package struct EvaluationRuntimeConfiguration: Codable, Sendable, Equatable {
       fileReadAllowlists.task == [PageEvaluationContract.inputFileName],
       fileReadAllowlists.synthesis == [PageEvaluationContract.synthesisInputFileName],
       maxCompletedModelRoundTrips
-        == PageEvaluationContract.maximumCompletedModelRoundTripsPerAttempt,
-      runBudget.maxInputTokens == PageEvaluationContract.runBudget.maxInputTokens,
-      runBudget.maxOutputTokens == PageEvaluationContract.runBudget.maxOutputTokens,
-      runBudget.maxTurns == PageEvaluationContract.runBudget.maxTurns,
-      runBudget.maxToolCalls == PageEvaluationContract.runBudget.maxToolCalls,
-      runBudget.deadlineSeconds == PageEvaluationContract.runBudget.wallClockDeadlineSeconds,
-      runBudget.retryBudget == PageEvaluationContract.runBudget.retryBudget,
-      inputMaxGraphemes == PageEvaluationContract.maximumInputGraphemes,
-      attemptOutputLimits == PageEvaluationContract.outputLimits,
+        == contract.maximumCompletedModelRoundTripsPerAttempt,
+      runBudget.maxInputTokens == contract.runBudget.maxInputTokens,
+      runBudget.maxOutputTokens == contract.runBudget.maxOutputTokens,
+      runBudget.maxTurns == contract.runBudget.maxTurns,
+      runBudget.maxToolCalls == contract.runBudget.maxToolCalls,
+      runBudget.deadlineSeconds == contract.runBudget.wallClockDeadlineSeconds,
+      runBudget.retryBudget == contract.runBudget.retryBudget,
+      inputMaxGraphemes == contract.maximumInputGraphemes,
+      attemptOutputLimits == contract.outputLimits,
       retry.responsesSendsPerLogicalRoundTrip
-        == PageEvaluationContract.responsesSendsPerLogicalRoundTrip,
-      retry.maxResponsesSendsPerAttempt == PageEvaluationContract.maximumResponsesSendsPerAttempt,
+        == contract.responsesSendsPerLogicalRoundTrip,
+      retry.maxResponsesSendsPerAttempt == contract.maximumResponsesSendsPerAttempt,
       retry.providerInferenceRetryEnabled == false,
       retry.streamToBufferedReattemptEnabled == false,
-      retry.wholeAttemptReplacementMax == PageEvaluationContract.wholeAttemptReplacementMax
+      retry.wholeAttemptReplacementMax == contract.wholeAttemptReplacementMax
     else {
       throw EvaluationRuntimeConfigurationError.frozenValueMismatch
     }
@@ -211,8 +212,9 @@ enum EvaluationRuntimeContextFactory {
   }
 
   static func attemptBudget(toolDefinitions: [ToolDefinition]) -> ContextBudget {
+    let contract = EvaluationRuntimeContract.frozen
     let messageInputTokens = TokenEstimator.messageInputBudget(
-      maxInputTokens: PageEvaluationContract.runBudget.maxInputTokens,
+      maxInputTokens: contract.runBudget.maxInputTokens,
       tools: toolDefinitions
     )
     let defaults = ContextBudget.default
@@ -259,8 +261,8 @@ package enum EvaluationPolicyInspector {
 
   package static func policyVersion(
     evaluationRootURL: URL,
-    providerReference: String = PageEvaluationContract.providerReference,
-    wireModel: String = PageEvaluationContract.wireModel,
+    providerReference: String = EvaluationRuntimeContract.frozen.providerReference,
+    wireModel: String = EvaluationRuntimeContract.frozen.wireModel,
     allowedFileName: String = PageEvaluationContract.inputFileName
   ) -> String {
     let workspaceRootURL = evaluationRootURL.appendingPathComponent(

--- a/Tests/ClawEvaluationTests/Page/EvaluationProtocolContractTests.swift
+++ b/Tests/ClawEvaluationTests/Page/EvaluationProtocolContractTests.swift
@@ -10,6 +10,60 @@ import Testing
 @testable import ClawSecrets
 
 @Suite struct EvaluationProtocolContractTests {
+  @Test(
+    arguments: [
+      (EvaluationExperimentKind.pageChange, "D6", "D7"),
+      (.dependencyPrioritization, "D7", "D6"),
+    ]
+  )
+  func experimentProfilesBindOnlyTheirOwnApprovalDecision(
+    kind: EvaluationExperimentKind,
+    decision: String,
+    mismatchedDecision: String
+  ) {
+    // given
+    let profile = kind.profile
+    let otherProfile =
+      kind == .pageChange
+      ? EvaluationExperimentProfile.dependencyPrioritization
+      : .pageChange
+
+    // when
+    let matching = EvaluationExperimentProfile.matching(
+      decision: decision,
+      experiment: kind.rawValue
+    )
+    let mismatched = EvaluationExperimentProfile.matching(
+      decision: mismatchedDecision,
+      experiment: kind.rawValue
+    )
+
+    // then
+    #expect(profile.approvalDecision == decision)
+    #expect(matching == profile)
+    #expect(mismatched == nil)
+    #expect(
+      profile.matches(
+        decision: otherProfile.approvalDecision,
+        experiment: otherProfile.kind.rawValue
+      ) == false
+    )
+  }
+
+  @Test func unknownExperimentCannotSelectAProfile() {
+    // given
+    let unknownExperiment = "unknown-experiment"
+
+    // when
+    let profile = EvaluationExperimentProfile.matching(
+      decision: EvaluationExperimentProfile.pageChange.approvalDecision,
+      experiment: unknownExperiment
+    )
+
+    // then
+    #expect(profile == nil)
+  }
+
   @Test func terminalFailureMappingPreservesEveryProtocolClassAndHarnessFallback() {
     // given
     let cases: [(error: any Error, expected: EvaluationPageTerminalFailure)] = [
@@ -291,12 +345,18 @@ import Testing
       sha256: String(repeating: "a", count: 64)
     )
     let valid = EvaluationFreezeManifest(
+      schemaVersion: PageEvaluationContract.schemaVersion,
+      decision: PageEvaluationContract.profile.approvalDecision,
+      experiment: PageEvaluationContract.profile.kind.rawValue,
       categories: ["budget": validCategory],
       protectedArtifacts: []
     )
     var driftedValues = try #require(PageEvaluationContract.budgetManifestValues.objectValue)
     driftedValues["page_attempt_cap"] = .integer(77)
     let drifted = EvaluationFreezeManifest(
+      schemaVersion: PageEvaluationContract.schemaVersion,
+      decision: PageEvaluationContract.profile.approvalDecision,
+      experiment: PageEvaluationContract.profile.kind.rawValue,
       categories: [
         "budget": EvaluationManifestCategory(
           artifacts: [],
@@ -308,9 +368,9 @@ import Testing
     )
 
     // when
-    try valid.validateBudgetContract()
+    try valid.validateBudgetContract(for: .pageChange)
     let driftError = #expect(throws: EvaluationFreezeError.budgetContractMismatch) {
-      try drifted.validateBudgetContract()
+      try drifted.validateBudgetContract(for: .pageChange)
     }
 
     // then — a decoder that drops budget values would accept the drifted manifest.

--- a/Tests/ClawEvaluationTests/Security/EvaluationFreezeVerificationSecurityTests.swift
+++ b/Tests/ClawEvaluationTests/Security/EvaluationFreezeVerificationSecurityTests.swift
@@ -5,6 +5,48 @@ import Testing
 @testable import ClawEvaluation
 
 extension EvaluationFilesystemSecurityTests {
+  @Test func liveFreezeVerifierRejectsACrossDecisionManifestBeforeRuntimeOrPython() async throws {
+    // given
+    let root = try makeEvaluationTestRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let manifest = EvaluationFreezeManifest(
+      schemaVersion: PageEvaluationContract.schemaVersion,
+      decision: EvaluationExperimentProfile.dependencyPrioritization.approvalDecision,
+      experiment: EvaluationExperimentKind.pageChange.rawValue,
+      categories: [
+        "budget": EvaluationManifestCategory(
+          artifacts: [],
+          values: PageEvaluationContract.budgetManifestValues,
+          sha256: String(repeating: "a", count: 64)
+        )
+      ],
+      protectedArtifacts: []
+    )
+    let manifestURL = root.appendingPathComponent("manifest.json")
+    let manifestData = try EvaluationCanonicalJSON.data(encoding: manifest)
+    try manifestData.write(to: manifestURL)
+    let inputs = EvaluationFreezeInputs(
+      repositoryRoot: root.path,
+      manifestPath: manifestURL.path,
+      manifestSHA256: SHA256Digest.hex(manifestData),
+      approvalRecordPath: root.appendingPathComponent("approval.json").path,
+      approvalBodyPath: root.appendingPathComponent("approval.txt").path,
+      runtimeConfigurationPath: root.appendingPathComponent("runtime.json").path,
+      receiptPath: root.appendingPathComponent("receipt.json").path
+    )
+
+    // when
+    let error = await #expect(throws: EvaluationFreezeError.experimentProfileMismatch) {
+      _ = try await EvaluationLiveFreezeVerifier(
+        profile: .pageChange,
+        runningExecutablePath: { root.appendingPathComponent("claw-eval").path }
+      ).verifyLocal(inputs)
+    }
+
+    // then
+    #expect(error != nil)
+  }
+
   @Test func liveFreezeVerifierRejectsEveryRawPathBeforeNormalization() async throws {
     // given
     let root = try makeEvaluationTestRoot()
@@ -108,6 +150,9 @@ extension EvaluationFilesystemSecurityTests {
       sha256: SHA256Digest.hex(executableData)
     )
     let manifest = EvaluationFreezeManifest(
+      schemaVersion: PageEvaluationContract.schemaVersion,
+      decision: PageEvaluationContract.profile.approvalDecision,
+      experiment: PageEvaluationContract.profile.kind.rawValue,
       categories: [
         "configuration": EvaluationManifestCategory(
           artifacts: [runtimeRecord] + moduleRecords,

--- a/Tests/ClawEvaluationTests/Support/EvaluationFreezeFixtures.swift
+++ b/Tests/ClawEvaluationTests/Support/EvaluationFreezeFixtures.swift
@@ -163,6 +163,9 @@ func makeEvaluationFreeze(
     sha256: digest
   )
   let manifest = EvaluationFreezeManifest(
+    schemaVersion: PageEvaluationContract.schemaVersion,
+    decision: PageEvaluationContract.profile.approvalDecision,
+    experiment: PageEvaluationContract.profile.kind.rawValue,
     categories: categories,
     protectedArtifacts: Array(
       Dictionary(


### PR DESCRIPTION
## Summary

- add a closed `EvaluationExperimentKind` and profile binding for D6/page-change and D7/dependency-prioritization
- centralize route, transport, retry, output, and global-cap constants in one immutable runtime contract
- require the selected profile to match both the manifest and live receipt before invoking protected Python
- keep Page fixture topology, stages, and budgets Page-owned; dependency remains fail-closed until its budget contract lands
- ignore the local #118 audit journal

## Verification

- `swift test --filter EvaluationFilesystemSecurityTests`: 18/18
- `swift test --skip-build --filter ClawEvaluationTests`: 100/100
- `scripts/lint.sh`
- `git diff --check`
- independent P0/P1 code/security review: GO
- independent test-value/redundancy review: GO

Parent: #118
Integration: #120