### PR TITLE
Define self-improving scheduled task architecture and security boundaries

### DIFF
--- a/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
+++ b/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Proposed M1 RFC/ADR, compact v3.1 |
+| **Status** | Accepted M1 RFC/ADR, compact v3.1 |
 | **Date** | 29 August 2026 |
 | **Parent** | Issue 115 |
 | **Scope issue** | Issue 167 |

--- a/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
+++ b/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
@@ -2,32 +2,30 @@
 
 **Status:** Proposed — M1 / #167 · **Date:** 2026-08-28 · **Parent:** #115 · **Baseline:** #118 frozen Protocol 0.6
 
-**Production scope:** generic job-scoped learning for every scheduled task swift-claw can execute. **First deterministic adapter/benchmark:** scheduled page-change monitoring.
+**Scope:** generic job-scoped learning for every executable scheduled task. **First deterministic adapter:** scheduled page-change monitoring.
 
 ## 1. Decision and guarantee
 
 Every created scheduled run uses one generic learning control plane. Existing `run_id` remains the only task-attempt identity. The fire transaction binds it to exact occurrence, fire kind, job-definition digest, execution surface and effective lesson-set digest; execution stays on the ordinary proactive `TurnRunner`/`AgentRuntime` path with existing tools, policy, approvals, budgets and delivery.
 
-Every terminal transition writes an immutable receipt. After late usage/approval observations settle, an idempotent worker seals bounded evidence or a technical exclusion. A deterministic eligibility classifier runs before learning LLM spend. Eligible evidence may enter a fresh, tool-free, blind evaluator. Reflection is a separate fresh/tool-free call and may only propose an immutable complete replacement lesson set.
+Every terminal transition writes an immutable receipt. After late usage/approval observations settle, an idempotent worker seals bounded evidence or a technical exclusion. Deterministic eligibility runs before learning LLM spend. Eligible evidence may enter a fresh, tool-free, blind evaluator. Reflection is a separate fresh/tool-free call and may only propose an immutable complete replacement lesson set.
 
 Owner feedback is durable, authenticated, typed, append-only and exact-subject-bound. It is evidence, never activation. Each job has one stable lesson pointer and at most one bounded trial override; trials cannot stack. Promotion CASes stable from recorded base to candidate; fallback closes trial and leaves stable untouched.
 
-**Guarantee:** any executable scheduled task can participate in capture → eligibility → evaluation → feedback → reflection → candidate → bounded trial → promote/fallback without expanding its authority. This does not guarantee objective verification or improvement for subjective tasks. Natural runs/LLM evaluation are heuristic; owner feedback establishes owner intent; only a deterministic adapter over a named frozen oracle/dataset may issue scoped `deterministically_verified` evidence.
+**Guarantee:** any executable scheduled task can participate in capture → eligibility → evaluation → feedback → reflection → candidate → bounded trial → promote/fallback without expanding authority. This does not guarantee objective verification/improvement for subjective tasks. Natural runs/LLM evaluation are heuristic; owner feedback establishes owner intent; only a deterministic adapter over a named frozen oracle/dataset may issue scoped `deterministically_verified` evidence.
 
 No unresolved P0 architecture/security blocker remains. Exact algorithm parameters are deferred to M2 (§12).
 
 ## 2. Invariants / security boundary
 
-- `run_id` is canonical; no parallel attempt entity.
-- Generic core contains no page/HTML/selector/region/snapshot types.
+- `run_id` is canonical; no parallel attempt entity. Generic core contains no page/HTML/selector/region/snapshot types.
 - Scheduled execution remains an ordinary proactive agent run.
 - Lessons are data, never authority: they cannot change job prompt, schedule, budgets, model route, tool catalog/risk, approvals, recipients, paths, commands or destinations.
-- Lessons use a trusted harness wrapper around bounded **untrusted payload**; they never enter global/workspace memory, conversation history or FTS.
+- Lessons use a trusted harness wrapper around bounded **untrusted payload** and never enter global/workspace memory, conversation history or FTS.
 - Non-empty lessons establish taint before sensitive-memory selection, first provider call and first tool-policy decision.
 - Evaluation/reflection get fresh contexts with no tools, workspace memory, session history, approvals or provider replay state.
 - Evaluator is blind to lesson text/IDs, stable/candidate digests, trial condition, prior scores, promotion state and expected improvement.
-- Deterministic eligibility precedes learning LLM spend.
-- Feedback cannot activate lessons or expand authority.
+- Deterministic eligibility precedes learning LLM spend. Feedback cannot activate lessons or expand authority.
 - One stable pointer + at most one trial; promotion requires positive eligible evidence. Silence/evaluator failure/ineligible runs are never positive.
 - DB effects are idempotent; external LLM inference is not exactly-once.
 - Export/retention/purge include derivatives; deleting private source data cannot leave an active lesson encoding it.
@@ -36,7 +34,7 @@ No unresolved P0 architecture/security blocker remains. Exact algorithm paramete
 
 **Scheduler/fire.** `ScheduledJobStore.claimAndFire` already fuses occurrence compare-and-advance with session/trigger, `PENDING` run and audit; `fireNow` reuses the insert set without schedule advance; overlap prevents a second live job-session run. Extend the successful transaction with `learning_run_binding(run_id, job_id, occurrence, fire_kind, job_definition_digest, execution_surface_version, effective_lesson_id/digest, stable_base_digest, trial_id/generation?)`. Resolve trial expiry first; consume an assignment only after overlap passes and `run_id` exists. Misfire, overlap skip and CAS loser consume none.
 
-**Run persistence.** `RunStore` owns pickup, completion/degradation, cancel/supersede, approval suspension/resume and boot reconciliation. Every legal terminal transition (`DONE/FAILED/CANCELLED/SUPERSEDED`, including reconciliation) writes one `learning_terminal_receipt` in the same transaction. Seal later unless a normal `DONE` transaction already has all settled facts.
+**Run persistence.** `RunStore` owns pickup, completion/degradation, cancel/supersede, approval suspension/resume and boot reconciliation. Every legal terminal transition (`DONE/FAILED/CANCELLED/SUPERSEDED`, including reconciliation) writes one `learning_terminal_receipt` in the same transaction. Seal later unless normal `DONE` already has all settled facts.
 
 **Context/taint.** `TurnRunner` loads bounded context/budgets and calls `AgentRuntime` with taint/private-data state. Add a job-scoped lesson section: trusted wrapper, untrusted payload. Non-empty lessons set initial taint before context memory selection.
 
@@ -44,7 +42,7 @@ No unresolved P0 architecture/security blocker remains. Exact algorithm paramete
 
 **Usage/budgets.** Evaluation/reflection are durable runless learning operations, not fake runs. Usage counts toward global and proactive/learning budgets. Owner delivery never waits for learning calls.
 
-**Telegram feedback.** Reuse the fail-closed callback pattern (claim update → numeric allowlist → strict namespace → random nonce → owner binding → CAS → redacted audit) in a separate `fb:` domain. Do not reuse tool approvals or `AWAITING_APPROVAL`.
+**Telegram feedback.** Reuse the fail-closed callback pattern (claim update → numeric allowlist → strict namespace → random nonce → owner binding → CAS → redacted audit) in a separate `fb:` domain; do not reuse tool approvals or `AWAITING_APPROVAL`.
 
 ## 4. Architecture and data model
 
@@ -61,15 +59,15 @@ Optional LearningEvaluatorAdapter → page-change frozen scorer/fixtures first
 
 Learning sits beside scheduler/persistence; `AgentRuntime` only consumes pinned lessons and produces ordinary run facts.
 
-Conceptual generic records (names are not M1 migrations):
+Conceptual records (names are not M1 migrations):
 
-- `learning_job_state`: job PK, stable lesson ID/digest, nullable open trial, monotonic generation. Stable pointer is the only production activation pointer.
-- `learning_lesson_sets`: immutable complete replacement set, bounded payload, digest/base digest, source, schema/timestamps. No in-place edit.
+- `learning_job_state`: job PK, stable lesson ID/digest, nullable open trial, monotonic generation; stable pointer is the only production activation pointer.
+- `learning_lesson_sets`: immutable complete replacement set, bounded payload, digest/base digest, source, schema/timestamps; no in-place edit.
 - `learning_run_bindings`: one per created scheduled `run_id`; exact occurrence/fire kind and pinned job/execution/lesson/trial digests.
 - `learning_terminal_receipts`: one per terminal run; winning terminal state, timestamp, schema/digest.
-- `learning_evidence`: one sealed projection or typed exclusion. Projection contains bindings/digests, terminal classification, bounded final output/digest, bounded tool facts (name/status/policy decision/result size/trust flags), actual model route, primary usage refs, versions and optional adapter facts. Excludes raw tool args, secrets, private raw observations, replay state and audit projections.
+- `learning_evidence`: sealed projection or typed exclusion. Projection contains bindings/digests, terminal classification, bounded final output/digest, bounded tool facts (name/status/policy decision/result size/trust flags), actual model route, primary usage refs, versions and optional adapter facts. Excludes raw tool args, secrets, private raw observations, replay state and audit projections.
 - `learning_operations`: durable evaluation/reflection ID, source evidence, phase/status (`pending/in_flight/succeeded/failed/interrupted_unknown`), model route/schema, attempts, usage/cost refs, timestamps.
-- `learning_evaluations`: evidence binding, rubric/adapter versions, closed result `no_issue | reusable_issue | transient_issue | uncertain`, bounded findings/digest.
+- `learning_evaluations`: evidence binding, rubric/adapter versions, result `no_issue | reusable_issue | transient_issue | uncertain`, bounded findings/digest.
 - `learning_feedback_targets/events`: random one-time nonce + owner + exact subject digest; append-only typed event with Telegram update/nonce and optional superseded link.
 - `learning_trials`: job, base/candidate digests, generation, state, deadline, max/consumed assignments, admission evidence; unique open trial/job.
 - `learning_decision_receipts`: immutable promotion/fallback/reject inputs, evidence/feedback, evidence strength, CAS generations/digest.
