### PR TITLE
docs: preserve Dactyl preview spike results

### DIFF
--- a/docs/research/dactyl-preview-spike/README.md
+++ b/docs/research/dactyl-preview-spike/README.md
@@ -1,0 +1,16 @@
+# SwiftUI preview spike artifacts
+
+These files preserve the source written during issue
+[#179](https://github.com/ivan-magda/swift-claw/issues/179). They are evidence, not supported tools
+or production dependencies.
+
+- [`local`](local/README.md) contains the first, superseded local Apple-renderer probe.
+- [`dactyl`](dactyl/README.md) contains the selected remote Dactyl probe.
+
+The spike excludes:
+
+- browser profiles, cookies, and login databases;
+- Dactyl project identifiers and account data;
+- downloaded WebAssembly modules and browser caches;
+- compiled applications and renderer binaries;
+- temporary Cloudflare tunnel binaries and URLs.

--- a/docs/research/dactyl-preview-spike/dactyl/ContentView.swift
+++ b/docs/research/dactyl-preview-spike/dactyl/ContentView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct Counter: Identifiable {
+  let id = UUID()
+  var name: String
+  var count: Int
+  var color: Color
+}
+struct ContentView: View {
+  @State private var counters: [Counter] = [
+    Counter(name: "Workouts", count: 28, color: Color(red: 0.47, green: 0.60, blue: 0.47)),
+    Counter(name: "Projects", count: 14, color: Color(red: 0.42, green: 0.65, blue: 0.72)),
+    Counter(name: "Ideas", count: 14, color: Color(red: 0.35, green: 0.58, blue: 0.62)),
+  ]
+
+  var body: some View {
+    NavigationStack {
+      List {
+        ForEach($counters) { $counter in
+          NavigationLink(destination: DetailView(counter: $counter)) {
+            CounterRow(counter: counter)
+          }
+          .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16))
+          .listRowBackground(Color.clear)
+          .listRowSeparator(.hidden)
+        }
+      }
+      .listStyle(.plain)
+      .navigationTitle("PulseCount")
+    }
+  }
+}
+
+struct CounterRow: View {
+  let counter: Counter
+
+  var body: some View {
+    ZStack(alignment: .bottomTrailing) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(counter.name)
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(.white.opacity(0.85))
+        Text("\(counter.count)")
+          .font(.system(size: 38, weight: .bold))
+          .foregroundStyle(.white)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(.horizontal, 16)
+      .padding(.vertical, 14)
+      .background(counter.color, in: RoundedRectangle(cornerRadius: 12))
+
+      Text("+1")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(.white)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Circle().fill(.black.opacity(0.25)))
+        .padding(12)
+    }
+  }
+}

--- a/docs/research/dactyl-preview-spike/dactyl/DetailView.swift
+++ b/docs/research/dactyl-preview-spike/dactyl/DetailView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct DetailView: View {
+  @Binding var counter: Counter
+  @State private var step: Int = 1
+
+  var body: some View {
+    VStack(spacing: 32) {
+      Text("\(counter.count)")
+        .font(.system(size: 80, weight: .bold))
+        .foregroundStyle(counter.color)
+        .contentTransition(.numericText())
+        .animation(.spring(duration: 0.3), value: counter.count)
+
+      HStack(spacing: 20) {
+        Button {
+          withAnimation {
+            counter.count += step
+          }
+        } label: {
+          Image(systemName: "plus")
+            .font(.system(size: 28, weight: .bold))
+            .foregroundStyle(.white)
+            .frame(width: 72, height: 72)
+            .background(counter.color, in: RoundedRectangle(cornerRadius: 14))
+        }
+
+        Button {
+          withAnimation {
+            counter.count -= step
+          }
+        } label: {
+          Image(systemName: "minus")
+            .font(.system(size: 28, weight: .bold))
+            .foregroundStyle(.white)
+            .frame(width: 72, height: 72)
+            .background(counter.color.opacity(0.7), in: RoundedRectangle(cornerRadius: 14))
+        }
+      }
+
+      HStack {
+        Text("Step")
+          .foregroundStyle(.secondary)
+        Spacer()
+        Stepper("\(step)", value: $step, in: 1...100)
+          .fixedSize()
+      }
+      .padding(.horizontal, 32)
+
+      Button("Reset Counter") {
+        withAnimation {
+          counter.count = 0
+        }
+      }
+      .font(.system(size: 16, weight: .semibold))
+      .foregroundStyle(.white)
+      .frame(maxWidth: .infinity)
+      .padding(.vertical, 14)
+      .background(Color(red: 0.82, green: 0.45, blue: 0.35), in: RoundedRectangle(cornerRadius: 12))
+      .padding(.horizontal, 32)
+
+      Spacer()
+    }
+    .padding(.top, 40)
+    .navigationTitle(counter.name)
+    .navigationBarTitleDisplayMode(.inline)
+  }
+}

