### PR TITLE
docs: rewrite CLAUDE.md around portability and a definition of done

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,44 +1,52 @@
-# CLAUDE.md
+# swift-claw — agent instructions
+
+`AGENTS.md` is a symlink to this file: Claude Code and Codex read the same rules. Edit this file, never replace the symlink.
 
 ## What this is
 
 swift-claw — a persistent, always-on, **single-owner personal AI assistant** controlled via **Telegram**, written in **pure Swift**. Clean-room, OpenClaw-inspired.
 
-## Read first (authoritative)
+SwiftPM package, executable `clawd`. The dependency graph is a layered DAG: **seams (protocols + value types) live in `ClawCore`, implementations in sibling `Claw*` targets, composed at the `clawd` root** — `ClawAgent` and `ClawGateway` reach persistence only through `ClawCore` protocols.
 
-- Before starting any task → read learned preferences and behavioral rules at `/Users/jetbrains/.claude/projects/-Users-jetbrains-Developer-swift-claw/memory/MEMORY.md`, then open any topic files relevant to the task.
-- Before implementing or changing the design → **`docs/ARCHITECTURE.md` is the NORMATIVE technical spec**; where it and anything else disagree, it wins.
-- Before writing or changing tests → **`docs/TESTING.md`** is the normative testing guide (what earns a test its place, isolation, determinism, the decision rubric).
-- Before adding tests → inspect the changed production branches, search the existing suite for the same behavior, and record the brief test-intent map required by `docs/TESTING.md`.
-- Before committing test changes → run the pre-commit redundancy pass from `docs/TESTING.md`; every added test must name a reachable mutant that the nearest existing test would not catch.
-- Cross-cutting test diffs → assign an independent reviewer or agent to challenge only test value and redundancy before committing.
+## Authority and routing
+
+- **`docs/ARCHITECTURE.md` is the accepted technical design.** For architecture-affecting, cross-module, or normative-contract work, read the relevant sections first. Never diverge from it silently; when a task deliberately changes a contract, change the spec in the same commit.
 - Product scope, phasing, success criteria → `docs/PRD.md`.
-- Cited background research → `docs/research/`.
 - Building, running, or operating `clawd` locally → `docs/LOCAL_DEV.md`.
-- Changing any user-visible surface (a command, flag, env var, default, secret, or install/release step) → update the public set in lockstep: `README.md`, `docs/GETTING_STARTED.md`, `docs/INSTALL.md`, `docs/CUSTOMIZATION.md`, `deploy/README.md`. They document each other's state, so a change in one usually invalidates a sibling.
+- Cited background research → `docs/research/` — evidence, not a normative spec.
+- **Any test diff → follow `docs/TESTING.md` end to end**, including its test-intent map and its pre-commit redundancy pass. Every added test must name a reachable mutant that the nearest existing test would not kill.
+- **Cross-cutting test diffs get an independent review of test value and redundancy alone** — a subagent where one is available, otherwise a separate pass with the diff re-read from scratch.
+- Changing a user-visible surface (command, flag, env var, default, secret, install/release step) → re-read the whole public set (`README.md`, `docs/GETTING_STARTED.md`, `docs/INSTALL.md`, `docs/CUSTOMIZATION.md`, `deploy/README.md`) and update every document the change actually reaches. They describe each other's state, so one edit usually invalidates a sibling — but do not edit unaffected siblings just to touch all five.
 
-## Non-negotiable conventions
+## Architectural invariants
 