@@ -99,111 +97,70 @@ candidate → TRIAL (stable untouched)
        └─ won → ACTIVE; close trial
 ```
 
-Keep dimensions separate:
-
-```text
-lifecycle: candidate | trial | active | rolled_back | superseded
-evidence: heuristic | owner_supported | owner_confirmed | deterministically_verified
-```
-
-An active lesson may remain heuristic. LLM evaluation never yields deterministic verification.
+Keep dimensions separate: `lifecycle = candidate | trial | active | rolled_back | superseded`; `evidence = heuristic | owner_supported | owner_confirmed | deterministically_verified`. An active lesson may remain heuristic. LLM evaluation never yields deterministic verification.
 
 ## 6. Evidence, evaluator and reflection
 
 Terminal receipt is settlement-independent and unique by run. Sealer is idempotent by run + evidence-schema version, waits for required usage/approval observations, and writes sealed evidence or `excluded(reason)`. Audit is observability, not provenance.
 
-Initial deterministic eligibility taxonomy: `eligible_task_evidence`, `transient_infrastructure_failure`, `policy_or_security_block`, `owner_interruption`, `insufficient_evidence`, `unsupported_terminal_state`. Provider/storage/credential/budget failures do not create behavioral lessons; cancellation, supersession and security blocks never enter reflection. One-shot jobs may retain evidence/evaluation/feedback but cannot trial without another occurrence.
+Initial eligibility taxonomy: `eligible_task_evidence`, `transient_infrastructure_failure`, `policy_or_security_block`, `owner_interruption`, `insufficient_evidence`, `unsupported_terminal_state`. Provider/storage/credential/budget failures do not create behavioral lessons; cancellation, supersession and security blocks never enter reflection. One-shot jobs may retain evidence/evaluation/feedback but cannot trial without another occurrence.
 
 Evaluator input is exactly frozen job prompt, frozen quality rubric, final output, safe evidence projection and optional adapter facts. No tools. Reflection is a separate call over compatible saved evaluations/multi-run evidence plus current lesson set and proposes one complete replacement. Evaluation failure cannot start reflection; reflection failure cannot create a candidate. Compatibility includes job semantics, evidence schema, execution surface, rubric and adapter version.
 
-## 7. Candidate authority firewall and feedback
+## 7. Candidate firewall and owner feedback
 
 Admission deterministically validates schema/canonical encoding, lesson count/size, Unicode/invisible/bidi handling, exact-loaded-secret leakage, base/source integrity and forbidden authority operands (schedule, recipients, model route, budgets, tools/risk/approval config, paths, commands, destinations, credentials). Text classification is defense in depth; runtime policy is the boundary.
 
-Feedback transaction: atomically claim external event → numeric-ID allowlist → parse `fb:` → load random-nonce target → verify owner + exact subject digest → append event → consume target where one-shot → append redacted audit in same write.
+Feedback transaction: claim external event → numeric-ID allowlist → parse `fb:` → load random-nonce target → verify owner + exact subject digest → append event → consume one-time target if applicable → append redacted audit in same write.
 
-Useful/not-useful supports/contradicts one result; correction is owner-attested expected behavior and possible one-run trial seed; evaluation dispute blocks dependent promotion; candidate approve permits an owner-supported trial through the common gate, never direct activation; reject vetoes/stops exact candidate; edit creates a new candidate and reruns all gates. Owner statements establish intent, not deterministic verification.
+Useful/not-useful supports/contradicts one result; correction is owner-attested expected behavior and possible one-run trial seed; evaluation dispute blocks dependent promotion; candidate approve permits owner-supported trial through common gate, never direct activation; reject vetoes/stops exact candidate; edit creates a new candidate and reruns all gates. Owner statements establish intent, not deterministic verification.
 
 ## 8. Trial semantics
 
-Candidate is a complete replacement set with incumbent digest. Repeated compatible evidence may admit an automatic heuristic trial; explicit owner correction/approval may admit after one eligible occurrence. Exact thresholds are M2.
+Candidate is a complete replacement set with incumbent digest. Repeated compatible evidence may admit automatic heuristic trial; explicit owner correction/approval may admit after one eligible occurrence. Exact thresholds are M2.
 
 Fire atomically resolves expiry → passes existing occurrence/overlap guard → creates run → pins stable/trial digest → consumes one assignment. A created run consumes it even if later technically failed; only eligible completed evaluations count positive. Trials cannot stack.
 
-Expiry, assignment exhaustion, critical failure/regression, security/deterministic veto, explicit rejection/dispute or insufficient positive evidence closes the exact trial; future runs use stable. Promotion writes decision receipt, CASes stable only if base/generation match, then closes trial. Hard veto and owner reject/dispute outrank heuristic support.
+Expiry, assignment exhaustion, critical failure/regression, security/deterministic veto, explicit rejection/dispute or insufficient positive evidence closes exact trial; future runs use stable. Promotion writes decision receipt, CASes stable only if base/generation match, then closes trial. Hard veto and owner reject/dispute outrank heuristic support.
 
-## 9. Trust and data lifecycle
+## 9. Trust, lifecycle and restart
 
-```text
-CONTROL/trusted code: scheduler claims, policy, budgets, admission, trial/CAS, owner auth
-UNTRUSTED data: lessons, outputs, tool facts, evaluator/reflection prose
-OWNER-ATTESTED: authenticated feedback for exact subject
-DETERMINISTIC: scoped adapter receipt for frozen oracle/dataset only
-```
+Trust classes: **CONTROL** = scheduler claims/policy/budgets/admission/trial-CAS/owner auth; **UNTRUSTED DATA** = lessons/outputs/tool facts/evaluator-reflection prose; **OWNER-ATTESTED** = authenticated exact-subject feedback; **DETERMINISTIC** = scoped adapter receipt only.
 
-Export/retention/purge cover evidence, operations/evaluations, feedback, candidates, lesson sets, trials and verification/decision receipts. Job cancellation blocks new learning spend/promotion but retains immutable history per retention. Job-learning purge must deactivate/remove derived active lessons depending on purged private data or conservatively reset stable to an unaffected ancestor/empty set.
+Export/retention/purge cover evidence, operations/evaluations, feedback, candidates, lesson sets, trials and verification/decision receipts. Job cancellation blocks new learning spend/promotion but retains history per policy. Purge must deactivate/remove active lessons depending on purged private data or reset stable to unaffected ancestor/empty set.
 
-## 10. Transaction and restart matrix
+Transaction/restart rules:
 
-| Operation | Atomic boundary / restart rule |
-|---|---|
-| Fire | occurrence/overlap claim + run + binding + trial assignment; no run ⇒ no assignment; created run keeps pinned digest |
-| Terminal | run terminal transition + receipt; unique/idempotent and agrees with winning state |
-| Evidence | seal/exclusion keyed by run+schema; DB construction retry is idempotent |
-| Feedback | external-event claim + owner/target validation + event + audit; duplicate cannot append twice |
-| Eval/reflect | durable `in_flight` before request; pre-crash in-flight → `interrupted_unknown`, no automatic repeat of same logical synthesis |
-| Eval/reflect finish | structured result + terminal op status + usage refs; committed result reusable; no exactly-once inference claim |
-| Trial admit | validation + unique open trial + job-state CAS; prevents stacking |
-| Trial assign | successful fire + binding + assignment increment; run exists ⇒ consumed |
-| Promotion | decision receipt + stable CAS + trial close; CAS loser never overwrites newer stable |
-| Fallback/reject | decision receipt + exact trial close; stable unchanged |
-| Job cancel | block new learning/promotion; immutable history retained per policy |
+- **Fire:** occurrence/overlap claim + run + binding + trial assignment; no run ⇒ no assignment; created run keeps pinned digest.
+- **Terminal:** state transition + receipt; unique/idempotent and agrees with winning state.
+- **Evidence:** seal/exclusion keyed by run+schema; DB retry idempotent.
+- **Feedback:** event claim + owner/target validation + event + audit; duplicate cannot append twice.
+- **Eval/reflect:** durable `in_flight` before request; crash-window operation becomes `interrupted_unknown`; do not automatically repeat same logical synthesis.
+- **Trial admission:** validation + unique open trial + job-state CAS prevents stacking.
+- **Promotion:** decision receipt + stable CAS + trial close; loser never overwrites newer stable.
+- **Fallback/reject:** exact trial closes; stable unchanged.
 
-## 11. Page-change adapter / evidence claims
+## 10. Page-change adapter
 
-Page-change is the first deterministic benchmark, not product boundary. Adapter supplies frozen inputs, deterministic scorer/oracle, adapter version and regression fixtures through generic contracts; generic types contain no page concepts.
+Page-change is first deterministic benchmark, not product boundary. Adapter supplies frozen inputs, deterministic scorer/oracle, version and regression fixtures through generic contracts; generic types contain no page concepts. Verification is scoped to named dataset/oracle + adapter/execution-surface version. Route/rubric/policy/adapter incompatibility requires revalidation or downgrade to heuristic. Protocol 0.6 remains frozen.
 
-Deterministic verification is scoped to named dataset/oracle, adapter version and execution surface. Route/rubric/policy/adapter incompatibility requires revalidation or downgrade to heuristic use. Protocol 0.6 from #118 remains frozen.
+## 11. Implementation increments
 
-## 12. Deferred algorithm parameters (M2)
+1. Capture: run binding + terminal receipt + safe evidence/exclusion; no behavior change.
+2. Eligibility/evaluator: deterministic taxonomy, durable operations, blind tool-free evaluation, budget accounting.
+3. Owner feedback: `fb:` targets/events and exact-subject overlays.
+4. Reflection/inert candidates: immutable replacement sets + admission firewall; no activation.
+5. Bounded trial: stable pointer + one trial override, atomic assignment, initial lesson taint, expiry/fallback/no stacking.
+6. Promotion/rollback: decision receipts, positive-evidence gate, CAS promotion, veto precedence.
+7. Page-change adapter: deterministic fixtures/scorer and scoped verification receipts.
+8. Lifecycle completion: export/retention/purge, doctor/observability, restart fault injection.
 
-M2 selects with benchmark evidence: compatible-evidence window/recency; minimum supporting runs; owner-signal weighting beyond hard veto precedence; trial assignment count/deadline; automatic-trial support threshold; acceptance/regression formula and uncertainty band; reflection cadence/consolidation; lesson count/size limits (architecture only requires finite caps); evaluator/reflector model choice and per-operation budgets; retention durations; deterministic-adapter score thresholds/revalidation window.
+## 12. Deferred to M2
 
-## 13. Implementation increments — smallest usable generic vertical first
+Compatible-evidence window/recency; minimum supporting runs; owner-signal weighting beyond hard veto precedence; trial assignment count/deadline; automatic-trial threshold; acceptance/regression formula/uncertainty band; reflection cadence/consolidation; exact lesson caps; evaluator/reflector model and operation budgets; retention durations; deterministic-adapter score thresholds/revalidation window.
 
-1. **Capture only:** run binding + terminal receipt + sealed safe evidence/exclusion; no LLM learning, no runtime behavior change.
-2. **Eligibility + evaluator:** deterministic taxonomy, durable operations, blind tool-free evaluator, learning budget accounting; still no lessons applied.
-3. **Owner feedback:** `fb:` targets/events, authenticated callback capture, exact-subject overlays; still no activation.
-4. **Reflection + inert candidates:** tool-free reflection, immutable replacement sets, deterministic admission firewall; candidates cannot run yet.
-5. **Bounded trial:** job stable pointer + one trial override, atomic assignment at fire, initial lesson taint, expiry/fallback/no-stacking.
-6. **Promotion/rollback:** decision receipts, positive-evidence gate, CAS promotion, veto precedence and rollback/fallback.
-7. **Page-change adapter:** frozen deterministic scorer/fixtures and scoped verification receipts used to validate the generic loop.
-8. **Lifecycle completion:** export/retention/job-learning purge, doctor/observability and restart fault-injection coverage.
+## 13. Acceptance
 
-Each increment is independently testable and preserves existing scheduler behavior until the trial increment explicitly injects a pinned lesson set.
+This RFC satisfies #167's acceptance contract: canonical `run_id`; generic core; atomic occurrence/lesson pinning; terminal receipt + post-settlement sealing; deterministic eligibility before LLM; blind evaluator separated from reflector; durable authenticated feedback; no feedback activation/authority expansion; one bounded non-stacking trial with CAS; positive-evidence requirement; distinct heuristic/owner/deterministic claims; global + proactive learning budget participation; initial lesson taint; defense-in-depth candidate validation; honest restart semantics; derivative export/retention/purge; page-change as first deterministic adapter; and no unresolved P0 blocker.
 
-## 14. Acceptance checklist
-
-- [x] Capability guarantee and subjective evidence limits stated.
-- [x] Existing `run_id` is the only attempt identity.
-- [x] Generic core has no page-change domain types.
-- [x] Fire atomically pins effective lesson digest and occurrence.
-- [x] Terminal receipt + post-settlement sealing cover legal terminal paths.
-- [x] Eligibility precedes evaluator LLM.
-- [x] Evaluator blindness and evaluator/reflector separation explicit.
-- [x] Owner feedback durable/authenticated/typed/append-only/exact-bound.
-- [x] Feedback cannot activate lessons or expand authority.
-- [x] Stable pointer + single bounded trial + expiry/no-stacking/CAS specified.
-- [x] Positive eligible evidence required; silence/evaluator failure not positive.
-- [x] Heuristic, owner-supported/confirmed and deterministic evidence separated.
-- [x] Learning usage participates in global + proactive/learning budgets.
-- [x] Initial lesson taint occurs before memory selection/provider/tool policy.
-- [x] Candidate validation is not the sole prompt-injection defense.
-- [x] Restart handling does not claim exactly-once LLM inference.
-- [x] Retention/export/purge cover derivatives and provenance.
-- [x] Page-change is first deterministic adapter/benchmark.
-- [x] No unresolved P0 architecture/security blocker identified.
-
-## 15. Out of scope for M1
-
-Swift production code/migrations/tests; exact thresholds/windows/trial duration/consolid
+**M1 remains architecture-only:** no production Swift/migrations/tests, exact thresholds/windows/trial duration/consolidation, page-change importer/benchmark implementation, global/cross-job lessons, generic global-memory platform, authority changes through lessons, policy weakening, Protocol 0.6 rewrite, merge, or issue closure.

--- a/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
+++ b/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
@@ -406,8 +406,8 @@ candidate-record digest and replacement lesson-set digest are distinct. Trusted 
 closed origin and an immutable source manifest with the exact evidence, evaluation, feedback, base-set
 and predecessor-candidate edges. A cutoff alone is not provenance.
 
-The same admission validator runs on reflector output, owner edits and future candidate sources before
-lesson bytes persist or a trial opens. It validates only boundaries that provide concrete value now:
+The same admission validator runs on reflector output and owner edits before lesson bytes persist or
+a trial opens. It validates only boundaries that provide concrete value now:
 
 - closed versioned schema and canonical encoding;
 - finite lesson count and UTF-8 byte caps;
@@ -418,9 +418,8 @@ lesson bytes persist or a trial opens. It validates only boundaries that provide
 Lessons are not parsed into schedule, route, tool, recipient, path, command or approval
 configuration. Lexical scanning may flag suspicious text as defense in depth, but it is not relied on
 to prove safety and must not reject ordinary useful prose merely for mentioning a file, URL or
-command. The candidate schema contains no authority-operand fields. A future structured operand may
-only repeat an owner-confirmed job or configuration value; it cannot introduce a new recipient, URL,
-path or command. Runtime policy remains authoritative for every model-proposed tool argument.
+command. The candidate schema contains no authority-operand fields. Runtime policy remains
+authoritative for every model-proposed tool argument.
 
 Repeated compatible evidence may admit an automatic heuristic trial. An explicit owner correction
 or approval may admit a trial after one eligible occurrence. In both cases admission requires a

--- a/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
+++ b/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
@@ -1,0 +1,334 @@
+# RFC: Architecture and security boundaries for self-improving scheduled tasks
+
+| | |
+|---|---|
+| **Status** | Proposed — M1 / Issue #167 |
+| **Date** | 2026-08-28 |
+| **Parent** | #115 |
+| **Evidence baseline** | #118, frozen Protocol 0.6 |
+| **Production scope** | Generic job-scoped learning for every scheduled task swift-claw can execute |
+| **First deterministic adapter / benchmark** | Scheduled page-change monitoring |
+
+## 1. Decision summary
+
+Every created scheduled run participates in one generic, job-scoped learning control plane. The existing `run_id` remains the only task-attempt identity. The scheduler atomically binds each created run to the exact logical occurrence, job definition, execution surface, fire kind, and effective lesson-set digest. The ordinary proactive `AgentRuntime` executes the task; learning never replaces or bypasses that path.
+
+After a run becomes terminal, the system writes an immutable terminal receipt and later seals a bounded learning-evidence projection after late usage and approval observations settle. A deterministic eligibility classifier decides whether that evidence may reach a fresh, tool-free evaluator. Evaluation and reflection are separate LLM operations with durable operation identities and budget accounting. Reflection may propose only an immutable complete replacement lesson set; it cannot mutate scheduler, runtime, tool, approval, model-route, recipient, path, command, destination, or budget authority.
+
+Owner feedback is a durable, authenticated, append-only learning signal bound to exact subjects and digests. It may support, contradict, correct, approve, reject, edit, confirm, or dispute learning artifacts, but it never directly changes the stable lesson pointer.
+
+A job owns one stable lesson-set pointer and at most one bounded trial override. Trial assignment is consumed atomically only when a run is actually created. Trials cannot stack. Promotion is a compare-and-swap (CAS) from the recorded incumbent digest to the candidate digest; fallback closes the trial while leaving the stable pointer untouched.
+
+The capability guarantee is therefore:
+
+> If swift-claw can execute a scheduled job, the architecture can capture its attempts, classify learning eligibility, accept owner feedback, evaluate eligible evidence, derive job-scoped lesson candidates, trial candidates on future occurrences, and promote or fall back without expanding the job's authority.
+
+This is **not** a guarantee that every scheduled task can be objectively verified or will improve. For subjective tasks, natural runs, owner feedback, and LLM evaluation remain heuristic or owner-attested evidence. Only a deterministic adapter with a named frozen oracle/dataset may issue a scoped `deterministically_verified` receipt.
+
+No unresolved P0 architecture or security blocker remains for implementation planning. Exact learning-policy parameters are intentionally deferred to M2 (§16).
+
+## 2. Non-negotiable invariants
+
+1. **One task-attempt identity.** `runs.id` / `run_id` is canonical. Learning adds immutable bindings and receipts; it does not create a parallel attempt entity.
+2. **Generic core.** The core contains no page, HTML, selector, region, DOM, or page-snapshot types. Page-change behavior lives behind an adapter.
+3. **Ordinary execution path.** Scheduled tasks still enter the existing session lane and `TurnRunner`/`AgentRuntime` path with existing proactive budgets, policy, tools, approvals, taint, and delivery semantics.
+4. **Lessons are data, not authority.** Lessons may influence task strategy only. They cannot modify prompt ownership, schedule, budgets, model route, tool catalog, risk tiers, approvals, recipients, paths, commands, destinations, or policy.
+5. **Initial taint.** A non-empty effective lesson set marks the run tainted before sensitive-memory selection, the first provider call, and the first tool-policy decision. This is conservative: learned text is durable model-generated/untrusted payload.
+6. **Fresh learning contexts.** Evaluation and reflection receive no tools, workspace memory, session history, approval capability, or provider replay state.
+7. **Blind evaluation.** Evaluators never see lesson text/IDs, stable/candidate digests, trial condition, prior scores, promotion state, or expected improvement.
+8. **Deterministic eligibility first.** No evaluation/reflection LLM spend occurs before technical eligibility classification.
+9. **Owner feedback is evidence, not activation.** Feedback cannot update the stable pointer or expand authority.
+10. **Single bounded trial.** One stable pointer, at most one trial override, no stacking.
+11. **Positive evidence required.** Silence, missing feedback, evaluator failure, interrupted learning operations, and ineligible runs never count as positive trial evidence.
+12. **No exactly-once LLM claim.** Database effects are idempotent; external inference is not. Ambiguous crash windows become `interrupted_unknown` and are not blindly replayed.
+13. **Derived-data lifecycle follows source provenance.** Export, retention, purge, and deletion cover learning derivatives. Removing source private data must not leave an active lesson encoding that fact.
+
+## 3. Existing seam map
+
+M1 extends existing seams rather than introducing a second scheduler/runtime.
+
+### 3.1 Scheduler and fire transaction
+
+Current `ScheduledJobStore.claimAndFire` already performs the occurrence compare-and-advance and then creates the session trigger, `PENDING` run, and audit in one database write. `fireNow` reuses the same fused insert set without advancing the schedule. The existing overlap guard prevents a second live run on the job session.
+
+**M1 extension:** the same successful fire transaction must additionally persist a `learning_run_binding` keyed by `run_id` containing:
+
+- `job_id`;
+- logical `occurrence_at`;
+- `fire_kind` (`scheduled`, `run_now`, later other explicit kinds);
+- immutable `job_definition_digest`;
+- `execution_surface_version` / digest;
+- effective `lesson_set_id` and `lesson_set_digest` (empty-set digest allowed);
+- trial identity/generation when the run consumed a trial assignment;
+- schema version and creation timestamp.
+
+The transaction resolves trial expiry first, then uses the existing occurrence/overlap guard, creates `run_id`, pins stable-or-trial lessons, and consumes a trial assignment. A CAS loser, misfire skip, or overlap skip creates no run and consumes no trial assignment.
+
+### 3.2 Run persistence and terminal commits
+
+Current `RunStore` owns `PENDING → RUNNING` pickup, completed/degraded commits, cancellation/supersession, approval suspension/resume, and boot reconciliation. `commitAssistantTurn` already fuses assistant output, `DONE`, provider usage, and outbox; degradation paths fuse failure state and delivery.
+
+**M1 extension:** every legal transition into a terminal run state (`DONE`, `FAILED`, `CANCELLED`, `SUPERSEDED`, including boot reconciliation) writes exactly one immutable `learning_terminal_receipt` in the same transaction as the state transition. The receipt is intentionally small and settlement-independent. It proves what terminal state won and when.
+
+A later evidence sealer reads the terminal receipt plus settled run-linked facts and writes one immutable bounded evidence projection or one technical exclusion. A normal `DONE` path may seal evidence in the terminal transaction when all required facts are already complete; cancellation/supersession and ambiguous approval/late-usage paths must not assume settlement.
+
+### 3.3 Context building and taint
+
+Current `TurnRunner` loads a bounded context snapshot, obtains global and proactive spend totals, then calls `ContextBuilder.assemble`. `AgentRuntime.runTurn` receives session taint/private-data state before any tool work.
+
+**M1 extension:** effective lessons are a distinct context section with a trusted harness wrapper and bounded **untrusted payload**. They are job-scoped and never stored in session messages, global memory, workspace memory, or FTS. If the effective lesson set is non-empty, the run starts tainted before context memory selection. The lesson section is included only for `RunOrigin.scheduled` executions with a valid run binding.
+
+### 3.4 Policy and approvals
+
+Current policy/approval boundaries bind consequential actions to canonical arguments, policy version, owner identity, and durable approval state. These remain authoritative.
+
+**M1 extension:** lessons cannot supply policy operands. Any lesson text that appears to request a new tool, destination, recipient, path, command, permission, approval bypass, model route, schedule, or budget is inert text and is also rejected by candidate admission as defense in depth. Existing code policy remains the security boundary.
+
+### 3.5 Usage and budgets
+
+Current `UsageStore` supports run-linked and runless provider usage; proactive totals are derived from scheduled/heartbeat run origins.
+
+**M1 extension:** learning calls are **runless learning operations**, not fake agent runs. Each operation records its own durable operation ID and usage references. Its provider usage contributes to:
+
+- the existing global daily budget; and
+- the proactive/learning budget pool defined for scheduled work.
+
+Owner delivery never waits for evaluator or reflector calls. A budget stop skips learning spend; it never delays or changes the already-completed task result.
+
+### 3.6 Telegram owner-feedback binding
+
+Current approval callbacks already demonstrate the required fail-closed pattern: claim Telegram update, numeric-ID allowlist, strict namespace parsing, random nonce lookup, exact owner binding, CAS, audit.
+
+**M1 extension:** feedback uses a separate `fb:` callback namespace and separate learning-feedback tables. It does **not** reuse tool `approvals`, `AWAITING_APPROVAL`, or approval suspension. A feedback target is durable and binds a random one-time callback nonce to owner ID plus exact subject type/id/digest. Native reactions or reply-based correction may later adapt into the same event model.
+
+## 4. Generic architecture
+
+```text
+SchedulerService
+  │
+  ├─ fire transaction
+  │    ├─ resolve stable/trial lesson digest
+  │    ├─ create ordinary run_id
+  │    ├─ pin occurrence + job/execution digests
+  │    └─ consume trial assignment if applicable
+  │
+  └─ TurnEnqueuer → TurnRunner → AgentRuntime → existing policy/tools/outbox
+                                │
+                                └─ terminal run transaction
+                                     └─ immutable terminal receipt
+
+LearningCoordinator (post-delivery, asynchronous)
+  ├─ EvidenceSealer
+  │    └─ terminal receipt + settled safe facts → sealed evidence | exclusion
+  ├─ EligibilityClassifier (deterministic)
+  ├─ Evaluator (fresh context, no tools, blind)
+  ├─ FeedbackStore / fb: callback adapter
+  ├─ Reflector (fresh context, no tools)
+  ├─ CandidateAdmissionPolicy (deterministic validation)
+  └─ TrialController
+       ├─ admit one bounded trial
+       ├─ collect eligible evidence
+       ├─ promote via stable-pointer CAS
+       └─ close/fallback without touching stable pointer
+
+Optional LearningEvaluatorAdapter
+  └─ page-change adapter first: frozen inputs + deterministic scorer + fixtures
+```
+
+The generic learning layer belongs conceptually beside scheduling/persistence, not inside `AgentRuntime`. `AgentRuntime` consumes a pinned lesson payload and reports ordinary run facts; it does not decide evaluation, reflection, trial, or promotion.
+
+## 5. Generic data model
+
+Names are conceptual M1 contracts; migrations and exact Swift names are implementation work.
+
+### 5.1 `learning_job_state`
+
+One row per scheduled job:
+
+- `job_id` PK/FK;
+- `stable_lesson_set_id`, `stable_digest`;
+- `trial_id` nullable;
+- `generation` monotonic CAS generation;
+- timestamps.
+
+The stable pointer is the only production activation pointer.
+
+### 5.2 `learning_lesson_sets`
+
+Immutable complete replacement sets:
+
+- `id`, `job_id`, `digest` UNIQUE;
+- bounded ordered lesson payload;
+- `base_digest` nullable for initial empty set;
+- `created_by` (`reflection`, `owner_edit`, migration/import if ever supported);
+- source reflection/feedback IDs;
+- schema version, timestamps.
+
+No in-place edit. Owner edit creates a new set/digest.
+
+### 5.3 `learning_run_bindings`
+
+Exactly one per created scheduled `run_id`:
+
+- run/job/occurrence/fire-kind binding;
+- job-definition digest;
+- execution-surface/schema versions;
+- effective lesson-set id/digest;
+- stable base digest;
+- optional trial id/generation;
+- created timestamp.
+
+This is not an attempt entity; `run_id` remains canonical.
+
+### 5.4 `learning_terminal_receipts`
+
+Exactly one immutable row per terminal scheduled run:
+
+- `run_id` PK;
+- terminal `RunState` and terminal classification facts available at commit time;
+- terminal timestamp;
+- receipt schema version/digest.
+
+### 5.5 `learning_evidence`
+
+Exactly one terminal outcome per binding: `sealed` or `excluded`.
+
+A sealed projection contains only evaluator-relevant bounded facts:
+
+- run/job/occurrence bindings and digests;
+- terminal classification;
+- final output or bounded output/digest according to retention policy;
+- tool facts: tool name, status, policy decision, result size, trust/taint flags — **not raw arguments or raw private observations**;
+- actual model route and primary-run usage references;
+- execution-surface/schema versions;
+- optional adapter facts;
+- evidence digest and timestamps.
+
+Exclusions carry a typed technical reason. Evidence excludes secrets, provider replay state, audit-log projections, raw tool args, and private raw observations.
+
+### 5.6 `learning_operations`
+
+Durable evaluator/reflector operation record:
+
+- operation ID and kind (`evaluation`, `reflection`);
+- job ID and source evidence IDs/digests;
+- phase/status (`pending`, `in_flight`, `succeeded`, `failed`, `interrupted_unknown`);
+- model route, prompt/schema version;
+- attempts, usage/cost references;
+- created/started/finished timestamps.
+
+A crash after request dispatch but before durable response commit resolves to `interrupted_unknown`; the same logical synthesis is not automatically replayed.
+
+### 5.7 `learning_evaluations`
+
+Immutable structured evaluator result:
+
+- evaluation ID;
+- evidence ID/digest;
+- rubric/adapter versions;
+- closed result: `no_issue | reusable_issue | transient_issue | uncertain`;
+- bounded structured findings/reasons;
+- evidence-strength classification (`heuristic` unless a deterministic adapter receipt is separately attached);
+- timestamp/digest.
+
+### 5.8 `learning_feedback_targets` and `learning_feedback_events`
+
+Target:
+
+- random one-time callback nonce;
+- owner user ID;
+- job ID;
+- exact subject type/id/digest;
+- expiry/consumed state.
+
+Append-only event:
+
+- owner user ID;
+- job and run/output identity where relevant;
+- optional evaluation/candidate identity;
+- typed signal;
+- bounded payload;
+- Telegram update ID or callback nonce;
+- created timestamp;
+- optional `supersedes_event_id`.
+
+Signals: `result_useful`, `result_not_useful`, `result_correction`, `evaluation_confirm`, `evaluation_dispute`, `candidate_approve`, `candidate_reject`, `candidate_edit`.
+
+### 5.9 `learning_trials`
+
+- trial ID, job ID;
+- base stable digest + candidate digest;
+- generation;
+- state (`open`, `promoted`, `fallen_back`, `rejected`, `expired`, `exhausted`, `invalidated`);
+- assignment deadline;
+- maximum assignments and consumed assignments;
+- admission reason/evidence IDs;
+- timestamps.
+
+At most one open trial per job.
+
+### 5.10 `learning_decision_receipts`
+
+Immutable promotion/fallback/rejection receipts:
+
+- job/trial/base/candidate digests;
+- evidence IDs and feedback overlays considered;
+- decision + evidence-strength label;
+- policy/version inputs;
+- CAS generation before/after where applicable;
+- timestamp/digest.
+
+Audit rows may reference these receipts, but audit is observability, not provenance.
+
+### 5.11 Optional `deterministic_verification_receipts`
+
+Issued only by an adapter with a deterministic oracle:
+
+- adapter ID/version;
+- named frozen dataset/oracle version;
+- execution-surface version;
+- candidate/base/evidence digests;
+- deterministic score/result;
+- receipt digest.
+
+A rubric, route, policy, adapter, dataset, oracle, or execution-surface incompatibility requires revalidation or downgrade to heuristic use.
+
+## 6. Lifecycle state diagrams
+
+### 6.1 Evidence and synthesis
+
+```text
+created scheduled run
+      │
+      v
+terminal receipt
+      │
+      v
+settlement pending ──technical impossibility──> evidence EXCLUDED
+      │
+      v
+sealed evidence
+      │
+      v
+deterministic eligibility classifier
+   ┌──┴─────────────────────────────────────────────┐
+   │ eligible                                      │ ineligible
+   v                                               v
+evaluation op                                  stop (retain evidence)
+   │
+   ├─ fail/interrupted_unknown ─────────────────> stop
+   v
+saved evaluation
+   │
+   ├─ no reflection support yet ────────────────> stop
+   v
+reflection op
+   │
+   ├─ fail/interrupted_unknown ─────────────────> stop
+   v
+immutable candidate
+   │
+   v
+admission validation
+   │
+   ├─ reject/veto ──────────────────────────────> superseded/rejected

--- a/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
+++ b/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
@@ -9,326 +9,260 @@
 | **Production scope** | Generic job-scoped learning for every scheduled task swift-claw can execute |
 | **First deterministic adapter / benchmark** | Scheduled page-change monitoring |
 
-## 1. Decision summary
+## 1. Decision
 
-Every created scheduled run participates in one generic, job-scoped learning control plane. The existing `run_id` remains the only task-attempt identity. The scheduler atomically binds each created run to the exact logical occurrence, job definition, execution surface, fire kind, and effective lesson-set digest. The ordinary proactive `AgentRuntime` executes the task; learning never replaces or bypasses that path.
+Every created scheduled run participates in one generic job-scoped learning control plane. Existing `run_id` remains the only task-attempt identity. The fire transaction binds that run to its exact logical occurrence, fire kind, job-definition digest, execution-surface version and effective lesson-set digest. The task then executes through the ordinary proactive `TurnRunner` / `AgentRuntime` path with existing tools, policy, approvals, budgets and delivery.
 
-After a run becomes terminal, the system writes an immutable terminal receipt and later seals a bounded learning-evidence projection after late usage and approval observations settle. A deterministic eligibility classifier decides whether that evidence may reach a fresh, tool-free evaluator. Evaluation and reflection are separate LLM operations with durable operation identities and budget accounting. Reflection may propose only an immutable complete replacement lesson set; it cannot mutate scheduler, runtime, tool, approval, model-route, recipient, path, command, destination, or budget authority.
+After terminal execution, the system records an immutable terminal receipt and seals a bounded evidence projection after late usage/approval observations settle. A deterministic eligibility classifier runs before any learning LLM call. Eligible evidence may enter a fresh, tool-free, procedurally blind evaluator; reflection is a separate fresh tool-free call. Reflection may propose only an immutable complete replacement lesson set.
 
-Owner feedback is a durable, authenticated, append-only learning signal bound to exact subjects and digests. It may support, contradict, correct, approve, reject, edit, confirm, or dispute learning artifacts, but it never directly changes the stable lesson pointer.
+Owner feedback is durable, authenticated, typed, append-only and bound to an exact subject/digest. Feedback is evidence: it never directly changes the stable lesson pointer or expands task authority.
 
-A job owns one stable lesson-set pointer and at most one bounded trial override. Trial assignment is consumed atomically only when a run is actually created. Trials cannot stack. Promotion is a compare-and-swap (CAS) from the recorded incumbent digest to the candidate digest; fallback closes the trial while leaving the stable pointer untouched.
+Each job has one stable lesson-set pointer and at most one bounded trial override. Trials cannot stack. A created run consumes a trial assignment atomically; skips and CAS losers consume none. Promotion compare-and-swaps the stable pointer from the recorded base digest to the candidate digest. Fallback closes the trial and leaves the stable pointer untouched.
 
-The capability guarantee is therefore:
+**Capability guarantee:** if swift-claw can execute a scheduled job, this architecture can capture attempts, classify learning eligibility, accept owner feedback, evaluate eligible evidence, derive job-scoped lesson candidates, trial them on future occurrences, and promote or fall back without expanding the job's authority.
 
-> If swift-claw can execute a scheduled job, the architecture can capture its attempts, classify learning eligibility, accept owner feedback, evaluate eligible evidence, derive job-scoped lesson candidates, trial candidates on future occurrences, and promote or fall back without expanding the job's authority.
+This does **not** guarantee objective verification or improvement for every task. Natural runs and LLM evaluation are observational/heuristic. Owner feedback establishes owner intent for its bound subject. Only a deterministic adapter over a named frozen dataset/oracle may issue scoped `deterministically_verified` evidence.
 
-This is **not** a guarantee that every scheduled task can be objectively verified or will improve. For subjective tasks, natural runs, owner feedback, and LLM evaluation remain heuristic or owner-attested evidence. Only a deterministic adapter with a named frozen oracle/dataset may issue a scoped `deterministically_verified` receipt.
+No unresolved P0 architecture or security blocker remains. Exact policy parameters are deferred to M2 (§15).
 
-No unresolved P0 architecture or security blocker remains for implementation planning. Exact learning-policy parameters are intentionally deferred to M2 (§16).
+## 2. Non-negotiable boundaries
 
-## 2. Non-negotiable invariants
+1. `runs.id` / `run_id` is canonical; no second attempt entity.
+2. Generic core contains no page/HTML/selector/region/snapshot types.
+3. Scheduled execution remains an ordinary proactive agent run.
+4. Lessons are data, never authority: they cannot change job prompt, schedule, budgets, model route, tool catalog, risk tiers, approvals, recipients, paths, commands or destinations.
+5. Effective lessons use a trusted harness wrapper around bounded **untrusted payload**.
+6. A non-empty lesson set establishes taint before sensitive-memory selection, first provider call and first tool-policy decision.
+7. Lessons never enter global memory, workspace memory, conversation history or FTS.
+8. Evaluation/reflection use fresh contexts with no tools, workspace memory, session history, approval capability or provider replay state.
+9. Evaluator input is blind to lesson text/IDs, active/candidate digest, trial condition, prior scores, promotion state and expected improvement.
+10. Deterministic eligibility runs before learning LLM spend.
+11. Feedback cannot activate lessons or expand authority.
+12. One stable pointer + at most one trial; no stacking.
+13. Positive eligible evidence is required for promotion. Silence, evaluator failure and ineligible runs are not positive evidence.
+14. Database claims/effects are idempotent; external LLM inference is never claimed exactly-once.
+15. Derived learning data follows source provenance through export, retention, deletion and purge.
 