--- a/docs/research/dactyl-preview-spike/dactyl/README.md
+++ b/docs/research/dactyl-preview-spike/dactyl/README.md
@@ -1,0 +1,55 @@
+# Dactyl remote renderer probe
+
+This directory retains the account-independent pieces of the Dactyl experiment. The successful
+live project remains in Dactyl. Its project ID and authentication state do not belong in Git.
+
+## Files
+
+- `ContentView.swift` and `DetailView.swift` preserve the two files from the successful persistent
+  project build, with layout normalized by the repository formatter.
+- `files-envelope.example.json` records the observed multi-file and asset request shape.
+- `mount-preview.html` mounts a Dactyl Wasm URL through the browser SDK.
+- `capture-preview.mjs` drives a Chromium debugging target and saves a screenshot.
+- `mcp.example.yaml` shows the fixed-project sidecar configuration that current `swift-claw` can
+  consume.
+
+## Mounting an existing build
+
+The HTML fixture needs a Wasm URL returned by a Dactyl build. It does not invoke the build API:
+
+```bash
+python3 -m http.server 8878 --directory .
+open 'http://127.0.0.1:8878/mount-preview.html?wasm=https%3A%2F%2Fbuilder1.dactyl.dev%2F...wasm'
+```
+
+The SDK, symbol atlas, fonts, and glyphs still load from `builder1.dactyl.dev`. Cache or mirror them
+before claiming an offline renderer.
+
+## Capturing the canvas
+
+Launch a disposable Chromium profile with a debugging port, then pass its page WebSocket URL to
+the script:
+
+```bash
+node capture-preview.mjs \
+  'ws://127.0.0.1:9222/devtools/page/PAGE_ID' \
+  'http://127.0.0.1:8878/mount-preview.html?wasm=https%3A%2F%2Fbuilder1.dactyl.dev%2F...wasm' \
+  '/tmp/dactyl-preview.png'
+```
+
+Do not reuse a profile that contains personal browsing data.
+
+## Sidecar boundary
+
+The proposed localhost MCP sidecar owns one Dactyl project ID and exposes:
+
+```text
+project_list_files
+project_read_file
+project_apply_files
+preview_build
+preview_snapshot
+```
+
+The account used in the spike did not expose Dactyl's beta coding-agent integration. Implement the
+sidecar after Dactyl supplies the official MCP or local-sync contract.

--- a/docs/research/dactyl-preview-spike/dactyl/capture-preview.mjs
+++ b/docs/research/dactyl-preview-spike/dactyl/capture-preview.mjs
@@ -1,0 +1,71 @@
+import { writeFileSync } from "node:fs";
+
+const [, , websocketURL, previewURL, outputPath] = process.argv;
+if (!websocketURL || !previewURL || !outputPath) {
+  throw new Error("usage: capture-preview.mjs <page-websocket-url> <preview-url> <output-path>");
+}
+
+const socket = new WebSocket(websocketURL);
+let nextID = 0;
+const pending = new Map();
+
+socket.addEventListener("message", (event) => {
+  const message = JSON.parse(event.data);
+  if (!message.id) return;
+
+  const waiter = pending.get(message.id);
+  if (!waiter) return;
+
+  pending.delete(message.id);
+  if (message.error) {
+    waiter.reject(new Error(JSON.stringify(message.error)));
+  } else {
+    waiter.resolve(message.result);
+  }
+});
+
+await new Promise((resolve, reject) => {
+  socket.addEventListener("open", resolve, { once: true });
+  socket.addEventListener("error", reject, { once: true });
+});
+
+const call = (method, params = {}) =>
+  new Promise((resolve, reject) => {
+    const id = ++nextID;
+    pending.set(id, { resolve, reject });
+    socket.send(JSON.stringify({ id, method, params }));
+  });
+
+await call("Page.enable");
+await call("Runtime.enable");
+await call("Page.navigate", { url: previewURL });
+
+let state;
+const deadline = Date.now() + 120_000;
+while (Date.now() < deadline) {
+  const response = await call("Runtime.evaluate", {
+    expression: `(() => ({
+      status: document.body.dataset.previewStatus || "starting",
+      probe: window.previewProbe || null
+    }))()`,
+    returnByValue: true,
+  });
+
+  state = response.result?.value;
+  if (state?.status === "ready" || state?.status === "fatal") break;
+  await new Promise((resolve) => setTimeout(resolve, 500));
+}
+
+if (state?.status !== "ready") {
+  throw new Error(`preview failed to become ready: ${JSON.stringify(state)}`);
+}
+
+const screenshot = await call("Page.captureScreenshot", {
+  format: "png",
+  fromSurface: true,
+  captureBeyondViewport: true,
+});
+
+writeFileSync(outputPath, Buffer.from(screenshot.data, "base64"));
+console.log(JSON.stringify({ outputPath, state }));
+socket.close();

