### PR TITLE
docs(branding): explore premium product-first identity directions

### DIFF
--- a/docs/assets/branding/exploration/README.md
+++ b/docs/assets/branding/exploration/README.md
@@ -1,0 +1,38 @@
+# swift-claw — premium brand exploration
+
+This is a design-review artifact. The production README and existing branding remain untouched until a direction is selected.
+
+## All directions
+
+![Five product-first brand directions](contact-sheet.svg)
+
+The board compares:
+
+1. **Quiet Utility** — a calm local software appliance.
+2. **Product, Not Mascot** — the Telegram experience as the hero.
+3. **Technical Editorial** — the daemon architecture as the visual language.
+4. **New Mark System** — Local Loop, Claw Aperture, and an SC monogram.
+5. **Recommended Hybrid** — premium typography, Local Loop, and the owner-approval product surface.
+
+## Recommended direction
+
+![Recommended Hybrid](recommended-hybrid.svg)
+
+The recommended route is **Recommended Hybrid + Local Loop**. It gives the repository a distinctive identity while grounding the hero in swift-claw's actual product: one owner, one local daemon, Telegram as the interface, durable local state, and explicit approval before consequential actions.
+
+## Primary mark
+
+<img src="local-loop-mark.svg" alt="Local Loop mark" width="240" />
+
+## Visual system
+
+![Visual system](design-system-board.svg)
+
+## Deliverables in this review
+
+- editable vector contact sheet with all five directions;
+- standalone recommended hero at 1400×700;
+- standalone Local Loop mark at 512×512;
+- visual-system board with palette, typography, and usage rule.
+
+The raster export package (README sizes, social cards, and light/dark avatars) is intentionally kept separate from the production branding until a direction is approved. No production asset or README reference is replaced by this PR.