-1. **One task-attempt identity.** `runs.id` / `run_id` is canonical. Learning adds immutable bindings and receipts; it does not create a parallel attempt entity.
-2. **Generic core.** The core contains no page, HTML, selector, region, DOM, or page-snapshot types. Page-change behavior lives behind an adapter.
-3. **Ordinary execution path.** Scheduled tasks still enter the existing session lane and `TurnRunner`/`AgentRuntime` path with existing proactive budgets, policy, tools, approvals, taint, and delivery semantics.
-4. **Lessons are data, not authority.** Lessons may influence task strategy only. They cannot modify prompt ownership, schedule, budgets, model route, tool catalog, risk tiers, approvals, recipients, paths, commands, destinations, or policy.
-5. **Initial taint.** A non-empty effective lesson set marks the run tainted before sensitive-memory selection, the first provider call, and the first tool-policy decision. This is conservative: learned text is durable model-generated/untrusted payload.
-6. **Fresh learning contexts.** Evaluation and reflection receive no tools, workspace memory, session history, approval capability, or provider replay state.
-7. **Blind evaluation.** Evaluators never see lesson text/IDs, stable/candidate digests, trial condition, prior scores, promotion state, or expected improvement.
-8. **Deterministic eligibility first.** No evaluation/reflection LLM spend occurs before technical eligibility classification.
-9. **Owner feedback is evidence, not activation.** Feedback cannot update the stable pointer or expand authority.
-10. **Single bounded trial.** One stable pointer, at most one trial override, no stacking.
-11. **Positive evidence required.** Silence, missing feedback, evaluator failure, interrupted learning operations, and ineligible runs never count as positive trial evidence.
-12. **No exactly-once LLM claim.** Database effects are idempotent; external inference is not. Ambiguous crash windows become `interrupted_unknown` and are not blindly replayed.
-13. **Derived-data lifecycle follows source provenance.** Export, retention, purge, and deletion cover learning derivatives. Removing source private data must not leave an active lesson encoding that fact.
+## 3. Existing-seam map
 
-## 3. Existing seam map
+### Scheduler / fire
 
-M1 extends existing seams rather than introducing a second scheduler/runtime.
+`ScheduledJobStore.claimAndFire` already fuses occurrence compare-and-advance with session/trigger creation, `PENDING` run creation and audit. `fireNow` reuses the same insert set without schedule advance; the overlap guard prevents a second live run on the job session.
 
-### 3.1 Scheduler and fire transaction
+**Extension:** the same successful fire transaction writes one immutable `learning_run_binding` keyed by `run_id`: `job_id`, logical occurrence, fire kind, job-definition digest, execution-surface/schema version, effective lesson-set ID/digest, stable base digest and optional trial ID/generation. It resolves trial expiry before selection and consumes one trial assignment only after the existing overlap guard permits run creation. Misfire, overlap skip and CAS loser consume none.
 
-Current `ScheduledJobStore.claimAndFire` already performs the occurrence compare-and-advance and then creates the session trigger, `PENDING` run, and audit in one database write. `fireNow` reuses the same fused insert set without advancing the schedule. The existing overlap guard prevents a second live run on the job session.
+### Run persistence
 
-**M1 extension:** the same successful fire transaction must additionally persist a `learning_run_binding` keyed by `run_id` containing:
+`RunStore` owns pickup, completion/degradation, cancellation/supersession, approval suspension/resume and boot reconciliation. Completed turns already fuse assistant output, `DONE`, usage and outbox.
 
-- `job_id`;
-- logical `occurrence_at`;
-- `fire_kind` (`scheduled`, `run_now`, later other explicit kinds);
-- immutable `job_definition_digest`;
-- `execution_surface_version` / digest;
-- effective `lesson_set_id` and `lesson_set_digest` (empty-set digest allowed);
-- trial identity/generation when the run consumed a trial assignment;
-- schema version and creation timestamp.
+**Extension:** every legal terminal transition (`DONE`, `FAILED`, `CANCELLED`, `SUPERSEDED`, including reconciliation) writes exactly one immutable `learning_terminal_receipt` in the same SQLite transaction as the state change. A settlement worker later seals evidence or a technical exclusion. A normal `DONE` may seal immediately only when all required facts are already settled; cancellation/supersession and ambiguous late-write paths may not assume this.
 
-The transaction resolves trial expiry first, then uses the existing occurrence/overlap guard, creates `run_id`, pins stable-or-trial lessons, and consumes a trial assignment. A CAS loser, misfire skip, or overlap skip creates no run and consumes no trial assignment.
+### Context / taint
 
-### 3.2 Run persistence and terminal commits
+`TurnRunner` loads a bounded snapshot, budgets and `ContextBuilder` output before calling `AgentRuntime.runTurn` with taint/private-data state.
 
-Current `RunStore` owns `PENDING → RUNNING` pickup, completed/degraded commits, cancellation/supersession, approval suspension/resume, and boot reconciliation. `commitAssistantTurn` already fuses assistant output, `DONE`, provider usage, and outbox; degradation paths fuse failure state and delivery.
+**Extension:** effective lessons are a separate job-scoped context section. The wrapper is harness-controlled; lesson text is bounded untrusted data. Non-empty lessons set initial taint before memory selection, so high-sensitivity memory and tool/exfil policy see the conservative state from the beginning.
 
-**M1 extension:** every legal transition into a terminal run state (`DONE`, `FAILED`, `CANCELLED`, `SUPERSEDED`, including boot reconciliation) writes exactly one immutable `learning_terminal_receipt` in the same transaction as the state transition. The receipt is intentionally small and settlement-independent. It proves what terminal state won and when.
+### Policy / approvals
 
-A later evidence sealer reads the terminal receipt plus settled run-linked facts and writes one immutable bounded evidence projection or one technical exclusion. A normal `DONE` path may seal evidence in the terminal transaction when all required facts are already complete; cancellation/supersession and ambiguous approval/late-usage paths must not assume settlement.
+Existing canonical-argument, policy-version, owner-binding and approval gates remain authoritative. Candidate text validation is defense in depth only. Lesson text never becomes a policy operand and cannot bypass or weaken approval, exfiltration, SSRF or proactive-budget policy.
 
-### 3.3 Context building and taint
+### Usage / budget
 
-Current `TurnRunner` loads a bounded context snapshot, obtains global and proactive spend totals, then calls `ContextBuilder.assemble`. `AgentRuntime.runTurn` receives session taint/private-data state before any tool work.
+`UsageStore` already supports run-linked and runless usage and global/proactive totals.
 
-**M1 extension:** effective lessons are a distinct context section with a trusted harness wrapper and bounded **untrusted payload**. They are job-scoped and never stored in session messages, global memory, workspace memory, or FTS. If the effective lesson set is non-empty, the run starts tainted before context memory selection. The lesson section is included only for `RunOrigin.scheduled` executions with a valid run binding.
+**Extension:** evaluation/reflection are durable **runless learning operations**, not fake agent runs. Their usage counts toward global and proactive/learning budgets. Owner delivery never waits for learning calls.
 
-### 3.4 Policy and approvals
+### Telegram feedback
 
-Current policy/approval boundaries bind consequential actions to canonical arguments, policy version, owner identity, and durable approval state. These remain authoritative.
+The existing approval callback path demonstrates the reusable security pattern: atomically claim update, numeric-ID allowlist, strict namespace parse, random nonce lookup, exact owner binding, CAS and redacted audit.
 
-**M1 extension:** lessons cannot supply policy operands. Any lesson text that appears to request a new tool, destination, recipient, path, command, permission, approval bypass, model route, schedule, or budget is inert text and is also rejected by candidate admission as defense in depth. Existing code policy remains the security boundary.
+**Extension:** learning feedback uses its own `fb:` namespace, feedback target/event domain and callback handler. It does not reuse tool-approval rows or suspend a run. Native reactions and reply-based corrections may later adapt into the same event type.
 
-### 3.5 Usage and budgets
-
-Current `UsageStore` supports run-linked and runless provider usage; proactive totals are derived from scheduled/heartbeat run origins.
-
-**M1 extension:** learning calls are **runless learning operations**, not fake agent runs. Each operation records its own durable operation ID and usage references. Its provider usage contributes to:
-
-- the existing global daily budget; and
-- the proactive/learning budget pool defined for scheduled work.
-
-Owner delivery never waits for evaluator or reflector calls. A budget stop skips learning spend; it never delays or changes the already-completed task result.
-
-### 3.6 Telegram owner-feedback binding
-
-Current approval callbacks already demonstrate the required fail-closed pattern: claim Telegram update, numeric-ID allowlist, strict namespace parsing, random nonce lookup, exact owner binding, CAS, audit.
-
-**M1 extension:** feedback uses a separate `fb:` callback namespace and separate learning-feedback tables. It does **not** reuse tool `approvals`, `AWAITING_APPROVAL`, or approval suspension. A feedback target is durable and binds a random one-time callback nonce to owner ID plus exact subject type/id/digest. Native reactions or reply-based correction may later adapt into the same event model.
-
-## 4. Generic architecture
+## 4. Architecture
 
 ```text
 SchedulerService
-  │
-  ├─ fire transaction
-  │    ├─ resolve stable/trial lesson digest
-  │    ├─ create ordinary run_id
-  │    ├─ pin occurrence + job/execution digests
-  │    └─ consume trial assignment if applicable
-  │
-  └─ TurnEnqueuer → TurnRunner → AgentRuntime → existing policy/tools/outbox
-                                │
-                                └─ terminal run transaction
-                                     └─ immutable terminal receipt
+  └─ fire transaction
+       ├─ resolve stable/trial lessons
+       ├─ create ordinary run_id
+       ├─ pin occurrence + digests
+       └─ consume trial assignment (if any)
+             │
+             v
+TurnEnqueuer → TurnRunner → AgentRuntime → existing policy/tools/outbox
+             │
+             └─ terminal transaction → terminal receipt
 
-LearningCoordinator (post-delivery, asynchronous)
-  ├─ EvidenceSealer
-  │    └─ terminal receipt + settled safe facts → sealed evidence | exclusion
+LearningCoordinator (async; never blocks owner delivery)
+  ├─ EvidenceSealer → sealed evidence | technical exclusion
   ├─ EligibilityClassifier (deterministic)
-  ├─ Evaluator (fresh context, no tools, blind)
-  ├─ FeedbackStore / fb: callback adapter
-  ├─ Reflector (fresh context, no tools)
-  ├─ CandidateAdmissionPolicy (deterministic validation)
-  └─ TrialController
-       ├─ admit one bounded trial
-       ├─ collect eligible evidence
-       ├─ promote via stable-pointer CAS
-       └─ close/fallback without touching stable pointer
+  ├─ Evaluator (fresh, tool-free, blind)
+  ├─ FeedbackStore + fb: Telegram adapter
+  ├─ Reflector (fresh, tool-free)
+  ├─ CandidateAdmissionPolicy (deterministic)
+  └─ TrialController → trial → promote CAS | fallback
 
-Optional LearningEvaluatorAdapter
-  └─ page-change adapter first: frozen inputs + deterministic scorer + fixtures
+LearningEvaluatorAdapter (optional)
+  └─ page-change first: frozen inputs + deterministic scorer + fixtures
 ```
 
-The generic learning layer belongs conceptually beside scheduling/persistence, not inside `AgentRuntime`. `AgentRuntime` consumes a pinned lesson payload and reports ordinary run facts; it does not decide evaluation, reflection, trial, or promotion.
+The learning subsystem sits beside scheduler/persistence. `AgentRuntime` only consumes a pinned lesson payload and produces ordinary run facts; it does not own evaluation, reflection, trial or promotion.
 
 ## 5. Generic data model
 
-Names are conceptual M1 contracts; migrations and exact Swift names are implementation work.
+Conceptual names are contracts, not M1 migrations.
 
-### 5.1 `learning_job_state`
+- **`learning_job_state`** — `job_id` PK, stable lesson-set ID/digest, nullable open trial ID, monotonic generation, timestamps. The stable pointer is the only production activation pointer.
+- **`learning_lesson_sets`** — immutable complete replacement sets: job, digest, bounded ordered payload, base digest, source reflection/owner edit, schema version, timestamps. No in-place edit.
+- **`learning_run_bindings`** — one per created scheduled `run_id`: job/occurrence/fire-kind, job-definition digest, execution-surface/schema versions, effective lesson-set ID/digest, stable base digest, optional trial/generation.
+- **`learning_terminal_receipts`** — one immutable row per terminal scheduled run: run ID, winning terminal state/classification facts, timestamp, schema version/digest.
+- **`learning_evidence`** — one terminal result per binding: sealed projection or typed technical exclusion. Projection includes run/job/occurrence bindings, digests, terminal classification, bounded final output or digest, bounded tool facts (name/status/policy decision/result size/trust flags), actual model route, primary-run usage references, versions, optional adapter facts, evidence digest/timestamps. It excludes raw tool args, secrets, private raw observations, provider replay state and audit projections.
+- **`learning_operations`** — durable evaluation/reflection operation ID, kind, source evidence, phase/status, model route, schema version, attempts, usage/cost refs, timestamps. Status includes `interrupted_unknown`.
+- **`learning_evaluations`** — immutable evidence binding, rubric/adapter versions, closed result (`no_issue | reusable_issue | transient_issue | uncertain`), bounded findings/reasons, digest/timestamp.
+- **`learning_feedback_targets`** — random one-time nonce, authenticated owner ID, exact subject type/id/digest, expiry/consumed state.
+- **`learning_feedback_events`** — append-only owner ID, job/run/output identity, optional evaluation/candidate identity, typed signal, bounded payload, Telegram update ID or nonce, timestamp, optional superseded-event link.
+- **`learning_trials`** — job, base/candidate digests, generation, state, assignment deadline, max/consumed assignments, admission evidence, timestamps. Unique open trial per job.
+- **`learning_decision_receipts`** — immutable promotion/fallback/reject decision, base/candidate/trial, considered evidence/feedback, evidence-strength label, policy/version inputs, CAS generations, digest/timestamp.
+- **`deterministic_verification_receipts`** (adapter-only) — adapter/version, frozen dataset/oracle, execution surface, subject digests, deterministic result, receipt digest.
 
-One row per scheduled job:
+Feedback signals are: `result_useful`, `result_not_useful`, `result_correction`, `evaluation_confirm`, `evaluation_dispute`, `candidate_approve`, `candidate_reject`, `candidate_edit`. Candidate edit creates a new immutable digest and invalidates old approvals/support.
 
-- `job_id` PK/FK;
-- `stable_lesson_set_id`, `stable_digest`;
-- `trial_id` nullable;
-- `generation` monotonic CAS generation;
-- timestamps.
+## 6. Lifecycle diagrams
 
-The stable pointer is the only production activation pointer.
-
-### 5.2 `learning_lesson_sets`
-
-Immutable complete replacement sets:
-
-- `id`, `job_id`, `digest` UNIQUE;
-- bounded ordered lesson payload;
-- `base_digest` nullable for initial empty set;
-- `created_by` (`reflection`, `owner_edit`, migration/import if ever supported);
-- source reflection/feedback IDs;
-- schema version, timestamps.
-
-No in-place edit. Owner edit creates a new set/digest.
-
-### 5.3 `learning_run_bindings`
-
-Exactly one per created scheduled `run_id`:
-
-- run/job/occurrence/fire-kind binding;
-- job-definition digest;
-- execution-surface/schema versions;
-- effective lesson-set id/digest;
-- stable base digest;
-- optional trial id/generation;
-- created timestamp.
-
-This is not an attempt entity; `run_id` remains canonical.
-
-### 5.4 `learning_terminal_receipts`
-
-Exactly one immutable row per terminal scheduled run:
-
-- `run_id` PK;
-- terminal `RunState` and terminal classification facts available at commit time;
-- terminal timestamp;
-- receipt schema version/digest.
-
-### 5.5 `learning_evidence`
-
-Exactly one terminal outcome per binding: `sealed` or `excluded`.
-
-A sealed projection contains only evaluator-relevant bounded facts:
-
-- run/job/occurrence bindings and digests;
-- terminal classification;
-- final output or bounded output/digest according to retention policy;
-- tool facts: tool name, status, policy decision, result size, trust/taint flags — **not raw arguments or raw private observations**;
-- actual model route and primary-run usage references;
-- execution-surface/schema versions;
-- optional adapter facts;
-- evidence digest and timestamps.
-
-Exclusions carry a typed technical reason. Evidence excludes secrets, provider replay state, audit-log projections, raw tool args, and private raw observations.
-
-### 5.6 `learning_operations`
-
-Durable evaluator/reflector operation record:
-
-- operation ID and kind (`evaluation`, `reflection`);
-- job ID and source evidence IDs/digests;
-- phase/status (`pending`, `in_flight`, `succeeded`, `failed`, `interrupted_unknown`);
-- model route, prompt/schema version;
-- attempts, usage/cost references;
-- created/started/finished timestamps.
-
-A crash after request dispatch but before durable response commit resolves to `interrupted_unknown`; the same logical synthesis is not automatically replayed.
-
-### 5.7 `learning_evaluations`
-
-Immutable structured evaluator result:
-
-- evaluation ID;
-- evidence ID/digest;
-- rubric/adapter versions;
-- closed result: `no_issue | reusable_issue | transient_issue | uncertain`;
-- bounded structured findings/reasons;
-- evidence-strength classification (`heuristic` unless a deterministic adapter receipt is separately attached);
-- timestamp/digest.
-
-### 5.8 `learning_feedback_targets` and `learning_feedback_events`
-
-Target:
-
-- random one-time callback nonce;
-- owner user ID;
-- job ID;
-- exact subject type/id/digest;
-- expiry/consumed state.
-
-Append-only event:
-
-- owner user ID;
-- job and run/output identity where relevant;
-- optional evaluation/candidate identity;
-- typed signal;
-- bounded payload;
-- Telegram update ID or callback nonce;
-- created timestamp;
-- optional `supersedes_event_id`.
-
-Signals: `result_useful`, `result_not_useful`, `result_correction`, `evaluation_confirm`, `evaluation_dispute`, `candidate_approve`, `candidate_reject`, `candidate_edit`.
-
-### 5.9 `learning_trials`
-
-- trial ID, job ID;
-- base stable digest + candidate digest;
-- generation;
-- state (`open`, `promoted`, `fallen_back`, `rejected`, `expired`, `exhausted`, `invalidated`);
-- assignment deadline;
-- maximum assignments and consumed assignments;
-- admission reason/evidence IDs;
-- timestamps.
-
-At most one open trial per job.
-
-### 5.10 `learning_decision_receipts`
-
-Immutable promotion/fallback/rejection receipts:
-
-- job/trial/base/candidate digests;
-- evidence IDs and feedback overlays considered;
-- decision + evidence-strength label;
-- policy/version inputs;
-- CAS generation before/after where applicable;
-- timestamp/digest.
-
-Audit rows may reference these receipts, but audit is observability, not provenance.
-
-### 5.11 Optional `deterministic_verification_receipts`
-
-Issued only by an adapter with a deterministic oracle:
-
-- adapter ID/version;
-- named frozen dataset/oracle version;
-- execution-surface version;
-- candidate/base/evidence digests;
-- deterministic score/result;
-- receipt digest.
-
-A rubric, route, policy, adapter, dataset, oracle, or execution-surface incompatibility requires revalidation or downgrade to heuristic use.
-
-## 6. Lifecycle state diagrams
-
-### 6.1 Evidence and synthesis
+### Evidence → candidate
 
 ```text
-created scheduled run
-      │
-      v
-terminal receipt
-      │
-      v
-settlement pending ──technical impossibility──> evidence EXCLUDED
-      │
-      v
-sealed evidence
-      │
-      v
-deterministic eligibility classifier
-   ┌──┴─────────────────────────────────────────────┐
-   │ eligible                                      │ ineligible
-   v                                               v
-evaluation op                                  stop (retain evidence)
+created run
+  → terminal receipt
+  → settlement
+      ├─ impossible/incomplete → technical exclusion
+      └─ sealed evidence
+           → deterministic eligibility
+              ├─ ineligible → retain; no LLM learning call
+              └─ eligible → evaluation operation
+                   ├─ failed/interrupted_unknown → stop
+                   └─ saved evaluation
+                        → reflection operation (when policy permits)
+                           ├─ failed/interrupted_unknown → stop
+                           └─ immutable replacement candidate
+                                → admission validation
+                                   ├─ veto/reject → inert history
+                                   └─ trial admission gate
+```
+
+### Candidate / trial / activation
+
+```text
+candidate
    │
-   ├─ fail/interrupted_unknown ─────────────────> stop
-   v
-saved evaluation
+   ├─ insufficient support ───────────────> inert candidate
    │
-   ├─ no reflection support yet ────────────────> stop
-   v
-reflection op
-   │
-   ├─ fail/interrupted_unknown ─────────────────> stop
-   v
-immutable candidate
-   │
-   v
-admission validation
-   │
-   ├─ reject/veto ──────────────────────────────> superseded/rejected
+   └─ admitted
+        v
+      TRIAL (base stable pointer untouched)
+        │
+        ├─ expiry / assignment exhaustion
+        ├─ hard security/deterministic veto
+        ├─ regression / critical failure
+        ├─ owner reject/dispute
+        └─ insufficient positive eligible evidence
+              └───────────────────────────> FALLBACK / close trial
+        │
+        └─ acceptance policy satisfied
+              → decision receipt
+              → CAS stable(base → candidate)
+                   ├─ CAS lost → close stale trial
+                   └─ CAS won  → ACTIVE; close trial
+```
+
+Lifecycle and evidence strength are orthogonal:
+
+```text
+lifecycle: candidate | trial | active | rolled_back | superseded
+evidence:  heuristic | owner_supported | owner_confirmed | deterministically_verified
+```
+
+An active lesson may still be heuristic. `deterministically_verified` is never produced by an LLM evaluator.
+
+## 7. Evidence sealing and eligibility
+
+### Terminal receipt
+
+The terminal receipt is deliberately smaller than evaluation evidence so it can be committed on every terminal path without depending on late writes. Its transaction shares the run-state transition; duplicate terminal handling is `INSERT OR IGNORE`/unique-by-run and must agree with the winning terminal state.
+
+### Post-settlement sealing
+
+The sealer is idempotent by `run_id` + evidence schema version. It waits until required run-linked usage and approval observations are settled. It then writes either:
+
+- `sealed` evidence with an immutable digest; or
+- `excluded(reason)` when a safe/complete projection cannot be formed.
+
+Sealing never reads the ordinary audit log as provenance.
+
+### Initial eligibility taxonomy
+
+The deterministic classifier must distinguish at least:
+
+- `eligible_task_evidence`;
+- `transient_infrastructure_failure`;
+- `policy_or_security_block`;
+- `owner_interruption`;
+- `insufficient_evidence`;
+- `unsupported_terminal_state`.
+
+Provider/storage/credential/budget failures do not create behavioral lessons. Cancellation, supersession and security-policy blocks never enter reflection. A one-shot job may retain evidence/evaluation/feedback, but cannot exercise a trial without another occurrence.
+
+## 8. Evaluator and reflector contracts
+
+### Evaluator
+
+Model-visible input is exactly: frozen job prompt, frozen quality rubric, final output, safe bounded evidence projection, and optional adapter facts. It excludes lessons, lesson IDs/digests, candidate/stable digest, trial assignment, prior score, promotion state and expected improvement.
+
+The evaluator has no tools and returns a closed schema: `no_issue`, `reusable_issue`, `transient_issue`, or `uncertain`, plus bounded structured findings. This is heuristic evidence, not semantic proof.
+
+### Reflector
+
+Reflection is a distinct operation/call. It may receive compatible saved evaluations, compatible multi-run evidence and the current lesson set. It produces **one complete immutable replacement set**, never an imperative control-plane mutation. Evaluation failure cannot start reflection; reflection failure cannot create a candidate.
+
+Compatibility requires matching or explicitly compatible job-definition semantics, evidence schema, execution surface, rubric and adapter version. Incompatible evidence is retained but not silently pooled.
+
+## 9. Candidate admission and authority firewall
+
+Before persistence/trial, deterministic validation checks:
+
+- closed schema and canonical encoding;
+- lesson count and per-item/total size limits;
+- Unicode normalization and invisible/bidi handling;
+- secret/exact-loaded-secret leakage;
+- forbidden authority operands: schedule, recipient/chat, model route, budgets, tool/risk/approval configuration, paths, commands, destinations, credentials;
+- job binding and incumbent/base digest;
+- source operation/evidence integrity.
+
+Text classification/pattern checks are defense in depth only. The actual security boundary is the data/control-plane split plus existing policy gates. A candidate that says “ignore approvals” is both rejected by admission and powerless if it reached runtime.
+
+Lessons may describe strategy at the semantic task level (for example, “compare the stable article body before alerting”), but may not encode executable destinations/commands or grant new capabilities.
+
+## 10. Owner feedback semantics
+
+Feedback capture transaction:
+
+1. atomically claim the external Telegram update/nonce;
+2. enforce numeric-ID allowlist;
+3. parse only the `fb:` namespace;
+4. load target by random nonce;
+5. verify exact owner and subject digest;
+6. append immutable feedback event;
+7. mark one-time target consumed where applicable;
+8. append a redacted audit event in the same write.
+
+Semantics:
+
+- useful/not useful: supporting/contradicting sentiment for one delivered result;
+- result correction: owner-attested expected behavior for that occurrence; may seed one-run trial support;
+- evaluation confirm/dispute: overlay on exact evaluation; dispute blocks dependent promotion;
+- candidate approve: permits owner-supported trial through the common admission gate, never direct activation;
+- candidate reject: vetoes/stops exact candidate/trial;
+- candidate edit: creates a new candidate/digest, invalidates prior approvals, reruns every gate.
+
+Owner statements establish owner intent