--- a/docs/research/dactyl-preview-spike/dactyl/files-envelope.example.json
+++ b/docs/research/dactyl-preview-spike/dactyl/files-envelope.example.json
@@ -1,0 +1,7 @@
+{
+  "files": {
+    "ContentView.swift": "import SwiftUI\nstruct ContentView: View { var body: some View { DetailView() } }",
+    "DetailView.swift": "import SwiftUI\nstruct DetailView: View { var body: some View { Image(\"dot\") } }",
+    "Assets/dot.png": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+  }
+}

--- a/docs/research/dactyl-preview-spike/dactyl/mcp.example.yaml
+++ b/docs/research/dactyl-preview-spike/dactyl/mcp.example.yaml
@@ -1,0 +1,11 @@
+servers:
+  - name: dactyl_preview
+    url: http://127.0.0.1:8787/projects/PROJECT_ID/mcp
+    requestTimeoutSeconds: 120
+    tools:
+      include:
+        - project_list_files
+        - project_read_file
+        - project_apply_files
+        - preview_build
+        - preview_snapshot

--- a/docs/research/dactyl-preview-spike/dactyl/mount-preview.html
+++ b/docs/research/dactyl-preview-spike/dactyl/mount-preview.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Dactyl multi-file preview probe</title>
+<style>
+  html,
+  body {
+    margin: 0;
+    background: #fff;
+  }
+
+  canvas {
+    display: block;
+  }
+
+  pre {
+    font: 12px monospace;
+    white-space: pre-wrap;
+  }
+</style>
+<canvas id="stage"></canvas>
+<pre id="log">starting</pre>
+<script type="module">
+  import { mount } from "https://builder1.dactyl.dev/src/sdk/src/index.mjs";
+
+  const builderOrigin = "https://builder1.dactyl.dev";
+  const params = new URLSearchParams(window.location.search);
+  const wasmParam = params.get("wasm");
+  const log = document.querySelector("#log");
+
+  window.previewProbe = { status: "starting", logs: [] };
+
+  try {
+    if (!wasmParam) {
+      throw new Error("missing ?wasm= URL");
+    }
+
+    const wasmURL = new URL(wasmParam);
+    if (wasmURL.origin !== builderOrigin || !wasmURL.pathname.endsWith(".wasm")) {
+      throw new Error("the probe accepts Dactyl builder Wasm URLs only");
+    }
+
+    window.preview = await mount("#stage", wasmURL.href, {
+      scale: 1,
+      atlasUrl: `${builderOrigin}/src/host/symbols/index.json`,
+      builderOrigin,
+      onReady: ({ width, height }) => {
+        window.previewProbe.status = "ready";
+        window.previewProbe.size = { width, height };
+        document.body.dataset.previewStatus = "ready";
+        log.textContent = `ready ${width}x${height}`;
+      },
+      onLog: ({ level, text }) => {
+        window.previewProbe.logs.push({ level, text });
+        log.textContent += `\n${level}: ${text}`;
+      },
+    });
+  } catch (error) {
+    window.previewProbe.status = "fatal";
+    window.previewProbe.error = String(error);
+    document.body.dataset.previewStatus = "fatal";
+    log.textContent = `fatal: ${error}`;
+  }
+</script>

--- a/docs/research/dactyl-preview-spike/local/GeneratedPreview.swift
+++ b/docs/research/dactyl-preview-spike/local/GeneratedPreview.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct GeneratedPreview: View {
+  var body: some View {
+    VStack(spacing: 16) {
+      Image(systemName: "wand.and.stars")
+        .font(.system(size: 48))
+        .foregroundStyle(.purple)
+      Text("Generated screen")
+        .font(.title.bold())
+      Text("The app entry point came from a fixed harness.")
+        .multilineTextAlignment(.center)
+        .foregroundStyle(.secondary)
+    }
+    .padding()
+  }
+}

