### PR TITLE
Close evaluation protected-closure races

### DIFF
--- a/Sources/ClawEvaluation/Controller/EvaluationControllerExecution.swift
+++ b/Sources/ClawEvaluation/Controller/EvaluationControllerExecution.swift
@@ -533,6 +533,7 @@ extension EvaluationController {
         )
       ]
     )
+    try Self.verifyProtectedClosureBeforeLaunch(context.freeze)
     let launched = await launcher.launch(
       kind: .attempt,
       executablePath: context.executablePath,

--- a/Sources/ClawEvaluation/Controller/EvaluationControllerValidation.swift
+++ b/Sources/ClawEvaluation/Controller/EvaluationControllerValidation.swift
@@ -2,6 +2,14 @@ import ClawCore
 import Foundation
 
 extension EvaluationController {
+  static func verifyProtectedClosureBeforeLaunch(_ freeze: EvaluationFreezeContext) throws {
+    do {
+      try EvaluationProtectedClosure.verify(freeze)
+    } catch {
+      throw EvaluationControllerError.freezeChangedBeforeLaunch
+    }
+  }
+
   struct WrittenInvocation {
     let invocationID: UUID
     let configurationSHA256: String

--- a/Sources/ClawEvaluation/Page/EvaluationCanaryExecution.swift
+++ b/Sources/ClawEvaluation/Page/EvaluationCanaryExecution.swift
@@ -238,6 +238,7 @@ extension EvaluationController {
         )
       ]
     )
+    try Self.verifyProtectedClosureBeforeLaunch(freeze)
     let launched = await launcher.launch(
       kind: .canaryProcess,
       executablePath: request.executablePath,

--- a/Sources/ClawEvaluation/Runtime/EvaluationWorker.swift
+++ b/Sources/ClawEvaluation/Runtime/EvaluationWorker.swift
@@ -25,6 +25,7 @@ struct EvaluationLiveFreezeAdmission: Sendable {
         return .deny(cap: "evaluation-freeze-integrity")
       }
 
+      try EvaluationProtectedClosure.verify(refreshed)
       return .allow
     } catch {
       return .deny(cap: "evaluation-freeze-integrity")

--- a/Tests/ClawEvaluationTests/Controller/EvaluationControllerAdmissionTests.swift
+++ b/Tests/ClawEvaluationTests/Controller/EvaluationControllerAdmissionTests.swift
@@ -54,6 +54,52 @@ import Testing
     #expect(await launcher.observations.isEmpty)
   }
 
+  @Test func protectedArtifactDriftStopsBeforeAttemptWorkerLaunch() async throws {
+    // given
+    let root = try makeEvaluationTestRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let configured = try makeEvaluationConfiguration(root: root, attemptID: "changed-artifact")
+    let frozen = try makeEvaluationFreeze(root: root, configurations: [configured.configuration])
+    let sourceURL = URL(fileURLWithPath: configured.configuration.sourceArtifactPath)
+    let verifier = StaticEvaluationFreezeVerifier(
+      context: frozen.context,
+      beforeReturningLiveContext: {
+        try Data("changed during live verification".utf8).write(to: sourceURL)
+      }
+    )
+    let launcher = ScriptedEvaluationWorkerLauncher { _, _, _ in
+      EvaluationWorkerLaunchResult(termination: .rejected, processID: nil)
+    }
+    let journal = try EvaluationControllerJournal.startNew(
+      evaluationRoot: configured.configuration.evaluationRootURL,
+      manifestSHA256: configured.configuration.approval.manifestSHA256,
+      freezeCommit: configured.configuration.provenance.freezeCommit,
+      fixedTimestamp: configured.configuration.fixedTimestamp,
+      journalName: "changed-artifact.jsonl"
+    )
+    var accumulator = EvaluationController.Accumulator()
+
+    // when
+    await #expect(throws: EvaluationControllerError.freezeChangedBeforeLaunch) {
+      _ = try await EvaluationController(
+        launcher: launcher,
+        freezeVerifier: verifier
+      ).runOne(
+        executablePath: frozen.executable.path,
+        configurationPath: configured.configurationURL.path,
+        freezeInputs: frozen.inputs,
+        freeze: frozen.context,
+        limits: PageEvaluationContract.pageLimits,
+        sealedOutputKey: nil,
+        journal: journal,
+        accumulator: &accumulator
+      )
+    }
+
+    // then — removing the final whole-closure check would launch this worker.
+    #expect(await launcher.observations.isEmpty)
+  }
+
   @Test func controllerRejectsForgedResultAccounting() async throws {
     // given
     let root = try makeEvaluationTestRoot()

--- a/Tests/ClawEvaluationTests/Page/EvaluationCanaryControllerTests.swift
+++ b/Tests/ClawEvaluationTests/Page/EvaluationCanaryControllerTests.swift
@@ -54,6 +54,52 @@ import Testing
     #expect(await launcher.observations.isEmpty)
   }
 