--- a/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
+++ b/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
@@ -1,208 +1,138 @@
-# RFC: Architecture and security boundaries for self-improving scheduled tasks
+# RFC: Self-improving scheduled tasks — architecture and security boundaries
 
 | | |
 |---|---|
-| **Status** | Proposed — M1 / Issue #167 |
-| **Date** | 2026-08-28 |
-| **Parent** | #115 |
-| **Evidence baseline** | #118, frozen Protocol 0.6 |
-| **Production scope** | Generic job-scoped learning for every scheduled task swift-claw can execute |
-| **First deterministic adapter / benchmark** | Scheduled page-change monitoring |
+| Status | Proposed — M1 / #167 |
+| Date | 2026-08-28 |
+| Parent | #115 |
+| Evidence baseline | #118, frozen Protocol 0.6 |
+| Production scope | Generic job-scoped learning for every executable scheduled task |
+| First deterministic adapter | Scheduled page-change monitoring |
 
 ## 1. Decision
 
-Every created scheduled run participates in one generic job-scoped learning control plane. Existing `run_id` remains the only task-attempt identity. The fire transaction binds that run to its exact logical occurrence, fire kind, job-definition digest, execution-surface version and effective lesson-set digest. The task then executes through the ordinary proactive `TurnRunner` / `AgentRuntime` path with existing tools, policy, approvals, budgets and delivery.
+Every created scheduled run uses one generic job-scoped learning control plane. Existing `run_id` remains the only task-attempt identity. The fire transaction binds it to the exact occurrence, fire kind, job-definition digest, execution surface and effective lesson-set digest; execution remains the ordinary proactive `TurnRunner`/`AgentRuntime` path with existing tools, policy, approvals, budgets and delivery.
 
-After terminal execution, the system records an immutable terminal receipt and seals a bounded evidence projection after late usage/approval observations settle. A deterministic eligibility classifier runs before any learning LLM call. Eligible evidence may enter a fresh, tool-free, procedurally blind evaluator; reflection is a separate fresh tool-free call. Reflection may propose only an immutable complete replacement lesson set.
+Every terminal transition writes an immutable terminal receipt. After late usage/approval observations settle, an idempotent worker seals a bounded evidence projection or a technical exclusion. A deterministic eligibility classifier runs before any learning LLM call. Eligible evidence may enter a fresh, tool-free, procedurally blind evaluator. Reflection is a separate fresh, tool-free call and may only propose an immutable complete replacement lesson set.
 
-Owner feedback is durable, authenticated, typed, append-only and bound to an exact subject/digest. Feedback is evidence: it never directly changes the stable lesson pointer or expands task authority.
+Owner feedback is durable, authenticated, typed, append-only and bound to an exact subject/digest. It is evidence, never direct activation.
 
-Each job has one stable lesson-set pointer and at most one bounded trial override. Trials cannot stack. A created run consumes a trial assignment atomically; skips and CAS losers consume none. Promotion compare-and-swaps the stable pointer from the recorded base digest to the candidate digest. Fallback closes the trial and leaves the stable pointer untouched.
+Each job has one stable lesson-set pointer and at most one bounded trial override. Trials cannot stack. Only a created run consumes an assignment. Promotion CASes the stable pointer from the recorded base digest to the candidate digest; fallback closes the trial and leaves stable untouched.
 
-**Capability guarantee:** if swift-claw can execute a scheduled job, this architecture can capture attempts, classify learning eligibility, accept owner feedback, evaluate eligible evidence, derive job-scoped lesson candidates, trial them on future occurrences, and promote or fall back without expanding the job's authority.
+**Capability guarantee:** any scheduled task swift-claw can execute can participate in capture → eligibility → evaluation → feedback → reflection → candidate → bounded trial → promote/fallback. This is not a guarantee that subjective tasks are objectively verifiable or will improve. Natural runs/LLM evaluation are heuristic; owner feedback establishes owner intent; only a deterministic adapter over a named frozen oracle/dataset may issue scoped `deterministically_verified` evidence.
 
-This does **not** guarantee objective verification or improvement for every task. Natural runs and LLM evaluation are observational/heuristic. Owner feedback establishes owner intent for its bound subject. Only a deterministic adapter over a named frozen dataset/oracle may issue scoped `deterministically_verified` evidence.
+No unresolved P0 architecture/security blocker remains. Exact policy parameters are deferred to M2 (§14).
 
-No unresolved P0 architecture or security blocker remains. Exact policy parameters are deferred to M2 (§15).
+## 2. Invariants
 
-## 2. Non-negotiable boundaries
-
-1. `runs.id` / `run_id` is canonical; no second attempt entity.
+1. `run_id` is canonical; no parallel attempt entity.
 2. Generic core contains no page/HTML/selector/region/snapshot types.
 3. Scheduled execution remains an ordinary proactive agent run.
-4. Lessons are data, never authority: they cannot change job prompt, schedule, budgets, model route, tool catalog, risk tiers, approvals, recipients, paths, commands or destinations.
-5. Effective lessons use a trusted harness wrapper around bounded **untrusted payload**.
-6. A non-empty lesson set establishes taint before sensitive-memory selection, first provider call and first tool-policy decision.
-7. Lessons never enter global memory, workspace memory, conversation history or FTS.
-8. Evaluation/reflection use fresh contexts with no tools, workspace memory, session history, approval capability or provider replay state.
-9. Evaluator input is blind to lesson text/IDs, active/candidate digest, trial condition, prior scores, promotion state and expected improvement.
-10. Deterministic eligibility runs before learning LLM spend.
-11. Feedback cannot activate lessons or expand authority.
-12. One stable pointer + at most one trial; no stacking.
-13. Positive eligible evidence is required for promotion. Silence, evaluator failure and ineligible runs are not positive evidence.
-14. Database claims/effects are idempotent; external LLM inference is never claimed exactly-once.
-15. Derived learning data follows source provenance through export, retention, deletion and purge.
+4. Lessons are data, never authority. They cannot change job prompt, schedule, budgets, model route, tool catalog/risk, approvals, recipients, paths, commands or destinations.
+5. Lessons use a trusted harness wrapper around bounded untrusted payload and never enter global/workspace memory, conversation history or FTS.
+6. Non-empty lessons establish taint before sensitive-memory selection, first provider call and first tool-policy decision.
+7. Evaluation/reflection get fresh contexts with no tools, workspace memory, session history, approvals or provider replay state.
+8. Evaluator is blind to lesson text/IDs, stable/candidate digests, trial condition, prior scores, promotion state and expected improvement.
+9. Deterministic eligibility precedes learning LLM spend.
+10. Feedback cannot activate lessons or expand authority.
+11. One stable pointer + at most one trial; no stacking.
+12. Promotion needs positive eligible evidence. Silence, evaluator failure and ineligible runs never count positive.
+13. DB claims/effects are idempotent; external LLM inference is not exactly-once.
+14. Export/retention/purge cover derived learning data; deleting private source data cannot leave an active lesson encoding it.
 
 ## 3. Existing-seam map
 
-### Scheduler / fire
+**Scheduler/fire.** `ScheduledJobStore.claimAndFire` already fuses occurrence compare-and-advance with session/trigger creation, `PENDING` run and audit; `fireNow` reuses the insert set without schedule advance; overlap prevents a second live job-session run. Extend the successful fire transaction with `learning_run_binding(run_id, job_id, occurrence, fire_kind, job_definition_digest, execution_surface_version, effective_lesson_set_id/digest, stable_base_digest, trial_id/generation?)`. Resolve trial expiry first; consume one assignment only after overlap passes and `run_id` is created. Misfire, overlap skip and CAS loser consume none.
 
-`ScheduledJobStore.claimAndFire` already fuses occurrence compare-and-advance with session/trigger creation, `PENDING` run creation and audit. `fireNow` reuses the same insert set without schedule advance; the overlap guard prevents a second live run on the job session.
+**Run persistence.** `RunStore` owns pickup, completion/degradation, cancel/supersede, approval suspension/resume and boot reconciliation. Extend every legal terminal transition (`DONE/FAILED/CANCELLED/SUPERSEDED`, including boot reconciliation) to write one `learning_terminal_receipt` in the same SQLite transaction. Seal evidence later unless a normal `DONE` transaction already has all settled facts.
 
-**Extension:** the same successful fire transaction writes one immutable `learning_run_binding` keyed by `run_id`: `job_id`, logical occurrence, fire kind, job-definition digest, execution-surface/schema version, effective lesson-set ID/digest, stable base digest and optional trial ID/generation. It resolves trial expiry before selection and consumes one trial assignment only after the existing overlap guard permits run creation. Misfire, overlap skip and CAS loser consume none.
+**Context/taint.** `TurnRunner` loads bounded context/budgets and calls `AgentRuntime` with taint/private-data state. Add a job-scoped lesson section whose wrapper is trusted but payload untrusted. Non-empty lessons set initial taint before context memory selection.
 
-### Run persistence
+**Policy/approvals.** Existing canonical-args, policy-version, owner and approval gates stay authoritative. Candidate text scanning is defense in depth. Lessons never become policy operands and cannot weaken approval, exfiltration, SSRF or proactive-budget policy.
 
-`RunStore` owns pickup, completion/degradation, cancellation/supersession, approval suspension/resume and boot reconciliation. Completed turns already fuse assistant output, `DONE`, usage and outbox.
+**Usage/budgets.** Learning calls are durable runless operations, not fake agent runs. Their provider usage counts toward global and proactive/learning budgets. Owner delivery never waits for learning calls.
 
-**Extension:** every legal terminal transition (`DONE`, `FAILED`, `CANCELLED`, `SUPERSEDED`, including reconciliation) writes exactly one immutable `learning_terminal_receipt` in the same SQLite transaction as the state change. A settlement worker later seals evidence or a technical exclusion. A normal `DONE` may seal immediately only when all required facts are already settled; cancellation/supersession and ambiguous late-write paths may not assume this.
-
-### Context / taint
-
-`TurnRunner` loads a bounded snapshot, budgets and `ContextBuilder` output before calling `AgentRuntime.runTurn` with taint/private-data state.
-
-**Extension:** effective lessons are a separate job-scoped context section. The wrapper is harness-controlled; lesson text is bounded untrusted data. Non-empty lessons set initial taint before memory selection, so high-sensitivity memory and tool/exfil policy see the conservative state from the beginning.
-
-### Policy / approvals
-
-Existing canonical-argument, policy-version, owner-binding and approval gates remain authoritative. Candidate text validation is defense in depth only. Lesson text never becomes a policy operand and cannot bypass or weaken approval, exfiltration, SSRF or proactive-budget policy.
-
-### Usage / budget
-
-`UsageStore` already supports run-linked and runless usage and global/proactive totals.
-
-**Extension:** evaluation/reflection are durable **runless learning operations**, not fake agent runs. Their usage counts toward global and proactive/learning budgets. Owner delivery never waits for learning calls.
-
-### Telegram feedback
-
-The existing approval callback path demonstrates the reusable security pattern: atomically claim update, numeric-ID allowlist, strict namespace parse, random nonce lookup, exact owner binding, CAS and redacted audit.
-
-**Extension:** learning feedback uses its own `fb:` namespace, feedback target/event domain and callback handler. It does not reuse tool-approval rows or suspend a run. Native reactions and reply-based corrections may later adapt into the same event type.
+**Telegram feedback.** Reuse the security pattern of approval callbacks (claim update, numeric allowlist, strict namespace, random nonce, owner binding, CAS, redacted audit), but use separate `fb:` targets/events. Feedback never reuses tool approvals or `AWAITING_APPROVAL`.
 
 ## 4. Architecture
 
 ```text
 SchedulerService
-  └─ fire transaction
-       ├─ resolve stable/trial lessons
-       ├─ create ordinary run_id
-       ├─ pin occurrence + digests
-       └─ consume trial assignment (if any)
-             │
-             v
-TurnEnqueuer → TurnRunner → AgentRuntime → existing policy/tools/outbox
-             │
-             └─ terminal transaction → terminal receipt
+  → fire txn: resolve lessons → create ordinary run_id → pin digests → consume trial assignment
+  → TurnEnqueuer → TurnRunner → AgentRuntime → existing policy/tools/outbox
+                                      → terminal txn + terminal receipt
 
-LearningCoordinator (async; never blocks owner delivery)
-  ├─ EvidenceSealer → sealed evidence | technical exclusion
-  ├─ EligibilityClassifier (deterministic)
-  ├─ Evaluator (fresh, tool-free, blind)
-  ├─ FeedbackStore + fb: Telegram adapter
-  ├─ Reflector (fresh, tool-free)
-  ├─ CandidateAdmissionPolicy (deterministic)
-  └─ TrialController → trial → promote CAS | fallback
+LearningCoordinator (async, post-delivery)
+  → EvidenceSealer → sealed evidence | exclusion
+  → EligibilityClassifier (deterministic)
+  → Evaluator (fresh/tool-free/blind)
+  → durable owner feedback
+  → Reflector (fresh/tool-free)
+  → CandidateAdmissionPolicy
+  → TrialController → promote CAS | fallback
 
-LearningEvaluatorAdapter (optional)
-  └─ page-change first: frozen inputs + deterministic scorer + fixtures
+Optional LearningEvaluatorAdapter
+  → page-change first: frozen inputs + deterministic scorer + regression fixtures
 ```
 
-The learning subsystem sits beside scheduler/persistence. `AgentRuntime` only consumes a pinned lesson payload and produces ordinary run facts; it does not own evaluation, reflection, trial or promotion.
+Learning sits beside scheduler/persistence. `AgentRuntime` consumes pinned lessons and produces ordinary run facts; it does not own evaluation, reflection, trial or promotion.
 
 ## 5. Generic data model
 
-Conceptual names are contracts, not M1 migrations.
+Conceptual contracts; migrations/Swift names are implementation work.
 
-- **`learning_job_state`** — `job_id` PK, stable lesson-set ID/digest, nullable open trial ID, monotonic generation, timestamps. The stable pointer is the only production activation pointer.
-- **`learning_lesson_sets`** — immutable complete replacement sets: job, digest, bounded ordered payload, base digest, source reflection/owner edit, schema version, timestamps. No in-place edit.
-- **`learning_run_bindings`** — one per created scheduled `run_id`: job/occurrence/fire-kind, job-definition digest, execution-surface/schema versions, effective lesson-set ID/digest, stable base digest, optional trial/generation.
-- **`learning_terminal_receipts`** — one immutable row per terminal scheduled run: run ID, winning terminal state/classification facts, timestamp, schema version/digest.
-- **`learning_evidence`** — one terminal result per binding: sealed projection or typed technical exclusion. Projection includes run/job/occurrence bindings, digests, terminal classification, bounded final output or digest, bounded tool facts (name/status/policy decision/result size/trust flags), actual model route, primary-run usage references, versions, optional adapter facts, evidence digest/timestamps. It excludes raw tool args, secrets, private raw observations, provider replay state and audit projections.
-- **`learning_operations`** — durable evaluation/reflection operation ID, kind, source evidence, phase/status, model route, schema version, attempts, usage/cost refs, timestamps. Status includes `interrupted_unknown`.
-- **`learning_evaluations`** — immutable evidence binding, rubric/adapter versions, closed result (`no_issue | reusable_issue | transient_issue | uncertain`), bounded findings/reasons, digest/timestamp.
-- **`learning_feedback_targets`** — random one-time nonce, authenticated owner ID, exact subject type/id/digest, expiry/consumed state.
-- **`learning_feedback_events`** — append-only owner ID, job/run/output identity, optional evaluation/candidate identity, typed signal, bounded payload, Telegram update ID or nonce, timestamp, optional superseded-event link.
-- **`learning_trials`** — job, base/candidate digests, generation, state, assignment deadline, max/consumed assignments, admission evidence, timestamps. Unique open trial per job.
-- **`learning_decision_receipts`** — immutable promotion/fallback/reject decision, base/candidate/trial, considered evidence/feedback, evidence-strength label, policy/version inputs, CAS generations, digest/timestamp.
-- **`deterministic_verification_receipts`** (adapter-only) — adapter/version, frozen dataset/oracle, execution surface, subject digests, deterministic result, receipt digest.
+- `learning_job_state`: job PK, stable lesson ID/digest, nullable open trial ID, monotonic generation. Stable pointer is the only production activation pointer.
+- `learning_lesson_sets`: immutable complete replacement set, job/digest, bounded ordered payload, base digest, source reflection/owner edit, schema/timestamps. No in-place edit.
+- `learning_run_bindings`: one per created scheduled `run_id`; exact occurrence/fire kind and pinned job/execution/lesson/trial digests.
+- `learning_terminal_receipts`: one immutable row per terminal scheduled run; winning terminal state, timestamp, schema/digest.
+- `learning_evidence`: one `sealed` projection or typed `excluded` result per binding. Projection contains bindings/digests, terminal classification, bounded final output or digest, bounded tool facts (name/status/policy decision/result size/trust flags), actual model route, primary-run usage refs, versions and optional adapter facts. Excludes raw tool args, secrets, private raw observations, replay state and audit projections.
+- `learning_operations`: durable evaluation/reflection ID, kind, source evidence, phase/status, model route, schema, attempts, usage/cost refs, timestamps; includes `interrupted_unknown`.
+- `learning_evaluations`: immutable evidence/digest binding, rubric/adapter versions, result `no_issue | reusable_issue | transient_issue | uncertain`, bounded findings, digest/timestamp.
+- `learning_feedback_targets`: random one-time nonce, owner ID, exact subject type/id/digest, expiry/consumed state.
+- `learning_feedback_events`: append-only owner/job/run/output identity, optional evaluation/candidate, typed signal/payload, Telegram update ID or nonce, timestamp, optional superseded-event link.
+- `learning_trials`: job, base/candidate digests, generation, state, deadline, max/consumed assignments, admission evidence. Unique open trial per job.
+- `learning_decision_receipts`: immutable promotion/fallback/reject decision, trial/base/candidate, considered evidence/feedback, evidence-strength label, policy/version inputs, CAS generations, digest/timestamp.
+- `deterministic_verification_receipts` (adapter-only): adapter/version, frozen dataset/oracle, execution surface, subject digests, deterministic result/digest.
 
-Feedback signals are: `result_useful`, `result_not_useful`, `result_correction`, `evaluation_confirm`, `evaluation_dispute`, `candidate_approve`, `candidate_reject`, `candidate_edit`. Candidate edit creates a new immutable digest and invalidates old approvals/support.
+Feedback signals: `result_useful`, `result_not_useful`, `result_correction`, `evaluation_confirm`, `evaluation_dispute`, `candidate_approve`, `candidate_reject`, `candidate_edit`. Edit creates a new immutable digest and invalidates old approvals/support.
 
-## 6. Lifecycle diagrams
-
-### Evidence → candidate
+## 6. Lifecycles
 
 ```text
-created run
-  → terminal receipt
-  → settlement
-      ├─ impossible/incomplete → technical exclusion
-      └─ sealed evidence
-           → deterministic eligibility
-              ├─ ineligible → retain; no LLM learning call
-              └─ eligible → evaluation operation
-                   ├─ failed/interrupted_unknown → stop
-                   └─ saved evaluation
-                        → reflection operation (when policy permits)
-                           ├─ failed/interrupted_unknown → stop
-                           └─ immutable replacement candidate
-                                → admission validation
-                                   ├─ veto/reject → inert history
-                                   └─ trial admission gate
+created run → terminal receipt → settlement
+  ├─ cannot safely seal → technical exclusion
+  └─ sealed evidence → deterministic eligibility
+       ├─ ineligible → retain; no learning LLM
+       └─ eligible → evaluation
+            ├─ failed/interrupted_unknown → stop
+            └─ saved evaluation → reflection (when policy permits)
+                 ├─ failed/interrupted_unknown → stop
+                 └─ immutable candidate → admission validation → inert | trial
 ```
-
-### Candidate / trial / activation
 
 ```text
-candidate
-   │
-   ├─ insufficient support ───────────────> inert candidate
-   │
-   └─ admitted
-        v
-      TRIAL (base stable pointer untouched)
-        │
-        ├─ expiry / assignment exhaustion
-        ├─ hard security/deterministic veto
-        ├─ regression / critical failure
-        ├─ owner reject/dispute
-        └─ insufficient positive eligible evidence
-              └───────────────────────────> FALLBACK / close trial
-        │
-        └─ acceptance policy satisfied
-              → decision receipt
-              → CAS stable(base → candidate)
-                   ├─ CAS lost → close stale trial
-                   └─ CAS won  → ACTIVE; close trial
+candidate → admitted TRIAL (stable pointer untouched)
+  ├─ expiry / assignment exhaustion / security veto / regression / owner reject-dispute /
+  │  insufficient positive eligible evidence → close + FALLBACK
+  └─ acceptance satisfied → decision receipt → CAS stable(base→candidate)
+       ├─ CAS lost → close stale trial
+       └─ CAS won → ACTIVE; close trial
 ```
 
-Lifecycle and evidence strength are orthogonal:
+Lifecycle and evidence strength are independent:
 
 ```text
 lifecycle: candidate | trial | active | rolled_back | superseded
 evidence:  heuristic | owner_supported | owner_confirmed | deterministically_verified
 ```
 
-An active lesson may still be heuristic. `deterministically_verified` is never produced by an LLM evaluator.
+An active lesson may remain heuristic. LLM evaluation never produces `deterministically_verified`.
 
-## 7. Evidence sealing and eligibility
+## 7. Evidence and eligibility
 
-### Terminal receipt
+The terminal receipt is settlement-independent so every terminal path can commit it. The sealer is idempotent by run + evidence-schema version and waits for required usage/approval observations. It writes immutable sealed evidence or `excluded(reason)`; ordinary audit is observability, not provenance.
 