--- a/docs/assets/branding/exploration/contact-sheet.svg
+++ b/docs/assets/branding/exploration/contact-sheet.svg
@@ -1,0 +1,116 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1360" viewBox="0 0 1600 1360">
+  <defs>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="14" stdDeviation="20" flood-color="#111113" flood-opacity="0.10"/>
+    </filter>
+  </defs>
+  <rect width="1600" height="1360" fill="#F3F2EE"/>
+  <text x="72" y="72" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="13" font-weight="700" fill="#F05138" letter-spacing="2.3">SWIFT-CLAW / BRAND EXPLORATION</text>
+  <text x="72" y="132" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="48" font-weight="650" fill="#111113" letter-spacing="-1.6">Five product-first directions</text>
+  <text x="72" y="170" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="18" fill="#6E6E73">Premium restraint, local-first product proof, and one Swift-orange accent.</text>
+
+  <!-- 01 Quiet Utility -->
+  <g transform="translate(72 220)">
+    <rect width="700" height="330" rx="28" fill="#FFFFFF" stroke="#D8D7D2" filter="url(#shadow)"/>
+    <text x="32" y="42" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#F05138" letter-spacing="1.8">01 · QUIET UTILITY</text>
+    <path d="M77 72 A26 26 0 1 0 77 124" fill="none" stroke="#111113" stroke-width="7" stroke-linecap="round"/>
+    <path d="M75 84 L86 98 L75 112" fill="none" stroke="#F05138" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="112" y="108" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="43" font-weight="650" fill="#111113" letter-spacing="-1.4">swift-claw</text>
+    <text x="32" y="156" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="25" font-weight="560" fill="#111113">Personal AI,</text>
+    <text x="32" y="187" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="25" font-weight="560" fill="#111113">running locally.</text>
+    <text x="32" y="222" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="14" fill="#6E6E73">A calm software appliance, not an AI mascot.</text>
+    <rect x="426" y="70" width="238" height="214" rx="22" fill="#F7F7F5" stroke="#D8D7D2"/>
+    <text x="448" y="106" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="16" font-weight="700" fill="#111113">clawd</text>
+    <circle cx="636" cy="100" r="5" fill="#F05138"/>
+    <line x1="448" y1="126" x2="640" y2="126" stroke="#D8D7D2"/>
+    <text x="448" y="160" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="14" fill="#111113">Telegram</text><text x="640" y="160" text-anchor="end" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="13" fill="#6E6E73">connected</text>
+    <text x="448" y="195" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="14" fill="#111113">Memory</text><text x="640" y="195" text-anchor="end" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="13" fill="#6E6E73">ready</text>
+    <text x="448" y="230" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="14" fill="#111113">Policy</text><text x="640" y="230" text-anchor="end" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="13" fill="#6E6E73">default-deny</text>
+    <text x="32" y="292" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="12" fill="#6E6E73">ONE OWNER · ONE DAEMON · ONE MACHINE</text>
+  </g>
+
+  <!-- 02 Product, Not Mascot -->
+  <g transform="translate(828 220)">
+    <rect width="700" height="330" rx="28" fill="#FFFFFF" stroke="#D8D7D2" filter="url(#shadow)"/>
+    <text x="32" y="42" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#F05138" letter-spacing="1.8">02 · PRODUCT, NOT MASCOT</text>
+    <text x="32" y="102" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="38" font-weight="650" fill="#111113" letter-spacing="-1.2">Show the product.</text>
+    <text x="32" y="138" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="14" fill="#6E6E73">Telegram is the interface.</text>
+    <text x="32" y="158" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="14" fill="#6E6E73">Your machine is the home.</text>
+    <rect x="370" y="58" width="292" height="230" rx="26" fill="#EEF3F6" stroke="#D8D7D2"/>
+    <rect x="392" y="82" width="180" height="52" rx="16" fill="#FFFFFF"/>
+    <text x="408" y="105" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="12" fill="#111113">Summarize my notes</text>
+    <text x="408" y="122" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="10" fill="#6E6E73">from this week.</text>
+    <rect x="438" y="150" width="202" height="90" rx="17" fill="#FFFFFF"/>
+    <circle cx="458" cy="173" r="7" fill="#F05138"/>
+    <text x="474" y="178" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="12" font-weight="600" fill="#111113">swift-claw</text>
+    <text x="458" y="203" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" fill="#6E6E73">I found 8 notes and prepared</text>
+    <text x="458" y="219" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" fill="#6E6E73">a concise weekly summary.</text>
+    <text x="32" y="220" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="18" font-weight="600" fill="#111113">Immediate comprehension</text>
+    <text x="32" y="248" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="14" fill="#6E6E73">A visitor sees what swift-claw does in seconds.</text>
+    <text x="32" y="292" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="12" fill="#6E6E73">PRIVATE · LOCAL-FIRST · OWNER-CONTROLLED</text>
+  </g>
+
+  <!-- 03 Technical Editorial -->
+  <g transform="translate(72 600)">
+    <rect width="700" height="330" rx="28" fill="#FAFAF8" stroke="#D8D7D2"/>
+    <text x="32" y="42" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#F05138" letter-spacing="1.8">03 · TECHNICAL EDITORIAL</text>
+    <text x="32" y="95" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="34" font-weight="650" fill="#111113" letter-spacing="-1">One daemon. Legible architecture.</text>
+    <text x="32" y="129" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="15" fill="#6E6E73">An engineering-first identity for a GitHub audience.</text>
+    <line x1="108" y1="226" x2="584" y2="226" stroke="#C9C8C3" stroke-width="2"/>
+    <rect x="42" y="194" width="132" height="64" rx="16" fill="#FFFFFF" stroke="#D8D7D2"/>
+    <text x="108" y="232" text-anchor="middle" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="15" fill="#111113">Telegram</text>
+    <rect x="264" y="180" width="172" height="92" rx="22" fill="#111113"/>
+    <circle cx="292" cy="207" r="6" fill="#F05138"/>
+    <text x="350" y="232" text-anchor="middle" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="18" font-weight="700" fill="#FFFFFF">clawd</text>
+    <rect x="526" y="194" width="132" height="64" rx="16" fill="#FFFFFF" stroke="#D8D7D2"/>
+    <text x="592" y="232" text-anchor="middle" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="15" fill="#111113">LLM</text>
+    <line x1="350" y1="272" x2="350" y2="298" stroke="#C9C8C3" stroke-width="2"/>
+    <text x="350" y="318" text-anchor="middle" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="12" fill="#6E6E73">SQLite · memory · policy</text>
+  </g>
+
+  <!-- 04 New Mark System -->
+  <g transform="translate(828 600)">
+    <rect width="700" height="330" rx="28" fill="#FFFFFF" stroke="#D8D7D2"/>
+    <text x="32" y="42" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#F05138" letter-spacing="1.8">04 · NEW MARK SYSTEM</text>
+    <text x="32" y="92" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="30" font-weight="650" fill="#111113">Three compact identity routes</text>
+    <g transform="translate(82 136)">
+      <circle cx="60" cy="60" r="58" fill="#F3F2EE"/>
+      <path d="M75 25 A38 38 0 1 0 75 95" fill="none" stroke="#111113" stroke-width="10" stroke-linecap="round"/>
+      <path d="M72 44 L88 60 L72 76" fill="none" stroke="#F05138" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="60" y="146" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="12" fill="#6E6E73">LOCAL LOOP</text>
+    </g>
+    <g transform="translate(290 136)">
+      <circle cx="60" cy="60" r="58" fill="#F3F2EE"/>
+      <path d="M28 35 C54 12 90 20 98 48" fill="none" stroke="#111113" stroke-width="10" stroke-linecap="round"/>
+      <path d="M24 61 C50 38 86 46 94 74" fill="none" stroke="#F05138" stroke-width="10" stroke-linecap="round"/>
+      <path d="M29 88 C54 67 84 73 92 98" fill="none" stroke="#111113" stroke-width="10" stroke-linecap="round"/>
+      <text x="60" y="146" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="12" fill="#6E6E73">APERTURE</text>
+    </g>
+    <g transform="translate(498 136)">
+      <circle cx="60" cy="60" r="58" fill="#111113"/>
+      <path d="M81 34 C69 20 40 24 36 43 C32 64 80 53 78 78 C76 99 43 101 31 85" fill="none" stroke="#FFFFFF" stroke-width="9" stroke-linecap="round"/>
+      <path d="M91 40 A31 31 0 0 0 91 81" fill="none" stroke="#F05138" stroke-width="8" stroke-linecap="round"/>
+      <text x="60" y="146" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="12" fill="#6E6E73">SC MONOGRAM</text>
+    </g>
+  </g>
+
+  <!-- 05 Recommended Hybrid -->
+  <g transform="translate(72 980)">
+    <rect width="1456" height="300" rx="32" fill="#0B0B0D"/>
+    <text x="36" y="42" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#FF5A3D" letter-spacing="1.8">05 · RECOMMENDED HYBRID</text>
+    <path d="M82 73 A28 28 0 1 0 82 129" fill="none" stroke="#F7F7F5" stroke-width="8" stroke-linecap="round"/>
+    <path d="M79 87 L92 101 L79 115" fill="none" stroke="#FF5A3D" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="126" y="116" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="49" font-weight="650" fill="#F7F7F5" letter-spacing="-1.5">swift-claw</text>
+    <text x="36" y="180" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="31" font-weight="570" fill="#F7F7F5">Your AI. Your machine. Always on.</text>
+    <text x="36" y="216" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="15" fill="#A1A1A6">Premium typography + Local Loop + a real owner-approval product surface.</text>
+    <rect x="850" y="36" width="564" height="228" rx="26" fill="#1D1D20" stroke="#303034"/>
+    <text x="880" y="72" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#FF5A3D" letter-spacing="1.4">ACTION REQUIRES APPROVAL</text>
+    <text x="880" y="112" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="23" font-weight="620" fill="#F7F7F5">Write status.md</text>
+    <text x="880" y="140" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="13" fill="#A1A1A6">~/workspace/status.md</text>
+    <line x1="880" y1="162" x2="1384" y2="162" stroke="#303034"/>
+    <rect x="880" y="185" width="234" height="48" rx="14" fill="#2A2A2E"/>
+    <text x="997" y="215" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="14" font-weight="600" fill="#F7F7F5">Deny</text>
+    <rect x="1150" y="185" width="234" height="48" rx="14" fill="#FF5A3D"/>
+    <text x="1267" y="215" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="14" font-weight="650" fill="#FFFFFF">Approve</text>
+  </g>
+</svg>