--- a/docs/research/dactyl-preview-spike/local/Harness.swift
+++ b/docs/research/dactyl-preview-spike/local/Harness.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct PreviewHarness: App {
+  var body: some Scene {
+    WindowGroup {
+      GeneratedPreview()
+    }
+  }
+}

--- a/docs/research/dactyl-preview-spike/local/HostingRender.swift
+++ b/docs/research/dactyl-preview-spike/local/HostingRender.swift
@@ -1,0 +1,51 @@
+import AppKit
+import SwiftUI
+
+struct HostingPreview: View {
+  var body: some View {
+    VStack(alignment: .leading, spacing: 20) {
+      Text("NSHostingView")
+        .font(.largeTitle.bold())
+
+      HStack(spacing: 14) {
+        Image(systemName: "figure.walk")
+          .foregroundStyle(.indigo)
+        VStack(alignment: .leading, spacing: 8) {
+          Text("Morning walk")
+            .font(.headline)
+          ProgressView(value: 0.72)
+            .tint(.indigo)
+        }
+      }
+      .padding(16)
+      .background(.white, in: RoundedRectangle(cornerRadius: 18))
+    }
+    .padding(24)
+    .frame(width: 393, height: 300, alignment: .topLeading)
+    .background(Color(red: 0.95, green: 0.96, blue: 0.98))
+  }
+}
+
+@main
+struct HostingRenderCommand {
+  @MainActor
+  static func main() throws {
+    let output = CommandLine.arguments.dropFirst().first ?? "hosting.png"
+    let hostingView = NSHostingView(rootView: HostingPreview())
+    hostingView.frame = NSRect(x: 0, y: 0, width: 393, height: 300)
+    hostingView.appearance = NSAppearance(named: .aqua)
+    hostingView.layoutSubtreeIfNeeded()
+
+    guard let bitmap = hostingView.bitmapImageRepForCachingDisplay(in: hostingView.bounds) else {
+      throw CocoaError(.fileWriteUnknown)
+    }
+
+    hostingView.cacheDisplay(in: hostingView.bounds, to: bitmap)
+    guard let png = bitmap.representation(using: .png, properties: [:]) else {
+      throw CocoaError(.fileWriteUnknown)
+    }
+
+    try png.write(to: URL(fileURLWithPath: output), options: .atomic)
+    print("wrote \(output), \(png.count) bytes")
+  }
+}

--- a/docs/research/dactyl-preview-spike/local/Info.plist
+++ b/docs/research/dactyl-preview-spike/local/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>Swift Claw Preview</string>
+  <key>CFBundleExecutable</key>
+  <string>Preview</string>
+  <key>CFBundleIdentifier</key>
+  <string>dev.swiftclaw.previewspike</string>
+  <key>CFBundleName</key>
+  <string>Preview</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+  <key>UILaunchScreen</key>
+  <dict/>
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+  </array>
+</dict>
+</plist>

--- a/docs/research/dactyl-preview-spike/local/README.md
+++ b/docs/research/dactyl-preview-spike/local/README.md
@@ -1,0 +1,35 @@
+# Local Apple renderer probe
+
+This probe records the first research run. It proved MCP connectivity and image generation, but it
+violates issue #179's renderer boundary because generated Swift runs through the local Apple
+toolchain.
+
+Do not wire this renderer into group mode.
+
+## Files
+
+- `Render.swift` renders one SwiftUI screen with `ImageRenderer` and AppKit.
+- `HostingRender.swift` records the `NSHostingView` fallback probe.
+- `iOSApp.swift` and `Info.plist` form the Simulator app bundle used by the live probe.
+- `GeneratedPreview.swift` and `Harness.swift` record the split fixed-harness experiment.
+- `mcp-server.py` exposes the temporary Streamable HTTP MCP handshake used by `swift-claw`.
+- `mcp-client.py` calls the tool without involving the daemon.
+- `mcp.example.yaml` records the tested `swift-claw` configuration shape.
+
+## Historical reproduction
+
+On a Mac with the Apple Swift toolchain:
+
+```bash
+swiftc Render.swift -o /tmp/swiftui-render
+/tmp/swiftui-render /tmp/preview.png
+```
+
+The MCP handshake used Python's `mcp` package:
+
+```bash
+python3 mcp-server.py
+python3 mcp-client.py
+```
+
+These commands document the experiment. They do not define a supported development workflow.