-The terminal receipt is deliberately smaller than evaluation evidence so it can be committed on every terminal path without depending on late writes. Its transaction shares the run-state transition; duplicate terminal handling is `INSERT OR IGNORE`/unique-by-run and must agree with the winning terminal state.
-
-### Post-settlement sealing
-
-The sealer is idempotent by `run_id` + evidence schema version. It waits until required run-linked usage and approval observations are settled. It then writes either:
-
-- `sealed` evidence with an immutable digest; or
-- `excluded(reason)` when a safe/complete projection cannot be formed.
-
-Sealing never reads the ordinary audit log as provenance.
-
-### Initial eligibility taxonomy
-
-The deterministic classifier must distinguish at least:
+Initial deterministic eligibility taxonomy:
 
 - `eligible_task_evidence`;
 - `transient_infrastructure_failure`;
@@ -211,58 +141,74 @@ The deterministic classifier must distinguish at least:
 - `insufficient_evidence`;
 - `unsupported_terminal_state`.
 
-Provider/storage/credential/budget failures do not create behavioral lessons. Cancellation, supersession and security-policy blocks never enter reflection. A one-shot job may retain evidence/evaluation/feedback, but cannot exercise a trial without another occurrence.
+Provider/storage/credential/budget failures do not produce behavioral lessons. Cancellation, supersession and security-policy blocks do not enter reflection. One-shot jobs can retain evidence/evaluation/feedback but cannot exercise a trial without another occurrence.
 
-## 8. Evaluator and reflector contracts
+## 8. Evaluator, reflector and candidate firewall
 
-### Evaluator
+Evaluator input is exactly the frozen job prompt, frozen quality rubric, final output, safe evidence projection and optional adapter facts. It has no tools and returns the closed result above plus bounded findings. This is heuristic evidence.
 
-Model-visible input is exactly: frozen job prompt, frozen quality rubric, final output, safe bounded evidence projection, and optional adapter facts. It excludes lessons, lesson IDs/digests, candidate/stable digest, trial assignment, prior score, promotion state and expected improvement.
+Reflection is a separate call receiving compatible saved evaluations/multi-run evidence plus current lesson set; it proposes one complete immutable replacement set. Evaluation failure cannot start reflection; reflection failure cannot create a candidate. Compatibility must account for job semantics, evidence schema, execution surface, rubric and adapter version.
 
-The evaluator has no tools and returns a closed schema: `no_issue`, `reusable_issue`, `transient_issue`, or `uncertain`, plus bounded structured findings. This is heuristic evidence, not semantic proof.
+Before persistence/trial, deterministic admission validates schema/canonical encoding, lesson count/size, Unicode/invisible/bidi handling, exact-loaded-secret leakage, base digest/source integrity, and forbidden authority operands (schedule, recipients, model route, budgets, tools/risk/approval config, paths, commands, destinations, credentials). Text classification is defense in depth: runtime policy remains the security boundary.
 
-### Reflector
+## 9. Owner feedback
 
-Reflection is a distinct operation/call. It may receive compatible saved evaluations, compatible multi-run evidence and the current lesson set. It produces **one complete immutable replacement set**, never an imperative control-plane mutation. Evaluation failure cannot start reflection; reflection failure cannot create a candidate.
+Feedback transaction: claim external event → numeric-ID allowlist → parse `fb:` only → load random-nonce target → verify owner + exact subject digest → append event → consume one-time target if applicable → append redacted audit in the same write.
 
-Compatibility requires matching or explicitly compatible job-definition semantics, evidence schema, execution surface, rubric and adapter version. Incompatible evidence is retained but not silently pooled.
+Semantics: useful/not-useful supports/contradicts one result; correction is owner-attested expected behavior and possible one-run trial seed; evaluation confirm/dispute overlays exact evaluation and dispute blocks dependent promotion; candidate approve permits owner-supported trial through the common gate; reject vetoes/stops exact candidate; edit creates a new candidate/digest and reruns every gate. Owner statements establish owner intent, not deterministic verification.
 
-## 9. Candidate admission and authority firewall
+## 10. Trial rules
 
-Before persistence/trial, deterministic validation checks:
+A candidate is a complete replacement set with incumbent/base digest. Repeated compatible evidence may admit an automatic heuristic trial; explicit owner correction or candidate approval may admit a trial after one eligible occurrence. Exact support thresholds are M2.
 
-- closed schema and canonical encoding;
-- lesson count and per-item/total size limits;
-- Unicode normalization and invisible/bidi handling;
-- secret/exact-loaded-secret leakage;
-- forbidden authority operands: schedule, recipient/chat, model route, budgets, tool/risk/approval configuration, paths, commands, destinations, credentials;
-- job binding and incumbent/base digest;
-- source operation/evidence integrity.
+The fire transaction atomically: resolve expiry → pass existing occurrence/overlap guard → create run → pin stable/trial digest → consume one assignment. A created run consumes its assignment even if it later fails technically; only eligible completed evaluations count positive. Trials cannot stack.
 
-Text classification/pattern checks are defense in depth only. The actual security boundary is the data/control-plane split plus existing policy gates. A candidate that says “ignore approvals” is both rejected by admission and powerless if it reached runtime.
+Expiry, assignment exhaustion, critical failure/regression, deterministic/security veto, explicit rejection/dispute, or insufficient positive evidence closes the exact trial and future runs use untouched stable. Promotion writes a decision receipt, CASes stable only if base digest/generation still match, then closes trial. Hard security/deterministic veto and owner reject/dispute outrank heuristic support.
 
-Lessons may describe strategy at the semantic task level (for example, “compare the stable article body before alerting”), but may not encode executable destinations/commands or grant new capabilities.
+## 11. Trust and data lifecycle
 
-## 10. Owner feedback semantics
+Trust zones:
 
-Feedback capture transaction:
+```text
+CONTROL (trusted code): scheduler claims, policy, budgets, admission, trial/CAS, owner auth
+DATA (untrusted): lesson payloads, outputs, tool-derived facts, evaluator/reflection prose
+OWNER-ATTESTED: authenticated feedback for exact subject
+DETERMINISTIC: scoped adapter receipt for frozen oracle/dataset only
+```
 
-1. atomically claim the external Telegram update/nonce;
-2. enforce numeric-ID allowlist;
-3. parse only the `fb:` namespace;
-4. load target by random nonce;
-5. verify exact owner and subject digest;
-6. append immutable feedback event;
-7. mark one-time target consumed where applicable;
-8. append a redacted audit event in the same write.
+Learning never grants capabilities. Evaluation/reflection have no tools. Raw private observations and tool arguments are excluded from evaluator evidence. Lessons are job-scoped and excluded from memory/history/FTS. Non-empty lessons taint the run before memory/tool decisions.
 
-Semantics:
+Export/retention/purge cover evidence, evaluations, operations, feedback, candidates, lesson sets, trials, verification/decision receipts and provenance links. Job cancellation blocks new learning spend and promotion but retains immutable history until policy removes it. Explicit job-learning purge must either remove/deactivate derived active lessons whose provenance depends on purged private source data, or conservatively reset stable to an unaffected ancestor/empty set; it may not leave encoded deleted private facts active.
 
-- useful/not useful: supporting/contradicting sentiment for one delivered result;
-- result correction: owner-attested expected behavior for that occurrence; may seed one-run trial support;
-- evaluation confirm/dispute: overlay on exact evaluation; dispute blocks dependent promotion;
-- candidate approve: permits owner-supported trial through the common admission gate, never direct activation;
-- candidate reject: vetoes/stops exact candidate/trial;
-- candidate edit: creates a new candidate/digest, invalidates prior approvals, reruns every gate.
+## 12. Transaction + crash/restart matrix
 
-Owner statements establish owner intent
+| Operation | Atomic durable boundary | Crash/restart rule |
+|---|---|---|
+| Fire | existing occurrence/overlap claim + run + binding + trial assignment | no run ⇒ no assignment; created run keeps pinned digest forever |
+| Terminal | run terminal transition + terminal receipt | receipt agrees with winning terminal state; duplicate is idempotent |
+| Evidence seal | sealed projection/exclusion keyed by run+schema | retry DB construction idempotently; never duplicate evidence |
+| Feedback | external-event claim + owner/target validation + event + audit | duplicate update/nonce cannot append twice |
+| Eval/reflect start | operation row → `in_flight` before request | pre-crash in-flight becomes `interrupted_unknown`; do not auto-repeat same synthesis |
+| Eval/reflect finish | structured result + operation terminal status + usage refs | committed result reusable; ambiguous external inference is not replayed as exactly-once |
+| Trial admission | validate candidate + create single open trial + job-state trial pointer CAS | unique/CAS prevents stacking |
+| Trial assignment | successful fire + binding + assignment increment | run exists ⇒ assignment consumed even if run later fails |
+| Promotion | decision receipt + stable-pointer CAS + trial close | CAS winner activates once; loser closes stale/re-evaluates, never overwrites newer stable |
+| Fallback/reject | decision receipt + exact trial close | stable pointer unchanged; future fires resolve stable |
+| Job cancel | cancel state + block-new-learning marker/state | no new learning spend/promotion after cancel; history retained per lifecycle policy |
+
+External LLM inference is at-least-attempted, not exactly-once. Restart reconciliation never silently reissues an ambiguous synthesis.
+
+## 13. Page-change adapter
+
+Page-change is the first deterministic benchmark, not the product boundary. The adapter supplies frozen benchmark inputs, deterministic scorer/oracle, adapter version and regression fixtures through generic contracts. Generic persistence/lifecycle types contain no page concepts.
+
+A deterministic verification receipt is valid only for its named dataset/oracle, adapter version and execution surface. Route/rubric/policy/adapter incompatibility requires revalidation or downgrade to heuristic use. Protocol 0.6 from #118 remains frozen and is not rewritten by M1.
+
+## 14. Deferred to M2
+
+M2 selects, with benchmark evidence rather than architectural guesswork:
+
+- compatible-evidence window/recency policy;
+- minimum supporting runs/evaluations;
+- owner-signal weighting and conflict policy beyond hard veto precedence;
+- trial assignment count and wall-clock

--- a/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
+++ b/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
@@ -1,166 +1,651 @@
-# RFC: Self-improving scheduled tasks — architecture and security boundaries
+# Issue 167: Generic scheduled-task learning architecture
 
-**Status:** Proposed — M1 / #167 · **Date:** 2026-08-28 · **Parent:** #115 · **Baseline:** #118 frozen Protocol 0.6
+| | |
+|---|---|
+| **Status** | Proposed M1 RFC/ADR, compact v3.1 |
+| **Date** | 29 August 2026 |
+| **Parent** | Issue 115 |
+| **Scope issue** | Issue 167 |
+| **Baseline** | Issue 118 frozen Protocol 0.6 |
 
-**Scope:** generic job-scoped learning for every executable scheduled task. **First deterministic adapter:** scheduled page-change monitoring.
+`docs/ARCHITECTURE.md` remains the normative technical specification. A production increment must
+amend it before changing the scheduler, run, context, policy or persistence contracts defined there.
 
-## 1. Decision and guarantee
+This RFC fixes only the boundaries required for the current capability and realistic next
+increments. Exact algorithms, thresholds and physical storage shape are deferred until their
+implementation milestone.
 
-Every created scheduled run uses one generic learning control plane. Existing `run_id` remains the only task-attempt identity. The fire transaction binds it to exact occurrence, fire kind, job-definition digest, execution surface and effective lesson-set digest; execution stays on the ordinary proactive `TurnRunner`/`AgentRuntime` path with existing tools, policy, approvals, budgets and delivery.
+## 1. Decision and guarantees
 
-Every terminal transition writes an immutable receipt. After late usage/approval observations settle, an idempotent worker seals bounded evidence or a technical exclusion. Deterministic eligibility runs before learning LLM spend. Eligible evidence may enter a fresh, tool-free, blind evaluator. Reflection is a separate fresh/tool-free call and may only propose an immutable complete replacement lesson set.
+Swift Claw will add one durable, job-scoped learning control plane for scheduled tasks. A scheduled
+job keeps its ordinary prompt, runtime, tools, policy, approvals, budgets and delivery path. The
+learning control plane records task evidence, evaluates quality, accepts owner feedback, proposes a
+bounded lesson set and tests it through a finite trial before promotion.
 
-Owner feedback is durable, authenticated, typed, append-only and exact-subject-bound. It is evidence, never activation. Each job has one stable lesson pointer and at most one bounded trial override; trials cannot stack. Promotion CASes stable from recorded base to candidate; fallback closes trial and leaves stable untouched.
+Existing `run_id` remains the only task-attempt identity. The successful fire transaction binds the
+run to the exact logical occurrence, fire kind, job-definition digest, learning epoch, stable lesson
+base and effective lesson-set digest. Execution continues through the ordinary proactive
+`TurnRunner` / `AgentRuntime` path. Context assembly and provider execution record the actual ordered
+execution-surface segments; the sealer derives their aggregate digest after settlement.
 
-**Guarantee:** any executable scheduled task can participate in capture → eligibility → evaluation → feedback → reflection → candidate → bounded trial → promote/fallback without expanding authority. This does not guarantee objective verification/improvement for subjective tasks. Natural runs/LLM evaluation are heuristic; owner feedback establishes owner intent; only a deterministic adapter over a named frozen oracle/dataset may issue scoped `deterministically_verified` evidence.
+```text
+scheduled fire
+  -> pin the effective job-scoped lesson set to run_id
+  -> execute the ordinary proactive agent run
+  -> commit terminal state and terminal receipt
+  -> record that no more primary-run facts can arrive
+  -> seal bounded evidence or a technical exclusion
+  -> classify learning eligibility in code
+  -> run a blind, tool-free evaluator when eligible
+  -> combine saved evaluation with durable owner feedback
+  -> run separate tool-free reflection when policy permits
+  -> validate one immutable replacement candidate
+  -> assign a finite trial override
+  -> promote with compare-and-swap or fall back to stable lessons
+```
 
-No unresolved P0 architecture/security blocker remains. Exact algorithm parameters are deferred to M2 (§12).
+**Capability guarantee.** Every executable scheduled task can use the same capture, evaluation,
+feedback and lesson lifecycle. A repeatable job can trial and reuse lessons across restarts. A
+one-shot job can retain evidence, evaluation and feedback, but cannot exercise a trial until another
+occurrence exists.
 
-## 2. Invariants / security boundary
+**Evidence guarantee.** Natural runs and LLM evaluation provide heuristic evidence. Authenticated
+owner feedback establishes owner intent for an exact subject. Only a deterministic adapter over a
+named, versioned dataset and oracle may issue scoped `deterministically_verified` evidence. The
+system does not claim objective improvement for arbitrary subjective tasks.
 
-- `run_id` is canonical; no parallel attempt entity. Generic core contains no page/HTML/selector/region/snapshot types.
+## 2. Goals and non-goals
+
+M1 defines the smallest architecture that can:
+
+- preserve `run_id` as the sole attempt identity;
+- isolate durable lessons by scheduled job;
+- separate task quality from `RunState`;
+- apply lessons only through a bounded, attributable trial;
+- make owner feedback durable and exact-subject-bound;
+- survive restart without claiming exactly-once LLM inference;
+- keep lessons outside scheduling, policy and authority control planes;
+- account learning calls against global and proactive budgets;
+- support page-change as an optional deterministic adapter, not a product boundary;
+- export, retain and purge derived learning data with its provenance.
+
+M1 does not define or implement:
+
+- global or cross-job lessons;
+- a second task runtime or a page-specific production coordinator;
+- exact support thresholds, evidence windows, trial sizes or acceptance formulas;
+- automatic changes to prompts, schedules, tools, model routes, recipients or budgets;
+- a generic memory/evaluation platform;
+- a live page importer or benchmark corpus;
+- Swift production code, migrations or tests;
+- changes to the frozen Protocol 0.6 artifact.
+
+## 3. Core invariants and trust boundary
+
+- `run_id` is canonical. The learning subsystem adds a one-to-one binding, not another attempt row.
+- The generic domain contains no page, HTML, selector, region or snapshot types.
 - Scheduled execution remains an ordinary proactive agent run.
-- Lessons are data, never authority: they cannot change job prompt, schedule, budgets, model route, tool catalog/risk, approvals, recipients, paths, commands or destinations.
-- Lessons use a trusted harness wrapper around bounded **untrusted payload** and never enter global/workspace memory, conversation history or FTS.
-- Non-empty lessons establish taint before sensitive-memory selection, first provider call and first tool-policy decision.
-- Evaluation/reflection get fresh contexts with no tools, workspace memory, session history, approvals or provider replay state.
-- Evaluator is blind to lesson text/IDs, stable/candidate digests, trial condition, prior scores, promotion state and expected improvement.
-- Deterministic eligibility precedes learning LLM spend. Feedback cannot activate lessons or expand authority.
-- One stable pointer + at most one trial; promotion requires positive eligible evidence. Silence/evaluator failure/ineligible runs are never positive.
-- DB effects are idempotent; external LLM inference is not exactly-once.
-- Export/retention/purge include derivatives; deleting private source data cannot leave an active lesson encoding it.
+- Each job has one stable lesson-set pointer and at most one nonterminal trial override. Trials never
+  stack, and the stable pointer remains unchanged until promotion.
+- A lesson set is immutable, bounded and replaced as a whole. An edit creates a new digest.
+- Lessons are advisory **untrusted data**, never authority. They cannot modify the job prompt,
+  schedule, budgets, model route, tool catalog, risk tier, approvals, recipients, paths, commands,
+  destinations or policy.
+- Lesson bytes are rendered inside a trusted harness wrapper and never enter global/workspace
+  memory, conversation history or FTS.
+- Non-empty lessons add initial taint before sensitive-memory selection, the first provider call and
+  the first tool-policy decision. They never replace persisted session taint or untrusted tool-metadata
+  taint.
+- Evaluation and reflection use fresh contexts with no tools, workspace memory, session history,
+  approvals or provider replay state.
+- The evaluator is blind to lesson text and IDs, stable/candidate digests, trial assignment, prior
+  scores, promotion state and expected improvement.
+- Deterministic adapter gold data, oracle results, holdouts and regression gates never enter a
+  model-visible evaluator, reflector or candidate-synthesis carrier. Trusted code may attach only a
+  scoped deterministic receipt after candidate freeze.
+- Deterministic eligibility runs before any learning LLM spend.
+- Feedback is evidence and control input, never direct activation or authority expansion.
+- Promotion requires positive eligible evidence. Silence, evaluator failure and ineligible runs are
+  not positive evidence.
+- Database effects are idempotent. External provider inference is not exactly-once.
+- Candidate text checks are defense in depth. Existing runtime policy, canonicalization, approval,
+  egress and budget gates remain the security boundary.
 
-## 3. Existing-seam map
+## 4. Existing seams and ownership
 
-**Scheduler/fire.** `ScheduledJobStore.claimAndFire` already fuses occurrence compare-and-advance with session/trigger, `PENDING` run and audit; `fireNow` reuses the insert set without schedule advance; overlap prevents a second live job-session run. Extend the successful transaction with `learning_run_binding(run_id, job_id, occurrence, fire_kind, job_definition_digest, execution_surface_version, effective_lesson_id/digest, stable_base_digest, trial_id/generation?)`. Resolve trial expiry first; consume an assignment only after overlap passes and `run_id` exists. Misfire, overlap skip and CAS loser consume none.
+The design extends current seams instead of introducing a second runtime.
 
-**Run persistence.** `RunStore` owns pickup, completion/degradation, cancel/supersede, approval suspension/resume and boot reconciliation. Every legal terminal transition (`DONE/FAILED/CANCELLED/SUPERSEDED`, including reconciliation) writes one `learning_terminal_receipt` in the same transaction. Seal later unless normal `DONE` already has all settled facts.
+**Scheduler/fire.** Extend the existing fused fire transaction after its occurrence and overlap
+checks. The transaction selects stable or trial lessons, creates `run_id`, writes the learning
+binding and consumes a trial assignment only when a run is created. Misfires, overlap
+skips and compare-and-swap losers consume none.
 
-**Context/taint.** `TurnRunner` loads bounded context/budgets and calls `AgentRuntime` with taint/private-data state. Add a job-scoped lesson section: trusted wrapper, untrusted payload. Non-empty lessons set initial taint before context memory selection.
+**Run persistence.** `RunStore` already owns completion, degradation, cancellation, supersession,
+approval suspension/resume and boot reconciliation. Every legal terminal transition for a bound run
+must write one terminal receipt from a typed terminal-cause carrier in the same transaction as the
+winning state. An approval resolution stores its typed cause as a primary immutable fact in the same
+compare-and-swap that resolves the approval; the later terminal receipt references that fact.
 
-**Policy/approvals.** Existing canonical-args, policy-version, owner and approval gates stay authoritative. Candidate scanning is defense in depth; lessons never become policy operands and cannot weaken approval, exfiltration, SSRF or proactive-budget policy.
+**Context and runtime.** `TurnRunner` loads the lesson set pinned to `run_id` and passes it to
+`ContextBuilder` before memory selection. The store verifies
+`binding.job_id == run.job_id == lesson_set.job_id` and the canonical digest. The complete set becomes
+one required, untrusted-labeled, non-truncatable context component before residual-budget fitting. If
+it cannot fit, the run fails before provider dispatch; a bound run never substitutes current, empty or
+partially truncated lessons.
 
-**Usage/budgets.** Evaluation/reflection are durable runless learning operations, not fake runs. Usage counts toward global and proactive/learning budgets. Owner delivery never waits for learning calls.
+Lesson taint augments the existing inputs. Memory fetch and rank use
+`snapshot.isTainted || hasPinnedLessons`. Initial provider and tool dispatch use
+`untrustedToolMetadata || hasPinnedLessons`, while persisted session taint remains an independent
+input. These values apply before memory selection and before the first policy decision.
 
-**Telegram feedback.** Reuse the fail-closed callback pattern (claim update → numeric allowlist → strict namespace → random nonce → owner binding → CAS → redacted audit) in a separate `fb:` domain; do not reuse tool approvals or `AWAITING_APPROVAL`.
+**Policy.** Existing tool policy, canonical-argument, approval, SSRF, exfiltration and proactive
+budget checks remain authoritative. Lessons are never parsed as configuration or policy operands.
 
-## 4. Architecture and data model
+**Usage.** Evaluation and reflection are durable learning operations, not fake agent runs. Their
+usage counts toward global and proactive learning totals without contaminating primary-run totals.
+
+**Owner feedback.** M1 uses a separate `fb:` callback domain following the existing fail-closed
+pattern: transport deduplication, numeric owner allowlist, private-DM binding, random one-time nonce,
+exact subject digest, compare-and-swap consumption and redacted audit. It does not reuse tool-approval
+rows, approval suspension or `AWAITING_APPROVAL`.
 
 ```text
 SchedulerService
- → fire txn: resolve lessons → create run_id → pin digests → consume trial assignment
- → TurnEnqueuer → TurnRunner → AgentRuntime → existing policy/tools/outbox
-                                      → terminal txn + receipt
-LearningCoordinator (async; post-delivery)
- → EvidenceSealer → EligibilityClassifier → Evaluator → Feedback/Reflector
- → CandidateAdmissionPolicy → TrialController → promote CAS | fallback
-Optional LearningEvaluatorAdapter → page-change frozen scorer/fixtures first
+  -> fire transaction: bind run and effective lessons
+  -> ordinary TurnRunner / AgentRuntime / tools / policy / outbox
+  -> terminal and settlement records
+
+ScheduledLearningService (asynchronous; never blocks owner delivery)
+  -> evidence sealing -> eligibility -> evaluation -> reflection
+  -> candidate admission -> trial -> promotion | fallback | rollback
+
+Optional LearningEvaluatorAdapter
+  -> page-change frozen scorer and fixtures first
 ```
 
-Learning sits beside scheduler/persistence; `AgentRuntime` only consumes pinned lessons and produces ordinary run facts.
+## 5. Minimal logical model
 