+  @Test func protectedArtifactDriftStopsBeforeCanaryWorkerLaunch() async throws {
+    // given
+    let root = try makeEvaluationTestRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let fixture = try makeCanaryControllerFixture(root: root)
+    let sourceURL = URL(fileURLWithPath: fixture.configurations[0].sourceArtifactPath)
+    let verifier = StaticEvaluationFreezeVerifier(
+      context: fixture.context,
+      beforeReturningLiveContext: {
+        try Data("changed during live verification".utf8).write(to: sourceURL)
+      }
+    )
+    let launcher = ScriptedEvaluationWorkerLauncher { _, _, _ in
+      EvaluationWorkerLaunchResult(termination: .rejected, processID: nil)
+    }
+    let journal = try EvaluationControllerJournal.startNew(
+      evaluationRoot: fixture.configurations[0].evaluationRootURL,
+      manifestSHA256: fixture.configurations[0].approval.manifestSHA256,
+      freezeCommit: fixture.configurations[0].provenance.freezeCommit,
+      fixedTimestamp: fixture.configurations[0].fixedTimestamp,
+      journalName: "canary-changed-artifact.jsonl"
+    )
+    var accumulator = EvaluationController.Accumulator()
+
+    // when
+    await #expect(throws: EvaluationControllerError.freezeChangedBeforeLaunch) {
+      _ = try await EvaluationController(
+        launcher: launcher,
+        freezeVerifier: verifier
+      ).executeCanary(
+        EvaluationCanaryExecutionRequest(
+          order: fixture.order,
+          factory: fixture.factory,
+          executablePath: fixture.executable.path,
+          journal: journal,
+          configurationPaths: [fixture.paths.canaryProcessA, fixture.paths.canaryProcessB],
+          evidenceURL: fixture.paths.canarySummary
+        ),
+        accumulator: &accumulator
+      )
+    }
+
+    // then — removing the canary branch's final whole-closure check would launch this worker.
+    #expect(await launcher.observations.isEmpty)
+  }
+
   @Test func controllerLaunchesTwoCanaryProcessesAndStartsProcessBWithAnEmptyWorkspace()
     async throws
   {

--- a/Tests/ClawEvaluationTests/Runtime/EvaluationAttemptRunnerIntegrityTests.swift
+++ b/Tests/ClawEvaluationTests/Runtime/EvaluationAttemptRunnerIntegrityTests.swift
@@ -235,6 +235,63 @@ import Testing
     #expect(persisted.audit == result.audit)
   }
 