--- a/docs/assets/branding/exploration/design-system-board.svg
+++ b/docs/assets/branding/exploration/design-system-board.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="700" viewBox="0 0 1400 700">
+  <rect width="1400" height="700" fill="#F3F2EE"/>
+  <text x="72" y="78" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="12" font-weight="700" fill="#F05138" letter-spacing="2.2">SWIFT-CLAW / VISUAL SYSTEM</text>
+  <text x="72" y="150" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="54" font-weight="600" fill="#111113" letter-spacing="-1.6">Quiet, local, precise.</text>
+  <text x="72" y="194" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="20" fill="#6E6E73">Product-first branding for a persistent personal daemon.</text>
+  <rect x="72" y="252" width="270" height="112" rx="22" fill="#111113"/><text x="90" y="338" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#FFFFFF" letter-spacing="1.5">WARM BLACK · #111113</text>
+  <rect x="382" y="252" width="270" height="112" rx="22" fill="#F05138"/><text x="400" y="338" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#FFFFFF" letter-spacing="1.5">SWIFT ORANGE · #F05138</text>
+  <rect x="692" y="252" width="270" height="112" rx="22" fill="#F3F2EE" stroke="#D8D7D2"/><text x="710" y="338" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#111113" letter-spacing="1.5">WARM WHITE · #F3F2EE</text>
+  <rect x="1002" y="252" width="270" height="112" rx="22" fill="#6E6E73"/><text x="1020" y="338" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#FFFFFF" letter-spacing="1.5">SYSTEM GREY · #6E6E73</text>
+  <text x="72" y="438" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#6E6E73" letter-spacing="1.8">TYPE</text>
+  <text x="72" y="508" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="68" font-weight="650" fill="#111113" letter-spacing="-2.2">swift-claw</text>
+  <text x="72" y="550" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="17" fill="#6E6E73">System sans — calm, legible, non-futuristic</text>
+  <text x="770" y="438" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#6E6E73" letter-spacing="1.8">TECHNICAL</text>
+  <text x="770" y="504" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="30" fill="#111113">$ clawd status</text>
+  <text x="770" y="550" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="17" fill="#6E6E73">System mono for implementation details</text>
+  <line x1="72" y1="612" x2="1328" y2="612" stroke="#D8D7D2"/>
+  <text x="72" y="650" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#F05138" letter-spacing="1.8">RULE</text>
+  <text x="132" y="650" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="16" font-weight="520" fill="#111113">One accent. No glow. No speed lines. Product proof over illustration.</text>
+</svg>