-Conceptual records (names are not M1 migrations):
+The following are logical records, not a requirement for one Swift type or SQLite table per item.
+The first implementation should expose one cohesive scheduled-learning store and split it only when
+concrete callers need separate responsibilities.
 
-- `learning_job_state`: job PK, stable lesson ID/digest, nullable open trial, monotonic generation; stable pointer is the only production activation pointer.
-- `learning_lesson_sets`: immutable complete replacement set, bounded payload, digest/base digest, source, schema/timestamps; no in-place edit.
-- `learning_run_bindings`: one per created scheduled `run_id`; exact occurrence/fire kind and pinned job/execution/lesson/trial digests.
-- `learning_terminal_receipts`: one per terminal run; winning terminal state, timestamp, schema/digest.
-- `learning_evidence`: sealed projection or typed exclusion. Projection contains bindings/digests, terminal classification, bounded final output/digest, bounded tool facts (name/status/policy decision/result size/trust flags), actual model route, primary usage refs, versions and optional adapter facts. Excludes raw tool args, secrets, private raw observations, replay state and audit projections.
-- `learning_operations`: durable evaluation/reflection ID, source evidence, phase/status (`pending/in_flight/succeeded/failed/interrupted_unknown`), model route/schema, attempts, usage/cost refs, timestamps.
-- `learning_evaluations`: evidence binding, rubric/adapter versions, result `no_issue | reusable_issue | transient_issue | uncertain`, bounded findings/digest.
-- `learning_feedback_targets/events`: random one-time nonce + owner + exact subject digest; append-only typed event with Telegram update/nonce and optional superseded link.
-- `learning_trials`: job, base/candidate digests, generation, state, deadline, max/consumed assignments, admission evidence; unique open trial/job.
-- `learning_decision_receipts`: immutable promotion/fallback/reject inputs, evidence/feedback, evidence strength, CAS generations/digest.
-- adapter-only `deterministic_verification_receipts`: adapter/version, frozen dataset/oracle, execution surface, subject digests and deterministic result.
+- **Job learning state:** job ID, learning epoch, stable lesson-set digest and revision, and nullable
+  open trial identity. The stable pointer is the only production activation pointer.
+- **Lesson set:** immutable canonical bounded bytes, job ID, schema version, digest, creation source
+  and time. The canonical empty set is valid.
+- **Run learning binding:** one per created scheduled `run_id`; exact occurrence, fire kind,
+  job-definition digest, learning epoch, stable and effective lesson-set digests, and optional trial
+  identity/generation.
+- **Terminal receipt:** one per terminal run; winning state, typed cause and terminal time.
+- **Settlement receipt or marker:** durable proof that no further primary-run facts may arrive for
+  the run. It may share storage with another record, but it is a distinct correctness boundary.
+- **Execution-segment receipt:** immutable ordered record of the pinned lesson digest, context,
+  policy, tool and skill versions, configured route, outbound model, terminal model and model-visible
+  carrier digest for one context/provider segment.
+- **Learning evidence:** one sealed, bounded projection or typed technical exclusion. It contains the
+  run binding, terminal/settlement facts, complete bounded canonical final output, source message ID
+  and digest, bounded ordered tool facts, ordered execution-segment receipts, usage references,
+  relevant versions, a derived aggregate execution-surface digest and optional adapter facts. It
+  excludes raw tool arguments, secrets, private raw observations, replay state and audit projections.
+- **Eligibility receipt:** immutable classification keyed by sealed evidence or exclusion digest and
+  classifier version.
+- **Learning operation:** durable evaluator or reflector operation with source digest, learning
+  epoch, model-visible carrier digest, route, schema/prompt versions, unique provider-call identity,
+  attempt generation, optional superseded-operation link, usage references and state
+  `pending | claimed | started | succeeded | failed_no_call | failed | interrupted_unknown`.
+- **Evaluation:** exact evidence binding, frozen rubric and adapter versions, structured result and
+  bounded findings.
+- **Feedback target, input challenge and event:** authenticated owner, random nonce, exact run/output,
+  evaluation or candidate digest, job, learning epoch, allowed action and expiry; append-only typed
+  events with actor, transport identity, event time and optional supersession link.
+- **Candidate:** immutable record digest distinct from its complete replacement lesson-set digest,
+  bound to job, learning epoch, exact base digest/revision, frozen source and feedback revision,
+  closed origin and an exact source manifest covering evidence, evaluations, feedback, base set and
+  predecessor candidate.
+- **Trial lease:** exact base and candidate digests, generation, assignment deadline, decision
+  deadline, maximum and consumed assignments, frozen cohort cutoff, state and close reason.
+- **Decision receipt:** immutable admission, promotion, fallback, rejection or rollback inputs and
+  result.
+- **Deterministic adapter receipt:** adapter, dataset, oracle and execution-surface versions plus the
+  exact subject digests covered by the result.
 
-Feedback types: result useful/not-useful/correction; evaluation confirm/dispute; candidate approve/reject/edit. Edit creates a new digest and invalidates old support.
-
-## 5. Lifecycles
+Activation and evidence strength remain separate:
 
 ```text
-created run → terminal receipt → settlement → sealed evidence | exclusion
-sealed → deterministic eligibility
-  ├─ ineligible → retain; no learning LLM
-  └─ eligible → evaluation
-       ├─ fail/interrupted_unknown → stop
-       └─ saved evaluation → reflection (when policy permits)
-            ├─ fail/interrupted_unknown → stop
-            └─ immutable candidate → admission → inert | trial
+activation: candidate | trial | active | rolled_back | superseded
+evidence:   heuristic | owner_supported | owner_confirmed | deterministically_verified
 ```
+
+An active lesson may remain heuristic. LLM evaluation can never produce deterministic verification.
+
+## 6. Run capture, settlement and evidence
+
+### 6.1 Fire binding
+
+The existing fire transaction performs this order atomically:
+
+1. resolve the current learning epoch and trial assignment eligibility;
+2. pass the existing occurrence, misfire and overlap guards;
+3. create the trigger and `run_id`;
+4. pin job-definition, stable and effective lesson-set digests;
+5. consume one trial assignment when the trial was selected.
+
+A created run consumes its assignment even if it later fails technically. Scheduled and run-now
+fires use the same selection rule; run-now consumes an assignment when it creates a run. A run
+already bound to a lesson set keeps that exact digest through restart and approval resume. Retention
+cannot collect lesson bytes referenced by a live bound run.
+
+An upgrade may find pending, running or approval-suspended scheduled runs created before learning
+bindings exist. They continue through the ordinary lifecycle as `legacy_unbound`, load no lessons and
+produce only a technical learning exclusion. Code does not invent occurrence, job-definition or
+lesson provenance, and a missing binding cannot roll back a legal terminal transition.
+
+When the trial assignment deadline or assignment limit is reached, new fires use stable lessons and
+the trial enters **draining**. Already assigned trial runs may finish until the decision deadline.
+This separates bounded exposure from the time needed to evaluate assigned work.
+
+Pausing a job stops ticker-created occurrences only. It does not extend trial deadlines or revoke
+assignments already bound to runs. A run-now fire uses the same assignment and expiry rules as a
+scheduled fire.
+
+### 6.2 Terminal and settlement boundaries
+
+Every legal `DONE`, `FAILED`, `CANCELLED` or `SUPERSEDED` transition writes a terminal receipt in the
+same transaction. `RunState` alone is insufficient because it does not distinguish task failure from
+provider, storage, budget, policy, approval or owner-interruption causes. An ordinary `DONE` commit
+may also write settlement when all primary facts are final. It never seals learning evidence: the
+task result and outbox transaction cannot depend on learning-specific consistency work.
+
+Every terminal commit carrier supplies the typed cause. A split approval path first persists its
+resolution cause with the approval compare-and-swap. If a legacy or damaged run lacks that fact, the
+receipt records `unknown` or `incomplete`; code never reconstructs the cause from `RunState` or audit.
+
+Evidence sealing also requires a durable settlement marker proving that no later usage, approval or
+execution fact can arrive. The last primary fact and settlement marker commit together, and every
+primary fact, message and usage writer rejects writes after settlement. Ordinary success may write
+terminal and settlement together. Cancellation and supersession settle through the shared session-lane
+finalizer after live work unwinds; approval recovery settles after its placeholder is resolved. After
+run and approval reconciliation, boot reconciliation marks every prior-process bound terminal run
+without settlement, including `CANCELLED` and `SUPERSEDED`, as explicitly `incomplete` or `unknown`.
+Approval reconciliation may register asynchronous lane work. The boot fallback excludes runs owned
+by a current-process lane, and each lane must commit settlement before it unregisters. The sealer never
+guesses settlement or lane quiescence from a timeout.
+
+Primary-run code appends bounded tool lifecycle facts immediately after every dispatch, independently
+of complete `ToolExchange` values, and carries them through every early exit. Each proposed call has a
+provider-call identity plus segment, round and call ordinals. Its lifecycle records tool-call ID,
+resolved tool name, proposal/approval/dispatch/final disposition, observation status, policy decision,
+policy-produced canonical target digest, result size, `ingestedUntrusted`, `readPrivateData` and an
+optional policy-permitted redacted excerpt. Raw arguments, secrets and private excerpts are excluded.
+Settlement requires one allowed final disposition for every proposed-call ordinal.
+
+Each context assembly and provider segment also writes an immutable ordered execution-segment receipt
+while route and context values remain available. This captures primary-to-fallback changes and
+approval-resume segments without reconstructing them from mutable state. Audit remains observability
+and is not learning provenance.
+
+### 6.3 Sealing and eligibility
+
+After settlement, `ScheduledLearningService` runs one idempotent transaction that verifies source
+digests and complete tool lifecycles, compares the binding epoch with current job state and the purge
+barrier, snapshots ordered segment receipts, and writes either sealed evidence or `excluded(reason)`.
+An old-epoch or purging claim may write only a content-free stale tombstone; it cannot recreate
+evidence or eligibility. Sealed evidence copies the complete canonical final-output bytes within the
+evidence cap, source message ID and digest; it never substitutes a digest-only or truncated result. A
+cap mismatch, retention loss or corruption produces `insufficient_evidence`.
+
+The same transaction writes the immutable eligibility receipt for the sealed evidence or exclusion
+digest and classifier version. An ineligible receipt is a terminal classification, not pending work
+that a later worker may reinterpret. No evaluator receives a partial reconstruction.
+
+The learning service atomically claims only bound terminal runs whose versioned eligibility receipt
+is eligible, evaluation state is pending, and current job epoch permits a call. One current attempt
+per logical hypothesis prevents two workers or a restart from committing two results for the same
+operation generation.
+
+The initial deterministic eligibility taxonomy is:
 
 ```text
-candidate → TRIAL (stable untouched)
-  ├─ expiry/exhaustion/security veto/regression/owner reject-dispute/
-  │  insufficient positive evidence → close + FALLBACK
-  └─ acceptance satisfied → decision receipt → CAS stable(base→candidate)
-       ├─ lost → close stale trial
-       └─ won → ACTIVE; close trial
+eligible_task_evidence
+transient_infrastructure_failure
+policy_or_security_block
+owner_interruption
+insufficient_evidence
+unsupported_terminal_state
 ```
 
-Keep dimensions separate: `lifecycle = candidate | trial | active | rolled_back | superseded`; `evidence = heuristic | owner_supported | owner_confirmed | deterministically_verified`. An active lesson may remain heuristic. LLM evaluation never yields deterministic verification.
+Provider, credential, storage and budget failures do not produce behavioral lessons. Cancellation,
+supersession, unresolved/rejected approval and security-policy blocks never enter reflection.
 
-## 6. Evidence, evaluator and reflection
+## 7. Evaluation and reflection
 
-Terminal receipt is settlement-independent and unique by run. Sealer is idempotent by run + evidence-schema version, waits for required usage/approval observations, and writes sealed evidence or `excluded(reason)`. Audit is observability, not provenance.
+The evaluator receives only a whitelisted, condition-neutral carrier:
 
-Initial eligibility taxonomy: `eligible_task_evidence`, `transient_infrastructure_failure`, `policy_or_security_block`, `owner_interruption`, `insufficient_evidence`, `unsupported_terminal_state`. Provider/storage/credential/budget failures do not create behavioral lessons; cancellation, supersession and security blocks never enter reflection. One-shot jobs may retain evidence/evaluation/feedback but cannot trial without another occurrence.
+- the frozen job prompt and quality rubric;
+- one final output;
+- the safe bounded evidence projection;
+- optional task input facts supplied by an adapter before any oracle join.
 
-Evaluator input is exactly frozen job prompt, frozen quality rubric, final output, safe evidence projection and optional adapter facts. No tools. Reflection is a separate call over compatible saved evaluations/multi-run evidence plus current lesson set and proposes one complete replacement. Evaluation failure cannot start reflection; reflection failure cannot create a candidate. Compatibility includes job semantics, evidence schema, execution surface, rubric and adapter version.
+It receives no applied lesson text or identity, trial/candidate identity, stable digest, prior score,
+promotion state or expected direction of improvement. The call has no tools.
 
-## 7. Candidate firewall and owner feedback
+Adapter gold data, oracle results, holdout inputs, expected labels, regression gates and their raw
+results never enter evaluator, reflector or candidate-synthesis carriers. Trusted code may join a
+scoped deterministic receipt only after the candidate has frozen. The model never receives the
+verification inputs or oracle result.
 
-Admission deterministically validates schema/canonical encoding, lesson count/size, Unicode/invisible/bidi handling, exact-loaded-secret leakage, base/source integrity and forbidden authority operands (schedule, recipients, model route, budgets, tools/risk/approval config, paths, commands, destinations, credentials). Text classification is defense in depth; runtime policy is the boundary.
+The evaluator returns a closed structured result such as:
 
-Feedback transaction: claim external event → numeric-ID allowlist → parse `fb:` → load random-nonce target → verify owner + exact subject digest → append event → consume one-time target if applicable → append redacted audit in same write.
+```text
+no_issue | reusable_issue | transient_issue | uncertain
+```
 
-Useful/not-useful supports/contradicts one result; correction is owner-attested expected behavior and possible one-run trial seed; evaluation dispute blocks dependent promotion; candidate approve permits owner-supported trial through common gate, never direct activation; reject vetoes/stops exact candidate; edit creates a new candidate and reruns all gates. Owner statements establish intent, not deterministic verification.
+with bounded issue codes and evidence references. This is heuristic evidence, not semantic proof or
+a calibrated probability.
 
-## 8. Trial semantics
+Before either call, the exact serialized carrier passes the configured privacy/provider policy and
+secret-redaction checks. A second learning call is not automatically permitted merely because the
+primary provider saw the task output. A denied carrier terminates that learning operation as
+`failed_no_call(carrier_policy_denied)` and leaves the immutable task-evidence eligibility receipt
+unchanged.
 
-Candidate is a complete replacement set with incumbent digest. Repeated compatible evidence may admit automatic heuristic trial; explicit owner correction/approval may admit after one eligible occurrence. Exact thresholds are M2.
+Reflection is a separate fresh, tool-free call over a closed, code-built `ReflectorCarrier`. It
+contains compatible saved evaluations, normalized issue references, bounded policy-permitted evidence
+excerpts, bounded owner-feedback payloads and the current stable lesson set at a frozen cutoff. Each
+lesson, evidence and feedback body has its own ordinary untrusted-data fence.
 
-Fire atomically resolves expiry → passes existing occurrence/overlap guard → creates run → pins stable/trial digest → consumes one assignment. A created run consumes it even if later technically failed; only eligible completed evaluations count positive. Trials cannot stack.
+The carrier excludes owner and transport IDs, feedback nonces and challenge state, raw evidence,
+audit rows, private observations and provider replay state. Its canonical bytes and digest bind the
+learning operation and candidate source manifest. Reflection may return one complete replacement set
+or no candidate. Evaluation failure cannot start reflection; reflection failure cannot create a
+candidate.
 
-Expiry, assignment exhaustion, critical failure/regression, security/deterministic veto, explicit rejection/dispute or insufficient positive evidence closes exact trial; future runs use stable. Promotion writes decision receipt, CASes stable only if base/generation match, then closes trial. Hard veto and owner reject/dispute outrank heuristic support.
+Compatible evidence must share the same job semantics and compatible evidence, execution-surface,
+rubric and adapter versions. Exact grouping rules and support counts belong to M2.
 
-## 9. Trust, lifecycle and restart
+## 8. Owner feedback and candidate admission
 
-Trust classes: **CONTROL** = scheduler claims/policy/budgets/admission/trial-CAS/owner auth; **UNTRUSTED DATA** = lessons/outputs/tool facts/evaluator-reflection prose; **OWNER-ATTESTED** = authenticated exact-subject feedback; **DETERMINISTIC** = scoped adapter receipt only.
+Owner feedback is durable, authenticated, typed, append-only and bound to an exact subject digest.
+The authenticated envelope is trusted control; free-text correction and edit bytes remain untrusted
+task data. The store atomically claims the external update, verifies the numeric owner and private
+chat, validates the target/nonce, appends the event, advances a monotonic feedback revision and
+writes a redacted audit event. Candidate rejection and evaluation dispute also close an exact matching
+open trial in this transaction when epoch, trial generation, candidate, replacement and base digests
+still match. Duplicate transport events or consumed nonces cannot append twice.
 
-Export/retention/purge cover evidence, operations/evaluations, feedback, candidates, lesson sets, trials and verification/decision receipts. Job cancellation blocks new learning spend/promotion but retains history per policy. Purge must deactivate/remove active lessons depending on purged private data or reset stable to unaffected ancestor/empty set.
+The audit stores actor and action, subject IDs and digests, signal kind, payload byte count and outcome.
+Correction, edit and evidence bytes never enter audit arguments, decisions or logs.
 
-Transaction/restart rules:
+Every feedback-bearing result or review notice commits its durable target and all outbox chunks in one
+transaction. Multipart delivery places the keyboard on the final chunk and every resend carries the
+same opaque nonce. Free-text correction and candidate edit use a separate durable one-shot input
+challenge committed with its prompt outbox. No committed target or challenge means no valid feedback
+action. A challenge binds job, learning epoch and exact target digest; consumption compares the current
+epoch in the same transaction that appends feedback. One owner private DM may have at most one live
+free-text challenge. Creating a newer correction or edit prompt atomically supersedes the prior live
+challenge, so the next owner message has one exact subject.
 
-- **Fire:** occurrence/overlap claim + run + binding + trial assignment; no run ⇒ no assignment; created run keeps pinned digest.
-- **Terminal:** state transition + receipt; unique/idempotent and agrees with winning state.
-- **Evidence:** seal/exclusion keyed by run+schema; DB retry idempotent.
-- **Feedback:** event claim + owner/target validation + event + audit; duplicate cannot append twice.
-- **Eval/reflect:** durable `in_flight` before request; crash-window operation becomes `interrupted_unknown`; do not automatically repeat same logical synthesis.
-- **Trial admission:** validation + unique open trial + job-state CAS prevents stacking.
-- **Promotion:** decision receipt + stable CAS + trial close; loser never overwrites newer stable.
-- **Fallback/reject:** exact trial closes; stable unchanged.
+Supported signals are:
 
-## 10. Page-change adapter
+- **result useful / not useful:** supporting or contradicting sentiment for one output;
+- **result correction:** owner-attested expected behavior and a possible one-run reflection/trial seed;
+- **evaluation confirm / dispute:** confirmation creates an immutable `owner_confirmed` claim for that
+  exact evaluation; dispute blocks dependent admission or promotion;
+- **candidate approve / reject:** approval permits a trial through the common gate; rejection vetoes
+  or closes that exact candidate/trial;
+- **candidate edit:** creates a new immutable candidate and digest; prior approvals do not carry over.
 
-Page-change is first deterministic benchmark, not product boundary. Adapter supplies frozen inputs, deterministic scorer/oracle, version and regression fixtures through generic contracts; generic types contain no page concepts. Verification is scoped to named dataset/oracle + adapter/execution-surface version. Route/rubric/policy/adapter incompatibility requires revalidation or downgrade to heuristic. Protocol 0.6 remains frozen.
+Simple thumbs-up and thumbs-down map to `result useful` and `result not useful`. M1 carries them over
+authenticated `fb:` controls because native Telegram reaction updates do not provide the required
+actor binding in the current client. Native reaction transport and unbound reply inference are
+deferred. Feedback never writes the stable lesson pointer and never grants tools, destinations,
+recipients, policy exceptions or budget increases.
 
-## 11. Implementation increments
+A candidate is one complete replacement set bound to the exact incumbent digest and revision. Its
+candidate-record digest and replacement lesson-set digest are distinct. Trusted code attaches one
+closed origin and an immutable source manifest with the exact evidence, evaluation, feedback, base-set
+and predecessor-candidate edges. A cutoff alone is not provenance.
 
-1. Capture: run binding + terminal receipt + safe evidence/exclusion; no behavior change.
-2. Eligibility/evaluator: deterministic taxonomy, durable operations, blind tool-free evaluation, budget accounting.
-3. Owner feedback: `fb:` targets/events and exact-subject overlays.
-4. Reflection/inert candidates: immutable replacement sets + admission firewall; no activation.
-5. Bounded trial: stable pointer + one trial override, atomic assignment, initial lesson taint, expiry/fallback/no stacking.
-6. Promotion/rollback: decision receipts, positive-evidence gate, CAS promotion, veto precedence.
-7. Page-change adapter: deterministic fixtures/scorer and scoped verification receipts.
-8. Lifecycle completion: export/retention/purge, doctor/observability, restart fault injection.
+The same admission validator runs on reflector output, owner edits and future candidate sources before
+lesson bytes persist or a trial opens. It validates only boundaries that provide concrete value now:
 
-## 12. Deferred to M2
+- closed versioned schema and canonical encoding;
+- finite lesson count and UTF-8 byte caps;
+- rejection of control, invisible, zero-width and bidirectional formatting characters;
+- exact-loaded-secret and credential leakage checks;
+- exact job, epoch, base and source bindings.
 
-Compatible-evidence window/recency; minimum supporting runs; owner-signal weighting beyond hard veto precedence; trial assignment count/deadline; automatic-trial threshold; acceptance/regression formula/uncertainty band; reflection cadence/consolidation; exact lesson caps; evaluator/reflector model and operation budgets; retention durations; deterministic-adapter score thresholds/revalidation window.
+Lessons are not parsed into schedule, route, tool, recipient, path, command or approval
+configuration. Lexical scanning may flag suspicious text as defense in depth, but it is not relied on
+to prove safety and must not reject ordinary useful prose merely for mentioning a file, URL or
+command. The candidate schema contains no authority-operand fields. A future structured operand may
+only repeat an owner-confirmed job or configuration value; it cannot introduce a new recipient, URL,
+path or command. Runtime policy remains authoritative for every model-proposed tool argument.
 
-## 13. Acceptance
+Repeated compatible evidence may admit an automatic heuristic trial. An explicit owner correction
+or approval may admit a trial after one eligible occurrence. In both cases admission requires a
+repeatable non-cancelled job, a matching current base, no unresolved veto, successful validation,
+available learning budget and no open trial. Admission compare-and-swaps the candidate's frozen
+feedback revision against current job state and verifies that every feedback edge in its source
+manifest remains effective and unsuperseded. The same transaction verifies that the job remains
+repeatable and non-cancelled, the immutable validator/gate receipt still matches, and the learning
+budget reservation succeeds. A mismatch makes the candidate stale; the worker cannot rebind it to a
+newer cutoff. Passing admission means only that the candidate may enter a bounded experiment.
 
-This RFC satisfies #167's acceptance contract: canonical `run_id`; generic core; atomic occurrence/lesson pinning; terminal receipt + post-settlement sealing; deterministic eligibility before LLM; blind evaluator separated from reflector; durable authenticated feedback; no feedback activation/authority expansion; one bounded non-stacking trial with CAS; positive-evidence requirement; distinct heuristic/owner/deterministic claims; global + proactive learning budget participation; initial lesson taint; defense-in-depth candidate validation; honest restart semantics; derivative export/retention/purge; page-change as first deterministic adapter; and no unresolved P0 blocker.
+## 9. Trial, promotion, fallback and rollback
 