--- a/docs/research/dactyl-preview-spike/local/Render.swift
+++ b/docs/research/dactyl-preview-spike/local/Render.swift
@@ -1,0 +1,95 @@
+import AppKit
+import SwiftUI
+
+struct Habit: Identifiable {
+  let id = UUID()
+  let title: String
+  let icon: String
+  let progress: Double
+}
+struct PreviewScreen: View {
+  private let habits = [
+    Habit(title: "Morning walk", icon: "figure.walk", progress: 0.72),
+    Habit(title: "Read 20 min", icon: "book.fill", progress: 0.48),
+    Habit(title: "Drink water", icon: "drop.fill", progress: 0.86),
+  ]
+
+  var body: some View {
+    ZStack {
+      Color(red: 0.95, green: 0.96, blue: 0.98)
+        .ignoresSafeArea()
+
+      VStack(alignment: .leading, spacing: 22) {
+        HStack {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Today")
+              .font(.largeTitle.bold())
+            Text("3 habits in progress")
+              .foregroundStyle(.secondary)
+          }
+
+          Spacer()
+
+          Image(systemName: "person.crop.circle.fill")
+            .font(.system(size: 42))
+            .foregroundStyle(.indigo)
+        }
+
+        VStack(spacing: 12) {
+          ForEach(habits) { habit in
+            HStack(spacing: 14) {
+              Image(systemName: habit.icon)
+                .frame(width: 38, height: 38)
+                .background(.indigo.opacity(0.12), in: Circle())
+                .foregroundStyle(.indigo)
+
+              VStack(alignment: .leading, spacing: 8) {
+                Text(habit.title)
+                  .font(.headline)
+                ProgressView(value: habit.progress)
+                  .tint(.indigo)
+              }
+            }
+            .padding(16)
+            .background(.white, in: RoundedRectangle(cornerRadius: 18))
+          }
+        }
+
+        Spacer()
+
+        Button("Add a habit", systemImage: "plus") {}
+          .font(.headline)
+          .frame(maxWidth: .infinity)
+          .padding(.vertical, 14)
+          .background(.indigo, in: RoundedRectangle(cornerRadius: 16))
+          .foregroundStyle(.white)
+      }
+      .padding(24)
+    }
+    .frame(width: 393, height: 852)
+  }
+}
+
+@main
+struct RenderCommand {
+  @MainActor
+  static func main() throws {
+    let output = CommandLine.arguments.dropFirst().first ?? "preview.png"
+    let content = PreviewScreen()
+      .environment(\.colorScheme, .light)
+    let renderer = ImageRenderer(content: content)
+    renderer.scale = 2
+    renderer.proposedSize = ProposedViewSize(width: 393, height: 852)
+
+    guard let image = renderer.nsImage,
+      let tiff = image.tiffRepresentation,
+      let bitmap = NSBitmapImageRep(data: tiff),
+      let png = bitmap.representation(using: .png, properties: [:])
+    else {
+      throw CocoaError(.fileWriteUnknown)
+    }
+
+    try png.write(to: URL(fileURLWithPath: output), options: .atomic)
+    print("wrote \(output), \(png.count) bytes")
+  }
+}

--- a/docs/research/dactyl-preview-spike/local/iOSApp.swift
+++ b/docs/research/dactyl-preview-spike/local/iOSApp.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+struct SimulatorHabit: Identifiable {
+  let id = UUID()
+  let title: String
+  let icon: String
+  let progress: Double
+}
+
+struct SimulatorContentView: View {
+  private let habits = [
+    SimulatorHabit(title: "Morning walk", icon: "figure.walk", progress: 0.72),
+    SimulatorHabit(title: "Read 20 min", icon: "book.fill", progress: 0.48),
+    SimulatorHabit(title: "Drink water", icon: "drop.fill", progress: 0.86),
+  ]
+
+  var body: some View {
+    ZStack {
+      Color(red: 0.95, green: 0.96, blue: 0.98)
+        .ignoresSafeArea()
+
+      VStack(alignment: .leading, spacing: 22) {
+        HStack {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Your habits")
+              .font(.largeTitle.bold())
+            Text("3 habits in progress")
+              .foregroundStyle(.secondary)
+          }
+
+          Spacer()
+
+          Image(systemName: "person.crop.circle.fill")
+            .font(.system(size: 42))
+            .foregroundStyle(.indigo)
+        }
+
+        VStack(spacing: 12) {
+          ForEach(habits) { habit in
+            HStack(spacing: 14) {
+              Image(systemName: habit.icon)
+                .frame(width: 38, height: 38)
+                .background(.indigo.opacity(0.12), in: Circle())
+                .foregroundStyle(.indigo)
+
+              VStack(alignment: .leading, spacing: 8) {
+                Text(habit.title)
+                  .font(.headline)
+                ProgressView(value: habit.progress)
+                  .tint(.indigo)
+              }
+            }
+            .padding(16)
+            .background(.white, in: RoundedRectangle(cornerRadius: 18))
+          }
+        }
+
+        Spacer()
+
+        Button("Add a habit", systemImage: "plus") {}
+          .font(.headline)
+          .frame(maxWidth: .infinity)
+          .padding(.vertical, 14)
+          .background(.indigo, in: RoundedRectangle(cornerRadius: 16))
+          .foregroundStyle(.white)
+      }
+      .padding(24)
+    }
+  }
+}
+
+@main
+struct PreviewApp: App {
+  var body: some Scene {
+    WindowGroup {
+      SimulatorContentView()
+    }
+  }
+}