--- a/docs/assets/branding/exploration/local-loop-mark.svg
+++ b/docs/assets/branding/exploration/local-loop-mark.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="112" fill="#111113"/>
+  <path d="M310 120 A142 142 0 1 0 310 392" fill="none" stroke="#F7F7F5" stroke-width="42" stroke-linecap="round"/>
+  <path d="M300 190 L364 256 L300 322" fill="none" stroke="#F05138" stroke-width="38" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="214" cy="256" r="22" fill="#F05138"/>
+</svg>

--- a/docs/assets/branding/exploration/recommended-hybrid.svg
+++ b/docs/assets/branding/exploration/recommended-hybrid.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="700" viewBox="0 0 1400 700">
+  <defs><radialGradient id="glow"><stop stop-color="#FF5A3D" stop-opacity=".20"/><stop offset="1" stop-color="#FF5A3D" stop-opacity="0"/></radialGradient></defs>
+  <rect width="1400" height="700" fill="#0B0B0D"/>
+  <ellipse cx="1110" cy="220" rx="390" ry="330" fill="url(#glow)"/>
+  <rect x="72" y="74" width="252" height="34" rx="17" fill="#351B16"/>
+  <text x="198" y="97" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="12" font-weight="700" fill="#FF5A3D" letter-spacing="1.6">RECOMMENDED DIRECTION</text>
+  <path d="M126 138 A36 36 0 1 0 126 210" fill="none" stroke="#F7F7F5" stroke-width="9" stroke-linecap="round"/>
+  <path d="M124 155 L140 174 L124 193" fill="none" stroke="#FF5A3D" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="166" y="202" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="80" font-weight="650" fill="#F7F7F5" letter-spacing="-2.2">swift-claw</text>
+  <text x="72" y="304" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="52" font-weight="570" fill="#F7F7F5" letter-spacing="-1.5">Your AI. Your machine.</text>
+  <text x="72" y="366" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="52" font-weight="570" fill="#F7F7F5" letter-spacing="-1.5">Always on.</text>
+  <text x="72" y="436" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="20" fill="#A1A1A6">A private Telegram assistant running as a pure-Swift daemon.</text>
+  <text x="72" y="468" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="20" fill="#A1A1A6">Local state. Explicit control. No cloud control plane.</text>
+  <rect x="816" y="84" width="512" height="532" rx="36" fill="#1D1D20" stroke="#303034"/>
+  <text x="852" y="128" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="18" font-weight="650" fill="#F7F7F5">swift-claw</text>
+  <circle cx="1288" cy="122" r="6" fill="#FF5A3D"/>
+  <line x1="844" y1="150" x2="1300" y2="150" stroke="#303034"/>
+  <rect x="844" y="176" width="360" height="78" rx="20" fill="#151517" stroke="#303034"/>
+  <text x="864" y="208" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="15" font-weight="550" fill="#F7F7F5">I prepared the weekly status.</text>
+  <text x="864" y="233" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="15" fill="#A1A1A6">Write it to your workspace?</text>
+  <rect x="844" y="278" width="456" height="264" rx="26" fill="#151517" stroke="#303034"/>
+  <text x="872" y="318" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="750" fill="#FF5A3D" letter-spacing="1.6">ACTION REQUIRES APPROVAL</text>
+  <text x="872" y="356" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="24" font-weight="620" fill="#F7F7F5">Write status.md</text>
+  <text x="872" y="388" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="14" fill="#A1A1A6">~/workspace/status.md</text>
+  <line x1="872" y1="410" x2="1272" y2="410" stroke="#303034"/>
+  <text x="872" y="442" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="14" fill="#A1A1A6">Create file</text>
+  <text x="1272" y="442" text-anchor="end" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="14" fill="#A1A1A6">2.4 KB</text>
+  <rect x="872" y="466" width="194" height="48" rx="15" fill="#1D1D20"/>
+  <text x="969" y="496" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="15" font-weight="600" fill="#F7F7F5">Deny</text>
+  <rect x="1078" y="466" width="194" height="48" rx="15" fill="#FF5A3D"/>
+  <text x="1175" y="496" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="15" font-weight="650" fill="#FFFFFF">Approve</text>
+  <line x1="72" y1="580" x2="738" y2="580" stroke="#303034"/>
+  <text x="72" y="620" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#A1A1A6" letter-spacing="1.7">PURE SWIFT</text>
+  <text x="72" y="648" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="17" fill="#F7F7F5">6.3</text>
+  <text x="280" y="620" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#A1A1A6" letter-spacing="1.7">OWNER</text>
+  <text x="280" y="648" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="17" fill="#F7F7F5">single</text>
+  <text x="488" y="620" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif" font-size="11" font-weight="700" fill="#A1A1A6" letter-spacing="1.7">STATE</text>
+  <text x="488" y="648" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="17" fill="#F7F7F5">local</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds a visual design-review package for a calmer, product-first swift-claw identity. The exploration replaces generic AI-startup cues with restrained typography, a single Swift-orange accent, and product proof grounded in the local daemon, Telegram interface, durable state, and explicit approvals.