-**M1 remains architecture-only:** no production Swift/migrations/tests, exact thresholds/windows/trial duration/consolidation, page-change importer/benchmark implementation, global/cross-job lessons, generic global-memory platform, authority changes through lessons, policy weakening, Protocol 0.6 rewrite, merge, or issue closure.
+One job may have one nonterminal trial. The stable pointer remains unchanged while the scheduler
+assigns the candidate lesson set to a bounded number of runs.
+
+The trial stores two absolute deadlines:
+
+- **assignment deadline:** after this point, or after assignment exhaustion, new runs use stable
+  lessons and the trial drains;
+- **decision deadline:** by this point, assigned runs must provide enough eligible evidence or the
+  trial closes without promotion.
+
+Only settled runs with the exact trial digest, eligible evidence and a completed evaluation count as
+positive support. Technical failures consume exposure but do not support the candidate. Silence,
+uncertain evaluation, missing evaluation and absence of contradiction do not count as success.
+
+Promotion waits until assignment closes and the frozen cohort has settled, or until the decision
+deadline classifies its missing members. One early positive run cannot promote a candidate while
+already assigned trial runs remain capable of producing contradictory evidence.
+
+Immediate hard stop conditions include security/deterministic veto, critical failure or regression,
+owner candidate rejection, an evaluation dispute invalidating required evidence, job cancellation
+or trial-state corruption. Hard vetoes outrank heuristic support.
+
+Promotion is one transaction that:
+
+1. verifies that the job remains repeatable and non-cancelled;
+2. verifies learning epoch, exact trial/generation, candidate and replacement digests;
+3. verifies the stable pointer and revision still equal the recorded base;
+4. verifies the reviewed feedback revision and absence of unresolved reject/dispute;
+5. verifies the required evidence and versioned gates;
+6. inserts a decision receipt, compare-and-swaps the stable pointer and closes the trial.
+
+A compare-and-swap miss is stale. The worker never retries the same candidate against a new base.
+Fallback or rejection closes only the exact trial and leaves stable lessons untouched.
+
+A veto or verified regression discovered after promotion may make rollback eligible. Rollback is a
+separate transaction bound to the current learning epoch, exact promotion, candidate-record and
+replacement digests, retained base, current stable revision, and exact trigger ID/digest/version. An
+owner-feedback trigger must remain effective, not superseded, and match the frozen feedback revision;
+a failure or regression trigger must match its immutable receipt and gate version.
+
+The transaction restores the retained base only while the current stable digest and revision still
+identify that promotion. A stale epoch, trigger or compare-and-swap miss cannot retarget a later
+activation. Recording feedback alone never mutates stable state.
+
+## 10. Operations, restart, budgets and data lifecycle
+
+Claiming an operation cannot dispatch a provider request. Before HTTP handoff, one transaction
+rechecks job state, learning epoch, exact carrier privacy result, global and proactive breakers, then
+records `started` with a unique provider-call ID, route and budget reservation. The logical operation
+key covers phase, source digest and prompt, schema and rubric versions. The attempt key also includes
+a monotonic generation; at most one generation is current.
+
+A prior-process `claimed` operation may be reclaimed because durable state proves that no provider
+call started.
+
+After a response, one transaction with `state == started` writes exactly one structured result or
+rejection, usage linkage and terminal operation state. A prior-process `started` operation becomes
+`interrupted_unknown` at boot and is not automatically resent as the same logical inference. The boot
+transaction records any missing conservative usage reservation or ceiling under the saved call ID
+before changing state. A later authorized attempt uses a new operation generation and provider-call
+ID, links `supersedes` to the interrupted attempt, and compare-and-swaps which attempt is current. It
+does not reuse or rewrite the earlier result.
+
+This provides idempotent database results and honest ambiguity at the network boundary. It does not
+claim exactly-once dispatch or provider billing.
+
+Evaluation and reflection usage:
+
+- counts toward global and proactive learning budgets;
+- remains separate from primary task-run totals;
+- is recorded even when a sent call later becomes unusable because of cancellation or purge;
+- never delays persistence or owner delivery of the task result.
+
+Job cancellation atomically blocks new learning calls, closes the exact open trial with a receipt, and
+prevents admission or promotion. Existing bound runs retain their pinned lesson digest and may settle,
+but their evidence cannot activate new learning decisions. History remains until retention or purge
+removes it.
+
+Cancellation is not purge. Purge uses a separate authenticated, confirm-gated owner control. Export
+uses the same owner-only control path, a code-defined bounded scope and a no-follow `0600` file below
+the application state root; only the fixed owner DM receives its path. No model, lesson or tool chooses
+the export scope, path or recipient, and the export omits raw trajectories, private observations and
+provider replay state.
+
+Every binding, operation, feedback target, input challenge, candidate and trial carries a monotonic
+`learning_epoch`. Purge first increments the epoch and installs a durable barrier that:
+
+- disables new learning starts, admission and promotion for the old epoch;
+- invalidates outstanding feedback targets and input challenges, then closes the exact trial;
+- resets stable lessons to the canonical empty set or an ancestor proven unaffected by exact source
+  manifest traversal;
+- prevents late old-epoch results from creating evaluations, candidates, trials or activations.
+
+A late provider result may still record mandatory usage and terminal operation status. Purge removes
+owner-derived learning payloads and provenance only after old-epoch live runs and `started` learning
+operations settle. Export, retention and purge cover run bindings, terminal and settlement receipts,
+evidence, eligibility, evaluations, feedback targets, input challenges, events, candidates, lesson
+sets, trials, operations and decision/verification receipts. Deleting source data cannot leave an
+active lesson that still encodes it. The purge transaction follows exact candidate-source edges to
+invalidate dependent candidates, decisions and lesson sets; a cutoff digest alone cannot prove
+independence.
+
+### Transaction and restart matrix
+
+| Boundary | Atomic durable effect | Crash/replay rule |
+|---|---|---|
+| Fire | occurrence/overlap claim + run + binding + optional trial assignment | no committed run means no assignment; committed run keeps its digest |
+| Segment facts | append tool lifecycle facts and route/surface receipt with their owning segment or suspension commit | duplicate identity must match; missing final disposition makes evidence incomplete |
+| Terminal | winning run state + terminal receipt | unique and idempotent; conflicting duplicate is a consistency failure |
+| Settlement | final primary fact + settlement marker | every later primary-fact writer rejects the write; no timer-based settlement |
+| Evidence/eligibility | compare epoch/barrier + verify receipts/digests + snapshot facts + evidence/exclusion + eligibility | stale purge-era work cannot recreate payload; replay uses run/schema/classifier identity |
+| Feedback notice | target or input challenge + every outbox chunk | resend carries the same opaque target; no notice means no valid action |
+| Feedback event | transport claim + owner/target check + event + revision + audit + exact veto effect | update and nonce cannot be consumed twice; a conflicting replay is stale |
+| Provider start | recheck epoch/privacy/breakers + attempt generation + reservation + unique call ID + `started` | a no-call denial becomes terminal; boot accounts ambiguous exposure and changes a started attempt to `interrupted_unknown` without resend |
+| Provider result | structured result/rejection + usage + terminal operation state | `state == started` predicate permits one exact durable result |
+| Trial admission | job/base/epoch/feedback + source/gate checks + budget reservation + unique trial + receipt | cancellation or stale input cannot open or rebind a trial |
+| Promotion | current job status + exact predicates + decision receipt + stable CAS + trial close | cancellation or CAS loss prevents activation |
+| Fallback/reject/cancel | exact trial close + receipt | stable pointer remains unchanged |
+| Rollback | exact epoch/promotion/trigger/feedback/gate checks + stable CAS to retained base | stale or superseded trigger cannot overwrite later activation |
+| Purge | epoch/barrier first, payload deletion after settlement | late old-epoch results cannot repopulate learning state |
+
+## 11. Page-change adapter
+
+Page-change monitoring is the first deterministic benchmark, not the production boundary. The
+adapter supplies frozen task inputs, a deterministic scorer/oracle, version and regression fixtures
+through generic contracts. The generic domain contains no page-specific types.
+
+A verification receipt is scoped to the exact lesson digest, dataset/oracle, adapter version and
+execution surface. A route, rubric, policy or adapter incompatibility requires revalidation or a
+downgrade to heuristic evidence. Corpus size, split and score thresholds belong to the later
+validation protocol, not this architecture RFC. Protocol 0.6 remains frozen.
+
+The Protocol 0.6 controller batch stopped incomplete after exhausting its regression retry pool. The
+completed direct experiment remains an exploratory scenario-selection result. Neither artifact proves
+a production learning loop, protocol conformance or a second improvement claim, and neither may issue
+a new deterministic verification receipt. M3 must freeze fresh validation inputs and keep oracle,
+gold, holdout and regression data outside evaluator and reflector carriers.
+
+## 12. Validation and implementation sequence
+
+M2 first chooses the versioned algorithm parameters in section 13.
+
+M3 then lands the generic harness and a fresh page-change adapter before production activation. It
+freezes a new corpus, split, scorer, oracle and gates, then exercises clean, trial, active and
+post-restart conditions through generic contracts.
+
+M4 delivers the production capability in this order:
+
+1. **Capture:** run binding, terminal and settlement receipts, complete bounded tool/segment facts,
+   and safe evidence/exclusion; no behavior change.
+2. **Pinned lesson read path:** immutable job lesson sets, exact-digest loading, whole-set context row
+   and initial taint; stable remains the only production pointer.
+3. **Eligibility and evaluation:** versioned deterministic taxonomy, durable learning operations,
+   blind tool-free evaluator and budget accounting.
+4. **Owner feedback:** atomic `fb:` notices, input challenges, typed append-only events and
+   exact-subject veto/support.
+5. **Reflection and inert candidates:** closed reflector carrier, exact source manifests, immutable
+   replacement sets and deterministic admission; no activation.
+6. **Lifecycle controls:** authenticated export/purge, retention, observability and restart fault
+   injection. The production activation gate stays closed until this step and the M3 gates pass.
+7. **Bounded activation:** one trial override, atomic assignment, draining, expiry, fallback, guarded
+   promotion and active rollback.
+
+Each increment must leave ordinary scheduled execution usable when learning is unavailable. After a
+run binding commits, the task either loads the exact pinned lesson bytes or fails before provider
+dispatch; it never substitutes another set.
+
+## 13. Deferred to M2
+
+M2 chooses and versions:
+
+- compatible-evidence window and minimum support count;
+- reflection timing and consolidation rules;
+- lesson count and byte caps within finite M1 bounds;
+- trial assignment count, assignment deadline and decision deadline;
+- heuristic acceptance, regression and uncertainty rules;
+- owner-signal weighting beyond hard veto precedence;
+- evaluator/reflector routes and operation budgets;
+- retention windows and deterministic-adapter thresholds.
+
+M2 cannot change the M1 invariants: one attempt identity, job-scoped lessons, stable plus one bounded
+trial, no stacking, evaluator blindness, feedback through the common gate, no authority expansion,
+honest restart behavior, and distinct heuristic/owner/deterministic evidence claims.
+
+## 14. Acceptance
+
+This RFC satisfies Issue 167's architecture contract:
+
+- existing `run_id` remains canonical and the generic core contains no page types;
+- fire atomically pins exact occurrence, learning epoch and effective lesson digest; ordered segment
+  receipts capture the actual execution surface later;
+- every terminal path has a receipt, settlement blocks later primary writes, and asynchronous sealing
+  copies the complete bounded output and emits versioned eligibility;
+- independent ordered tool lifecycles preserve policy, approval, status and trust facts across early
+  exits;
+- eligibility precedes LLM evaluation; evaluator and closed-whitelist reflector carriers are separate,
+  tool-free and isolated from deterministic oracle data;
+- owner feedback is durable, authenticated, typed, append-only and exact-subject-bound;
+- feedback notices bind atomically to delivery, hard vetoes close exact trials, and feedback or lesson
+  text cannot activate themselves or expand authority;
+- candidates distinguish record and replacement digests and retain exact transitive source manifests;
+- one bounded non-stacking trial has separate assignment and decision deadlines and a frozen cohort;
+- promotion, fallback and rollback use exact epoch, feedback, trigger and compare-and-swap predicates;
+- positive eligible evidence is required and evidence-strength claims remain distinct;
+- learning operations atomically bind provider-call identity, result, usage and restart ambiguity
+  without fake runs; usage joins global and proactive budgets;
+- the complete pinned lesson set reaches context intact and adds taint before memory selection and tool
+  dispatch without replacing existing taint;
+- restart handling does not claim exactly-once provider inference;
+- owner-only export and epoch-barrier purge cover derived data, source deletion and late-result races
+  before production activation;
+- page-change remains the first deterministic adapter and benchmark, while M0 stays exploratory.
+
+No known P0 architecture or security decision remains unresolved in M1. Exact algorithm parameters
+and physical implementation details are intentionally deferred to their owning milestone.

--- a/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
+++ b/docs/research/self-improving-scheduled-tasks-architecture-security-rfc.md
@@ -1,214 +1,209 @@
 # RFC: Self-improving scheduled tasks — architecture and security boundaries
 
-| | |
-|---|---|
-| Status | Proposed — M1 / #167 |
-| Date | 2026-08-28 |
-| Parent | #115 |
-| Evidence baseline | #118, frozen Protocol 0.6 |
-| Production scope | Generic job-scoped learning for every executable scheduled task |
-| First deterministic adapter | Scheduled page-change monitoring |
+**Status:** Proposed — M1 / #167 · **Date:** 2026-08-28 · **Parent:** #115 · **Baseline:** #118 frozen Protocol 0.6
 
-## 1. Decision
+**Production scope:** generic job-scoped learning for every scheduled task swift-claw can execute. **First deterministic adapter/benchmark:** scheduled page-change monitoring.
 
-Every created scheduled run uses one generic job-scoped learning control plane. Existing `run_id` remains the only task-attempt identity. The fire transaction binds it to the exact occurrence, fire kind, job-definition digest, execution surface and effective lesson-set digest; execution remains the ordinary proactive `TurnRunner`/`AgentRuntime` path with existing tools, policy, approvals, budgets and delivery.
+## 1. Decision and guarantee
 
-Every terminal transition writes an immutable terminal receipt. After late usage/approval observations settle, an idempotent worker seals a bounded evidence projection or a technical exclusion. A deterministic eligibility classifier runs before any learning LLM call. Eligible evidence may enter a fresh, tool-free, procedurally blind evaluator. Reflection is a separate fresh, tool-free call and may only propose an immutable complete replacement lesson set.
+Every created scheduled run uses one generic learning control plane. Existing `run_id` remains the only task-attempt identity. The fire transaction binds it to exact occurrence, fire kind, job-definition digest, execution surface and effective lesson-set digest; execution stays on the ordinary proactive `TurnRunner`/`AgentRuntime` path with existing tools, policy, approvals, budgets and delivery.
 
-Owner feedback is durable, authenticated, typed, append-only and bound to an exact subject/digest. It is evidence, never direct activation.
+Every terminal transition writes an immutable receipt. After late usage/approval observations settle, an idempotent worker seals bounded evidence or a technical exclusion. A deterministic eligibility classifier runs before learning LLM spend. Eligible evidence may enter a fresh, tool-free, blind evaluator. Reflection is a separate fresh/tool-free call and may only propose an immutable complete replacement lesson set.
 
-Each job has one stable lesson-set pointer and at most one bounded trial override. Trials cannot stack. Only a created run consumes an assignment. Promotion CASes the stable pointer from the recorded base digest to the candidate digest; fallback closes the trial and leaves stable untouched.
+Owner feedback is durable, authenticated, typed, append-only and exact-subject-bound. It is evidence, never activation. Each job has one stable lesson pointer and at most one bounded trial override; trials cannot stack. Promotion CASes stable from recorded base to candidate; fallback closes trial and leaves stable untouched.
 
-**Capability guarantee:** any scheduled task swift-claw can execute can participate in capture → eligibility → evaluation → feedback → reflection → candidate → bounded trial → promote/fallback. This is not a guarantee that subjective tasks are objectively verifiable or will improve. Natural runs/LLM evaluation are heuristic; owner feedback establishes owner intent; only a deterministic adapter over a named frozen oracle/dataset may issue scoped `deterministically_verified` evidence.
+**Guarantee:** any executable scheduled task can participate in capture → eligibility → evaluation → feedback → reflection → candidate → bounded trial → promote/fallback without expanding its authority. This does not guarantee objective verification or improvement for subjective tasks. Natural runs/LLM evaluation are heuristic; owner feedback establishes owner intent; only a deterministic adapter over a named frozen oracle/dataset may issue scoped `deterministically_verified` evidence.
 
-No unresolved P0 architecture/security blocker remains. Exact policy parameters are deferred to M2 (§14).
+No unresolved P0 architecture/security blocker remains. Exact algorithm parameters are deferred to M2 (§12).
 
-## 2. Invariants
+## 2. Invariants / security boundary
 
-1. `run_id` is canonical; no parallel attempt entity.
-2. Generic core contains no page/HTML/selector/region/snapshot types.
-3. Scheduled execution remains an ordinary proactive agent run.
-4. Lessons are data, never authority. They cannot change job prompt, schedule, budgets, model route, tool catalog/risk, approvals, recipients, paths, commands or destinations.
-5. Lessons use a trusted harness wrapper around bounded untrusted payload and never enter global/workspace memory, conversation history or FTS.
-6. Non-empty lessons establish taint before sensitive-memory selection, first provider call and first tool-policy decision.
-7. Evaluation/reflection get fresh contexts with no tools, workspace memory, session history, approvals or provider replay state.
-8. Evaluator is blind to lesson text/IDs, stable/candidate digests, trial condition, prior scores, promotion state and expected improvement.
-9. Deterministic eligibility precedes learning LLM spend.
-10. Feedback cannot activate lessons or expand authority.
-11. One stable pointer + at most one trial; no stacking.
-12. Promotion needs positive eligible evidence. Silence, evaluator failure and ineligible runs never count positive.
-13. DB claims/effects are idempotent; external LLM inference is not exactly-once.
-14. Export/retention/purge cover derived learning data; deleting private source data cannot leave an active lesson encoding it.
+- `run_id` is canonical; no parallel attempt entity.
+- Generic core contains no page/HTML/selector/region/snapshot types.
+- Scheduled execution remains an ordinary proactive agent run.
+- Lessons are data, never authority: they cannot change job prompt, schedule, budgets, model route, tool catalog/risk, approvals, recipients, paths, commands or destinations.
+- Lessons use a trusted harness wrapper around bounded **untrusted payload**; they never enter global/workspace memory, conversation history or FTS.
+- Non-empty lessons establish taint before sensitive-memory selection, first provider call and first tool-policy decision.
+- Evaluation/reflection get fresh contexts with no tools, workspace memory, session history, approvals or provider replay state.
+- Evaluator is blind to lesson text/IDs, stable/candidate digests, trial condition, prior scores, promotion state and expected improvement.
+- Deterministic eligibility precedes learning LLM spend.
+- Feedback cannot activate lessons or expand authority.
+- One stable pointer + at most one trial; promotion requires positive eligible evidence. Silence/evaluator failure/ineligible runs are never positive.
+- DB effects are idempotent; external LLM inference is not exactly-once.
+- Export/retention/purge include derivatives; deleting private source data cannot leave an active lesson encoding it.
 
 ## 3. Existing-seam map
 
-**Scheduler/fire.** `ScheduledJobStore.claimAndFire` already fuses occurrence compare-and-advance with session/trigger creation, `PENDING` run and audit; `fireNow` reuses the insert set without schedule advance; overlap prevents a second live job-session run. Extend the successful fire transaction with `learning_run_binding(run_id, job_id, occurrence, fire_kind, job_definition_digest, execution_surface_version, effective_lesson_set_id/digest, stable_base_digest, trial_id/generation?)`. Resolve trial expiry first; consume one assignment only after overlap passes and `run_id` is created. Misfire, overlap skip and CAS loser consume none.
+**Scheduler/fire.** `ScheduledJobStore.claimAndFire` already fuses occurrence compare-and-advance with session/trigger, `PENDING` run and audit; `fireNow` reuses the insert set without schedule advance; overlap prevents a second live job-session run. Extend the successful transaction with `learning_run_binding(run_id, job_id, occurrence, fire_kind, job_definition_digest, execution_surface_version, effective_lesson_id/digest, stable_base_digest, trial_id/generation?)`. Resolve trial expiry first; consume an assignment only after overlap passes and `run_id` exists. Misfire, overlap skip and CAS loser consume none.
 
-**Run persistence.** `RunStore` owns pickup, completion/degradation, cancel/supersede, approval suspension/resume and boot reconciliation. Extend every legal terminal transition (`DONE/FAILED/CANCELLED/SUPERSEDED`, including boot reconciliation) to write one `learning_terminal_receipt` in the same SQLite transaction. Seal evidence later unless a normal `DONE` transaction already has all settled facts.
+**Run persistence.** `RunStore` owns pickup, completion/degradation, cancel/supersede, approval suspension/resume and boot reconciliation. Every legal terminal transition (`DONE/FAILED/CANCELLED/SUPERSEDED`, including reconciliation) writes one `learning_terminal_receipt` in the same transaction. Seal later unless a normal `DONE` transaction already has all settled facts.
 
-**Context/taint.** `TurnRunner` loads bounded context/budgets and calls `AgentRuntime` with taint/private-data state. Add a job-scoped lesson section whose wrapper is trusted but payload untrusted. Non-empty lessons set initial taint before context memory selection.
+**Context/taint.** `TurnRunner` loads bounded context/budgets and calls `AgentRuntime` with taint/private-data state. Add a job-scoped lesson section: trusted wrapper, untrusted payload. Non-empty lessons set initial taint before context memory selection.
 
-**Policy/approvals.** Existing canonical-args, policy-version, owner and approval gates stay authoritative. Candidate text scanning is defense in depth. Lessons never become policy operands and cannot weaken approval, exfiltration, SSRF or proactive-budget policy.
+**Policy/approvals.** Existing canonical-args, policy-version, owner and approval gates stay authoritative. Candidate scanning is defense in depth; lessons never become policy operands and cannot weaken approval, exfiltration, SSRF or proactive-budget policy.
 
-**Usage/budgets.** Learning calls are durable runless operations, not fake agent runs. Their provider usage counts toward global and proactive/learning budgets. Owner delivery never waits for learning calls.
+**Usage/budgets.** Evaluation/reflection are durable runless learning operations, not fake runs. Usage counts toward global and proactive/learning budgets. Owner delivery never waits for learning calls.
 
-**Telegram feedback.** Reuse the security pattern of approval callbacks (claim update, numeric allowlist, strict namespace, random nonce, owner binding, CAS, redacted audit), but use separate `fb:` targets/events. Feedback never reuses tool approvals or `AWAITING_APPROVAL`.
+**Telegram feedback.** Reuse the fail-closed callback pattern (claim update → numeric allowlist → strict namespace → random nonce → owner binding → CAS → redacted audit) in a separate `fb:` domain. Do not reuse tool approvals or `AWAITING_APPROVAL`.
 