+  @Test func protectedArtifactDriftBetweenRoundsStopsBeforeTheSecondProviderSend() async throws {
+    // given
+    let root = try makeEvaluationTestRoot()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let configured = try makeEvaluationConfiguration(root: root)
+    let frozen = try makeEvaluationFreeze(root: root, configurations: [configured.configuration])
+    let sourceURL = URL(fileURLWithPath: configured.configuration.sourceArtifactPath)
+    let provider = SequenceProvider(scriptedTwoRoundResponses())
+    let verifier = SequencedEvaluationFreezeVerifier(
+      liveContexts: [frozen.context, frozen.context],
+      localContext: frozen.context,
+      beforeReturningLiveContext: { refreshIndex in
+        guard refreshIndex == 1 else {
+          return
+        }
+        try Data("changed during live verification".utf8).write(to: sourceURL)
+      }
+    )
+    let admission = EvaluationLiveFreezeAdmission(
+      verifier: verifier,
+      inputs: frozen.inputs,
+      initial: frozen.context
+    )
+    let roster = ProviderRoster(
+      primary: LLMRouteBinding(
+        provider: provider,
+        wireModel: PageEvaluationContract.wireModel,
+        configuredReference: PageEvaluationContract.providerReference,
+        costPolicy: .includedPlan,
+        reservationPolicy: .chatGPTReplayState
+      )
+    )
+    let recorder = EvaluationHTTPRecorder(base: ScriptedHTTPExecutor([]))
+
+    // when
+    let result = try await EvaluationAttemptRunner(
+      roster: roster,
+      httpRecorder: recorder
+    ).run(
+      configuration: configured.configuration,
+      sendBudget: EvaluationSendBudgetSnapshot(
+        stageAccountedTokens: 0,
+        globalAccountedTokens: 0,
+        stageResponsesSends: 0,
+        globalResponsesSends: 0,
+        stageAccountedTokenThreshold: PageEvaluationContract.pageLimits.accountedTokenThreshold,
+        stageResponsesSendCap: PageEvaluationContract.pageLimits.maximumResponsesSends
+      ),
+      integrityAdmission: { await admission.evaluate() }
+    )
+
+    // then — deleting the full-closure refresh check allows provider request 2.
+    #expect(await provider.requests.count == 1)
+    #expect(result.outcome == .harnessFailure)
+    #expect(result.criticalCode == "evaluation-freeze-integrity")
+  }
+
   @Test func preInferenceNoStartSendCountsTowardTheCapWithoutAProxyDebit() async throws {
     // given
     let root = try makeEvaluationTestRoot()

--- a/Tests/ClawEvaluationTests/Support/EvaluationDoubles.swift
+++ b/Tests/ClawEvaluationTests/Support/EvaluationDoubles.swift
@@ -8,19 +8,30 @@ import Testing
 struct StaticEvaluationFreezeVerifier: EvaluationFreezeVerifying {
   let liveContext: EvaluationFreezeContext
   let localContext: EvaluationFreezeContext
+  let beforeReturningLiveContext: @Sendable () throws -> Void
 
-  init(context: EvaluationFreezeContext) {
+  init(
+    context: EvaluationFreezeContext,
+    beforeReturningLiveContext: @escaping @Sendable () throws -> Void = {}
+  ) {
     liveContext = context
     localContext = context
+    self.beforeReturningLiveContext = beforeReturningLiveContext
   }
 
-  init(liveContext: EvaluationFreezeContext, localContext: EvaluationFreezeContext) {
+  init(
+    liveContext: EvaluationFreezeContext,
+    localContext: EvaluationFreezeContext,
+    beforeReturningLiveContext: @escaping @Sendable () throws -> Void = {}
+  ) {
     self.liveContext = liveContext
     self.localContext = localContext
+    self.beforeReturningLiveContext = beforeReturningLiveContext
   }
 
   func verify(_ inputs: EvaluationFreezeInputs) async throws -> EvaluationFreezeContext {
-    liveContext
+    try beforeReturningLiveContext()
+    return liveContext
   }
 
   func verifyLocal(_ inputs: EvaluationFreezeInputs) async throws -> EvaluationFreezeContext {
@@ -31,17 +42,24 @@ struct StaticEvaluationFreezeVerifier: EvaluationFreezeVerifying {
 actor SequencedEvaluationFreezeVerifier: EvaluationFreezeVerifying {
   private let liveContexts: [EvaluationFreezeContext]
   private let localContext: EvaluationFreezeContext
+  private let beforeReturningLiveContext: @Sendable (Int) throws -> Void
   private var liveIndex = 0
 
-  init(liveContexts: [EvaluationFreezeContext], localContext: EvaluationFreezeContext) {
+  init(
+    liveContexts: [EvaluationFreezeContext],
+    localContext: EvaluationFreezeContext,
+    beforeReturningLiveContext: @escaping @Sendable (Int) throws -> Void = { _ in }
+  ) {
     self.liveContexts = liveContexts
     self.localContext = localContext
+    self.beforeReturningLiveContext = beforeReturningLiveContext
   }
 
   func verify(_ inputs: EvaluationFreezeInputs) async throws -> EvaluationFreezeContext {
     guard liveContexts.indices.contains(liveIndex) else {
       throw EvaluationHarnessTestError.unexpectedFreezeCall
     }
+    try beforeReturningLiveContext(liveIndex)
     defer { liveIndex += 1 }
     return liveContexts[liveIndex]
   }


### PR DESCRIPTION
## Summary

- revalidate the complete protected closure immediately before ordinary and canary worker launch
- revalidate the complete protected closure after each live approval refresh and before every provider send
- fail closed with the existing evaluation integrity errors

## Why

The interrupted replacement D6 batch exposed a controller time-of-check/time-of-use gap: worker-local verification prevented a model send, but the controller could still launch after protected source bytes changed.

## Test intent

- ordinary launch test kills removal of the final `launchAttempt` closure check
- canary launch test kills removal of the independent `runCanaryProcess` closure check
- round-trip test kills removal of the per-send full-closure check while approval binding remains unchanged

The nearest existing tests cover approval metadata changes or another subprocess seam and do not catch these mutants. Independent test-value review found no P0/P1 redundancy.

## Verification

- `swift test --filter protectedArtifactDrift` — 3/3 passed
- `swift format lint --strict` on all changed Swift files — passed
- `git diff --check` — passed
- signed commit verified

Part of #118; base is the #118 aggregation branch.