-- **Reuse before you add.** Before introducing a constant, helper, type, test double, or pattern, search for an existing equivalent (grep the protocol/seam and the shared support module) and reuse or promote it to a shared home — never write a second copy. Duplicates silently drift out of sync.
-- **Clean-room, not blinkered.** Study OpenClaw, Hermes, and the author's prior `swift-claude-code`, and borrow their ideas and hard-won practices freely — they solve the same problems at real scale. Banned is transcription: no copied code, no line-by-line ports; re-derive each borrowed idea in our own design and Swift.
-- **Swift 6 strict concurrency.** Mutable state in actors; domain types are `Sendable` value types.
-- **Secure-by-default; enforce policy in code, not the prompt.** Untrusted inbound (messages/web/tool output/durable memory) is data, never instructions — see `docs/ARCHITECTURE.md` §12.
-- **LLM provider = one `LLMProvider` contract with two wire adapters** (a Chat Completions adapter and a ChatGPT Responses adapter, selected by the `CLAW_LLM_MODEL` route), with authentication behind a **separate `LLMCredentialSource` seam** — see `docs/ARCHITECTURE.md` §8. **Telegram = a thin roll-your-own client** over AsyncHTTPClient, not a third-party lib.
-- **MCP = client only — the official SDK for the wire format, our own transport.** `ClawMCP` speaks Streamable HTTP over the shared `HTTPExecuting`/`HTTPStreaming` seam, never the SDK's `HTTPClientTransport` (URLSession; no SSE on Linux). A remote tool is an ordinary `Tool` at `.ask` by default and `.arbitraryDestination` with untrusted results; a named `.safe` override removes the default tap but not the exfiltration gate. No gate, FSM, or fingerprint code learns the word MCP — see `docs/ARCHITECTURE.md` §10.3.
-- **Persistence = GRDB + SQLite (WAL, FTS5)**; secrets via `SecretStore` (swift-crypto AES-GCM envelope + a local `0600` key), **not** the macOS Keychain (a launchd daemon can't use it).
-- **Store errors are domain-typed at the seam.** GRDB stores use `writer.writeMapping`/`readMapping` (not raw `write`/`read`), routing SQLite failures through `ClawDatabase.classifyError` into `StoreError` (e.g. `SQLITE_FULL → .diskFull`) — a raw `DatabaseError` must never leak past a store.
+- **Search before you add.** Before introducing a constant, helper, type, test double, or pattern, grep the protocol/seam and the shared support module for a semantic equivalent, and reuse or promote it when the contracts match. Do not merge two concepts into one abstraction because they look alike.
+- **Name the domain, not the literal.** Elevate one-offs into typed domain abstractions — no magic strings: branch and assert on the enum `rawValue` or named constant the production code already emits, never a duplicated literal.
+- **Clean-room, not blinkered.** Where a task calls for comparative design work, study OpenClaw, Hermes, and the author's prior `swift-claude-code`, and borrow their ideas and hard-won practices freely. Banned is transcription: no copied code, no line-by-line ports — re-derive each borrowed idea in our own design and Swift.
+- **Swift 6 strict concurrency.** Shared mutable in-memory state lives in actors; domain types are `Sendable` value types. GRDB stores are the deliberate exception — thin `Sendable` wrappers over `any DatabaseWriter` that lean on GRDB's own serialization; do not put an actor around them.
 - **Concurrency trap:** a Swift actor does NOT serialize across `await`. The per-session lane chains a stored `Task` (`var currentTurn`), it does not rely on actor isolation alone — `docs/ARCHITECTURE.md` §5.
+- **Secure-by-default; enforce policy in code, not the prompt.** Untrusted inbound (messages/web/tool output/durable memory) is data, never instructions — `docs/ARCHITECTURE.md` §12.
+- **LLM provider = one `LLMProvider` contract with two wire adapters** (a Chat Completions adapter and a ChatGPT Responses adapter, selected by the `CLAW_LLM_MODEL` route), with authentication behind a **separate `LLMCredentialSource` seam** — `docs/ARCHITECTURE.md` §8. **Telegram = a thin roll-your-own client** over AsyncHTTPClient, not a third-party lib.
+- **MCP = client only — the official SDK for the wire format, our own transport.** `ClawMCP` speaks Streamable HTTP over the shared `HTTPExecuting`/`HTTPStreaming` seam, never the SDK's `HTTPClientTransport` (URLSession; no SSE on Linux). A remote tool is an ordinary `Tool` at `.ask` by default and `.arbitraryDestination` with untrusted results; a named `.safe` override removes the default tap but not the exfiltration gate. No gate, FSM, or fingerprint code learns the word MCP — `docs/ARCHITECTURE.md` §10.3.
+- **Persistence = GRDB + SQLite (WAL, FTS5)**; secrets via `SecretStore` (swift-crypto AES-GCM envelope + a local `0600` key), **not** the macOS Keychain — a launchd daemon cannot reach it.
+- **Store errors are domain-typed at the seam.** GRDB stores use `writer.writeMapping`/`readMapping` (not raw `write`/`read`), routing SQLite failures through `ClawDatabase.classifyError` into `StoreError` (e.g. `SQLITE_FULL → .diskFull`) — a raw `DatabaseError` must never leak past a store.
 
 ## Code style
 
-- **Lint gate = `scripts/lint.sh`** — swift-format owns layout (`.swift-format`: 2-space, width 100, one-arg-per-line), SwiftLint owns correctness/idiom (`.swiftlint.yml`). Run `scripts/lint.sh --fix` to auto-apply both, then `scripts/lint.sh` to check; both must pass before committing (CI enforces it).
+- **Lint gate = `scripts/lint.sh`** over `Sources`, `Tests`, `Package.swift`; `.swift-format` and `.swiftlint.yml` hold the exact rules. Run `scripts/lint.sh --fix`, read the diff it produced, then `scripts/lint.sh` to check. Both tools must pass before committing (CI enforces it).
 - **Wrapped conditions:** `swiftlint --fix` and `swift format` disagree on the `{` of a multi-line `if let X, cond {` (the gate then fails) — use `guard … else {` (brace attaches to `else`) or keep the condition single-line; if the single line would exceed width 100 (another case `--fix` never converges on), hoist a subexpression into a named local first.
+- **Guard bodies are always multiline** — never `guard condition else { return }`.
+- **Names:** use descriptive identifiers; `.swiftlint.yml` `identifier_name` is the source of truth for the limits and for the domain exceptions it allows (`id`, `db`, `ts`, `ok`, `sh`).
 - **Tests follow Given-When-Then** — separate the body with `// given` / `// when` / `// then` sections (AAA equivalent).
-- **Variable names ≥ 3 chars** — no single/double-letter locals (`incoming`, not `m`).
 - **Comments: signal, not noise** — `///` states contract the signature can't express; `//` states a non-obvious *why*; never restate the code. Change history (task/increment/review tags) belongs to git, not comments.
 - **Never cite internal spec coordinates in comments** — no bare `§N`; write the why in place, self-contained. Allowed pointers: stable external IDs (RFCs, vendor docs) or, only where code would otherwise read as a bug, the full form `ARCHITECTURE.md §N` — the durable direction is docs→code (see the `ARCHITECTURE.md` §3.1 code map).
 - **Group private helpers into `private extension TypeName { }` blocks** by logical grouping, headed by a bare `// MARK: - <Group Name>` comment, no prose above it (see `RunCommand.swift`).
 
-## Build & test
+## Definition of done
 
-SwiftPM package (executable `clawd`): `swift build`, `swift test`, `swift test --filter <Suite>/<test>` for a single test. Build order + each increment's acceptance test → `docs/ARCHITECTURE.md` §20.
+SwiftPM commands: `swift build`, `swift test`, `swift test --filter <Suite>/<test>` for a single test. Build order and each increment's acceptance test → `docs/ARCHITECTURE.md` §20.
+
+- While iterating, run the narrowest relevant `--filter` for fast feedback.
+- Before calling a Swift change done — not merely before committing — run `scripts/lint.sh`, then `swift build`, then `swift test`.
+- Re-read the final diff for unrelated edits, missing tests, documentation impact, and violations of the invariants above.
+- Report which checks ran and what they printed. If one could not run, say so and why. Reading the code is not a substitute for the compiler, the test suite, or the lint gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,4 @@
-# swift-claw — agent instructions
-
-`AGENTS.md` is a symlink to this file: Claude Code and Codex read the same rules. Edit this file, never replace the symlink.
+# Agent instructions
 
 ## What this is
 


### PR DESCRIPTION
## Summary

- Removed the absolute path into one user's Claude Code auto-memory directory. It resolved on one machine and one account, so Codex, CI and contributors all read a dead pointer. Claude Code loads that index on its own.
- Added a **Definition of done**. The gate keys off calling the work complete, not off committing: run `scripts/lint.sh`, `swift build`, `swift test`, re-read the diff, then report what each check printed.
- Fixed a contradiction. The prose demanded identifiers of three or more characters; `.swiftlint.yml` allows `id`, `db`, `ts`, `ok` and `sh`. `.swiftlint.yml` now owns naming.
- Wrote down two invariants the code follows and the file omitted:
  - GRDB stores are thin `Sendable` wrappers over `any DatabaseWriter`, not actors. The old "mutable state in actors" line pointed the other way (`ARCHITECTURE.md` §3).
  - A "no magic strings / canonical abstractions" rule. `docs/TESTING.md:106` cites it as a `CLAUDE.md` rule, and `CLAUDE.md` never contained one.
- Added the module layout in one line: seams in `ClawCore`, implementations in sibling `Claw*` targets, composition at `clawd`.
- Softened three absolutes that invite the wrong reflex: "never write a second copy" (premature abstraction), updating five public docs "in lockstep" (mechanical edits to untouched files), and studying OpenClaw, Hermes and `swift-claude-code` on every task.
- Condensed four test bullets into two so `docs/TESTING.md` stays the single source for the test-intent map and the redundancy pass.
- Renamed the H1 to a project title, since Codex reads this file as `AGENTS.md` through the symlink. One added line warns a future edit not to replace that symlink with a regular file.

The file grows from 44 lines to 52, under Anthropic's 200-line guidance and Codex's 32 KiB `project_doc_max_bytes`.

### Kept on purpose

A review suggested dropping several rules. This rewrite keeps them: Telegram as a roll-your-own client, the `CLAW_LLM_MODEL` route selector, the MCP risk tiers (`.ask` by default, `.arbitraryDestination`, `.safe` leaving the exfiltration gate in place), why `HTTPClientTransport` is banned, why the Keychain is banned, WAL/FTS5, `swift test --filter`, and the `RunCommand.swift` example.

### Merge note

`feature/issue-118-scenario-validation` edits the same section of `CLAUDE.md`: it describes the lint gate as three tools and adds a guard-body rule. This branch states the guard-body rule and points at `scripts/lint.sh` plus the config files instead of listing tools, so both versions hold. Resolving that conflict means taking this version and restoring the clause about the gate rejecting single-line guard bodies.

## Test plan

- [x] `scripts/lint.sh` passes (`lint: ok`; the SwiftLint warnings it prints are pre-existing on `main`)
- [x] `swift build` clean
- [x] `swift test` passes, 2669 tests in 332 suites
- [x] `AGENTS.md` still resolves through the symlink and serves the new content
- [x] No `.md` in the repository references the renamed section headings