-## 4. Architecture
+## 4. Architecture and data model
 
 ```text
 SchedulerService
-  → fire txn: resolve lessons → create ordinary run_id → pin digests → consume trial assignment
-  → TurnEnqueuer → TurnRunner → AgentRuntime → existing policy/tools/outbox
-                                      → terminal txn + terminal receipt
-
-LearningCoordinator (async, post-delivery)
-  → EvidenceSealer → sealed evidence | exclusion
-  → EligibilityClassifier (deterministic)
-  → Evaluator (fresh/tool-free/blind)
-  → durable owner feedback
-  → Reflector (fresh/tool-free)
-  → CandidateAdmissionPolicy
-  → TrialController → promote CAS | fallback
-
-Optional LearningEvaluatorAdapter
-  → page-change first: frozen inputs + deterministic scorer + regression fixtures
+ → fire txn: resolve lessons → create run_id → pin digests → consume trial assignment
+ → TurnEnqueuer → TurnRunner → AgentRuntime → existing policy/tools/outbox
+                                      → terminal txn + receipt
+LearningCoordinator (async; post-delivery)
+ → EvidenceSealer → EligibilityClassifier → Evaluator → Feedback/Reflector
+ → CandidateAdmissionPolicy → TrialController → promote CAS | fallback
+Optional LearningEvaluatorAdapter → page-change frozen scorer/fixtures first
 ```
 
-Learning sits beside scheduler/persistence. `AgentRuntime` consumes pinned lessons and produces ordinary run facts; it does not own evaluation, reflection, trial or promotion.
+Learning sits beside scheduler/persistence; `AgentRuntime` only consumes pinned lessons and produces ordinary run facts.
 
-## 5. Generic data model
+Conceptual generic records (names are not M1 migrations):
 
-Conceptual contracts; migrations/Swift names are implementation work.
-
-- `learning_job_state`: job PK, stable lesson ID/digest, nullable open trial ID, monotonic generation. Stable pointer is the only production activation pointer.
-- `learning_lesson_sets`: immutable complete replacement set, job/digest, bounded ordered payload, base digest, source reflection/owner edit, schema/timestamps. No in-place edit.
+- `learning_job_state`: job PK, stable lesson ID/digest, nullable open trial, monotonic generation. Stable pointer is the only production activation pointer.
+- `learning_lesson_sets`: immutable complete replacement set, bounded payload, digest/base digest, source, schema/timestamps. No in-place edit.
 - `learning_run_bindings`: one per created scheduled `run_id`; exact occurrence/fire kind and pinned job/execution/lesson/trial digests.
-- `learning_terminal_receipts`: one immutable row per terminal scheduled run; winning terminal state, timestamp, schema/digest.
-- `learning_evidence`: one `sealed` projection or typed `excluded` result per binding. Projection contains bindings/digests, terminal classification, bounded final output or digest, bounded tool facts (name/status/policy decision/result size/trust flags), actual model route, primary-run usage refs, versions and optional adapter facts. Excludes raw tool args, secrets, private raw observations, replay state and audit projections.
-- `learning_operations`: durable evaluation/reflection ID, kind, source evidence, phase/status, model route, schema, attempts, usage/cost refs, timestamps; includes `interrupted_unknown`.
-- `learning_evaluations`: immutable evidence/digest binding, rubric/adapter versions, result `no_issue | reusable_issue | transient_issue | uncertain`, bounded findings, digest/timestamp.
-- `learning_feedback_targets`: random one-time nonce, owner ID, exact subject type/id/digest, expiry/consumed state.
-- `learning_feedback_events`: append-only owner/job/run/output identity, optional evaluation/candidate, typed signal/payload, Telegram update ID or nonce, timestamp, optional superseded-event link.
-- `learning_trials`: job, base/candidate digests, generation, state, deadline, max/consumed assignments, admission evidence. Unique open trial per job.
-- `learning_decision_receipts`: immutable promotion/fallback/reject decision, trial/base/candidate, considered evidence/feedback, evidence-strength label, policy/version inputs, CAS generations, digest/timestamp.
-- `deterministic_verification_receipts` (adapter-only): adapter/version, frozen dataset/oracle, execution surface, subject digests, deterministic result/digest.
+- `learning_terminal_receipts`: one per terminal run; winning terminal state, timestamp, schema/digest.
+- `learning_evidence`: one sealed projection or typed exclusion. Projection contains bindings/digests, terminal classification, bounded final output/digest, bounded tool facts (name/status/policy decision/result size/trust flags), actual model route, primary usage refs, versions and optional adapter facts. Excludes raw tool args, secrets, private raw observations, replay state and audit projections.
+- `learning_operations`: durable evaluation/reflection ID, source evidence, phase/status (`pending/in_flight/succeeded/failed/interrupted_unknown`), model route/schema, attempts, usage/cost refs, timestamps.
+- `learning_evaluations`: evidence binding, rubric/adapter versions, closed result `no_issue | reusable_issue | transient_issue | uncertain`, bounded findings/digest.
+- `learning_feedback_targets/events`: random one-time nonce + owner + exact subject digest; append-only typed event with Telegram update/nonce and optional superseded link.
+- `learning_trials`: job, base/candidate digests, generation, state, deadline, max/consumed assignments, admission evidence; unique open trial/job.
+- `learning_decision_receipts`: immutable promotion/fallback/reject inputs, evidence/feedback, evidence strength, CAS generations/digest.
+- adapter-only `deterministic_verification_receipts`: adapter/version, frozen dataset/oracle, execution surface, subject digests and deterministic result.
 
-Feedback signals: `result_useful`, `result_not_useful`, `result_correction`, `evaluation_confirm`, `evaluation_dispute`, `candidate_approve`, `candidate_reject`, `candidate_edit`. Edit creates a new immutable digest and invalidates old approvals/support.
+Feedback types: result useful/not-useful/correction; evaluation confirm/dispute; candidate approve/reject/edit. Edit creates a new digest and invalidates old support.
 
-## 6. Lifecycles
+## 5. Lifecycles
 
 ```text
-created run → terminal receipt → settlement
-  ├─ cannot safely seal → technical exclusion
-  └─ sealed evidence → deterministic eligibility
-       ├─ ineligible → retain; no learning LLM
-       └─ eligible → evaluation
-            ├─ failed/interrupted_unknown → stop
-            └─ saved evaluation → reflection (when policy permits)
-                 ├─ failed/interrupted_unknown → stop
-                 └─ immutable candidate → admission validation → inert | trial
+created run → terminal receipt → settlement → sealed evidence | exclusion
+sealed → deterministic eligibility
+  ├─ ineligible → retain; no learning LLM
+  └─ eligible → evaluation
+       ├─ fail/interrupted_unknown → stop
+       └─ saved evaluation → reflection (when policy permits)
+            ├─ fail/interrupted_unknown → stop
+            └─ immutable candidate → admission → inert | trial
 ```
 
 ```text
-candidate → admitted TRIAL (stable pointer untouched)
-  ├─ expiry / assignment exhaustion / security veto / regression / owner reject-dispute /
-  │  insufficient positive eligible evidence → close + FALLBACK
+candidate → TRIAL (stable untouched)
+  ├─ expiry/exhaustion/security veto/regression/owner reject-dispute/
+  │  insufficient positive evidence → close + FALLBACK
   └─ acceptance satisfied → decision receipt → CAS stable(base→candidate)
-       ├─ CAS lost → close stale trial
-       └─ CAS won → ACTIVE; close trial
+       ├─ lost → close stale trial
+       └─ won → ACTIVE; close trial
 ```
 
-Lifecycle and evidence strength are independent:
+Keep dimensions separate:
 
 ```text
 lifecycle: candidate | trial | active | rolled_back | superseded
-evidence:  heuristic | owner_supported | owner_confirmed | deterministically_verified
+evidence: heuristic | owner_supported | owner_confirmed | deterministically_verified
 ```
 
-An active lesson may remain heuristic. LLM evaluation never produces `deterministically_verified`.
+An active lesson may remain heuristic. LLM evaluation never yields deterministic verification.
 
-## 7. Evidence and eligibility
+## 6. Evidence, evaluator and reflection
 
-The terminal receipt is settlement-independent so every terminal path can commit it. The sealer is idempotent by run + evidence-schema version and waits for required usage/approval observations. It writes immutable sealed evidence or `excluded(reason)`; ordinary audit is observability, not provenance.
+Terminal receipt is settlement-independent and unique by run. Sealer is idempotent by run + evidence-schema version, waits for required usage/approval observations, and writes sealed evidence or `excluded(reason)`. Audit is observability, not provenance.
 
-Initial deterministic eligibility taxonomy:
+Initial deterministic eligibility taxonomy: `eligible_task_evidence`, `transient_infrastructure_failure`, `policy_or_security_block`, `owner_interruption`, `insufficient_evidence`, `unsupported_terminal_state`. Provider/storage/credential/budget failures do not create behavioral lessons; cancellation, supersession and security blocks never enter reflection. One-shot jobs may retain evidence/evaluation/feedback but cannot trial without another occurrence.
 
-- `eligible_task_evidence`;
-- `transient_infrastructure_failure`;
-- `policy_or_security_block`;
-- `owner_interruption`;
-- `insufficient_evidence`;
-- `unsupported_terminal_state`.
+Evaluator input is exactly frozen job prompt, frozen quality rubric, final output, safe evidence projection and optional adapter facts. No tools. Reflection is a separate call over compatible saved evaluations/multi-run evidence plus current lesson set and proposes one complete replacement. Evaluation failure cannot start reflection; reflection failure cannot create a candidate. Compatibility includes job semantics, evidence schema, execution surface, rubric and adapter version.
 
-Provider/storage/credential/budget failures do not produce behavioral lessons. Cancellation, supersession and security-policy blocks do not enter reflection. One-shot jobs can retain evidence/evaluation/feedback but cannot exercise a trial without another occurrence.
+## 7. Candidate authority firewall and feedback
 
-## 8. Evaluator, reflector and candidate firewall
+Admission deterministically validates schema/canonical encoding, lesson count/size, Unicode/invisible/bidi handling, exact-loaded-secret leakage, base/source integrity and forbidden authority operands (schedule, recipients, model route, budgets, tools/risk/approval config, paths, commands, destinations, credentials). Text classification is defense in depth; runtime policy is the boundary.
 
-Evaluator input is exactly the frozen job prompt, frozen quality rubric, final output, safe evidence projection and optional adapter facts. It has no tools and returns the closed result above plus bounded findings. This is heuristic evidence.
+Feedback transaction: atomically claim external event → numeric-ID allowlist → parse `fb:` → load random-nonce target → verify owner + exact subject digest → append event → consume target where one-shot → append redacted audit in same write.
 
-Reflection is a separate call receiving compatible saved evaluations/multi-run evidence plus current lesson set; it proposes one complete immutable replacement set. Evaluation failure cannot start reflection; reflection failure cannot create a candidate. Compatibility must account for job semantics, evidence schema, execution surface, rubric and adapter version.
+Useful/not-useful supports/contradicts one result; correction is owner-attested expected behavior and possible one-run trial seed; evaluation dispute blocks dependent promotion; candidate approve permits an owner-supported trial through the common gate, never direct activation; reject vetoes/stops exact candidate; edit creates a new candidate and reruns all gates. Owner statements establish intent, not deterministic verification.
 
-Before persistence/trial, deterministic admission validates schema/canonical encoding, lesson count/size, Unicode/invisible/bidi handling, exact-loaded-secret leakage, base digest/source integrity, and forbidden authority operands (schedule, recipients, model route, budgets, tools/risk/approval config, paths, commands, destinations, credentials). Text classification is defense in depth: runtime policy remains the security boundary.
+## 8. Trial semantics
 
-## 9. Owner feedback
+Candidate is a complete replacement set with incumbent digest. Repeated compatible evidence may admit an automatic heuristic trial; explicit owner correction/approval may admit after one eligible occurrence. Exact thresholds are M2.
 
-Feedback transaction: claim external event → numeric-ID allowlist → parse `fb:` only → load random-nonce target → verify owner + exact subject digest → append event → consume one-time target if applicable → append redacted audit in the same write.
+Fire atomically resolves expiry → passes existing occurrence/overlap guard → creates run → pins stable/trial digest → consumes one assignment. A created run consumes it even if later technically failed; only eligible completed evaluations count positive. Trials cannot stack.
 
-Semantics: useful/not-useful supports/contradicts one result; correction is owner-attested expected behavior and possible one-run trial seed; evaluation confirm/dispute overlays exact evaluation and dispute blocks dependent promotion; candidate approve permits owner-supported trial through the common gate; reject vetoes/stops exact candidate; edit creates a new candidate/digest and reruns every gate. Owner statements establish owner intent, not deterministic verification.
+Expiry, assignment exhaustion, critical failure/regression, security/deterministic veto, explicit rejection/dispute or insufficient positive evidence closes the exact trial; future runs use stable. Promotion writes decision receipt, CASes stable only if base/generation match, then closes trial. Hard veto and owner reject/dispute outrank heuristic support.
 
-## 10. Trial rules
-
-A candidate is a complete replacement set with incumbent/base digest. Repeated compatible evidence may admit an automatic heuristic trial; explicit owner correction or candidate approval may admit a trial after one eligible occurrence. Exact support thresholds are M2.
-
-The fire transaction atomically: resolve expiry → pass existing occurrence/overlap guard → create run → pin stable/trial digest → consume one assignment. A created run consumes its assignment even if it later fails technically; only eligible completed evaluations count positive. Trials cannot stack.
-
-Expiry, assignment exhaustion, critical failure/regression, deterministic/security veto, explicit rejection/dispute, or insufficient positive evidence closes the exact trial and future runs use untouched stable. Promotion writes a decision receipt, CASes stable only if base digest/generation still match, then closes trial. Hard security/deterministic veto and owner reject/dispute outrank heuristic support.
-
-## 11. Trust and data lifecycle
-
-Trust zones:
+## 9. Trust and data lifecycle
 
 ```text
-CONTROL (trusted code): scheduler claims, policy, budgets, admission, trial/CAS, owner auth
-DATA (untrusted): lesson payloads, outputs, tool-derived facts, evaluator/reflection prose
+CONTROL/trusted code: scheduler claims, policy, budgets, admission, trial/CAS, owner auth
+UNTRUSTED data: lessons, outputs, tool facts, evaluator/reflection prose
 OWNER-ATTESTED: authenticated feedback for exact subject
 DETERMINISTIC: scoped adapter receipt for frozen oracle/dataset only
 ```
 
-Learning never grants capabilities. Evaluation/reflection have no tools. Raw private observations and tool arguments are excluded from evaluator evidence. Lessons are job-scoped and excluded from memory/history/FTS. Non-empty lessons taint the run before memory/tool decisions.
+Export/retention/purge cover evidence, operations/evaluations, feedback, candidates, lesson sets, trials and verification/decision receipts. Job cancellation blocks new learning spend/promotion but retains immutable history per retention. Job-learning purge must deactivate/remove derived active lessons depending on purged private data or conservatively reset stable to an unaffected ancestor/empty set.
 
-Export/retention/purge cover evidence, evaluations, operations, feedback, candidates, lesson sets, trials, verification/decision receipts and provenance links. Job cancellation blocks new learning spend and promotion but retains immutable history until policy removes it. Explicit job-learning purge must either remove/deactivate derived active lessons whose provenance depends on purged private source data, or conservatively reset stable to an unaffected ancestor/empty set; it may not leave encoded deleted private facts active.
+## 10. Transaction and restart matrix
 
-## 12. Transaction + crash/restart matrix
+| Operation | Atomic boundary / restart rule |
+|---|---|
+| Fire | occurrence/overlap claim + run + binding + trial assignment; no run ⇒ no assignment; created run keeps pinned digest |
+| Terminal | run terminal transition + receipt; unique/idempotent and agrees with winning state |
+| Evidence | seal/exclusion keyed by run+schema; DB construction retry is idempotent |
+| Feedback | external-event claim + owner/target validation + event + audit; duplicate cannot append twice |
+| Eval/reflect | durable `in_flight` before request; pre-crash in-flight → `interrupted_unknown`, no automatic repeat of same logical synthesis |
+| Eval/reflect finish | structured result + terminal op status + usage refs; committed result reusable; no exactly-once inference claim |
+| Trial admit | validation + unique open trial + job-state CAS; prevents stacking |
+| Trial assign | successful fire + binding + assignment increment; run exists ⇒ consumed |
+| Promotion | decision receipt + stable CAS + trial close; CAS loser never overwrites newer stable |
+| Fallback/reject | decision receipt + exact trial close; stable unchanged |
+| Job cancel | block new learning/promotion; immutable history retained per policy |
 
-| Operation | Atomic durable boundary | Crash/restart rule |
-|---|---|---|
-| Fire | existing occurrence/overlap claim + run + binding + trial assignment | no run ⇒ no assignment; created run keeps pinned digest forever |
-| Terminal | run terminal transition + terminal receipt | receipt agrees with winning terminal state; duplicate is idempotent |
-| Evidence seal | sealed projection/exclusion keyed by run+schema | retry DB construction idempotently; never duplicate evidence |
-| Feedback | external-event claim + owner/target validation + event + audit | duplicate update/nonce cannot append twice |
-| Eval/reflect start | operation row → `in_flight` before request | pre-crash in-flight becomes `interrupted_unknown`; do not auto-repeat same synthesis |
-| Eval/reflect finish | structured result + operation terminal status + usage refs | committed result reusable; ambiguous external inference is not replayed as exactly-once |
-| Trial admission | validate candidate + create single open trial + job-state trial pointer CAS | unique/CAS prevents stacking |
-| Trial assignment | successful fire + binding + assignment increment | run exists ⇒ assignment consumed even if run later fails |
-| Promotion | decision receipt + stable-pointer CAS + trial close | CAS winner activates once; loser closes stale/re-evaluates, never overwrites newer stable |
-| Fallback/reject | decision receipt + exact trial close | stable pointer unchanged; future fires resolve stable |
-| Job cancel | cancel state + block-new-learning marker/state | no new learning spend/promotion after cancel; history retained per lifecycle policy |
+## 11. Page-change adapter / evidence claims
 
-External LLM inference is at-least-attempted, not exactly-once. Restart reconciliation never silently reissues an ambiguous synthesis.
+Page-change is the first deterministic benchmark, not product boundary. Adapter supplies frozen inputs, deterministic scorer/oracle, adapter version and regression fixtures through generic contracts; generic types contain no page concepts.
 
-## 13. Page-change adapter
+Deterministic verification is scoped to named dataset/oracle, adapter version and execution surface. Route/rubric/policy/adapter incompatibility requires revalidation or downgrade to heuristic use. Protocol 0.6 from #118 remains frozen.
 
-Page-change is the first deterministic benchmark, not the product boundary. The adapter supplies frozen benchmark inputs, deterministic scorer/oracle, adapter version and regression fixtures through generic contracts. Generic persistence/lifecycle types contain no page concepts.
+## 12. Deferred algorithm parameters (M2)
 
-A deterministic verification receipt is valid only for its named dataset/oracle, adapter version and execution surface. Route/rubric/policy/adapter incompatibility requires revalidation or downgrade to heuristic use. Protocol 0.6 from #118 remains frozen and is not rewritten by M1.
+M2 selects with benchmark evidence: compatible-evidence window/recency; minimum supporting runs; owner-signal weighting beyond hard veto precedence; trial assignment count/deadline; automatic-trial support threshold; acceptance/regression formula and uncertainty band; reflection cadence/consolidation; lesson count/size limits (architecture only requires finite caps); evaluator/reflector model choice and per-operation budgets; retention durations; deterministic-adapter score thresholds/revalidation window.
 
-## 14. Deferred to M2
+## 13. Implementation increments — smallest usable generic vertical first
 
-M2 selects, with benchmark evidence rather than architectural guesswork:
+1. **Capture only:** run binding + terminal receipt + sealed safe evidence/exclusion; no LLM learning, no runtime behavior change.
+2. **Eligibility + evaluator:** deterministic taxonomy, durable operations, blind tool-free evaluator, learning budget accounting; still no lessons applied.
+3. **Owner feedback:** `fb:` targets/events, authenticated callback capture, exact-subject overlays; still no activation.
+4. **Reflection + inert candidates:** tool-free reflection, immutable replacement sets, deterministic admission firewall; candidates cannot run yet.
+5. **Bounded trial:** job stable pointer + one trial override, atomic assignment at fire, initial lesson taint, expiry/fallback/no-stacking.
+6. **Promotion/rollback:** decision receipts, positive-evidence gate, CAS promotion, veto precedence and rollback/fallback.
+7. **Page-change adapter:** frozen deterministic scorer/fixtures and scoped verification receipts used to validate the generic loop.
+8. **Lifecycle completion:** export/retention/job-learning purge, doctor/observability and restart fault-injection coverage.
 
-- compatible-evidence window/recency policy;
-- minimum supporting runs/evaluations;
-- owner-signal weighting and conflict policy beyond hard veto precedence;
-- trial assignment count and wall-clock
+Each increment is independently testable and preserves existing scheduler behavior until the trial increment explicitly injects a pinned lesson set.
+
+## 14. Acceptance checklist
+
+- [x] Capability guarantee and subjective evidence limits stated.
+- [x] Existing `run_id` is the only attempt identity.
+- [x] Generic core has no page-change domain types.
+- [x] Fire atomically pins effective lesson digest and occurrence.
+- [x] Terminal receipt + post-settlement sealing cover legal terminal paths.
+- [x] Eligibility precedes evaluator LLM.
+- [x] Evaluator blindness and evaluator/reflector separation explicit.
+- [x] Owner feedback durable/authenticated/typed/append-only/exact-bound.
+- [x] Feedback cannot activate lessons or expand authority.
+- [x] Stable pointer + single bounded trial + expiry/no-stacking/CAS specified.
+- [x] Positive eligible evidence required; silence/evaluator failure not positive.
+- [x] Heuristic, owner-supported/confirmed and deterministic evidence separated.
+- [x] Learning usage participates in global + proactive/learning budgets.
+- [x] Initial lesson taint occurs before memory selection/provider/tool policy.
+- [x] Candidate validation is not the sole prompt-injection defense.
+- [x] Restart handling does not claim exactly-once LLM inference.
+- [x] Retention/export/purge cover derivatives and provenance.
+- [x] Page-change is first deterministic adapter/benchmark.
+- [x] No unresolved P0 architecture/security blocker identified.
+
+## 15. Out of scope for M1
+
+Swift production code/migrations/tests; exact thresholds/windows/trial duration/consolid


### PR DESCRIPTION
## Summary

Defines the compact v3.1 M1 architecture/security contract for #167 and the generic job-scoped self-learning lifecycle under #115.

The RFC covers:
- existing scheduler/run/context/policy/usage/Telegram feedback seams;
- canonical `run_id` binding, typed terminal/settlement lifecycle and ordered execution-surface evidence;
- generic data model and lifecycle diagrams;
- evaluator blindness and evaluator/reflector separation;
- durable authenticated owner feedback;
- candidate authority firewall;
- single bounded trial, CAS promotion and fallback;
- transaction/crash/restart semantics;
- trust, evidence-strength and data-lifecycle boundaries;
- M2-deferred algorithm parameters;
- implementation increments ordered by the smallest usable generic vertical;
- page-change as the first deterministic adapter/benchmark, not the product boundary.

## Scope

Documentation/RFC only. No production Swift, migrations or tests. Protocol 0.6 from #118 is unchanged.

## Key decisions

- Existing `run_id` remains the only task-attempt identity.
- Every created scheduled run pins exact occurrence and effective lesson digest atomically; runtime segments capture the actual execution surface.
- Non-empty lessons are bounded untrusted payload and establish initial taint before memory/tool decisions.
- Evaluation/reflection are fresh, tool-free learning operations; evaluation is procedurally blind.
- Feedback is append-only evidence and can never directly activate lessons.
- One stable lesson pointer + at most one bounded trial; no stacking.
- Promotion requires positive eligible evidence and uses a stable-pointer CAS.
- External LLM inference is not claimed exactly-once; ambiguous crash-window synthesis becomes `interrupted_unknown`, with conservative usage accounting.
- Heuristic, owner-attested and deterministic evidence claims remain separate.

Closes no issue and performs no merge.

Refs #167
Refs #115