--- a/docs/research/dactyl-preview-spike/local/mcp-client.py
+++ b/docs/research/dactyl-preview-spike/local/mcp-client.py
@@ -1,0 +1,24 @@
+import asyncio
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+
+async def main() -> None:
+    async with streamablehttp_client("http://127.0.0.1:8767/mcp") as streams:
+        read_stream, write_stream, _ = streams
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            result = await session.call_tool(
+                "render_swiftui",
+                {
+                    "source": (
+                        "import SwiftUI\n"
+                        "struct Preview: View { var body: some View { Text(\"Hello\") } }"
+                    )
+                },
+            )
+            print(result.content[0].text)
+
+
+asyncio.run(main())

--- a/docs/research/dactyl-preview-spike/local/mcp-server.py
+++ b/docs/research/dactyl-preview-spike/local/mcp-server.py
@@ -1,0 +1,14 @@
+from mcp.server.fastmcp import FastMCP
+
+
+mcp = FastMCP("swiftui-preview-spike", host="127.0.0.1", port=8767)
+
+
+@mcp.tool()
+def render_swiftui(source: str) -> str:
+    """Accept SwiftUI source and return the handoff used by the connectivity probe."""
+    return f"accepted {len(source)} characters; preview transport is reachable"
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/docs/research/dactyl-preview-spike/local/mcp.example.yaml
+++ b/docs/research/dactyl-preview-spike/local/mcp.example.yaml
@@ -1,0 +1,7 @@
+servers:
+  - name: swiftui-preview
+    url: http://127.0.0.1:8767/mcp
+    tools:
+      include: [render_swiftui]
+      risk:
+        render_swiftui: safe