![Five product-first brand directions](https://raw.githubusercontent.com/ivan-magda/swift-claw/refs/heads/design/branding-v2-exploration/docs/assets/branding/exploration/contact-sheet.svg)

## Directions

1. **Quiet Utility** — a calm local software appliance.
2. **Product, Not Mascot** — Telegram and the real interaction model as the hero.
3. **Technical Editorial** — the daemon architecture as the visual language.
4. **New Mark System** — Local Loop, Claw Aperture, and SC Monogram.
5. **Recommended Hybrid** — premium typography, Local Loop, and the owner-approval product surface.

## Recommended direction

![Recommended Hybrid](https://raw.githubusercontent.com/ivan-magda/swift-claw/refs/heads/design/branding-v2-exploration/docs/assets/branding/exploration/recommended-hybrid.svg)

My recommendation is **Recommended Hybrid + Local Loop**.

## Deliverables

- editable SVG contact sheet with all five directions;
- standalone 1400×700 recommended hero;
- standalone 512×512 Local Loop mark;
- visual-system board covering palette, typography, and usage rule;
- gallery README for review in the repository.

## Scope

This PR intentionally does **not** replace the current README hero or production branding. After a direction is approved, a follow-up can produce the final light/dark README exports, social/Open Graph card, avatars, and update the public README in one focused change.