--- a/docs/research/dactyl-swiftui-preview-2026-09-02.md
+++ b/docs/research/dactyl-swiftui-preview-2026-09-02.md
@@ -1,0 +1,261 @@
+# Dactyl-backed SwiftUI previews for Telegram topics
+
+Research report, 2026-09-02. Repository at `main` (`0f317c29`). Related issue:
+[#179](https://github.com/ivan-magda/swift-claw/issues/179).
+
+This report records two spikes. The first proved the local renderer and Telegram delivery pieces,
+but violated the product boundary. The second used Dactyl and established the path that fits the
+requested product.
+
+No production code or tests changed during either spike.
+
+## Target experience
+
+One Telegram forum topic represents one persistent application project. Participants ask the
+agent to add screens, navigation, state, and assets. The agent updates the project, asks Dactyl to
+build it to WebAssembly, captures the browser preview, and replies in the same topic.
+
+Generated Swift must not run through local Xcode, Apple Simulator, or the host Swift runtime.
+
+## Run 1: local Apple rendering
+
+The first spike tested this pipeline:
+
+```text
+Telegram request
+→ localhost MCP tool
+→ generated SwiftUI
+→ swiftc / Apple Simulator or AppKit renderer
+→ PNG
+→ public HTTPS URL
+→ Telegram rich Markdown
+```
+
+### Verified
+
+- `swift-claw` discovered and called a localhost Streamable HTTP MCP server.
+- A fixed Swift harness could compile generated SwiftUI and render a PNG.
+- A real iOS Simulator build produced screenshots.
+- Telegram `sendRichMessage` rendered a public HTTPS PNG and retained the original topic and
+  reply target.
+
+### Decision
+
+The renderer ran generated code through the local Apple toolchain. The harness also represented a
+screen better than a persistent application project. This route remains useful as evidence
+for MCP connectivity and Telegram image delivery, but it cannot serve as the product renderer.
+
+The retained source lives in
+[`dactyl-preview-spike/local`](dactyl-preview-spike/local/README.md).
+
+## Run 2: Dactyl
+
+The corrected spike used [Dactyl](https://dactyl.dev/) for remote SwiftUI compilation and browser
+rendering.
+
+### Persistent project
+
+We created one project from a prompt in the Dactyl console. ZIP import was unnecessary. Dactyl
+wrote and retained two files:
+
+- `ContentView.swift`
+- `DetailView.swift`
+
+The initial AI turn stopped after writing the files because its provider refused the request. The
+project still retained both files. Pressing **Reload simulator** compiled the saved project without
+another AI turn.
+
+The successful reload consumed one Dactyl credit. The account balance changed from 100 to 99.
+
+### Runtime behavior
+
+The browser preview showed the root counter list from `ContentView.swift`. A pointer tap opened
+`DetailView.swift`. Another tap changed the bound counter from 28 to 29. This verifies:
+
+- cross-file type resolution;
+- `NavigationStack` navigation;
+- `@State` and `@Binding` updates;
+- interaction in the WebAssembly runtime;
+- browser screenshot capture without an Apple runtime.
+
+The retained source lives in
+[`dactyl-preview-spike/dactyl`](dactyl-preview-spike/dactyl/README.md).
+
+### Multi-file builder contract
+
+The current Dactyl web client sends the builder a file map:
+
+```http
+POST https://builder1.dactyl.dev/build?project=<id>&base=<hash>&embedded=0&dynamic=0
+Content-Type: application/json
+
+{
+  "files": {
+    "ContentView.swift": "...",
+    "DetailView.swift": "...",
+    "Assets/dot.png": "data:image/png;base64,..."
+  }
+}
+```
+
+A request that used an array received an error asking for a
+`{"files":{path:source,...}}` envelope. A deliberately broken symbol in `HelperView.swift`
+produced a diagnostic attributed to that second file. Adding `Assets/dot.png` as a data URL passed
+request validation and reached the same Swift diagnostic.
+
+Two successful multi-file builds returned valid WebAssembly. One mounted result displayed text
+defined in both `ContentView.swift` and `DetailView.swift`. The generated modules were about 80 MB
+before transport compression.
+
+Dactyl does not document this hosted endpoint as a stable integration contract. The public SDK
+README tells integrators to host a build API. Treat the observed hosted endpoint as research
+evidence, not a production dependency.
+
+### Persistent project API
+
+The shipped client uses these session-authenticated routes:
+
+```text
+GET/POST       /api/projects
+GET/PUT/DELETE /api/projects/{id}
+POST           /api/projects/{id}/fs
+POST           /api/projects/{id}/revert
+PATCH          /api/projects/{id}/meta
+```
+
+File updates use optimistic versions:
+
+```json
+{
+  "baseVersion": 7,
+  "ops": [
+    {
+      "op": "write",
+      "path": "Screens/HomeView.swift",
+      "content": "..."
+    },
+    {
+      "op": "delete",
+      "path": "OldView.swift"
+    }
+  ]
+}
+```
+
+These routes require an authenticated session. We did not export browser cookies or put them in a
+tool, prompt, file, or Git artifact.
+
+### Coding-agent access
+
+The current web client contains a **Connect coding agent** dialog with two integration modes:
+
+- remote MCP for reading and editing files, running commands, building, and taking a live preview
+  screenshot;
+- local sync through Git, curl, a personal access token, and a Dactyl-provided skill.
+
+The client shows this menu item only for `user.admin`. The tested account cannot create a token or
+open the dialog. A support request asked Dactyl to enable the beta and provide its current tool and
+API documentation.
+
+Dactyl's MCP metadata advertises an authorization-code flow with PKCE S256 and refresh tokens. The
+current `swift-claw` MCP client accepts a static token. Dactyl can remove the adapter requirement by
+providing a PAT that its MCP endpoint accepts. An OAuth-only service needs a localhost sidecar that
+owns token refresh.
+
+### Screenshot behavior
+
+Dactyl does not expose a documented headless screenshot endpoint. Its MCP integration asks the
+open project tab for a snapshot over the project's agent WebSocket. The tab returns a JPEG data
+URL captured from the Canvas runtime.
+
+The experiment captured a PNG through browser automation. A production integration can keep the
+same project tab open under a dedicated browser profile or use Dactyl's MCP snapshot once support
+enables it.
+
+## Smallest useful integration
+
+Start with one supervised topic and one fixed project:
+
+```text
+Telegram topic
+→ swift-claw tool loop
+→ localhost Streamable HTTP MCP sidecar
+→ fixed Dactyl project ID
+→ read/apply files
+→ Dactyl build
+→ open project tab
+→ snapshot
+→ expiring HTTPS image URL
+→ Telegram rich Markdown reply
+```
+
+The sidecar exposes five tools:
+
+```text
+project_list_files()
+project_read_file(path)
+project_apply_files(baseVersion, writes, deletes)
+preview_build()
+preview_snapshot()
+```
+
+The sidecar configuration owns the project ID. Model-authored arguments cannot select a project.
+
+The first spike can use one dedicated `swift-claw` group installation and one chosen topic. The
+operator records the project ID in the sidecar configuration and documents the binding in the
+trusted `TOOLS.md`.
+
+## Current swift-claw constraints
+
+`SessionKey.telegramTopic` creates a stable key:
+
+```text
+tg:topic:<chatId>:<threadId|general>
+```
+
+`TurnRunner` passes the thread ID into `AgentRuntime`, but `ToolDispatchContext` contains only
+security state and `ChatMode`. `Tool.execute` receives model arguments and a canonical target.
+MCP sessions are composed once for the daemon and receive no session identity.
+
+The fixed-project spike therefore relies on operator configuration. A multi-topic implementation
+must pass the session key through the tool invocation path and resolve a stored topic-to-project
+binding outside model arguments.
+
+The MCP adapter reduces image content to `[image: MIME]`. It does not pass image bytes to the model
+or Telegram. `preview_snapshot` should publish the image at an expiring HTTPS URL and return that
+URL in text content. A trusted `TOOLS.md` rule can format it as:
+
+```markdown
+![](https://preview.example/random-id.png "iOS preview")
+```
+
+The first run verified that the current Telegram rich-message path renders this form and keeps the
+topic target. The URL should use an unguessable path and expire after the outbox retry window.
+
+## Security boundary
+
+- Run the spike from the supervised group installation and its separate state root.
+- Store the Dactyl token in the host secret store or OAuth sidecar.
+- Keep browser cookies inside the dedicated browser profile.
+- Restrict the sidecar to one project and the five tools above.
+- Exclude publishing, project deletion, arbitrary commands, and Apple credentials.
+- Upload files only from the topic-bound workspace.
+- Set build, repair-loop, project-size, and artifact-retention caps.
+- Label output as a Dactyl compatibility preview. Xcode and a real device remain authoritative.
+
+## Open work
+
+1. Receive Dactyl beta access, a PAT, or OAuth tool schemas.
+2. Verify the official edit, build, and snapshot loop against the retained project.
+3. Connect a fixed-project sidecar to one supervised Telegram topic.
+4. Add session identity to tool dispatch before supporting more than one topic.
+5. Add a durable outbound artifact model if temporary HTTPS media proves insufficient.
+
+## Sources
+
+- [How Dactyl works](https://dactyl.dev/blog/how-dactyl-works/)
+- [Dactyl workspace](https://dactyl.dev/docs/workspace/)
+- [Dactyl preview and testing](https://dactyl.dev/docs/preview/)
+- [Dactyl troubleshooting](https://dactyl.dev/docs/troubleshooting/)
+- [Dactyl pricing](https://dactyl.dev/pricing/)
+- [Dactyl SDK README](https://builder1.dactyl.dev/src/sdk/README.md)


### PR DESCRIPTION
## Summary

- record both SwiftUI preview research runs and why the local Apple renderer was rejected
- preserve sanitized source fixtures from the local and Dactyl probes
- document the verified Dactyl multi-file app flow and the smallest fixed-project MCP integration
- capture the current SwiftClaw session-routing and image-transport gaps

Related to #179. This PR intentionally does not close the issue because the official Dactyl edit/build/snapshot loop still needs beta access from Dactyl support.

No production code or tests changed.

## Verification

- `scripts/lint.sh`
- `swift build`
- `swift test` — 2,806 tests in 350 suites passed
- Python syntax check for the MCP fixtures
- Node syntax check for the capture fixture
- JSON and plist validation
- `git diff --check`
- secret and account-data scan of all added artifacts