### PR TITLE
feat(coder): Add generic Coder capability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,3 +161,18 @@ CLAW_LOG_LEVEL=
 # <stateRoot>/workspace/ (SOUL.md, AGENTS.md, TOOLS.md, USER.md, MEMORY.md, HEARTBEAT.md,
 # skills/<name>/SKILL.md).
 # See docs/CUSTOMIZATION.md.
+
+# Native Coder: opt-in owner-DM coding tasks, approved through Telegram.
+# Install/authenticate Codex and Git as the daemon user; GitHub tasks also need gh/repository rights.
+# Native Codex delegation is separate from execute_code's VM and ordinary LLM budgets.
+# Omit optional values to use defaults; explicit blank/invalid values fail even while disabled.
+CLAW_CODER_ENABLED=false
+# Any positive N; admission returns busy at capacity.
+# CLAW_CODER_MAX_CONCURRENT_JOBS=1
+# Independent supervisor deadline, 1...86400 seconds; not a hard dollar cap.
+# CLAW_CODER_JOB_TIMEOUT_SECONDS=1800
+# Program name or absolute executable path, never a command with arguments.
+# CLAW_CODER_EXECUTABLE=codex
+# Existing Codex profile and absolute configuration directory (child CODEX_HOME), optional.
+# CLAW_CODER_PROFILE=personal
+# CLAW_CODER_CONFIG_HOME=/absolute/path/to/codex-config

--- a/Package.swift
+++ b/Package.swift
@@ -123,7 +123,7 @@ let package = Package(
     .target(
       name: "ClawTestSupport",
       dependencies: [
-        "ClawCore", "ClawTools",
+        "ClawCore", "ClawTools", "ClawData",
         .product(name: "Logging", package: "swift-log"),
       ]
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -142,7 +142,7 @@ let package = Package(
       dependencies: [
         "ClawCore", "ClawData", "ClawSecrets", "ClawTelegram", "ClawGateway", "ClawLLM",
         "ClawAgent", "ClawWorkspace", "ClawTools", "ClawExec", "ClawAuth", "ClawAppleSpeech",
-        "ClawMCP",
+        "ClawMCP", "ClawCoder",
         .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
@@ -234,7 +234,7 @@ let package = Package(
       dependencies: [
         "clawd", "ClawGateway", "ClawAgent", "ClawTestSupport",
         "ClawCore", "ClawAuth", "ClawSecrets", "ClawLLM", "ClawData", "ClawTelegram",
-        "ClawWorkspace", "ClawMCP", "ClawTools",
+        "ClawWorkspace", "ClawMCP", "ClawTools", "ClawCoder",
         .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
         .product(name: "ServiceLifecycleTestKit", package: "swift-service-lifecycle"),
         .product(name: "AsyncHTTPClient", package: "async-http-client"),

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ database, encrypted secret envelopes, and Markdown files you edit by hand.
   code and treats inbound content as data, never as instructions.
 - **Sandboxed code execution.** Untrusted code runs in a fresh disposable VM per request
   (macOS 26 arm64, off by default).
+- **Coding tasks from chat.** Opt in to Coder to delegate an approved owner-DM task to your
+  native Codex installation, then receive its result when the background job finishes.
+  Local changes and GitHub pull requests use your installed tools and repository rights.
 - **Tools from MCP servers.** List a server, store its token encrypted, and its tools join
   the built-ins as the least-trusted tools clawd has. Calls ask by default; you may mark a
   named tool safe, but the exfiltration gate can still require approval. Only you can add a
@@ -99,6 +102,21 @@ sudo install -m755 .build/release/clawd /usr/local/bin/clawd
 The full walkthrough, including the ChatGPT-subscription route and troubleshooting, is
 in [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
 
+## Delegate a coding task
+
+With Codex and Git installed and authenticated as the daemon user (plus `gh` for GitHub work),
+set `CLAW_CODER_ENABLED=true` in `clawd.env`, load it and restart. In your private bot DM, try:
+
+> Use Coder in `/Users/me/Developer/my-app` to fix the failing parser test in place. Leave local changes.
+
+> Use Coder to resolve `https://github.com/my-org/my-app/issues/42` in a separate copy and open a pull request.
+
+Paths refer to the daemon machine. In-place work accepts dirty files; a separate copy starts from a
+committed ref. Review the Telegram approval before submission. Ask for a job's status or cancellation
+by its UUID. Capacity N is configurable (default 1); full means busy. Completion uses the existing
+outbox retries. There is no automatic apply-back or rollback, and child billing is separate from
+conversational `/cost`. v1 is owner DM only. See [Coder configuration](docs/CUSTOMIZATION.md#coder-configuration).
+
 ## Security model
 
 swift-claw assumes you are the only person it serves.
@@ -110,9 +128,9 @@ swift-claw assumes you are the only person it serves.
 - **Secrets encrypted at rest.** `clawd secrets seal` wraps the bot token and API keys in
   an AES-GCM envelope. Plaintext env secrets remain available as a dev fallback that
   warns on every boot.
-- **Approvals are durable and unforgeable.** File writes, memory writes, and code
-  execution suspend into a durable state machine until you tap Approve in Telegram. A
-  forged or third-party callback cannot approve, and pending approvals expire to deny.
+- **Approvals are durable and unforgeable.** File writes, memory writes, code execution,
+  and native Coder submissions suspend into a durable state machine until you tap Approve in
+  Telegram. A forged or third-party callback cannot approve, and pending approvals expire to deny.
 - **Prompt injection contained.** Messages, web content, tool output, and stored memory
   enter the context as untrusted data. Once a session has both ingested untrusted content
   and pulled your private files into context, fetching an arbitrary URL also needs your

--- a/Sources/ClawAgent/Runtime/AgentRuntime.swift
+++ b/Sources/ClawAgent/Runtime/AgentRuntime.swift
@@ -485,7 +485,17 @@ public struct AgentRuntime: Sendable {
           runPrivateData: runPrivateData,
           sessionHasPrivateData: sessionHasPrivateData,
           approvalAlreadyPending: pendingSuspension != nil,
-          mode: mode
+          mode: mode,
+          executionContext: ToolExecutionContext(
+            runId: runId,
+            sessionId: sessionId,
+            chatId: chatId,
+            requesterUserId: origin == .interactive && mode == .direct ? chatId : nil,
+            origin: origin,
+            mode: mode,
+            toolCallId: call.id,
+            approvalId: nil
+          )
         )
 
         guard let toolDispatcher else {

--- a/Sources/ClawCoder/Codex/CodexBackend.swift
+++ b/Sources/ClawCoder/Codex/CodexBackend.swift
@@ -1,6 +1,10 @@
 import ClawCore
 import Foundation
 
+public enum CodexAuthenticationStatus: Sendable, Equatable {
+  case authenticated, missing, unavailable, profileUnverified
+}
+
 public struct CodexBackend: CoderBackend {
   public static let approvalPolicy = CodexInvocation.approvalPolicy
   public let executable: String
@@ -61,6 +65,33 @@ public struct CodexBackend: CoderBackend {
       throw error
     } catch {
       throw CoderError.unavailable("Codex CLI compatibility probe failed.")
+    }
+  }
+
+  /// Local status never refreshes credentials or proves model entitlement; profiles are CLI-unobservable.
+  public func authenticationStatus() async -> CodexAuthenticationStatus {
+    if profile != nil { return .profileUnverified }
+    let command = CoderCommand(
+      executable: executable,
+      arguments: ["login", "status"],
+      environment: environment,
+      workingDirectory: "/",
+      input: "",
+      phase: .prepare,
+      timeout: CoderCommandRunner.readOnlyTimeout
+    )
+    let result = await CoderCommandRunner().run(command, tracking: .preApprovalReadOnly) { _ in }
+    guard !result.supervisionFailed, result.cleanupResolved, !result.cancelled,
+      !result.timedOut, result.signal == nil
+    else {
+      return .unavailable
+    }
+    switch result.exitCode {
+    case 0: return .authenticated
+    case 1:
+      return result.diagnostics.trimmingCharacters(in: .whitespacesAndNewlines) == "Not logged in"
+        ? .missing : .unavailable
+    default: return .unavailable
     }
   }
 

--- a/Sources/ClawCore/Config/AppConfig.swift
+++ b/Sources/ClawCore/Config/AppConfig.swift
@@ -127,6 +127,7 @@ public struct AppConfig: Sendable, Equatable {
 
   public let approvalExpirySeconds: Int
   public let webFetchExemptCIDRs: [CIDR]
+  public let coder: CoderConfig
   public let exec: ExecConfig
   public let voice: VoiceConfig
   public let image: ImageConfig
@@ -149,6 +150,7 @@ public struct AppConfig: Sendable, Equatable {
     heartbeatMaxPerDay: Int,
     approvalExpirySeconds: Int,
     webFetchExemptCIDRs: [CIDR],
+    coder: CoderConfig,
     exec: ExecConfig,
     voice: VoiceConfig,
     image: ImageConfig,
@@ -174,6 +176,7 @@ public struct AppConfig: Sendable, Equatable {
 
     self.approvalExpirySeconds = approvalExpirySeconds
     self.webFetchExemptCIDRs = webFetchExemptCIDRs
+    self.coder = coder
     self.exec = exec
     self.voice = voice
     self.image = image
@@ -241,6 +244,7 @@ public struct AppConfig: Sendable, Equatable {
       heartbeatMaxPerDay: heartbeat.maxPerDay,
       approvalExpirySeconds: approvalExpirySeconds,
       webFetchExemptCIDRs: webFetchExemptCIDRs,
+      coder: try CoderConfig.load(environment: env),
       exec: exec,
       voice: voice,
       image: image,

--- a/Sources/ClawCore/Domain/Coder/CoderExecutionPolicy.swift
+++ b/Sources/ClawCore/Domain/Coder/CoderExecutionPolicy.swift
@@ -1,0 +1,26 @@
+/// Non-secret native execution facts resolved once by composition and shared across approval seams.
+public struct CoderExecutionPolicy: Sendable, Equatable {
+  public let id: String
+
+  public init(
+    executable: String,
+    profile: String?,
+    configHome: String?,
+    approvalPolicy: String,
+    credentialSources: [String: String]
+  ) {
+    var parts = [executable]
+    for optional in [profile, configHome] {
+      if let optional {
+        parts += ["present", optional]
+      } else {
+        parts.append("absent")
+      }
+    }
+    parts.append(approvalPolicy)
+    for key in credentialSources.keys.sorted() {
+      parts += [key, credentialSources[key] ?? ""]
+    }
+    id = PolicyFingerprint.hash(parts: parts)
+  }
+}

--- a/Sources/ClawCore/Domain/Policy/PolicyFingerprint.swift
+++ b/Sources/ClawCore/Domain/Policy/PolicyFingerprint.swift
@@ -84,6 +84,7 @@ public enum PolicyFingerprint {
       parts.append(tool.fenceLabel)
       parts.append(egressLabel(tool.egressClass))
       parts.append(tool.invocationIdentity ?? "")
+      parts.append("requires_interactive_owner:\(tool.requiresInteractiveOwner)")
     }
     parts.append(egressIdentityLabel(inputs.llmEgress))
     parts.append(inputs.searchEndpointPresent ? "search:present" : "search:absent")

--- a/Sources/ClawCore/Domain/Tools/ToolApproval.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolApproval.swift
@@ -52,19 +52,22 @@ public struct PreparedToolAction: Sendable, Equatable {
   public let presentation: ToolApprovalPresentation
   public let guardTexts: [String]
   public let canExfiltrate: Bool
+  public let approvalReason: ApprovalReason
 
   public init(
     canonicalTarget: String,
     canonicalArgsJSON: String,
     presentation: ToolApprovalPresentation,
     guardTexts: [String],
-    canExfiltrate: Bool
+    canExfiltrate: Bool,
+    approvalReason: ApprovalReason
   ) {
     self.canonicalTarget = canonicalTarget
     self.canonicalArgsJSON = canonicalArgsJSON
     self.presentation = presentation
     self.guardTexts = guardTexts
     self.canExfiltrate = canExfiltrate
+    self.approvalReason = approvalReason
   }
 }
 

--- a/Sources/ClawCore/Domain/Tools/ToolContracts.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolContracts.swift
@@ -210,6 +210,7 @@ public struct ToolDefinition: Sendable, Equatable {
   /// not fully identify what will run (for example, an adapter backed by a configured endpoint).
   /// NOT advertised on the wire.
   public let invocationIdentity: String?
+  public let requiresInteractiveOwner: Bool
 
   public init(
     name: String,
@@ -219,7 +220,8 @@ public struct ToolDefinition: Sendable, Equatable {
     egressClass: ToolEgressClass,
     riskLevel: RiskLevel,
     fenceLabel: String? = nil,
-    invocationIdentity: String? = nil
+    invocationIdentity: String? = nil,
+    requiresInteractiveOwner: Bool = false
   ) {
     self.name = name
     self.description = description
@@ -230,6 +232,7 @@ public struct ToolDefinition: Sendable, Equatable {
     self.riskLevel = riskLevel
     self.fenceLabel = fenceLabel ?? name
     self.invocationIdentity = invocationIdentity
+    self.requiresInteractiveOwner = requiresInteractiveOwner
   }
 }
 
@@ -328,6 +331,12 @@ public protocol Tool: Sendable {
   /// exactly what was authorized, never re-derive it; `nil` for the other classes.
   func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload
 
+  func execute(
+    arguments: JSONValue,
+    canonicalTarget: String?,
+    context: ToolExecutionContext?
+  ) async -> ToolPayload
+
   /// The prompt inputs for an ask-tier or trifecta approval, produced at gate time on the
   /// gate-resolved `canonicalTarget`. The default is a generic egress presentation; write tools
   /// override with blast radius, a redacted preview, and any scan warnings.
@@ -338,6 +347,14 @@ public protocol Tool: Sendable {
 }
 
 extension Tool {
+  public func execute(
+    arguments: JSONValue,
+    canonicalTarget: String?,
+    context: ToolExecutionContext?
+  ) async -> ToolPayload {
+    await execute(arguments: arguments, canonicalTarget: canonicalTarget)
+  }
+
   public func prepareAction(arguments: JSONValue) async -> PreparedActionResolution? {
     nil
   }

--- a/Sources/ClawCore/Domain/Tools/ToolDispatching.swift
+++ b/Sources/ClawCore/Domain/Tools/ToolDispatching.swift
@@ -15,6 +15,7 @@ public struct ToolDispatchContext: Sendable, Equatable {
   /// How the conversation is served. A group topic has no approval keyboard and no single owner
   /// to press it, so the gate resolves consent itself instead of parking a prompt nobody owns.
   public let mode: ChatMode
+  public let executionContext: ToolExecutionContext?
 
   public init(
     sessionTainted: Bool,
@@ -23,7 +24,8 @@ public struct ToolDispatchContext: Sendable, Equatable {
     runPrivateData: Bool,
     sessionHasPrivateData: Bool,
     approvalAlreadyPending: Bool,
-    mode: ChatMode = .direct
+    mode: ChatMode = .direct,
+    executionContext: ToolExecutionContext? = nil
   ) {
     self.sessionTainted = sessionTainted
     self.runIngestedUntrusted = runIngestedUntrusted
@@ -32,6 +34,7 @@ public struct ToolDispatchContext: Sendable, Equatable {
     self.sessionHasPrivateData = sessionHasPrivateData
     self.approvalAlreadyPending = approvalAlreadyPending
     self.mode = mode
+    self.executionContext = executionContext
   }
 }
 

--- a/Sources/ClawCore/Persistence/CoderJobStore.swift
+++ b/Sources/ClawCore/Persistence/CoderJobStore.swift
@@ -18,6 +18,8 @@ public protocol CoderJobStore: Sendable {
     now: Date
   ) throws(StoreError) -> CoderAdmission
   func job(id: UUID) throws(StoreError) -> CoderJob?
+  /// The latest updated failed, timed-out or interrupted job, including released reservations.
+  func lastFailedJob() throws(StoreError) -> CoderJob?
   func reservedJobs() throws(StoreError) -> [CoderJob]
   func markRunning(id: UUID, now: Date) throws(StoreError) -> Bool
   func requestCancellation(id: UUID, now: Date) throws(StoreError) -> CoderJob?

--- a/Sources/ClawData/Stores/Coder/CoderJobStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Coder/CoderJobStoreGRDB.swift
@@ -61,6 +61,22 @@ public struct CoderJobStoreGRDB: CoderJobStore {
     }
   }
 
+  public func lastFailedJob() throws(StoreError) -> CoderJob? {
+    try database.readMapping { db in
+      try Row.fetchOne(
+        db,
+        sql: """
+          SELECT * FROM coder_jobs WHERE state IN (?, ?, ?)
+          ORDER BY updated_ts DESC, id DESC LIMIT 1
+          """,
+        arguments: [
+          CoderJobState.failed.rawValue, CoderJobState.timedOut.rawValue,
+          CoderJobState.interrupted.rawValue,
+        ]
+      ).map(CoderJobRecord.decode)
+    }
+  }
+
   public func reservedJobs() throws(StoreError) -> [CoderJob] {
     try database.readMapping { db in
       try Self.reservedJobs(db)

--- a/Sources/ClawGateway/Approval/ApprovedActionExecutor.swift
+++ b/Sources/ClawGateway/Approval/ApprovedActionExecutor.swift
@@ -137,11 +137,42 @@ private extension ApprovedActionExecutor {
         ingestedUntrusted: false
       )
     }
+    let context: ToolExecutionContext?
+    do {
+      if let origin = try runs.runOrigin(runId: approval.runId) {
+        context = ToolExecutionContext(
+          runId: approval.runId,
+          sessionId: approval.sessionId,
+          chatId: approval.ownerUserId,
+          requesterUserId: origin == .interactive ? approval.ownerUserId : nil,
+          origin: origin,
+          mode: .direct,
+          toolCallId: approval.toolCallId,
+          approvalId: approval.id
+        )
+      } else {
+        context = nil
+      }
+    } catch {
+      return ToolPayload(
+        content: "The approved action's origin could not be restored; nothing ran.",
+        status: .error,
+        ingestedUntrusted: false
+      )
+    }
+    if tool.definition.requiresInteractiveOwner, context == nil {
+      return ToolPayload(
+        content: "The approved action's origin is missing; nothing ran.",
+        status: .error,
+        ingestedUntrusted: false
+      )
+    }
     // Run to completion on the waiter task — direct await, NEVER `executeWithTimeout`'s
     // abandon-on-timeout race, so the observation is always truthful (file_write is atomic).
     return await tool.execute(
       arguments: arguments,
-      canonicalTarget: approval.canonicalTarget
+      canonicalTarget: approval.canonicalTarget,
+      context: context
     )
   }
 

--- a/Sources/ClawGateway/Coder/CoderCompletionReport.swift
+++ b/Sources/ClawGateway/Coder/CoderCompletionReport.swift
@@ -1,0 +1,92 @@
+import ClawCore
+
+public struct CoderCompletionReport: Sendable {
+  private let redact: @Sendable (String) -> String
+
+  public init(redact: @escaping @Sendable (String) -> String) {
+    self.redact = redact
+  }
+
+  public func chunks(job: CoderJob, result: CoderResult) -> [OutboxChunk] {
+    var lines = ["Coder \(job.id.uuidString): \(result.state.rawValue)", result.summary]
+    lines += workspaceEvidence(result)
+    lines += publicationEvidence(result.publication)
+    lines += executionEvidence(result)
+    if job.ownership != .none && job.ownership != .stopped {
+      lines.append(
+        "Process ownership unresolved; reservation retained. Operator recovery required."
+      )
+    }
+    return ReplySplitter.split(text: redact(lines.joined(separator: "\n")))
+      .enumerated().map { index, payload in
+        OutboxChunk(
+          stepIndex: index,
+          chatId: job.origin.chatID,
+          payload: payload,
+          payloadHash: ContentHash.fnv1a(payload)
+        )
+      }
+  }
+}
+
+// MARK: - Result Evidence
+
+private extension CoderCompletionReport {
+  func workspaceEvidence(_ result: CoderResult) -> [String] {
+    var lines: [String] = []
+    if let path = result.workspacePath { lines.append("Workspace: \(path)") }
+    if let start = result.startingCommit {
+      let evidence = result.baselineObserved ? "observed" : "worker-reported"
+      lines.append("Starting commit (\(evidence)): \(start)")
+    }
+    if let files = result.changedFiles {
+      lines.append(
+        "Observed changed files: \(files.isEmpty ? "none" : files.joined(separator: ", "))"
+      )
+    } else {
+      lines.append("Changed-file comparison: unavailable")
+    }
+    if let branch = result.branch { lines.append("Branch: \(branch)") }
+    if let commit = result.commit { lines.append("Commit: \(commit)") }
+    return lines
+  }
+
+  func publicationEvidence(_ publication: CoderPublication) -> [String] {
+    var lines: [String] = []
+    switch publication {
+    case .absent: lines.append("Publication: absent")
+    case .confirmed(let url): lines.append("Publication confirmed: \(url)")
+    case .unknown(let url):
+      lines.append(
+        "Publication: unknown"
+          + (url.map {
+            "; worker reported \($0)"
+          } ?? "")
+      )
+    }
+    return lines
+  }
+
+  func executionEvidence(_ result: CoderResult) -> [String] {
+    var lines: [String] = []
+    if !result.reportedChecks.isEmpty {
+      lines.append("Worker-reported checks: \(result.reportedChecks.joined(separator: "; "))")
+    }
+    if let usage = result.reportedUsage {
+      let fields = usage.sorted {
+        $0.key < $1.key
+      }.map {
+        "\($0.key)=\($0.value)"
+      }
+      lines.append("Worker-reported usage: \(fields.joined(separator: ", "))")
+    } else {
+      lines.append("Worker-reported usage: unavailable")
+    }
+    if let author = result.commitAuthor { lines.append("Commit author: \(author)") }
+    if let actor = result.githubActor { lines.append("GitHub actor: \(actor)") }
+    if let failure = result.failure {
+      lines.append("Failure (\(failure.stage.rawValue)): \(failure.message)")
+    }
+    return lines
+  }
+}

--- a/Sources/ClawGateway/Coder/CoderService+Execution.swift
+++ b/Sources/ClawGateway/Coder/CoderService+Execution.swift
@@ -1,0 +1,128 @@
+import ClawCore
+import Foundation
+
+extension CoderService {
+  func execute(_ admitted: CoderJob, backend: any CoderBackend) async {
+    defer { tasks[admitted.id] = nil }
+    do {
+      let result: CoderResult
+      if try store.markRunning(id: admitted.id, now: Date()) {
+        let invocation = CoderInvocation(
+          jobID: admitted.id,
+          prepared: admitted.prepared,
+          jobDirectory: URL(fileURLWithPath: jobRoot)
+            .appendingPathComponent(admitted.id.uuidString).path,
+          timeout: .seconds(config.jobTimeoutSeconds)
+        )
+        result = await backend.run(invocation) { event in
+          try await self.recordProcess(id: admitted.id, event: event)
+        }
+      } else {
+        result = Self.unfinishedResult(state: .cancelled)
+      }
+      if case .persistence = failure { return }
+      try await complete(id: admitted.id, result: result, recovering: false)
+    } catch let error as StoreError {
+      fail(.persistence(error))
+    } catch {
+      fail(.persistence(.unexpected("Coder completion failed: \(error)")))
+    }
+  }
+
+  func complete(id: UUID, result: CoderResult, recovering: Bool) async throws {
+    guard var job = try store.job(id: id) else {
+      throw StoreError.unexpected("Coder completion has no job")
+    }
+    while !job.state.isTerminal {
+      let selected = Self.selectedResult(result, persistedState: job.state)
+      let chunks = report.chunks(job: job, result: selected)
+      let resolved = job.ownership == .none || job.ownership == .stopped
+      let outcome = try store.complete(
+        id: id,
+        expectedState: job.state,
+        result: selected,
+        chunks: chunks,
+        releaseReservation: resolved,
+        now: Date()
+      )
+      switch outcome {
+      case .stateChanged(let current): job = current
+      case .alreadyTerminal: return
+      case .committed:
+        if !resolved {
+          recoveryRequiredJobIDs.insert(id)
+          if !recovering { fail(.cleanup(jobID: id)) }
+        }
+        await notifyOutbox()
+        return
+      }
+    }
+  }
+
+  static func unfinishedResult(state: CoderJobState) -> CoderResult {
+    let interrupted = state == .interrupted
+    return CoderResult(
+      state: state,
+      summary: interrupted
+        ? "Daemon interrupted this task. It was not rerun; inspect its workspace and publication."
+        : "Cancellation stopped this task before completion.",
+      workspacePath: nil,
+      startingCommit: nil,
+      baselineObserved: false,
+      changedFiles: nil,
+      branch: nil,
+      commit: nil,
+      publication: .unknown(reportedURL: nil),
+      reportedChecks: [],
+      reportedUsage: nil,
+      commitAuthor: nil,
+      githubActor: nil,
+      failure: interrupted
+        ? CoderFailure(
+          stage: .interrupted,
+          message: "Daemon stopped before a terminal result committed."
+        )
+        : nil
+    )
+  }
+}
+
+// MARK: - Process Events and Stop Precedence
+
+private extension CoderService {
+  func recordProcess(id: UUID, event: CoderProcessEvent) throws {
+    do {
+      if case .willLaunch = event, try store.job(id: id)?.state == .stopping {
+        throw CancellationError()
+      }
+      try store.recordProcess(id: id, event: event, now: Date())
+    } catch let error as StoreError {
+      fail(.persistence(error))
+      throw error
+    }
+  }
+
+  static func selectedResult(_ result: CoderResult, persistedState: CoderJobState) -> CoderResult {
+    guard persistedState == .stopping,
+      result.state != .cancelled, result.state != .timedOut, result.state != .interrupted
+    else {
+      return result
+    }
+    return CoderResult(
+      state: .cancelled,
+      summary: "Cancellation was requested before task completion committed.",
+      workspacePath: result.workspacePath,
+      startingCommit: result.startingCommit,
+      baselineObserved: result.baselineObserved,
+      changedFiles: result.changedFiles,
+      branch: result.branch,
+      commit: result.commit,
+      publication: result.publication,
+      reportedChecks: result.reportedChecks,
+      reportedUsage: result.reportedUsage,
+      commitAuthor: result.commitAuthor,
+      githubActor: result.githubActor,
+      failure: result.failure
+    )
+  }
+}

--- a/Sources/ClawGateway/Coder/CoderService+Recovery.swift
+++ b/Sources/ClawGateway/Coder/CoderService+Recovery.swift
@@ -1,0 +1,53 @@
+import ClawCore
+import Foundation
+
+extension CoderService {
+  func reconcile() async throws {
+    do {
+      for job in try store.reservedJobs() {
+        try await reconcileOwnership(job)
+        if job.state.isTerminal {
+          guard let current = try store.job(id: job.id) else {
+            throw StoreError.unexpected("Coder recovery lost a reserved job")
+          }
+          if current.ownership == .none || current.ownership == .stopped {
+            try store.releaseResolvedReservation(id: job.id, now: Date())
+          }
+        } else {
+          try await complete(
+            id: job.id,
+            result: Self.unfinishedResult(state: .interrupted),
+            recovering: true
+          )
+        }
+      }
+    } catch let error as StoreError {
+      fail(.persistence(error))
+      throw error
+    }
+  }
+}
+
+// MARK: - Read-only Ownership Reconciliation
+
+private extension CoderService {
+  func reconcileOwnership(_ job: CoderJob) async throws {
+    if job.ownership == .none || job.ownership == .stopped { return }
+    guard let receipt = job.processReceipt else {
+      throw StoreError.unexpected("Coder active ownership has no pending launch receipt")
+    }
+    let observation = await inspector.inspect(receipt)
+    switch observation {
+    case .stopped:
+      try store.recordProcess(id: job.id, event: .stopped(launchID: receipt.launchID), now: Date())
+      recoveryRequiredJobIDs.remove(job.id)
+    case .liveOwned, .unresolved:
+      try store.recordProcess(
+        id: job.id,
+        event: .unresolved(launchID: receipt.launchID),
+        now: Date()
+      )
+      recoveryRequiredJobIDs.insert(job.id)
+    }
+  }
+}

--- a/Sources/ClawGateway/Coder/CoderService.swift
+++ b/Sources/ClawGateway/Coder/CoderService.swift
@@ -1,0 +1,228 @@
+import ClawCore
+import Foundation
+import ServiceLifecycle
+
+public enum CoderServiceFailure: Error, Sendable, Equatable {
+  case persistence(StoreError)
+  case cleanup(jobID: UUID)
+}
+
+public actor CoderService: CoderServing, Service {
+  enum Lifecycle { case created, starting, accepting, stopping, stopped }
+
+  let store: any CoderJobStore
+  let backend: (any CoderBackend)?
+  let preparer: any CoderRequestPreparing
+  let inspector: any CoderProcessInspecting
+  let config: CoderConfig
+  let jobRoot: String
+  let executionPolicyID: String
+  let report: CoderCompletionReport
+  let notifyOutbox: @Sendable () async -> Void
+  let failures: AsyncStream<Void>
+  let failureSignal: AsyncStream<Void>.Continuation
+  var lifecycle: Lifecycle = .created
+  var startup: Task<Void, any Error>?
+  var tasks: [UUID: Task<Void, Never>] = [:]
+  public private(set) var failure: CoderServiceFailure?
+  public internal(set) var recoveryRequiredJobIDs: Set<UUID> = []
+
+  public init(
+    store: any CoderJobStore,
+    backend: (any CoderBackend)?,
+    preparer: any CoderRequestPreparing,
+    inspector: any CoderProcessInspecting,
+    config: CoderConfig,
+    jobRoot: String,
+    executionPolicyID: String,
+    redact: @escaping @Sendable (String) -> String,
+    notifyOutbox: @escaping @Sendable () async -> Void
+  ) {
+    self.store = store
+    self.backend = backend
+    self.preparer = preparer
+    self.inspector = inspector
+    self.config = config
+    self.jobRoot = jobRoot
+    self.executionPolicyID = executionPolicyID
+    report = CoderCompletionReport(redact: redact)
+    self.notifyOutbox = notifyOutbox
+    (failures, failureSignal) = AsyncStream.makeStream(bufferingPolicy: .bufferingNewest(1))
+  }
+
+  /// Reconciles old reservations once, before approval replay or new submission can admit work.
+  public func start() async throws {
+    if let failure { throw failure }
+    switch lifecycle {
+    case .accepting: return
+    case .stopping, .stopped: throw CoderError.unavailable("Coder is stopping.")
+    case .created:
+      lifecycle = .starting
+      startup = Task {
+        try await self.reconcile()
+      }
+    case .starting: break
+    }
+    try await startup?.value
+    guard lifecycle == .starting || lifecycle == .accepting else {
+      throw CoderError.unavailable("Coder is stopping.")
+    }
+    lifecycle = .accepting
+  }
+
+  public func run() async throws {
+    do { try await start() } catch {
+      try await shutdown()
+      throw error
+    }
+    await withTaskGroup(of: Void.self) { group in
+      group.addTask {
+        try? await gracefulShutdown()
+      }
+      group.addTask { [failures] in
+        for await _ in failures { break }
+      }
+      await group.next()
+      group.cancelAll()
+    }
+    try await shutdown()
+  }
+
+  /// Closes admission before suspension and joins every registered backend before returning.
+  public func shutdown() async throws {
+    lifecycle = .stopping
+    for (id, task) in tasks {
+      do { _ = try store.requestCancellation(id: id, now: Date()) } catch {
+        fail(.persistence(error))
+      }
+      task.cancel()
+    }
+    let owned = Array(tasks.values)
+    _ = await startup?.result
+    for task in owned { await task.value }
+    lifecycle = .stopped
+    if let failure { throw failure }
+  }
+
+  public func prepare(_ request: CoderRequest) async throws -> CoderPreparedRequest {
+    _ = try requireAdmission()
+    return try await preparer.prepare(request)
+  }
+
+  public func submit(
+    _ prepared: CoderPreparedRequest,
+    context: ToolExecutionContext
+  ) async throws -> CoderJob {
+    let origin = try approvedOrigin(context)
+    _ = try requireAdmission()
+    guard prepared.executionPolicyID == executionPolicyID else {
+      throw CoderError.staleApproval
+    }
+    let current: CoderPreparedRequest
+    do { current = try await preparer.prepare(prepared.request) } catch is CancellationError {
+      throw CancellationError()
+    } catch { throw CoderError.staleApproval }
+    try Task.checkCancellation()
+    let backend = try requireAdmission()
+    guard current == prepared else {
+      throw CoderError.staleApproval
+    }
+    do {
+      let admission = try store.admit(
+        id: UUID(),
+        prepared: prepared,
+        origin: origin,
+        maxConcurrentJobs: config.maxConcurrentJobs,
+        now: Date()
+      )
+      switch admission {
+      case .admitted(let job):
+        tasks[job.id] = Task {
+          await self.execute(job, backend: backend)
+        }
+        return job
+      case .existing(let job): return job
+      case .busy: throw CoderError.busy
+      case .workspaceBusy: throw CoderError.workspaceBusy
+      case .recoveryRequired: throw CoderError.recoveryRequired
+      }
+    } catch let error as StoreError {
+      fail(.persistence(error))
+      throw error
+    }
+  }
+
+  public func status(id: UUID, context: ToolExecutionContext) async throws -> CoderJob {
+    try scopedJob(id: id, context: context)
+  }
+
+  public func cancel(id: UUID, context: ToolExecutionContext) async throws -> CoderJob {
+    _ = try scopedJob(id: id, context: context)
+    do {
+      guard let job = try store.requestCancellation(id: id, now: Date()) else {
+        throw CoderError.invalidRequest("Coder job was not found.")
+      }
+      tasks[id]?.cancel()
+      return job
+    } catch let error as StoreError {
+      fail(.persistence(error))
+      throw error
+    }
+  }
+
+  func fail(_ error: CoderServiceFailure) {
+    switch (failure, error) {
+    case (nil, _), (.cleanup?, .persistence): failure = error
+    default: break
+    }
+    failureSignal.yield(())
+  }
+}
+
+// MARK: - Admission and Requester Scope
+
+private extension CoderService {
+  func requireAdmission() throws -> any CoderBackend {
+    guard config.enabled, lifecycle == .accepting, failure == nil, let backend else {
+      throw CoderError.unavailable("Coder is not accepting work.")
+    }
+    return backend
+  }
+
+  func approvedOrigin(_ context: ToolExecutionContext) throws -> CoderOrigin {
+    guard context.origin == .interactive, context.mode == .direct,
+      let requester = context.requesterUserId, requester == context.chatId,
+      let approval = context.approvalId
+    else {
+      throw CoderError.forbidden
+    }
+    return CoderOrigin(
+      runID: context.runId,
+      sessionID: context.sessionId,
+      requesterUserID: requester,
+      chatID: context.chatId,
+      toolCallID: context.toolCallId,
+      approvalID: approval
+    )
+  }
+
+  func scopedJob(id: UUID, context: ToolExecutionContext) throws -> CoderJob {
+    guard context.origin == .interactive, context.mode == .direct,
+      let requester = context.requesterUserId, requester == context.chatId
+    else {
+      throw CoderError.forbidden
+    }
+    do {
+      guard let job = try store.job(id: id) else {
+        throw CoderError.invalidRequest("Coder job was not found.")
+      }
+      guard job.origin.requesterUserID == requester else {
+        throw CoderError.forbidden
+      }
+      return job
+    } catch let error as StoreError {
+      fail(.persistence(error))
+      throw error
+    }
+  }
+}

--- a/Sources/ClawGateway/Infrastructure/DaemonRuntimeBundle.swift
+++ b/Sources/ClawGateway/Infrastructure/DaemonRuntimeBundle.swift
@@ -18,26 +18,26 @@ public actor LaneShutdownOutcome {
   }
 }
 
-/// What composition hands `RunCommand` in place of a bare `Daemon`: the service graph plus the two
-/// live pieces the shutdown sequence must own — the exact lane registry it drains and the exact
-/// credential sources whose rotation it commits — and the outcome the lane-admission service records.
-/// Carrying these here is what lets `RunCommand` sequence credential and client teardown after the
-/// lanes quiesce without composition having to leak its internals one accessor at a time.
+/// Carries the exact live owners into command shutdown, including Coder work admitted by boot replay.
+/// Coder remains available for the final joined-cleanup check before dependent teardown.
 public struct DaemonRuntimeBundle: Sendable {
   public let daemon: Daemon
   public let lanes: SessionLaneRegistry
   public let credentialSources: [any LLMCredentialSource]
   public let laneShutdownOutcome: LaneShutdownOutcome
+  public let coder: CoderService?
 
   public init(
     daemon: Daemon,
     lanes: SessionLaneRegistry,
     credentialSources: [any LLMCredentialSource],
-    laneShutdownOutcome: LaneShutdownOutcome
+    laneShutdownOutcome: LaneShutdownOutcome,
+    coder: CoderService? = nil
   ) {
     self.daemon = daemon
     self.lanes = lanes
     self.credentialSources = credentialSources
     self.laneShutdownOutcome = laneShutdownOutcome
+    self.coder = coder
   }
 }

--- a/Sources/ClawGateway/Infrastructure/RuntimeShutdownCoordinator.swift
+++ b/Sources/ClawGateway/Infrastructure/RuntimeShutdownCoordinator.swift
@@ -2,7 +2,7 @@ import ClawAgent
 import ClawCore
 import Logging
 
-/// Sequences dependent-resource teardown after the lanes have quiesced, in the one mandated order.
+/// Sequences dependent-resource teardown after lanes and Coder work have quiesced.
 /// It is library-testable: composition injects the credential-commit and client-close closures, so
 /// the ordering, the credential-error precedence rule, and the fatal-timeout refusal are all proven
 /// without a real HTTP client or provider.
@@ -14,6 +14,7 @@ public struct RuntimeShutdownCoordinator: Sendable {
     case clean
     case failed(any Error)
     case fatalLaneTimeout(activeRunIDs: [Int64])
+    case fatalCoderCleanup
   }
 
   public typealias CleanupStep = @Sendable () async throws -> Void
@@ -48,17 +49,23 @@ public struct RuntimeShutdownCoordinator: Sendable {
     self.redactor = redactor
   }
 
-  /// Runs credential commit, then the LLM, Telegram, and tool client closes — each exactly once,
-  /// even when an earlier step throws — but only after a clean lane drain. On a lane timeout it
-  /// refuses all of that and returns the active run IDs for the fatal boundary: tearing credentials
-  /// or clients down under still-running turns is the exact hazard that path exists to avoid.
+  /// Joins Coder before credential/client teardown; lane timeout or Coder cleanup failure refuses
+  /// dependent cleanup so the caller can terminate without unwinding resources under owned work.
   public func shutDown(
     daemonError: (any Error)?,
     laneDrain: SessionLaneDrainResult,
+    coder: CoderService? = nil,
     dependent: DependentCleanup
   ) async -> Outcome {
     if case .timedOut(let activeRunIDs) = laneDrain {
       return .fatalLaneTimeout(activeRunIDs: activeRunIDs)
+    }
+
+    if let coder {
+      do { try await coder.shutdown() } catch {
+        logger.critical("Coder shutdown could not prove persisted, joined cleanup")
+        return .fatalCoderCleanup
+      }
     }
 
     // A daemon failure already owns the exit; the credential error only fills a vacant slot.

--- a/Sources/ClawGateway/Response/DoctorReport.swift
+++ b/Sources/ClawGateway/Response/DoctorReport.swift
@@ -12,6 +12,7 @@ public enum DoctorGroup: String, Sendable, Codable, Equatable, CaseIterable {
   case connectivity
   case mcp
   case sandbox
+  case coder
 
   public var title: String {
     switch self {
@@ -26,6 +27,7 @@ public enum DoctorGroup: String, Sendable, Codable, Equatable, CaseIterable {
     case .connectivity: "Connectivity"
     case .mcp: "MCP"
     case .sandbox: "Sandbox"
+    case .coder: "Coder"
     }
   }
 }

--- a/Sources/ClawTestSupport/CoderApprovedOriginFixture.swift
+++ b/Sources/ClawTestSupport/CoderApprovedOriginFixture.swift
@@ -1,0 +1,166 @@
+import ClawCore
+import ClawData
+import Foundation
+import GRDB
+
+public enum CoderApprovedOriginFixture {
+  public static func make(
+    queue: DatabaseQueue,
+    updateID: Int64,
+    prepared: CoderPreparedRequest,
+    now: Date,
+    ownerID: Int64 = 7
+  ) throws -> CoderOrigin {
+    let sessions = SessionMessageStoreGRDB(writer: queue)
+    let runs = RunStoreGRDB(writer: queue)
+    let approvals = ApprovalStoreGRDB(writer: queue)
+    let toolCallID = "coder-submit-fixture-call-\(updateID)"
+    let policyVersion = PolicyFingerprint.combined(
+      staticSubhash: prepared.executionPolicyID,
+      promptMaterials: ["Coder store fixture"]
+    )
+    let claim = try sessions.claimAndPersistInbound(
+      inbound(prepared: prepared, updateID: updateID, ownerID: ownerID, now: now)
+    )
+    let runID = try required(claim.runId)
+    let sessionID = try required(claim.sessionId)
+    let pickedUpOrigin = try required(
+      try runs.pickUp(runId: runID, policyVersion: policyVersion, now: now)
+    )
+    guard pickedUpOrigin == .interactive else {
+      throw StoreError.unexpected("Coder fixture did not create an interactive run")
+    }
+    let receipt = try runs.commitSuspendedTurn(
+      runId: runID,
+      sessionId: sessionID,
+      commit: approvalCommit(
+        prepared: prepared,
+        ownerID: ownerID,
+        toolCallID: toolCallID,
+        now: now
+      ),
+      now: now
+    )
+    let resolution = try approvals.approve(
+      id: receipt.approvalId,
+      currentPolicyVersion: policyVersion,
+      now: now
+    )
+    guard case .approved(let approval) = resolution else {
+      throw StoreError.unexpected("Coder fixture approval was not granted")
+    }
+    let executionClaim = try runs.claimApprovedExecution(
+      runId: approval.runId,
+      observationMessageId: approval.observationMessageId,
+      notResumableObservationContent: "The task was stopped before admission.",
+      now: now
+    )
+    guard executionClaim == .committed else {
+      throw StoreError.unexpected("Coder fixture could not claim its approved execution")
+    }
+    return CoderOrigin(
+      runID: approval.runId,
+      sessionID: approval.sessionId,
+      requesterUserID: approval.ownerUserId,
+      chatID: approval.ownerUserId,
+      toolCallID: approval.toolCallId,
+      approvalID: approval.id
+    )
+  }
+}
+
+// MARK: - Approved Turn Construction
+
+private extension CoderApprovedOriginFixture {
+  static func inbound(
+    prepared: CoderPreparedRequest,
+    updateID: Int64,
+    ownerID: Int64,
+    now: Date
+  ) -> InboundMessage {
+    InboundMessage(
+      updateId: updateID,
+      sessionKey: SessionKey.telegramDM(chatId: ownerID),
+      chatId: ownerID,
+      userId: ownerID,
+      text: "Use Coder for \(prepared.canonicalSource).",
+      isEdited: false,
+      telegramMessageId: 11,
+      ts: now
+    )
+  }
+
+  static func approvalCommit(
+    prepared: CoderPreparedRequest,
+    ownerID: Int64,
+    toolCallID: String,
+    now: Date
+  ) throws -> SuspendedTurnCommit {
+    let canonicalArgsJSON = try required(CanonicalJSON.encode(prepared))
+    let task = prepared.request.task ?? "Resolve the issue"
+    let blastRadius =
+      "\(prepared.request.workspace.rawValue); local changes; "
+      + "native Codex with network access"
+    let recorded = RecordedToolAction(
+      tool: CoderToolNames.submit,
+      canonicalArgsJSON: canonicalArgsJSON,
+      argsHash: ApprovalArgsHash.sha256Hex(canonicalArgsJSON),
+      canonicalTarget: prepared.canonicalSource,
+      reason: .coderSubmit,
+      presentation: ToolApprovalPresentation(
+        blastRadius: blastRadius,
+        contentPreview: task,
+        warnings: []
+      )
+    )
+    let prompt = "Approve Coder for \(prepared.canonicalSource): \(task)"
+    return SuspendedTurnCommit(
+      assistantContent: "I can delegate this repository task to Coder.",
+      toolCallsJSON: try proposedToolCalls(prepared: prepared, toolCallID: toolCallID),
+      completedObservations: [],
+      pending: PendingToolAction(toolCallId: toolCallID, recorded: recorded),
+      ownerUserId: ownerID,
+      nonce: ApprovalNonce.generate(),
+      promptChunks: [
+        OutboxChunk(
+          stepIndex: 0,
+          chatId: ownerID,
+          payload: prompt,
+          payloadHash: ContentHash.fnv1a(prompt)
+        )
+      ],
+      setTainted: false,
+      setPrivateData: false,
+      expiresTs: now.addingTimeInterval(3_600)
+    )
+  }
+
+  static func proposedToolCalls(
+    prepared: CoderPreparedRequest,
+    toolCallID: String
+  ) throws -> String {
+    let request = prepared.request
+    let sourceJSON = try required(CanonicalJSON.encode(request.source))
+    let sourceArgument = try required(JSONValue.parse(sourceJSON))
+    let proposedArguments = JSONValue.object([
+      "source": sourceArgument,
+      "task": .string(request.task ?? "Resolve the issue"),
+      "workspace": .string(request.workspace.rawValue),
+      "deliverable": .string(request.deliverable.rawValue),
+      "publish_existing_changes": .bool(request.publishExistingChanges),
+    ])
+    let proposedArgsJSON = try required(CanonicalJSON.encode(proposedArguments))
+    return try required(
+      ToolCallCoding.encode([
+        ToolCall(id: toolCallID, name: CoderToolNames.submit, argumentsJSON: proposedArgsJSON)
+      ])
+    )
+  }
+
+  static func required<T>(_ value: T?) throws -> T {
+    guard let value else {
+      throw StoreError.unexpected("Coder approval fixture is missing a required value")
+    }
+    return value
+  }
+}

--- a/Sources/ClawTestSupport/ScriptedCoderBackend.swift
+++ b/Sources/ClawTestSupport/ScriptedCoderBackend.swift
@@ -1,0 +1,93 @@
+import ClawCore
+import Foundation
+
+public actor ScriptedCoderBackend: CoderBackend {
+  public final class Invocation: Sendable {
+    public let entered = AsyncGate()
+    public let allowLaunch = AsyncGate()
+    public let started = AsyncGate()
+    public let cleanupEntered = AsyncGate()
+    public let allowCompletion = AsyncGate()
+    public let allowCleanup = AsyncGate()
+    public let result: CoderResult
+    public let unresolvedCleanup: Bool
+
+    public init(
+      result: CoderResult,
+      holdCleanup: Bool = false,
+      unresolvedCleanup: Bool = false,
+      holdLaunch: Bool = false
+    ) {
+      self.result = result
+      self.unresolvedCleanup = unresolvedCleanup
+      if !holdLaunch { allowLaunch.open() }
+      if !holdCleanup { allowCleanup.open() }
+    }
+
+    public func release() {
+      allowLaunch.open()
+      allowCompletion.open()
+      allowCleanup.open()
+    }
+
+    deinit { release() }
+  }
+
+  nonisolated public let invocations: [Invocation]
+  nonisolated public var started: AsyncGate { invocations[0].started }
+  nonisolated public var allowCompletion: AsyncGate { invocations[0].allowCompletion }
+  nonisolated public var allowCleanup: AsyncGate { invocations[0].allowCleanup }
+  public private(set) var startedJobIDs: [UUID] = []
+
+  public init(invocations: [Invocation]) {
+    precondition(!invocations.isEmpty)
+    self.invocations = invocations
+  }
+
+  nonisolated public func releaseAll() {
+    for invocation in invocations { invocation.release() }
+  }
+
+  public func run(
+    _ invocation: CoderInvocation,
+    recordProcess: @Sendable (CoderProcessEvent) async throws -> Void
+  ) async -> CoderResult {
+    let index = startedJobIDs.count
+    startedJobIDs.append(invocation.jobID)
+    let script = invocations[min(index, invocations.count - 1)]
+    script.entered.open()
+    await script.allowLaunch.waitIgnoringCancellation()
+    let launchID = UUID()
+    let pending = CoderProcessReceipt(
+      launchID: launchID,
+      phase: .codex,
+      hostBootID: "scripted-boot",
+      pid: nil,
+      pgid: nil,
+      birthIdentity: nil
+    )
+    let receipt = CoderProcessReceipt(
+      launchID: launchID,
+      phase: .codex,
+      hostBootID: pending.hostBootID,
+      pid: 123,
+      pgid: 123,
+      birthIdentity: "scripted-birth"
+    )
+    do {
+      try await recordProcess(.willLaunch(pending))
+      try await recordProcess(.didLaunch(receipt))
+      script.started.open()
+      await script.allowCompletion.wait()
+      script.cleanupEntered.open()
+      await script.allowCleanup.waitIgnoringCancellation()
+      let event: CoderProcessEvent =
+        script.unresolvedCleanup
+        ? .unresolved(launchID: launchID) : .stopped(launchID: launchID)
+      try await recordProcess(event)
+    } catch {
+      script.started.open()
+    }
+    return script.result
+  }
+}

--- a/Sources/ClawTools/Policy/ToolPolicyGate.swift
+++ b/Sources/ClawTools/Policy/ToolPolicyGate.swift
@@ -23,16 +23,16 @@ public struct ToolPolicyGate: Sendable {
 
   private let argGuard: ExfilArgGuard
   private let privateFileLoader: @Sendable () -> [String]
-  private let execEnabled: Bool
+  private let enabledDangerousTools: Set<String>
 
   public init(
     argGuard: ExfilArgGuard,
     privateFileLoader: @escaping @Sendable () -> [String],
-    execEnabled: Bool
+    enabledDangerousTools: Set<String>
   ) {
     self.argGuard = argGuard
     self.privateFileLoader = privateFileLoader
-    self.execEnabled = execEnabled
+    self.enabledDangerousTools = enabledDangerousTools
   }
 
   public func evaluate(
@@ -40,6 +40,9 @@ public struct ToolPolicyGate: Sendable {
     tool: any Tool,
     context: ToolDispatchContext
   ) async -> Verdict {
+    if let refusal = ownerAdmissionRefusal(call: call, tool: tool, context: context) {
+      return refusal
+    }
     // Total over RiskLevel. Ask-tier resolves before the egress fast-path so a `.none`-egress
     // ask tool (file_write) still parks; dangerous consumes only a tool-prepared action; safe
     // egress falls through to the unconditional/trifecta tiers below.
@@ -164,6 +167,30 @@ public struct ToolPolicyGate: Sendable {
       ),
       argsRedacted: argsRedacted
     )
+  }
+}
+
+// MARK: - Owner Admission
+
+private extension ToolPolicyGate {
+  func ownerAdmissionRefusal(
+    call: ToolCall,
+    tool: any Tool,
+    context: ToolDispatchContext
+  ) -> Verdict? {
+    guard tool.definition.requiresInteractiveOwner else {
+      return nil
+    }
+    guard let execution = context.executionContext,
+      context.mode == .direct, execution.mode == .direct,
+      execution.origin == .interactive, execution.requesterUserId != nil
+    else {
+      return dangerousBlock(
+        reason: "\(call.name) requires an interactive owner direct message.",
+        call: call
+      )
+    }
+    return nil
   }
 }
 
@@ -376,7 +403,7 @@ private extension ToolPolicyGate {
 // MARK: - Dangerous-tier Approval
 
 private extension ToolPolicyGate {
-  /// Dangerous tools park ONLY over a tool-prepared canonical action. The `execEnabled` backstop
+  /// Dangerous tools park ONLY over a tool-prepared canonical action. The `enabledDangerousTools` backstop
   /// fails closed; the arg-guard scans run over the prepared `guardTexts` (never the model's raw
   /// arguments), and the recorded action binds the prepared canonical JSON verbatim.
   func evaluateDangerousTier(
@@ -384,8 +411,8 @@ private extension ToolPolicyGate {
     tool: any Tool,
     context: ToolDispatchContext
   ) async -> Verdict {
-    guard execEnabled else {
-      return dangerousBlock(reason: "Code execution is disabled.", call: call)
+    guard enabledDangerousTools.contains(tool.definition.name) else {
+      return dangerousBlock(reason: "\(tool.definition.name) is disabled.", call: call)
     }
     // A dangerous action can never take the second approval slot, and it cannot park or execute
     // while one is pending, so refuse here before the expensive staging and content scans run.
@@ -436,7 +463,7 @@ private extension ToolPolicyGate {
     }
 
     // Group mode runs the prepared action untapped — the sandbox is the containment, not a prompt.
-    // `execEnabled` and every scan above still apply; only the approval round-trip is gone.
+    // `enabledDangerousTools` and every scan above still apply; only the approval round-trip is gone.
     guard context.mode == .direct else {
       return .allow(
         argsRedacted: argGuard.renderRedacted(argsJSON: prepared.canonicalArgsJSON),
@@ -450,7 +477,7 @@ private extension ToolPolicyGate {
       canonicalArgsJSON: prepared.canonicalArgsJSON,
       argsHash: ApprovalArgsHash.sha256Hex(prepared.canonicalArgsJSON),
       canonicalTarget: prepared.canonicalTarget,
-      reason: .codeExec,
+      reason: prepared.approvalReason,
       presentation: prepared.presentation
     )
     return .requireApproval(recorded: recorded)
@@ -529,7 +556,8 @@ public struct GatedToolDispatcher: ToolDispatching {
         tool: tool,
         arguments: arguments,
         preparedArgsJSON: preparedArgsJSON,
-        canonicalTarget: action?.target
+        canonicalTarget: action?.target,
+        context: context.executionContext
       )
       return ToolDispatchOutcome(
         observation: ToolObservation(call: call, payload: payload),
@@ -556,7 +584,8 @@ public struct GatedToolDispatcher: ToolDispatching {
     tool: any Tool,
     arguments: JSONValue,
     preparedArgsJSON: String?,
-    canonicalTarget: String?
+    canonicalTarget: String?,
+    context: ToolExecutionContext?
   ) async -> ToolPayload {
     let executedArguments: JSONValue
     if let preparedArgsJSON {
@@ -578,7 +607,11 @@ public struct GatedToolDispatcher: ToolDispatching {
         try await clock.sleep(for: duration)
       },
       operation: {
-        await tool.execute(arguments: executedArguments, canonicalTarget: canonicalTarget)
+        await tool.execute(
+          arguments: executedArguments,
+          canonicalTarget: canonicalTarget,
+          context: context
+        )
       }
     )
 

--- a/Sources/ClawTools/Tools/Coder/CoderCancelTool.swift
+++ b/Sources/ClawTools/Tools/Coder/CoderCancelTool.swift
@@ -1,0 +1,56 @@
+import ClawCore
+import Foundation
+
+public struct CoderCancelTool: Tool {
+  private let service: any CoderServing
+  private let redactor: SecretRedactor
+
+  public init(service: any CoderServing, redactor: SecretRedactor) {
+    self.service = service
+    self.redactor = redactor
+  }
+
+  public var definition: ToolDefinition {
+    ToolDefinition(
+      name: CoderToolNames.cancel,
+      description: "Request cancellation of an owned background Coder job.",
+      parameters: CoderToolOutput.jobSchema,
+      metadataProvenance: .trusted,
+      egressClass: .none,
+      riskLevel: .safe,
+      requiresInteractiveOwner: true
+    )
+  }
+
+  public var timeout: Duration { .seconds(30) }
+
+  public func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? { nil }
+
+  public func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+    CoderToolOutput.missingContext
+  }
+
+  public func execute(
+    arguments: JSONValue,
+    canonicalTarget: String?,
+    context: ToolExecutionContext?
+  ) async -> ToolPayload {
+    guard let context else {
+      return CoderToolOutput.missingContext
+    }
+    guard let id = CoderToolOutput.jobID(arguments) else {
+      return CoderToolOutput.failure(
+        CoderError.invalidRequest("Provide only job_id as a UUID string."),
+        redactor: redactor
+      )
+    }
+    do {
+      return CoderToolOutput.job(
+        try await service.cancel(id: id, context: context),
+        redactor: redactor
+      )
+    } catch {
+      return CoderToolOutput.failure(error, redactor: redactor)
+    }
+  }
+}

--- a/Sources/ClawTools/Tools/Coder/CoderStatusTool.swift
+++ b/Sources/ClawTools/Tools/Coder/CoderStatusTool.swift
@@ -1,0 +1,56 @@
+import ClawCore
+import Foundation
+
+public struct CoderStatusTool: Tool {
+  private let service: any CoderServing
+  private let redactor: SecretRedactor
+
+  public init(service: any CoderServing, redactor: SecretRedactor) {
+    self.service = service
+    self.redactor = redactor
+  }
+
+  public var definition: ToolDefinition {
+    ToolDefinition(
+      name: CoderToolNames.status,
+      description: "Inspect an owned background Coder job.",
+      parameters: CoderToolOutput.jobSchema,
+      metadataProvenance: .trusted,
+      egressClass: .none,
+      riskLevel: .safe,
+      requiresInteractiveOwner: true
+    )
+  }
+
+  public var timeout: Duration { .seconds(30) }
+
+  public func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? { nil }
+
+  public func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+    CoderToolOutput.missingContext
+  }
+
+  public func execute(
+    arguments: JSONValue,
+    canonicalTarget: String?,
+    context: ToolExecutionContext?
+  ) async -> ToolPayload {
+    guard let context else {
+      return CoderToolOutput.missingContext
+    }
+    guard let id = CoderToolOutput.jobID(arguments) else {
+      return CoderToolOutput.failure(
+        CoderError.invalidRequest("Provide only job_id as a UUID string."),
+        redactor: redactor
+      )
+    }
+    do {
+      return CoderToolOutput.job(
+        try await service.status(id: id, context: context),
+        redactor: redactor
+      )
+    } catch {
+      return CoderToolOutput.failure(error, redactor: redactor)
+    }
+  }
+}

--- a/Sources/ClawTools/Tools/Coder/CoderSubmitArguments.swift
+++ b/Sources/ClawTools/Tools/Coder/CoderSubmitArguments.swift
@@ -1,0 +1,121 @@
+import ClawCore
+import Foundation
+
+/// The model-facing wire shape is deliberately narrower than the recorded prepared request.
+enum CoderSubmitArguments {
+  static let fields: Set<String> = [
+    "source", "task", "workspace", "start_ref", "deliverable", "base_branch", "instructions",
+    "publish_existing_changes",
+  ]
+
+  static var schema: JSONValue {
+    let optionalText: JSONValue = .object(["type": .array([.string("string"), .string("null")])])
+    let sourceCases = [("local", "path"), ("githubRepository", "url"), ("githubIssue", "url")]
+    let sources = sourceCases.map { name, field in
+      objectSchema(
+        properties: [
+          name: objectSchema(
+            properties: [field: .object(["type": .string("string")])],
+            required: [field]
+          )
+        ],
+        required: [name]
+      )
+    }
+    return objectSchema(
+      properties: [
+        "source": .object(["oneOf": .array(sources)]),
+        "task": optionalText,
+        "workspace": .object([
+          "type": .string("string"),
+          "enum": .array([
+            .string(CoderWorkspaceMode.inPlace.rawValue),
+            .string(CoderWorkspaceMode.separate.rawValue),
+          ]),
+        ]),
+        "start_ref": optionalText,
+        "deliverable": .object([
+          "type": .string("string"),
+          "enum": .array([
+            .string(CoderDeliverable.localChanges.rawValue),
+            .string(CoderDeliverable.pullRequest.rawValue),
+          ]),
+        ]),
+        "base_branch": optionalText,
+        "instructions": optionalText,
+        "publish_existing_changes": .object(["type": .string("boolean"), "default": .bool(false)]),
+      ],
+      required: ["source", "workspace", "deliverable"]
+    )
+  }
+
+  static func decode(_ value: JSONValue) throws -> CoderRequest {
+    guard let object = value.objectValue, Set(object.keys).isSubset(of: fields),
+      let sourceObject = object["source"]?.objectValue, sourceObject.count == 1,
+      let sourceCase = sourceObject.first,
+      let sourceFields = sourceCase.value.objectValue,
+      let workspaceText = object["workspace"]?.stringValue,
+      let workspace = CoderWorkspaceMode(rawValue: workspaceText),
+      let deliverableText = object["deliverable"]?.stringValue,
+      let deliverable = CoderDeliverable(rawValue: deliverableText)
+    else {
+      throw CoderError.invalidRequest("Use only the declared Coder fields and exactly one source.")
+    }
+    let source: CoderSource
+    switch sourceCase.key {
+    case "local":
+      source = .local(path: try sourceText(sourceFields, field: "path"))
+    case "githubRepository":
+      source = .githubRepository(url: try sourceText(sourceFields, field: "url"))
+    case "githubIssue":
+      source = .githubIssue(url: try sourceText(sourceFields, field: "url"))
+    default:
+      throw CoderError.invalidRequest("Unknown Coder source.")
+    }
+    let publish: Bool
+    switch object["publish_existing_changes"] {
+    case nil: publish = false
+    case .bool(let value): publish = value
+    default: throw CoderError.invalidRequest("publish_existing_changes must be a boolean.")
+    }
+    return try CoderRequest(
+      source: source,
+      task: optionalText(object, field: "task"),
+      workspace: workspace,
+      startRef: optionalText(object, field: "start_ref"),
+      deliverable: deliverable,
+      baseBranch: optionalText(object, field: "base_branch"),
+      instructions: optionalText(object, field: "instructions"),
+      publishExistingChanges: publish
+    ).validated()
+  }
+}
+
+// MARK: - Wire Fields
+
+private extension CoderSubmitArguments {
+  static func sourceText(_ fields: [String: JSONValue], field: String) throws -> String {
+    guard Set(fields.keys) == [field], let value = fields[field]?.stringValue else {
+      throw CoderError.invalidRequest("The source requires only its declared \(field) string.")
+    }
+    return value
+  }
+
+  static func optionalText(_ object: [String: JSONValue], field: String) throws -> String? {
+    switch object[field] {
+    case nil, .null: return nil
+    case .string(let text): return text
+    default: throw CoderError.invalidRequest("\(field) must be a string or null.")
+    }
+  }
+
+  static func objectSchema(properties: [String: JSONValue], required: [String]) -> JSONValue {
+    let requiredFields = required.map { field in
+      JSONValue.string(field)
+    }
+    return .object([
+      "type": .string("object"), "properties": .object(properties),
+      "required": .array(requiredFields), "additionalProperties": .bool(false),
+    ])
+  }
+}

--- a/Sources/ClawTools/Tools/Coder/CoderSubmitTool.swift
+++ b/Sources/ClawTools/Tools/Coder/CoderSubmitTool.swift
@@ -1,0 +1,147 @@
+import ClawCore
+import Foundation
+
+public struct CoderSubmitTool: Tool {
+  private let service: any CoderServing
+  private let executionPolicyID: String
+  private let redactor: SecretRedactor
+
+  public init(service: any CoderServing, executionPolicyID: String, redactor: SecretRedactor) {
+    self.service = service
+    self.executionPolicyID = executionPolicyID
+    self.redactor = redactor
+  }
+
+  public var definition: ToolDefinition {
+    ToolDefinition(
+      name: CoderToolNames.submit,
+      description:
+        "Delegate a coding task to the owner's native Codex installation after approval.",
+      parameters: CoderSubmitArguments.schema,
+      metadataProvenance: .trusted,
+      egressClass: .none,
+      riskLevel: .dangerous,
+      invocationIdentity: executionPolicyID,
+      requiresInteractiveOwner: true
+    )
+  }
+
+  public var timeout: Duration { .seconds(30) }
+
+  public func canonicalTarget(arguments: JSONValue) -> CanonicalTargetResolution? { nil }
+
+  public func prepareAction(arguments: JSONValue) async -> PreparedActionResolution? {
+    do {
+      let request = try CoderSubmitArguments.decode(arguments)
+      let prepared = try await service.prepare(request)
+      guard prepared.executionPolicyID == executionPolicyID,
+        let canonical = CanonicalJSON.encode(prepared)
+      else {
+        return .refused(reason: "The Coder execution policy changed; request fresh approval.")
+      }
+      return .prepared(
+        PreparedToolAction(
+          canonicalTarget: prepared.canonicalSource,
+          canonicalArgsJSON: canonical,
+          presentation: Self.presentation(prepared, redactor: redactor),
+          guardTexts: Self.guardTexts(prepared),
+          canExfiltrate: true,
+          approvalReason: .coderSubmit
+        )
+      )
+    } catch {
+      return .refused(reason: CoderToolOutput.failure(error, redactor: redactor).content)
+    }
+  }
+
+  public func execute(arguments: JSONValue, canonicalTarget: String?) async -> ToolPayload {
+    CoderToolOutput.missingContext
+  }
+
+  public func execute(
+    arguments: JSONValue,
+    canonicalTarget: String?,
+    context: ToolExecutionContext?
+  ) async -> ToolPayload {
+    guard let context, context.approvalId != nil else {
+      return CoderToolOutput.missingContext
+    }
+    guard let canonical = CanonicalJSON.encode(arguments),
+      let prepared = try? JSONDecoder().decode(
+        CoderPreparedRequest.self,
+        from: Data(canonical.utf8)
+      ),
+      prepared.canonicalSource == canonicalTarget,
+      prepared.executionPolicyID == executionPolicyID
+    else {
+      return CoderToolOutput.failure(CoderError.staleApproval, redactor: redactor)
+    }
+    do {
+      let job = try await service.submit(prepared, context: context)
+      return CoderToolOutput.job(job, redactor: redactor)
+    } catch {
+      return CoderToolOutput.failure(error, redactor: redactor)
+    }
+  }
+}
+
+// MARK: - Outbound Argument Guard
+
+private extension CoderSubmitTool {
+  static func guardTexts(_ prepared: CoderPreparedRequest) -> [String] {
+    let request = prepared.request
+    let source: String
+    switch request.source {
+    case .local(let value), .githubRepository(let value), .githubIssue(let value): source = value
+    }
+    var texts = [source, request.task, request.instructions, request.startRef]
+    if request.workspace == .inPlace { texts.append(prepared.checkoutPath) }
+    if request.deliverable == .pullRequest {
+      texts += [request.baseBranch, prepared.publicationRepository]
+    }
+    return texts.compactMap { text in
+      text
+    }
+  }
+}
+
+// MARK: - Approval Presentation
+
+extension CoderSubmitTool {
+  static func presentation(
+    _ prepared: CoderPreparedRequest,
+    redactor: SecretRedactor
+  ) -> ToolApprovalPresentation {
+    let request = prepared.request
+    let source: String
+    if case .githubIssue(let url) = request.source {
+      source = "GitHub issue \(url) (repository: \(prepared.canonicalSource))"
+    } else {
+      source = prepared.canonicalSource
+    }
+    let publication =
+      request.deliverable == .pullRequest
+      ? "pull request to \(prepared.publicationRepository ?? prepared.canonicalSource)"
+      : "local changes"
+    let base = request.baseBranch ?? "repository default"
+    let scope =
+      request.publishExistingChanges
+      ? "may publish existing changes" : "exclude unrelated existing changes from publication"
+    let effect = """
+      Native Codex; source: \(source); workspace: \(request.workspace.rawValue); \
+      start: \(request.startRef ?? "current/default HEAD"); deliverable: \(publication); \
+      base: \(base); \(scope).
+      """
+    return ToolApprovalPresentation(
+      blastRadius: redactor.redact(effect),
+      contentPreview: redactor.redact(
+        [request.task, request.instructions].compactMap { text in
+          text
+        }.joined(separator: "\n")
+      ),
+      warnings: [
+        "Uses your trusted native Codex installation, credentials and configured integrations. Inference leaves this machine; the working directory is not a security sandbox."
+      ]
+    )
+  }
+}

--- a/Sources/ClawTools/Tools/Coder/CoderToolOutput.swift
+++ b/Sources/ClawTools/Tools/Coder/CoderToolOutput.swift
@@ -1,0 +1,89 @@
+import ClawCore
+import Foundation
+
+enum CoderToolOutput {
+  static let missingContext = ToolPayload(
+    content: "Coder requires trusted owner context and submission requires durable approval.",
+    status: .error,
+    ingestedUntrusted: false
+  )
+
+  static let jobSchema: JSONValue = .object([
+    "type": .string("object"),
+    "properties": .object(["job_id": .object(["type": .string("string")])]),
+    "required": .array([.string("job_id")]), "additionalProperties": .bool(false),
+  ])
+
+  static func jobID(_ arguments: JSONValue) -> UUID? {
+    guard let object = arguments.objectValue, Set(object.keys) == ["job_id"],
+      let raw = object["job_id"]?.stringValue
+    else {
+      return nil
+    }
+    return UUID(uuidString: raw)
+  }
+
+  static func job(_ job: CoderJob, redactor: SecretRedactor) -> ToolPayload {
+    let result =
+      job.result.flatMap(CanonicalJSON.encode).flatMap(JSONValue.parse).map { value in
+        redact(value, using: redactor)
+      }.flatMap(CanonicalJSON.encode) ?? "Result pending."
+    let header = redactor.redact("Coder job \(job.id.uuidString)\nState: \(job.state.rawValue)")
+    let text = "\(header)\n\(result)"
+    return ToolPayload(
+      content: ToolOutputCap.cap(text),
+      status: .ok,
+      ingestedUntrusted: job.result != nil
+    )
+  }
+
+  static func failure(_ error: any Error, redactor: SecretRedactor) -> ToolPayload {
+    let content: String
+    switch error {
+    case CoderError.invalidRequest(let reason), CoderError.unavailable(let reason):
+      content = reason
+    case CoderError.forbidden:
+      content = "That Coder job is not available to this requester."
+    case CoderError.busy:
+      content = "Coder is at capacity; try again when a running job finishes."
+    case CoderError.workspaceBusy:
+      content = "Coder already has an active task in that checkout."
+    case CoderError.staleApproval:
+      content = "The Coder request or execution policy changed; request fresh approval."
+    case CoderError.recoveryRequired:
+      content = "Coder requires operator recovery before accepting this task."
+    default:
+      content = "Coder could not complete this operation."
+    }
+    return ToolPayload(
+      content: ToolOutputCap.cap(redactor.redact(content)),
+      status: .error,
+      ingestedUntrusted: false
+    )
+  }
+}
+
+// MARK: - Structured Result Redaction
+
+private extension CoderToolOutput {
+  static func redact(_ value: JSONValue, using redactor: SecretRedactor) -> JSONValue {
+    switch value {
+    case .string(let text):
+      return .string(redactor.redact(text))
+    case .array(let values):
+      return .array(
+        values.map { value in
+          redact(value, using: redactor)
+        }
+      )
+    case .object(let fields):
+      return .object(
+        fields.reduce(into: [:]) { result, field in
+          result[redactor.redact(field.key)] = redact(field.value, using: redactor)
+        }
+      )
+    default:
+      return value
+    }
+  }
+}

--- a/Sources/ClawTools/Tools/ExecuteCodeTool.swift
+++ b/Sources/ClawTools/Tools/ExecuteCodeTool.swift
@@ -16,6 +16,7 @@ public struct ExecuteCodeSettings: Sendable, Equatable {
 }
 
 public struct ExecuteCodeTool: Tool {
+  public static let name = "execute_code"
   public static let maxCodeBytes = ExecStagingLimits.standard.maxCodeBytes
   public static let maxStagedFileBytes = ExecStagingLimits.standard.maxStagedFileBytes
   public static let maxStagedTotalBytes = ExecStagingLimits.standard.maxStagedTotalBytes
@@ -42,7 +43,7 @@ public struct ExecuteCodeTool: Tool {
 
   public var definition: ToolDefinition {
     ToolDefinition(
-      name: "execute_code",
+      name: Self.name,
       description:
         "Run a short Python or shell script in a locked-down, throwaway sandbox (owner approval required; no network unless explicitly requested).",
       parameters: .object([
@@ -121,7 +122,8 @@ public struct ExecuteCodeTool: Tool {
           canonicalArgsJSON: canonicalArgsJSON,
           presentation: approvalPresentation(raw: raw, recorded: recorded),
           guardTexts: [raw.code] + loaded.map(\.guardText),
-          canExfiltrate: network
+          canExfiltrate: network,
+          approvalReason: .codeExec
         )
       )
     }

--- a/Sources/clawd/Bootstrap/FatalProcessTerminator.swift
+++ b/Sources/clawd/Bootstrap/FatalProcessTerminator.swift
@@ -24,6 +24,12 @@ struct FatalProcessTerminator: Sendable {
     _exit(code)
   }
 
+  /// Keeps dependent resources owned until process exit when Coder cleanup cannot be proved.
+  func fatalCoderCleanup(logger: Logger) throws -> Never {
+    logger.critical("Coder cleanup unresolved; exiting without dependent-resource teardown")
+    try terminate(1)
+  }
+
   /// Logs the runs still in flight, then terminates with a nonzero code BEFORE any scope unwinds, so
   /// no dependent resource is torn down underneath a still-running turn. The boot reconciler sweeps
   /// any run left `RUNNING` on the next start. Never returns normally.

--- a/Sources/clawd/Composition/CoderHealthRows.swift
+++ b/Sources/clawd/Composition/CoderHealthRows.swift
@@ -1,0 +1,156 @@
+import ClawCore
+import ClawGateway
+
+/// Coder facts use the existing doctor table; local probes never stand in for live task state.
+enum CoderHealthRows {
+  enum Key {
+    static let enabled = "coder.enabled"
+    static let available = "coder.available"
+    static let executable = "coder.executable"
+    static let version = "coder.version"
+    static let configHome = "coder.config_home"
+    static let profile = "coder.profile"
+    static let authentication = "coder.authentication"
+    static let capacity = "coder.capacity"
+    static let reserved = "coder.reserved"
+    static let ownership = "coder.unresolved_ownership"
+    static let lastFailure = "coder.last_failure"
+    static let serviceFailure = "coder.service_failure"
+    static let usage = "coder.usage"
+  }
+
+  static var disabled: [DoctorReport.Check] { [row(Key.enabled, "false")] }
+
+  static func unavailable(config: CoderConfig) -> [DoctorReport.Check] {
+    configurationRows(config) + [
+      row(Key.available, "false (Codex executable missing or incompatible)", ok: false),
+      row(Key.version, "unavailable"),
+      row(Key.authentication, "unverified (CLI unavailable)", ok: false),
+    ]
+  }
+
+  static func rows(config: CoderConfig, setup: CoderBackendSetup) -> [DoctorReport.Check] {
+    let authentication: String
+    let authOK: Bool
+    switch setup.authentication {
+    case .authenticated:
+      authentication = "local login present; runtime authorization not verified"
+      authOK = true
+    case .missing:
+      authentication = "missing login (blocker; authenticate Codex as the daemon user)"
+      authOK = false
+    case .unavailable:
+      authentication = "unreadable local status (blocker)"
+      authOK = false
+    case .profileUnverified:
+      authentication = "unverified: CLI status cannot inspect selected profile authentication"
+      authOK = false
+    }
+    return [
+      row(Key.enabled, "true"),
+      row(
+        Key.available,
+        setup.permitsSubmission ? "true (compatible CLI)" : "false",
+        ok: setup.permitsSubmission
+      ),
+      row(Key.executable, setup.executable), row(Key.version, setup.version),
+      row(Key.configHome, setup.configHome ?? "default"),
+      row(Key.profile, setup.profile ?? "default"),
+      row(Key.authentication, authentication, ok: authOK),
+      row(Key.capacity, String(config.maxConcurrentJobs)),
+      row(Key.usage, "child-reported per job; separate from conversational /cost"),
+    ]
+  }
+
+  static func configuration(
+    config: CoderConfig,
+    live: Bool,
+    resolve: @Sendable (CoderConfig) async throws -> CoderBackendSetup
+  ) async -> [DoctorReport.Check] {
+    guard config.enabled else {
+      return disabled
+    }
+    guard live else {
+      return configurationRows(config) + [
+        row(Key.available, "unverified (offline config check)"),
+        row(Key.version, "unverified (no CLI probe)"),
+        row(Key.authentication, "unverified (no CLI probe)"),
+      ]
+    }
+    do { return rows(config: config, setup: try await resolve(config)) } catch {
+      return unavailable(config: config)
+    }
+  }
+
+  static func persisted(
+    store: any CoderJobStore,
+    redactor: SecretRedactor
+  ) -> [DoctorReport.Check] {
+    var rows: [DoctorReport.Check] = []
+    do {
+      let jobs = try store.reservedJobs()
+      let unresolved = jobs.filter {
+        $0.ownership == .unresolved || $0.ownership == .launching
+      }
+      rows += [
+        row(Key.reserved, "\(jobs.count) (persisted reservations)"),
+        row(
+          Key.ownership,
+          unresolved.isEmpty
+            ? "none"
+            : unresolved.map {
+              $0.id.uuidString
+            }.joined(separator: ", "),
+          ok: unresolved.isEmpty
+        ),
+      ]
+    } catch {
+      rows += [unreadable(Key.reserved), unreadable(Key.ownership)]
+    }
+    do {
+      let job = try store.lastFailedJob()
+      let value =
+        job.map {
+          "\($0.id): \($0.state.rawValue); \($0.result?.failure?.message ?? "no diagnostic") (most recently updated failure record)"
+        } ?? "none"
+      rows.append(row(Key.lastFailure, redactor.redact(value)))
+    } catch { rows.append(unreadable(Key.lastFailure)) }
+    return rows
+  }
+
+  static func service(_ service: CoderService?) async -> [DoctorReport.Check] {
+    guard let service else {
+      return [row(Key.serviceFailure, "unavailable (live daemon observation only)")]
+    }
+    let failure = await service.failure
+    return [
+      row(
+        Key.serviceFailure,
+        failure == nil ? "none" : "fatal persistence/process cleanup failure",
+        ok: failure == nil
+      )
+    ]
+  }
+}
+
+// MARK: - Row Construction
+
+private extension CoderHealthRows {
+  static func configurationRows(_ config: CoderConfig) -> [DoctorReport.Check] {
+    [
+      row(Key.enabled, "true"), row(Key.executable, "\(config.executable) (configured)"),
+      row(Key.configHome, config.configHome ?? "inherited CODEX_HOME or daemon HOME/.codex"),
+      row(Key.profile, config.profile ?? "default"),
+      row(Key.capacity, String(config.maxConcurrentJobs)),
+      row(Key.usage, "child-reported per job; separate from conversational /cost"),
+    ]
+  }
+
+  static func row(_ key: String, _ value: String, ok: Bool = true) -> DoctorReport.Check {
+    DoctorReport.Check(key: key, value: value, ok: ok, group: .coder)
+  }
+
+  static func unreadable(_ key: String) -> DoctorReport.Check {
+    row(key, "unreadable (db read failed)", ok: false)
+  }
+}

--- a/Sources/clawd/Composition/DaemonBuilder+Agent.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Agent.swift
@@ -24,12 +24,14 @@ extension DaemonBuilder {
     workspace: FileSystemWorkspace,
     costResolver: CostResolver,
     sandbox: SandboxStack,
-    mcpTools: [any Tool]
+    mcpTools: [any Tool],
+    coderTools: [any Tool] = []
   ) -> AgentStack {
     let toolDispatcher = makeToolDispatcher(
       workspace: workspace,
       sandbox: sandbox,
-      mcpTools: mcpTools
+      mcpTools: mcpTools,
+      coderTools: coderTools
     )
     let staticSubhash = policyStaticSubhash(toolDispatcher: toolDispatcher, workspace: workspace)
     let agent = makeAgent(

--- a/Sources/clawd/Composition/DaemonBuilder+Boot.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Boot.swift
@@ -22,15 +22,13 @@ extension DaemonBuilder {
     BotMenuCommand(command: "help", description: "Show commands and confirm rules."),
   ]
 
-  /// Composes the daemon's one-shot boot reconciliation: register the command menu with Telegram
-  /// (`registerMenu`), sweep crash-orphaned runs (`reconcileRuns`), then re-park unresolved
-  /// approvals (`reconcileApprovals`). Each step is best-effort, but `reconcileApprovals` is
-  /// deliberately last: the run sweep must fail its orphans first so the approval sweep only sees
-  /// runs that are genuinely still parked. All three run before any update is served.
+  /// Reconciles runs and Coder before approval replay can start native work or restore parked lanes.
+  /// The graph starts after this boot hook; every resulting owner must also support fallback shutdown.
   func bootSequence(
     coordination: TurnCoordination,
     waiter: ApprovalWaiter,
-    heartbeatOwner: Int64?
+    heartbeatOwner: Int64?,
+    coder: CoderService? = nil
   ) -> @Sendable () async -> Void {
     let registerMenu = registerMenuCommands()
     let reconcileRuns = bootReconcile(heartbeatOwner: heartbeatOwner)
@@ -38,6 +36,12 @@ extension DaemonBuilder {
     return {
       await registerMenu()
       await reconcileRuns()
+      if let coder {
+        do { try await coder.start() } catch {
+          logger.error("Coder startup reconciliation failed; admission remains closed")
+          return
+        }
+      }
       await reconcileApprovals()
     }
   }

--- a/Sources/clawd/Composition/DaemonBuilder+Coder.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Coder.swift
@@ -1,0 +1,128 @@
+import ClawCoder
+import ClawCore
+import ClawGateway
+import ClawTools
+import Foundation
+
+struct CoderComposition: Sendable {
+  let service: CoderService?
+  let tools: [any Tool]
+  let checks: [DoctorReport.Check]
+}
+
+struct CoderBackendSetup: Sendable {
+  let backend: any CoderBackend
+  let executable: String
+  let profile: String?
+  let configHome: String?
+  let credentialSources: [String: String]
+  let version: String
+  let authentication: CodexAuthenticationStatus
+
+  var permitsSubmission: Bool {
+    authentication == .authenticated || authentication == .profileUnverified
+  }
+
+  static func live(_ config: CoderConfig) async throws -> Self {
+    let backend = try CodexBackend(config: config)
+    let version = try await backend.compatibility()
+    return Self(
+      backend: backend,
+      executable: backend.executable,
+      profile: backend.profile,
+      configHome: backend.configHome,
+      credentialSources: backend.credentialSources,
+      version: version,
+      authentication: await backend.authenticationStatus()
+    )
+  }
+}
+
+extension DaemonBuilder {
+  func prepareCoder(coordination: TurnCoordination) async -> CoderComposition {
+    guard config.coder.enabled else {
+      let reservedJobs = try? stores.coderJobs.reservedJobs()
+      let service =
+        reservedJobs?.isEmpty == true
+        ? nil
+        : makeCoderService(
+          backend: nil,
+          policyID: Self.unavailableCoderPolicyID,
+          coordination: coordination
+        )
+      return CoderComposition(service: service, tools: [], checks: CoderHealthRows.disabled)
+    }
+    do {
+      let setup = try await resolveCoder(config.coder)
+      let checks = CoderHealthRows.rows(config: config.coder, setup: setup)
+      let policy = CoderExecutionPolicy(
+        executable: setup.executable,
+        profile: setup.profile,
+        configHome: setup.configHome,
+        approvalPolicy: CodexBackend.approvalPolicy,
+        credentialSources: setup.credentialSources
+      )
+      let service = makeCoderService(
+        backend: setup.permitsSubmission ? setup.backend : nil,
+        policyID: policy.id,
+        coordination: coordination
+      )
+      let redactor = SecretRedactor(secretValues: redactionValues)
+      var tools: [any Tool] = [
+        CoderStatusTool(service: service, redactor: redactor),
+        CoderCancelTool(service: service, redactor: redactor),
+      ]
+      if setup.permitsSubmission {
+        tools.insert(
+          CoderSubmitTool(service: service, executionPolicyID: policy.id, redactor: redactor),
+          at: 0
+        )
+      }
+      return CoderComposition(service: service, tools: tools, checks: checks)
+    } catch {
+      let service = makeCoderService(
+        backend: nil,
+        policyID: Self.unavailableCoderPolicyID,
+        coordination: coordination
+      )
+      let redactor = SecretRedactor(secretValues: redactionValues)
+      return CoderComposition(
+        service: service,
+        tools: [
+          CoderStatusTool(service: service, redactor: redactor),
+          CoderCancelTool(service: service, redactor: redactor),
+        ],
+        checks: CoderHealthRows.unavailable(config: config.coder)
+      )
+    }
+  }
+}
+
+// MARK: - Service Ownership
+
+private extension DaemonBuilder {
+  static let unavailableCoderPolicyID = "coder-unavailable-no-execution-authority"
+
+  func makeCoderService(
+    backend: (any CoderBackend)?,
+    policyID: String,
+    coordination: TurnCoordination
+  ) -> CoderService {
+    let redactor = SecretRedactor(secretValues: redactionValues)
+    return CoderService(
+      store: stores.coderJobs,
+      backend: backend,
+      preparer: CoderRequestPreparer(executionPolicyID: policyID),
+      inspector: CoderProcessInspector(),
+      config: config.coder,
+      jobRoot: config.stateRoot.appendingPathComponent("coder/jobs").path,
+      executionPolicyID: policyID,
+      redact: {
+        redactor.redact($0)
+      },
+      notifyOutbox: {
+        coordination.outboxSignal.poke()
+      }
+    )
+  }
+}

--- a/Sources/clawd/Composition/DaemonBuilder+Doctor.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Doctor.swift
@@ -11,7 +11,8 @@ extension DaemonBuilder {
   func makeDoctorReporter(
     sandbox: SandboxStack,
     cooldown: any PrimaryRouteCooldownTracking,
-    mcpOutcomes: [MCPServerOutcome]
+    mcpOutcomes: [MCPServerOutcome],
+    coder: CoderComposition? = nil
   ) -> DaemonDoctorReporter {
     DaemonDoctorReporter(
       stores: stores,
@@ -21,7 +22,9 @@ extension DaemonBuilder {
       staticAPIKey: secrets.llmApiKey,
       makeManagedStore: makeManagedStore,
       mcp: mcp,
-      mcpOutcomes: mcpOutcomes
+      mcpOutcomes: mcpOutcomes,
+      coder: coder,
+      redactor: SecretRedactor(secretValues: redactionValues)
     )
   }
 }
@@ -37,6 +40,8 @@ struct DaemonDoctorReporter: DoctorReporting {
   let makeManagedStore: @Sendable () -> any LLMCredentialStore
   let mcp: MCPBootInputs
   let mcpOutcomes: [MCPServerOutcome]
+  let coder: CoderComposition?
+  let redactor: SecretRedactor
 
   func scanSkills() async -> SkillScanResult {
     DoctorHealth.skillScan(config: config)
@@ -89,6 +94,13 @@ struct DaemonDoctorReporter: DoctorReporting {
       report.add(contentsOf: [SandboxHealthRows.admittingRow(await maintenance.isAdmitting())])
     }
 
+    if config.coder.enabled {
+      report.add(contentsOf: coder?.checks ?? [])
+    } else {
+      report.add(contentsOf: CoderHealthRows.disabled)
+    }
+    report.add(contentsOf: CoderHealthRows.persisted(store: stores.coderJobs, redactor: redactor))
+    report.add(contentsOf: await CoderHealthRows.service(coder?.service))
     return report
   }
 }

--- a/Sources/clawd/Composition/DaemonBuilder+Intake.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Intake.swift
@@ -112,7 +112,8 @@ extension DaemonBuilder {
   func makeToolDispatcher(
     workspace: FileSystemWorkspace,
     sandbox: SandboxStack,
-    mcpTools: [any Tool]
+    mcpTools: [any Tool],
+    coderTools: [any Tool] = []
   ) -> GatedToolDispatcher {
     let secretValues = redactionValues
     let redactor = SecretRedactor(secretValues: secretValues)
@@ -156,6 +157,7 @@ extension DaemonBuilder {
       )
     }
 
+    tools.append(contentsOf: coderTools)
     tools.append(contentsOf: mcpTools)
 
     let privateFileLoader: @Sendable () -> [String] = {
@@ -172,7 +174,10 @@ extension DaemonBuilder {
       gate: ToolPolicyGate(
         argGuard: ExfilArgGuard(secretValues: secretValues),
         privateFileLoader: privateFileLoader,
-        execEnabled: config.exec.enabled
+        enabledDangerousTools: Set(
+          (config.exec.enabled ? [ExecuteCodeTool.name] : [])
+            + coderTools.map(\.definition.name)
+        )
       )
     )
   }

--- a/Sources/clawd/Composition/DaemonBuilder.swift
+++ b/Sources/clawd/Composition/DaemonBuilder.swift
@@ -36,6 +36,10 @@ struct DaemonBuilder: Sendable {
   /// real one; the current route never invokes it.
   let makeManagedStore: @Sendable () -> any LLMCredentialStore
 
+  /// Resolves native CLI readiness once; injectable at the unmanaged process boundary.
+  var resolveCoder: @Sendable (CoderConfig) async throws -> CoderBackendSetup = CoderBackendSetup
+    .live
+
   /// The one redaction set for this process — secret-store values plus MCP tokens. Every redactor
   /// and arg guard the builder makes reads this instead of `secrets.redactionValues`, so none of
   /// them can be built from a narrower list than the log backend was. Derived rather than passed in:
@@ -75,6 +79,7 @@ struct DaemonBuilder: Sendable {
   ) async throws -> DaemonRuntimeBundle {
     let sandbox = await prepareSandbox()
     let coordination = TurnCoordination()
+    let coder = await prepareCoder(coordination: coordination)
 
     // Hoisted so the agent and the /schedule parse share one offline-first cost resolver — both
     // meter spend against the same price snapshot and reference rate.
@@ -96,7 +101,8 @@ struct DaemonBuilder: Sendable {
       workspace: workspace,
       costResolver: costResolver,
       sandbox: sandbox,
-      mcpTools: mcpStack.tools
+      mcpTools: mcpStack.tools,
+      coderTools: coder.tools
     )
 
     let consumers = makeRunnerConsumers(
@@ -107,7 +113,8 @@ struct DaemonBuilder: Sendable {
       costResolver: costResolver,
       workspace: workspace,
       sandbox: sandbox,
-      mcpCatalog: mcpStack.catalog
+      mcpCatalog: mcpStack.catalog,
+      coder: coder
     )
 
     var services: [any Service] = [
@@ -132,8 +139,10 @@ struct DaemonBuilder: Sendable {
       boot: bootSequence(
         coordination: coordination,
         waiter: consumers.approvals.waiter,
-        heartbeatOwner: consumers.heartbeatOwner
-      )
+        heartbeatOwner: consumers.heartbeatOwner,
+        coder: coder.service
+      ),
+      coder: coder.service
     )
   }
 
@@ -157,7 +166,8 @@ struct DaemonBuilder: Sendable {
     costResolver: CostResolver,
     workspace: FileSystemWorkspace,
     sandbox: SandboxStack,
-    mcpCatalog: ResolvedMCPCatalog
+    mcpCatalog: ResolvedMCPCatalog,
+    coder: CoderComposition
   ) -> RunnerConsumers {
     let turnRunner = makeTurnRunner(
       coordination: coordination,
@@ -180,7 +190,8 @@ struct DaemonBuilder: Sendable {
       doctor: makeDoctorReporter(
         sandbox: sandbox,
         cooldown: cooldown,
-        mcpOutcomes: mcpCatalog.outcomes
+        mcpOutcomes: mcpCatalog.outcomes,
+        coder: coder
       )
     )
     let approvals = makeApprovalFabric(
@@ -211,6 +222,7 @@ struct DaemonBuilder: Sendable {
     coordination: TurnCoordination,
     credentialSources: [any LLMCredentialSource],
     boot: @escaping @Sendable () async -> Void,
+    coder: CoderService? = nil,
     laneDrainClock: any Clock<Duration> = ContinuousClock(),
     gracefulShutdownSignals: [UnixSignal] = [.sigterm, .sigint]
   ) -> DaemonRuntimeBundle {
@@ -224,7 +236,13 @@ struct DaemonBuilder: Sendable {
     )
 
     let daemon = Daemon(
-      services: Self.servicesWithLaneAdmissionLast(base: services, laneAdmission: laneAdmission),
+      services: Self.servicesWithLaneAdmissionLast(
+        base: services
+          + (coder.map {
+            [$0 as any Service]
+          } ?? []),
+        laneAdmission: laneAdmission
+      ),
       boot: boot,
       logger: logger,
       gracefulShutdownSignals: gracefulShutdownSignals,
@@ -235,7 +253,8 @@ struct DaemonBuilder: Sendable {
       daemon: daemon,
       lanes: coordination.lanes,
       credentialSources: credentialSources,
-      laneShutdownOutcome: laneShutdownOutcome
+      laneShutdownOutcome: laneShutdownOutcome,
+      coder: coder
     )
   }
 

--- a/Sources/clawd/Subcommands/DoctorCommand.swift
+++ b/Sources/clawd/Subcommands/DoctorCommand.swift
@@ -45,6 +45,8 @@ struct DoctorCommand: AsyncParsableCommand {
       report.add(contentsOf: await sandboxRows(config: config, live: false))
     }
 
+    report.add(contentsOf: await coderRows(config: config.coder))
+
     let secretsRow = SecretStoreResolver.doctorRow(
       stateRoot: config.stateRoot,
       environment: ProcessInfo.processInfo.environment
@@ -416,6 +418,13 @@ private extension DoctorCommand {
     )
     report.add(contentsOf: DoctorHealth.schedulerChecks(stores: stores, config: config, now: now))
     report.add(contentsOf: DoctorHealth.approvalChecks(stores: stores, config: config, now: now))
+    let secrets = try? EnvironmentLoader.loadSecrets(config: config)
+    report.add(
+      contentsOf: CoderHealthRows.persisted(
+        store: stores.coderJobs,
+        redactor: SecretRedactor(secretValues: secrets?.redactionValues ?? [])
+      )
+    )
   }
 }
 
@@ -492,5 +501,24 @@ private extension DoctorCommand {
   func emit(_ report: DoctorReport) {
     // swiftlint:disable:next no_print_in_production
     print(json ? report.renderJSON() : report.renderText())
+  }
+}
+
+// MARK: - Coder Diagnostics
+
+extension DoctorCommand {
+  func coderRows(
+    config: CoderConfig,
+    resolve: @Sendable (CoderConfig) async throws -> CoderBackendSetup = CoderBackendSetup.live
+  ) async -> [DoctorReport.Check] {
+    let rows = await CoderHealthRows.configuration(
+      config: config,
+      live: !checkConfig,
+      resolve: resolve
+    )
+    guard !checkConfig else {
+      return rows
+    }
+    return rows + (await CoderHealthRows.service(nil))
   }
 }

--- a/Sources/clawd/Subcommands/RunCommand.swift
+++ b/Sources/clawd/Subcommands/RunCommand.swift
@@ -97,6 +97,7 @@ extension RunCommand {
     let outcome = await coordinator.shutDown(
       daemonError: runFailure,
       laneDrain: laneDrain,
+      coder: bundle.coder,
       dependent: RuntimeShutdownCoordinator.DependentCleanup(
         commitCredentials: { try await Self.commitCredentials(bundle.credentialSources) },
         // The dedicated redirect-disabled LLM client, now its own resource rather than the Telegram
@@ -113,6 +114,8 @@ extension RunCommand {
       logger.info("clawd stopped")
     case .failed(let error):
       throw error
+    case .fatalCoderCleanup:
+      try terminator.fatalCoderCleanup(logger: logger)
     case .fatalLaneTimeout(let activeRunIDs):
       try terminator.fatalLaneDrainTimeout(
         activeRunIDs: activeRunIDs,

--- a/Tests/ClawCoderTests/Codex/CodexAuthenticationTests.swift
+++ b/Tests/ClawCoderTests/Codex/CodexAuthenticationTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+
+@testable import ClawCoder
+
+@Suite struct CodexAuthenticationTests {
+  @Test func localStatusDistinguishesMissingLoginAndUnverifiableProfile() async throws {
+    // given
+    let fixture = try await CodexFixture()
+    defer { try? FileManager.default.removeItem(at: fixture.git.root) }
+    try fixture.script(
+      "codex",
+      """
+      #!/bin/sh
+      [ "$1" = login ] && [ "$2" = status ] || exit 9
+      echo 'Not logged in' >&2
+      exit 1
+      """
+    )
+
+    // when
+    let missing = try await fixture.backend().authenticationStatus()
+    let profile = try await fixture.backend(profile: "coding").authenticationStatus()
+    try fixture.script(
+      "codex",
+      """
+      #!/bin/sh
+      [ "$1" = login ] && [ "$2" = status ] || exit 9
+      echo 'sensitive-output-must-not-be-rendered'
+      exit 0
+      """
+    )
+    let present = try await fixture.backend().authenticationStatus()
+    try fixture.script(
+      "codex",
+      """
+      #!/bin/sh
+      echo 'config error: task7-sensitive-token' >&2
+      exit 1
+      """
+    )
+    let unreadable = try await fixture.backend().authenticationStatus()
+
+    // then
+    #expect(missing == .missing)
+    #expect(profile == .profileUnverified)
+    #expect(present == .authenticated)
+    #expect(unreadable == .unavailable)
+  }
+}

--- a/Tests/ClawCoreTests/Config/CoderConfigTests.swift
+++ b/Tests/ClawCoreTests/Config/CoderConfigTests.swift
@@ -27,6 +27,28 @@ import Testing
     }
   }
 
+  @Test func explicitSettingsReachAppConfig() throws {
+    // given
+    let environment = [
+      EnvKey.llmModel: "test-model", EnvKey.llmBaseURL: "http://localhost:1234/v1",
+      EnvKey.stateRoot: NSTemporaryDirectory(),
+      EnvKey.coderEnabled: "yes", EnvKey.coderMaxConcurrentJobs: "3",
+      EnvKey.coderJobTimeoutSeconds: "86400", EnvKey.coderExecutable: "/absent/bin/codex",
+      EnvKey.coderProfile: "personal", EnvKey.coderConfigHome: "/absent/codex-config",
+    ]
+
+    // when
+    let config = try AppConfig.load(environment: environment).coder
+
+    // then
+    #expect(config.enabled)
+    #expect(config.maxConcurrentJobs == 3)
+    #expect(config.jobTimeoutSeconds == 86_400)
+    #expect(config.executable == environment[EnvKey.coderExecutable])
+    #expect(config.profile == environment[EnvKey.coderProfile])
+    #expect(config.configHome == environment[EnvKey.coderConfigHome])
+  }
+
   @Test(arguments: [
     (EnvKey.coderMaxConcurrentJobs, "many"),
     (EnvKey.coderJobTimeoutSeconds, "86401"),

--- a/Tests/ClawCoreTests/Domain/Coder/CoderExecutionPolicyTests.swift
+++ b/Tests/ClawCoreTests/Domain/Coder/CoderExecutionPolicyTests.swift
@@ -1,0 +1,46 @@
+import Testing
+
+@testable import ClawCore
+
+@Suite struct CoderExecutionPolicyTests {
+  @Test func everyResolvedExecutionFactChangesTheIdentity() {
+    // given
+    let original = policy()
+    let changes = [
+      policy(executable: "/other/codex"), policy(profile: "review"), policy(profile: nil),
+      policy(configHome: "/other/home"), policy(configHome: nil),
+      policy(approvalPolicy: "other"), policy(sources: ["github": "GITHUB_TOKEN"]),
+      policy(sources: ["other": "GH_TOKEN"]), policy(sources: [:]),
+    ]
+
+    // when / then
+    for changed in changes { #expect(changed.id != original.id) }
+  }
+
+  @Test func credentialSourceOrderDoesNotChangeIdentity() {
+    // given
+    let first = policy(sources: ["github": "GH_TOKEN", "codex": "/config/auth"])
+    let second = policy(sources: ["codex": "/config/auth", "github": "GH_TOKEN"])
+
+    // when / then
+    #expect(first.id == second.id)
+  }
+}
+
+private extension CoderExecutionPolicyTests {
+  func policy(
+    executable: String = "/bin/codex",
+    profile: String? = "default",
+    configHome: String? = "/config",
+    approvalPolicy: String = "on-request",
+    sources: [String: String] = ["github": "GH_TOKEN"]
+  ) -> CoderExecutionPolicy {
+    CoderExecutionPolicy(
+      executable: executable,
+      profile: profile,
+      configHome: configHome,
+      approvalPolicy: approvalPolicy,
+      credentialSources: sources
+    )
+  }
+}

--- a/Tests/ClawCoreTests/Domain/Policy/PolicyFingerprintTests.swift
+++ b/Tests/ClawCoreTests/Domain/Policy/PolicyFingerprintTests.swift
@@ -41,7 +41,8 @@ import Testing
     risk: RiskLevel = .safe,
     egress: ToolEgressClass = .none,
     fenceLabel: String? = nil,
-    invocationIdentity: String? = nil
+    invocationIdentity: String? = nil,
+    requiresInteractiveOwner: Bool = false
   ) -> ToolDefinition {
     ToolDefinition(
       name: name,
@@ -51,7 +52,8 @@ import Testing
       egressClass: egress,
       riskLevel: risk,
       fenceLabel: fenceLabel,
-      invocationIdentity: invocationIdentity
+      invocationIdentity: invocationIdentity,
+      requiresInteractiveOwner: requiresInteractiveOwner
     )
   }
 
@@ -147,6 +149,15 @@ import Testing
       subhash(tools: [tool(name: "t", egress: .none)])
         != subhash(tools: [tool(name: "t", egress: .arbitraryDestination)])
     )
+  }
+
+  @Test func interactiveOwnerRequirementIsAnInputClass() {
+    // given
+    let ordinary = tool(name: "t")
+    let ownerOnly = tool(name: "t", requiresInteractiveOwner: true)
+
+    // when / then
+    #expect(subhash(tools: [ordinary]) != subhash(tools: [ownerOnly]))
   }
 
   @Test func invocationIdentityIsAnInputClass() {

--- a/Tests/ClawCoreTests/Domain/Tools/ToolContractsTests.swift
+++ b/Tests/ClawCoreTests/Domain/Tools/ToolContractsTests.swift
@@ -164,7 +164,8 @@ private struct DefaultPrepareTool: Tool {
       canonicalArgsJSON: #"{"code":"print('hello')"}"#,
       presentation: presentation,
       guardTexts: ["print('hello')", "staged text"],
-      canExfiltrate: true
+      canExfiltrate: true,
+      approvalReason: .codeExec
     )
 
     // then

--- a/Tests/ClawDataTests/Stores/Coder/Support/CoderStoreFixture.swift
+++ b/Tests/ClawDataTests/Stores/Coder/Support/CoderStoreFixture.swift
@@ -1,4 +1,5 @@
 import ClawCore
+import ClawTestSupport
 import Foundation
 import GRDB
 import Testing
@@ -30,7 +31,7 @@ struct CoderStoreFixture: Sendable {
     self.store = CoderJobStoreGRDB(writer: queue)
     self.prepared = prepared
     self.now = now
-    self.origin = try Self.approvedOrigin(
+    self.origin = try CoderApprovedOriginFixture.make(
       queue: queue,
       updateID: updateID,
       prepared: prepared,
@@ -49,149 +50,9 @@ struct CoderStoreFixture: Sendable {
   }
 }
 
-// MARK: - Real Approval Origin
+// MARK: - Prepared Request
 
 private extension CoderStoreFixture {
-  static func approvedOrigin(
-    queue: DatabaseQueue,
-    updateID: Int64,
-    prepared: CoderPreparedRequest,
-    now: Date
-  ) throws -> CoderOrigin {
-    let sessions = SessionMessageStoreGRDB(writer: queue)
-    let runs = RunStoreGRDB(writer: queue)
-    let approvals = ApprovalStoreGRDB(writer: queue)
-    let ownerID: Int64 = 7
-    let toolCallID = "coder-submit-fixture-call-\(updateID)"
-    let policyVersion = PolicyFingerprint.combined(
-      staticSubhash: prepared.executionPolicyID,
-      promptMaterials: ["Coder store fixture"]
-    )
-    let claim = try sessions.claimAndPersistInbound(
-      InboundMessage(
-        updateId: updateID,
-        sessionKey: SessionKey.telegramDM(chatId: ownerID),
-        chatId: ownerID,
-        userId: ownerID,
-        text: "Use Coder for \(prepared.canonicalSource).",
-        isEdited: false,
-        telegramMessageId: 11,
-        ts: now
-      )
-    )
-    let runID = try #require(claim.runId)
-    let sessionID = try #require(claim.sessionId)
-    let pickedUpOrigin = try #require(
-      try runs.pickUp(runId: runID, policyVersion: policyVersion, now: now)
-    )
-    guard pickedUpOrigin == .interactive else {
-      throw StoreError.unexpected("Coder fixture did not create an interactive run")
-    }
-    let receipt = try runs.commitSuspendedTurn(
-      runId: runID,
-      sessionId: sessionID,
-      commit: approvalCommit(
-        prepared: prepared,
-        ownerID: ownerID,
-        toolCallID: toolCallID,
-        now: now
-      ),
-      now: now
-    )
-    let resolution = try approvals.approve(
-      id: receipt.approvalId,
-      currentPolicyVersion: policyVersion,
-      now: now
-    )
-    guard case .approved(let approval) = resolution else {
-      throw StoreError.unexpected("Coder fixture approval was not granted")
-    }
-    let executionClaim = try runs.claimApprovedExecution(
-      runId: approval.runId,
-      observationMessageId: approval.observationMessageId,
-      notResumableObservationContent: "The task was stopped before admission.",
-      now: now
-    )
-    guard executionClaim == .committed else {
-      throw StoreError.unexpected("Coder fixture could not claim its approved execution")
-    }
-    return CoderOrigin(
-      runID: approval.runId,
-      sessionID: approval.sessionId,
-      requesterUserID: approval.ownerUserId,
-      chatID: approval.ownerUserId,
-      toolCallID: approval.toolCallId,
-      approvalID: approval.id
-    )
-  }
-
-  static func approvalCommit(
-    prepared: CoderPreparedRequest,
-    ownerID: Int64,
-    toolCallID: String,
-    now: Date
-  ) throws -> SuspendedTurnCommit {
-    let canonicalArgsJSON = try #require(CanonicalJSON.encode(prepared))
-    let task = prepared.request.task ?? "Resolve the issue"
-    let blastRadius =
-      "\(prepared.request.workspace.rawValue); local changes; "
-      + "native Codex with network access"
-    let recorded = RecordedToolAction(
-      tool: CoderToolNames.submit,
-      canonicalArgsJSON: canonicalArgsJSON,
-      argsHash: ApprovalArgsHash.sha256Hex(canonicalArgsJSON),
-      canonicalTarget: prepared.canonicalSource,
-      reason: .coderSubmit,
-      presentation: ToolApprovalPresentation(
-        blastRadius: blastRadius,
-        contentPreview: task,
-        warnings: []
-      )
-    )
-    let prompt = "Approve Coder for \(prepared.canonicalSource): \(task)"
-    return SuspendedTurnCommit(
-      assistantContent: "I can delegate this repository task to Coder.",
-      toolCallsJSON: try proposedToolCalls(prepared: prepared, toolCallID: toolCallID),
-      completedObservations: [],
-      pending: PendingToolAction(toolCallId: toolCallID, recorded: recorded),
-      ownerUserId: ownerID,
-      nonce: ApprovalNonce.generate(),
-      promptChunks: [
-        OutboxChunk(
-          stepIndex: 0,
-          chatId: ownerID,
-          payload: prompt,
-          payloadHash: ContentHash.fnv1a(prompt)
-        )
-      ],
-      setTainted: false,
-      setPrivateData: false,
-      expiresTs: now.addingTimeInterval(3_600)
-    )
-  }
-
-  static func proposedToolCalls(
-    prepared: CoderPreparedRequest,
-    toolCallID: String
-  ) throws -> String {
-    let request = prepared.request
-    let sourceJSON = try #require(CanonicalJSON.encode(request.source))
-    let sourceArgument = try #require(JSONValue.parse(sourceJSON))
-    let proposedArguments = JSONValue.object([
-      "source": sourceArgument,
-      "task": .string(request.task ?? "Resolve the issue"),
-      "workspace": .string(request.workspace.rawValue),
-      "deliverable": .string(request.deliverable.rawValue),
-      "publish_existing_changes": .bool(request.publishExistingChanges),
-    ])
-    let proposedArgsJSON = try #require(CanonicalJSON.encode(proposedArguments))
-    return try #require(
-      ToolCallCoding.encode([
-        ToolCall(id: toolCallID, name: CoderToolNames.submit, argumentsJSON: proposedArgsJSON)
-      ])
-    )
-  }
-
   static func separateRequest() throws -> CoderPreparedRequest {
     let sourceURL = "https://github.com/owner/project"
     let request = try CoderRequest(

--- a/Tests/ClawGatewayTests/Acceptance/CoderApprovalFlowTests.swift
+++ b/Tests/ClawGatewayTests/Acceptance/CoderApprovalFlowTests.swift
@@ -1,0 +1,260 @@
+import ClawAgent
+import ClawCore
+import ClawData
+import ClawTestSupport
+import ClawTools
+import Foundation
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct CoderApprovalFlowTests {
+  @Test func approvalRestoresRecordedRequestAndAuthenticatedOrigin() async throws {
+    // given
+    let backend = ScriptedCoderBackend(invocations: [.init(result: CoderServiceFixture.result())])
+    let first = try makeSC3Harness(
+      scripts: [[toolCallResponse([proposal])]],
+      httpResponses: [:],
+      coderBackend: backend
+    )
+    let storage = CoderToolStorageCleanup()
+    try await first.withJoinedCleanup(backend: backend, storage: storage) {
+      let firstService = try #require(first.coderService)
+      try await firstService.start()
+      _ = await first.router.handle(
+        rawUpdate: textUpdate(id: 1, from: 7, text: "Fix retry handling")
+      )
+      let approval = try #require(
+        try await pollUntil {
+          try fetchApprovals(databasePath: first.databasePath).first
+        }
+      )
+      #expect(approval.reason == ApprovalReason.coderSubmit.rawValue)
+      #expect(approval.state == ApprovalState.pending.rawValue)
+      #expect(try first.stores.coderJobs.reservedJobs().isEmpty)
+      #expect(await backend.startedJobIDs.isEmpty)
+      try await first.stop()
+      let restarted = try makeSC3Harness(
+        scripts: [[okResponse(content: "Started")]],
+        httpResponses: [:],
+        databasePath: first.databasePath,
+        workspaceRoot: first.workspaceRoot,
+        coderBackend: backend
+      )
+      try await restarted.withJoinedCleanup(
+        backend: backend,
+        storage: storage,
+        removeFilesOnExit: false
+      ) {
+        let service = try #require(restarted.coderService)
+        try await service.start()
+        await restarted.runBootReconciliation()
+
+        // when
+        _ = await restarted.router.handle(
+          rawUpdate: callbackUpdate(id: 2, from: 7, data: approveData(approval.nonce))
+        )
+        let started = await backend.started.waitUntilOpen()
+
+        // then
+        #expect(started)
+        let id = try #require(await backend.startedJobIDs.first)
+        let job = try #require(try restarted.stores.coderJobs.job(id: id))
+        #expect(job.prepared == CoderServiceFixture.request())
+        #expect(job.origin.runID == approval.runId)
+        #expect(job.origin.sessionID == (try restarted.sessionId()))
+        #expect(job.origin.requesterUserID == 7)
+        #expect(job.origin.chatID == 7)
+        #expect(job.origin.approvalID == approval.id)
+        #expect(job.origin.toolCallID == proposal.id)
+        #expect(await backend.startedJobIDs == [job.id])
+      }
+    }
+  }
+
+  @Test func ownerCanInspectAndCancelThroughDispatcher() async throws {
+    // given
+    let fixture = try CoderServiceFixture()
+    try await fixture.withJoinedCleanup {
+      try await fixture.service.start()
+      let job = try await fixture.submitFirst()
+      #expect(await fixture.backend.started.waitUntilOpen())
+      let dispatcher = dispatcher(service: fixture.service)
+      let context = dispatchContext(fixture.ownerContext)
+
+      // when
+      let status = await dispatcher.dispatch(
+        call: jobCall(CoderToolNames.status, id: job.id),
+        context: context
+      )
+      let cancelled = await dispatcher.dispatch(
+        call: jobCall(CoderToolNames.cancel, id: job.id),
+        context: context
+      )
+
+      // then
+      #expect(status.observation.status == .ok)
+      #expect(status.observation.content.contains(job.id.uuidString))
+      #expect(status.observation.content.contains(CoderJobState.running.rawValue))
+      #expect(cancelled.observation.status == .ok)
+      let state = try fixture.store.job(id: job.id)?.state
+      #expect(state == .stopping || state == .cancelled)
+    }
+  }
+
+  @Test func proactiveProposalCannotParkCoder() async throws {
+    // given
+    let backend = ScriptedCoderBackend(invocations: [.init(result: CoderServiceFixture.result())])
+    let harness = try makeSC3Harness(
+      scripts: [
+        [toolCallResponse([proposal]), okResponse(content: "Cannot delegate proactively")]
+      ],
+      httpResponses: [:],
+      coderBackend: backend
+    )
+    try await harness.withJoinedCleanup(backend: backend) {
+      try await harness.coderService?.start()
+      let now = Date()
+      let scheduled = try harness.stores.scheduledJobs.create(
+        NewScheduledJob(
+          ownerChatId: 7,
+          label: "retry",
+          prompt: "Fix retry handling",
+          recurrence: nil,
+          timezone: "UTC",
+          nextOccurrence: now
+        ),
+        now: now
+      )
+      guard
+        case .fired(let fire) = try harness.stores.scheduledJobs.fireNow(
+          jobId: scheduled.id,
+          now: now
+        )
+      else {
+        Issue.record("Scheduled run was not created")
+        return
+      }
+      let origin = try #require(try harness.stores.runs.pickUp(runId: fire.runId, now: now))
+
+      // when
+      let outcome = try await harness.agent.runTurn(
+        runId: fire.runId,
+        sessionId: fire.sessionId,
+        chatId: fire.ownerChatId,
+        buildResult: BuildResult(messages: [], ownerNotices: [], hasPrivateDataAccess: false),
+        sessionTainted: false,
+        sessionHasPrivateData: false,
+        todayTokens: 0,
+        todayUSD: 0,
+        origin: origin
+      )
+
+      // then
+      if case .suspended = outcome.result {
+        Issue.record("Proactive Coder proposal parked approval")
+      }
+      #expect(outcome.exchanges.first?.observations.first?.status == .error)
+      #expect(await backend.startedJobIDs.isEmpty)
+    }
+  }
+
+  @Test func changedExecutionPolicyVoidsParkedApproval() async throws {
+    // given
+    let backend = ScriptedCoderBackend(invocations: [.init(result: CoderServiceFixture.result())])
+    let first = try makeSC3Harness(
+      scripts: [[toolCallResponse([proposal])]],
+      httpResponses: [:],
+      coderBackend: backend
+    )
+    let storage = CoderToolStorageCleanup()
+    try await first.withJoinedCleanup(backend: backend, storage: storage) {
+      try await first.coderService?.start()
+      _ = await first.router.handle(
+        rawUpdate: textUpdate(id: 1, from: 7, text: "Fix retry handling")
+      )
+      let approval = try #require(
+        try await pollUntil {
+          try fetchApprovals(databasePath: first.databasePath).first
+        }
+      )
+      let changed = try makeSC3Harness(
+        scripts: [],
+        httpResponses: [:],
+        databasePath: first.databasePath,
+        workspaceRoot: first.workspaceRoot,
+        coderBackend: backend,
+        coderPolicyID: "changed-policy"
+      )
+      try await changed.withJoinedCleanup(
+        backend: backend,
+        storage: storage,
+        removeFilesOnExit: false
+      ) {
+        // when
+        _ = await changed.router.handle(
+          rawUpdate: callbackUpdate(id: 2, from: 7, data: approveData(approval.nonce))
+        )
+
+        // then
+        #expect(
+          try fetchApprovals(databasePath: first.databasePath).first?.state
+            == ApprovalState.rejected.rawValue
+        )
+        #expect(
+          try changed.auditRows().contains { row in
+            row.decision == ApprovalDecision.stalePolicy.rawValue
+          }
+        )
+        #expect(await backend.startedJobIDs.isEmpty)
+        try await first.stop()
+      }
+    }
+  }
+}
+
+// MARK: - Fixtures
+
+private extension CoderApprovalFlowTests {
+  var proposal: ToolCall {
+    ToolCall(
+      id: "coder-1",
+      name: CoderToolNames.submit,
+      argumentsJSON: """
+        {"source":{"local":{"path":"/fixture/repository-1"}},"task":"Fix retry handling",
+        "workspace":"inPlace","deliverable":"localChanges","publish_existing_changes":false}
+        """
+    )
+  }
+
+  func dispatcher(service: any CoderServing) -> GatedToolDispatcher {
+    let redactor = SecretRedactor(secretValues: [])
+    return GatedToolDispatcher(
+      registry: ToolRegistry(tools: [
+        CoderStatusTool(service: service, redactor: redactor),
+        CoderCancelTool(service: service, redactor: redactor),
+      ]),
+      gate: ToolPolicyGate(
+        argGuard: ExfilArgGuard(secretValues: []),
+        privateFileLoader: { [] },
+        enabledDangerousTools: []
+      )
+    )
+  }
+
+  func dispatchContext(_ context: ToolExecutionContext) -> ToolDispatchContext {
+    ToolDispatchContext(
+      sessionTainted: false,
+      runIngestedUntrusted: false,
+      assemblyPrivateData: false,
+      runPrivateData: false,
+      sessionHasPrivateData: false,
+      approvalAlreadyPending: false,
+      executionContext: context
+    )
+  }
+
+  func jobCall(_ name: String, id: UUID) -> ToolCall {
+    ToolCall(id: name, name: name, argumentsJSON: "{\"job_id\":\"\(id.uuidString)\"}")
+  }
+}

--- a/Tests/ClawGatewayTests/Acceptance/CoderDoneWhenTests.swift
+++ b/Tests/ClawGatewayTests/Acceptance/CoderDoneWhenTests.swift
@@ -1,0 +1,160 @@
+import ClawCore
+import ClawTestSupport
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct CoderDoneWhenTests {
+  @Test func approvedTaskLeavesConversationResponsiveAndDeliversCompletion() async throws {
+    // given
+    let result = CoderServiceFixture.result()
+    let backend = ScriptedCoderBackend(invocations: [.init(result: result)])
+    let signal = OutboxSignal()
+    let ordinaryReply = "Your next message reached me while the coding task is running."
+    let harness = try makeSC3Harness(
+      scripts: [
+        [toolCallResponse([proposal])],
+        [okResponse(content: "The coding task has started.")],
+        [okResponse(content: ordinaryReply)],
+      ],
+      httpResponses: [:],
+      coderBackend: backend,
+      notifyOutbox: {
+        signal.poke()
+      }
+    )
+    try await harness.withJoinedCleanup(backend: backend) {
+      let (id, completionRows, completionsBeforeRelease) = try await withRunningOutbox(
+        harness,
+        signal: signal
+      ) {
+        let service = try #require(harness.coderService)
+        try await service.start()
+        let approval = try await approveTask(in: harness)
+        try #require(await backend.started.waitUntilOpen())
+        let id = try #require(await backend.startedJobIDs.first)
+
+        // when
+        _ = await harness.router.handle(
+          rawUpdate: textUpdate(id: 3, from: 7, text: "Can you still answer me?")
+        )
+        try #require(
+          try await pollUntilTrue {
+            try !rowIDs(containing: ordinaryReply, deliveredOnly: true, in: harness).isEmpty
+          }
+        )
+        let replies = await harness.transport.richSends
+        #expect(
+          replies.contains { reply in
+            reply.markdown.contains(ordinaryReply) && reply.target == .chat(7)
+          }
+        )
+        #expect(try harness.stores.coderJobs.job(id: id)?.state == .running)
+        let completionsBeforeRelease = await harness.provider.completions
+        backend.allowCompletion.open()
+
+        // then
+        let completionRows = try #require(
+          try await pollUntil {
+            let rows = try rowIDs(containing: result.summary, deliveredOnly: true, in: harness)
+            return rows.isEmpty ? nil : rows
+          }
+        )
+        let saved = try #require(try harness.stores.coderJobs.job(id: id))
+        #expect(saved.origin.runID == approval.runId)
+        #expect(saved.origin.sessionID == (try harness.sessionId()))
+        #expect(saved.result == result)
+        #expect(saved.state == .succeeded)
+        #expect(!saved.slotReserved)
+        #expect(completionRows.count == 1)
+        signal.poke()
+        signal.finish()
+        return (id, completionRows, completionsBeforeRelease)
+      }
+      let notices = await harness.transport.richSends.filter { send in
+        send.markdown.contains(result.summary)
+      }
+      #expect(notices.count == 1)
+      #expect(notices.first?.target == .chat(7))
+      #expect(notices.first?.markdown.contains(id.uuidString) == true)
+      #expect(
+        try rowIDs(containing: result.summary, deliveredOnly: false, in: harness) == completionRows
+      )
+      #expect(await harness.provider.completions == completionsBeforeRelease)
+    }
+  }
+}
+
+// MARK: - Fixtures
+
+private extension CoderDoneWhenTests {
+  var proposal: ToolCall {
+    ToolCall(
+      id: "coder-background",
+      name: CoderToolNames.submit,
+      argumentsJSON: """
+        {"source":{"local":{"path":"/fixture/repository-1"}},"task":"Fix retry handling",
+        "workspace":"\(CoderWorkspaceMode.inPlace.rawValue)",
+        "deliverable":"\(CoderDeliverable.localChanges.rawValue)","publish_existing_changes":false}
+        """
+    )
+  }
+
+  func approveTask(in harness: SC3Harness) async throws -> ApprovalRowSnapshot {
+    _ = await harness.router.handle(
+      rawUpdate: textUpdate(id: 1, from: 7, text: "Fix retry handling")
+    )
+    let approval = try #require(
+      try await pollUntil {
+        try fetchApprovals(databasePath: harness.databasePath).first
+      }
+    )
+    _ = await harness.router.handle(
+      rawUpdate: callbackUpdate(id: 2, from: 7, data: approveData(approval.nonce))
+    )
+    return approval
+  }
+
+  func rowIDs(
+    containing text: String,
+    deliveredOnly: Bool,
+    in harness: SC3Harness
+  ) throws -> [String] {
+    try harness.readPool.read { database in
+      try String.fetchAll(
+        database,
+        sql: """
+          SELECT dedup_key FROM outbound_deliveries
+          WHERE instr(payload, ?) > 0 AND (? = 0 OR telegram_message_id IS NOT NULL)
+          ORDER BY dedup_key
+          """,
+        arguments: [text, deliveredOnly]
+      )
+    }
+  }
+
+  func withRunningOutbox<Value: Sendable>(
+    _ harness: SC3Harness,
+    signal: OutboxSignal,
+    operation: () async throws -> Value
+  ) async throws -> Value {
+    let dispatcher = OutboxDispatcher(
+      outbox: harness.stores.outbox,
+      delivery: harness.transport,
+      signal: signal,
+      logger: TestLog.silent
+    )
+    return try await withThrowingTaskGroup(of: Void.self) { group in
+      group.addTask {
+        try await dispatcher.run()
+      }
+      defer { signal.finish() }
+      let value = try await operation()
+      signal.finish()
+      try await group.waitForAll()
+      return value
+    }
+  }
+}

--- a/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
+++ b/Tests/ClawGatewayTests/Acceptance/SC3Harness.swift
@@ -51,6 +51,25 @@ struct SC3Harness {
 
   let waiter: ApprovalWaiter
   let lanes: SessionLaneRegistry
+  let agent: AgentRuntime
+  let coderService: CoderService?
+
+  func stop() async throws {
+    await lanes.stopAcceptingAndCancel()
+    let drain = await lanes.drain(timeout: .seconds(30), clock: ContinuousClock())
+    #expect(drain == .drained)
+    try await coderService?.shutdown()
+    guard drain == .drained else {
+      throw CoderToolCleanupError.lanesNotDrained
+    }
+  }
+
+  func removeFiles() {
+    try? FileManager.default.removeItem(at: workspaceRoot)
+    for suffix in ["", "-wal", "-shm"] {
+      try? FileManager.default.removeItem(atPath: databasePath + suffix)
+    }
+  }
 
   /// Re-establishes the fabric against the SAME DB after a "restart" (a second harness over one
   /// `databasePath`): cleans terminal-run PENDING rows, re-parks unexpired approvals on their
@@ -167,6 +186,9 @@ func makeSC3Harness(
   extraTools: [any Tool] = [],
   execEnabled: Bool = false,
   executionBackend: (any ExecutionBackend)? = nil,
+  coderBackend: ScriptedCoderBackend? = nil,
+  coderPolicyID: String = CoderServiceFixture.executionPolicyID,
+  notifyOutbox: @escaping @Sendable () -> Void = {},
   execSettings: ExecuteCodeSettings = ExecuteCodeSettings(
     memoryMiB: 1024,
     cpus: 4,
@@ -232,6 +254,35 @@ func makeSC3Harness(
       )
     )
   }
+  let coderService = coderBackend.map { backend in
+    CoderService(
+      store: stores.coderJobs,
+      backend: backend,
+      preparer: CoderPreparationStub(),
+      inspector: CoderInspectionStub(observation: .stopped),
+      config: CoderConfig(
+        enabled: true,
+        maxConcurrentJobs: 1,
+        jobTimeoutSeconds: 600,
+        executable: CoderConfig.Defaults.executable,
+        profile: nil,
+        configHome: nil
+      ),
+      jobRoot: workspaceRoot.appendingPathComponent("coder-jobs").path,
+      executionPolicyID: coderPolicyID,
+      redact: { text in
+        redactor.redact(text)
+      },
+      notifyOutbox: notifyOutbox
+    )
+  }
+  if let coderService {
+    tools += [
+      CoderSubmitTool(service: coderService, executionPolicyID: coderPolicyID, redactor: redactor),
+      CoderStatusTool(service: coderService, redactor: redactor),
+      CoderCancelTool(service: coderService, redactor: redactor),
+    ]
+  }
   tools.append(contentsOf: extraTools)
 
   // 5. GatedToolDispatcher: tier-3 private files load from DISK at gate-evaluation time (rev.1 H1).
@@ -245,7 +296,12 @@ func makeSC3Harness(
     gate: ToolPolicyGate(
       argGuard: ExfilArgGuard(secretValues: secretValues),
       privateFileLoader: privateFileLoader,
-      execEnabled: execEnabled
+      enabledDangerousTools: Set(
+        tools.filter { tool in
+          (execEnabled && tool.definition.name == ExecuteCodeTool.name)
+            || (coderService != nil && tool.definition.name == CoderToolNames.submit)
+        }.map(\.definition.name)
+      )
     )
   )
 
@@ -257,7 +313,17 @@ func makeSC3Harness(
     memoryStore: stores.memory,
     retriever: stores.retriever,
     budget: .default,
-    fenceLabels: ToolFenceLabels(definitions: dispatcher.definitions)
+    fenceLabels: ToolFenceLabels(definitions: dispatcher.definitions),
+    policyStaticSubhash: PolicyFingerprint.staticSubhash(
+      inputs: .init(
+        tools: dispatcher.definitions,
+        llmEgress: .configuredEndpoint("https://llm.example"),
+        searchEndpointPresent: true,
+        workspaceRoot: workspaceRoot.path,
+        webFetchExemptCIDRs: [],
+        exec: .disabledDefault
+      )
+    )
   )
 
   // 6. AgentRuntime over the per-turn scripted provider and the real gated dispatcher.
@@ -295,7 +361,7 @@ func makeSC3Harness(
     budget: .default,
     contextBuilder: contextBuilder,
     imageCache: imageCache,
-    notifyOutbox: {},
+    notifyOutbox: notifyOutbox,
     parker: deferredParker,
     approvalExpirySeconds: testApprovalExpirySeconds,
     logger: logger
@@ -380,6 +446,8 @@ func makeSC3Harness(
     workspaceRoot: workspaceRoot,
     sessionKey: SessionKey.telegramDM(chatId: 7),
     waiter: waiter,
-    lanes: lanes
+    lanes: lanes,
+    agent: agent,
+    coderService: coderService
   )
 }

--- a/Tests/ClawGatewayTests/Acceptance/SC7Harness.swift
+++ b/Tests/ClawGatewayTests/Acceptance/SC7Harness.swift
@@ -209,7 +209,7 @@ func makeSC7Harness(
     gate: ToolPolicyGate(
       argGuard: ExfilArgGuard(secretValues: secretValues),
       privateFileLoader: privateFileLoader,
-      execEnabled: false
+      enabledDangerousTools: []
     )
   )
 

--- a/Tests/ClawGatewayTests/Coder/CoderCompletionTests.swift
+++ b/Tests/ClawGatewayTests/Coder/CoderCompletionTests.swift
@@ -1,0 +1,187 @@
+import ClawCore
+import ClawTestSupport
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawGateway
+
+extension CoderServiceTests {
+  @Test func completionRerendersAfterCancellationRace() async throws {
+    // given
+    let fixture = try CoderServiceFixture()
+    defer { fixture.cleanup() }
+    let service = fixture.restartedService { text in
+      if text.contains(CoderJobState.succeeded.rawValue) {
+        do {
+          for job in try fixture.store.reservedJobs() {
+            _ = try fixture.store.requestCancellation(id: job.id, now: Date())
+          }
+        } catch { Issue.record(error) }
+      }
+      return text
+    }
+    try await service.start()
+    let job = try await service.submit(fixture.prepared, context: fixture.ownerContext)
+    await fixture.backend.started.wait()
+    // when
+    fixture.backend.releaseAll()
+    await fixture.jobFinished.wait()
+    // then
+    #expect(try fixture.store.job(id: job.id)?.state == .cancelled)
+    let reports = try fixture.reports()
+    #expect(reports.count == 1)
+    let report = try #require(reports.first)
+    #expect(report.payload.contains(CoderJobState.cancelled.rawValue))
+    #expect(!report.payload.contains(CoderJobState.succeeded.rawValue))
+    #expect(await fixture.backend.startedJobIDs == [job.id])
+    try await service.shutdown()
+  }
+
+  @Test func selectedStopSurvivesCancellation() async throws {
+    // given
+    let script = ScriptedCoderBackend.Invocation(
+      result: CoderServiceFixture.result(state: .timedOut),
+      holdCleanup: true
+    )
+    let fixture = try CoderServiceFixture(scripts: [script])
+    defer { fixture.cleanup() }
+    try await fixture.service.start()
+    let job = try await fixture.submitFirst()
+    await script.started.wait()
+    // when
+    _ = try await fixture.service.cancel(id: job.id, context: fixture.ownerContext)
+    script.allowCleanup.open()
+    await fixture.jobFinished.wait()
+    // then
+    #expect(try fixture.store.job(id: job.id)?.state == .timedOut)
+    #expect(try fixture.reports().first?.payload.contains(CoderJobState.timedOut.rawValue) == true)
+    try await fixture.service.shutdown()
+  }
+
+  @Test(arguments: [false, true])
+  func persistenceFailureIsUnhealthyAndReserved(receiptWrite: Bool) async throws {
+    // given
+    let fixture = try CoderServiceFixture()
+    defer { fixture.cleanup() }
+    try await fixture.service.start()
+    try await fixture.queue.write { db in
+      if receiptWrite {
+        try db.execute(
+          sql: """
+            CREATE TRIGGER fail_coder_receipt BEFORE UPDATE OF process_ownership ON coder_jobs
+            BEGIN SELECT RAISE(ABORT, 'receipt write failed'); END
+            """
+        )
+      } else {
+        try db.execute(
+          sql: """
+            CREATE TRIGGER fail_coder_notice BEFORE INSERT ON outbound_deliveries
+            WHEN NEW.approval_id IS NULL BEGIN SELECT RAISE(ABORT, 'report write failed'); END
+            """
+        )
+      }
+    }
+    let job = try await fixture.submitFirst()
+    await fixture.backend.started.wait()
+    let finished = AsyncGate()
+    let running = Task {
+      defer { finished.open() }
+      try await fixture.service.run()
+    }
+    // when
+    fixture.backend.releaseAll()
+    let finishedWithoutCancellation = await finished.waitUntilOpen()
+    if !finishedWithoutCancellation { running.cancel() }
+    let outcome = await running.result
+    // then
+    #expect(finishedWithoutCancellation)
+    guard case .failure(let error) = outcome,
+      case .persistence = error as? CoderServiceFailure
+    else {
+      Issue.record("Service did not propagate terminal persistence failure")
+      return
+    }
+    #expect(try fixture.store.job(id: job.id)?.slotReserved == true)
+    #expect(try fixture.store.job(id: job.id)?.result == nil)
+    #expect(try fixture.reports().isEmpty)
+    #expect(!fixture.jobFinished.isOpen)
+  }
+
+  @Test(arguments: [false, true])
+  func cleanupFailureUsesOwnership(unresolved: Bool) async throws {
+    // given
+    let script = ScriptedCoderBackend.Invocation(
+      result: CoderServiceFixture.result(
+        state: .failed,
+        failure: CoderFailure(stage: .cleanup, message: "Cleanup failed")
+      ),
+      unresolvedCleanup: unresolved
+    )
+    let fixture = try CoderServiceFixture(scripts: [script])
+    defer { fixture.cleanup() }
+    try await fixture.service.start()
+    let job = try await fixture.submitFirst()
+    await script.started.wait()
+    // when
+    fixture.backend.releaseAll()
+    await fixture.jobFinished.wait()
+    // then
+    #expect(try fixture.store.job(id: job.id)?.slotReserved == unresolved)
+    #expect(try fixture.store.job(id: job.id)?.result?.failure?.stage == .cleanup)
+    if unresolved {
+      await #expect(throws: CoderServiceFailure.cleanup(jobID: job.id)) {
+        try await fixture.service.shutdown()
+      }
+    } else {
+      try await fixture.service.shutdown()
+      #expect(await fixture.service.failure == nil)
+    }
+  }
+
+  @Test func completionReportPreservesEvidenceAndRedacts() async throws {
+    // given
+    let secret = "fixture-secret-value"
+    let result = CoderResult(
+      state: .failed,
+      summary: "Worker \(secret)",
+      workspacePath: "/work/\(secret)",
+      startingCommit: "abc",
+      baselineObserved: false,
+      changedFiles: nil,
+      branch: "branch-\(secret)",
+      commit: "def",
+      publication: .unknown(reportedURL: secret),
+      reportedChecks: ["check \(secret)"],
+      reportedUsage: ["tokens": 42],
+      commitAuthor: "author \(secret)",
+      githubActor: "actor \(secret)",
+      failure: CoderFailure(stage: .inspection, message: secret)
+    )
+    let redactor = SecretRedactor(secretValues: [secret])
+    let fixture = try CoderServiceFixture(
+      scripts: [.init(result: result)],
+      redactor: redactor.redact
+    )
+    defer { fixture.cleanup() }
+    try await fixture.service.start()
+    let job = try await fixture.submitFirst()
+    await fixture.backend.started.wait()
+    // when
+    fixture.backend.releaseAll()
+    await fixture.jobFinished.wait()
+    // then
+    let report = try fixture.reports().map(\.payload).joined()
+    #expect(!report.contains(secret))
+    #expect(report.contains(SecretRedactor.replacement))
+    #expect(report.contains(job.id.uuidString))
+    #expect(report.contains("unknown"))
+    #expect(report.contains("unavailable"))
+    let startingEvidence = report.split(separator: "\n").first { line in
+      line.contains("abc")
+    }
+    #expect(startingEvidence?.contains("worker-reported") == true)
+    #expect(report.contains("42"))
+    try await fixture.service.shutdown()
+  }
+}

--- a/Tests/ClawGatewayTests/Coder/CoderRecoveryTests.swift
+++ b/Tests/ClawGatewayTests/Coder/CoderRecoveryTests.swift
@@ -1,0 +1,72 @@
+import ClawCore
+import ClawTestSupport
+import Foundation
+import Testing
+
+@testable import ClawGateway
+
+struct CoderRecoveryTests {
+  @Test func interruptionIsReportedOnceWithoutRerun() async throws {
+    // given
+    let fixture = try CoderServiceFixture()
+    defer { fixture.cleanup() }
+    let id = try fixture.seedUnfinished()
+    // when
+    try await fixture.service.start()
+    try await fixture.service.shutdown()
+    let next = fixture.restartedService()
+    try await next.start()
+    // then
+    let job = try #require(try fixture.store.job(id: id))
+    #expect(job.state == .interrupted)
+    #expect(!job.slotReserved)
+    #expect(job.result?.publication == .unknown(reportedURL: nil))
+    #expect(try fixture.reports().count == 1)
+    #expect(await fixture.backend.startedJobIDs.isEmpty)
+    try await next.shutdown()
+  }
+
+  @Test func recoveryRetainsAmbiguousOwnershipAcrossRestarts() async throws {
+    // given
+    let fixture = try CoderServiceFixture(inspection: .liveOwned)
+    defer { fixture.cleanup() }
+    let id = try fixture.seedUnfinished(receipt: CoderServiceFixture.receipt(launched: true))
+    // when
+    try await fixture.service.start()
+    try await fixture.service.shutdown()
+    let next = fixture.restartedService()
+    try await next.start()
+    let another = CoderServiceFixture.request(index: 2)
+    let context = try CoderServiceFixture.context(queue: fixture.queue, prepared: another, index: 2)
+    let replay = try await next.submit(fixture.prepared, context: fixture.ownerContext)
+    // then
+    #expect(replay.id == id)
+    await #expect(throws: CoderError.recoveryRequired) {
+      try await next.submit(another, context: context)
+    }
+    #expect(try fixture.store.job(id: id)?.ownership == .unresolved)
+    #expect(try fixture.store.job(id: id)?.slotReserved == true)
+    #expect(try fixture.reports().count == 1)
+    #expect(await fixture.backend.startedJobIDs.isEmpty)
+    try await next.shutdown()
+  }
+
+  @Test func recoveryReleasesVerifiedStoppedOwnership() async throws {
+    // given
+    let fixture = try CoderServiceFixture(inspection: .unresolved)
+    defer { fixture.cleanup() }
+    let id = try fixture.seedUnfinished(receipt: CoderServiceFixture.receipt(launched: false))
+    try await fixture.service.start()
+    #expect(try fixture.store.job(id: id)?.slotReserved == true)
+    try await fixture.service.shutdown()
+    // when
+    await fixture.inspector.set(.stopped)
+    let next = fixture.restartedService()
+    try await next.start()
+    // then
+    #expect(try fixture.store.job(id: id)?.ownership == .stopped)
+    #expect(try fixture.store.job(id: id)?.slotReserved == false)
+    #expect(try fixture.reports().count == 1)
+    try await next.shutdown()
+  }
+}

--- a/Tests/ClawGatewayTests/Coder/CoderServiceTests.swift
+++ b/Tests/ClawGatewayTests/Coder/CoderServiceTests.swift
@@ -1,0 +1,237 @@
+import ClawCore
+import ClawTestSupport
+import Foundation
+import Testing
+
+@testable import ClawGateway
+
+struct CoderServiceTests {
+  @Test func startupBlocksSubmissionDuringInspection() async throws {
+    // given
+    let fixture = try CoderServiceFixture(limit: 4)
+    defer { fixture.cleanup() }
+    _ = try fixture.seedUnfinished(receipt: CoderServiceFixture.receipt(launched: true))
+    await fixture.inspector.holdInspection()
+    defer { fixture.inspector.proceed.open() }
+    // when
+    let startup = Task {
+      try await fixture.service.start()
+    }
+    #expect(await fixture.inspector.entered.waitUntilOpen())
+    let submission = await fixture.submitAnotherApprovedOrigin()
+    // then
+    if case .failure(.unavailable) = submission {
+    } else {
+      Issue.record("Submission proceeded before startup reconciliation finished")
+    }
+    fixture.inspector.proceed.open()
+    fixture.backend.releaseAll()
+    try await startup.value
+    try await fixture.service.shutdown()
+  }
+
+  @Test func cancelBeforeLaunchKeepsServiceHealthy() async throws {
+    // given
+    let script = ScriptedCoderBackend.Invocation(
+      result: CoderServiceFixture.result(state: .cancelled),
+      holdLaunch: true
+    )
+    let fixture = try CoderServiceFixture(scripts: [script])
+    defer { fixture.cleanup() }
+    try await fixture.service.start()
+    let job = try await fixture.submitFirst()
+    await script.entered.wait()
+    // when
+    _ = try await fixture.service.cancel(id: job.id, context: fixture.ownerContext)
+    script.allowLaunch.open()
+    let shutdown = Task {
+      try await fixture.service.shutdown()
+    }
+    let outcome = await shutdown.result
+    // then
+    if case .failure(let error) = outcome { Issue.record(error) }
+    #expect(await fixture.service.failure == nil)
+    #expect(try fixture.store.job(id: job.id)?.state == .cancelled)
+    #expect(try fixture.store.job(id: job.id)?.slotReserved == false)
+    #expect(try fixture.reports().count == 1)
+  }
+
+  @Test func cancelKeepsReservationUntilJoined() async throws {
+    // given
+    let script = ScriptedCoderBackend.Invocation(
+      result: CoderServiceFixture.result(),
+      holdCleanup: true
+    )
+    let fixture = try CoderServiceFixture(scripts: [script])
+    defer { fixture.cleanup() }
+    try await fixture.service.start()
+    let first = try await fixture.submitFirst()
+    await fixture.backend.started.wait()
+    let cancelReturned = AsyncGate()
+    // when
+    let cancellation = Task {
+      let value = try await fixture.service.cancel(id: first.id, context: fixture.ownerContext)
+      cancelReturned.open()
+      return value
+    }
+    let returnedPromptly = await cancelReturned.waitUntilOpen()
+    // then
+    #expect(returnedPromptly)
+    let reservation = Result {
+      try fixture.store.job(id: first.id)?.slotReserved
+    }
+    script.allowCleanup.open()
+    let stopped = try await cancellation.value
+    await fixture.jobFinished.wait()
+    #expect(stopped.state == .stopping)
+    #expect(try reservation.get() == true)
+    #expect(try fixture.store.job(id: first.id)?.slotReserved == false)
+    #expect(try fixture.store.job(id: first.id)?.state == .cancelled)
+    try await fixture.service.shutdown()
+  }
+
+  @Test func twoJobsStartBeforeEitherFinishes() async throws {
+    // given
+    let scripts = (0..<2).map { _ in
+      ScriptedCoderBackend.Invocation(result: CoderServiceFixture.result())
+    }
+    let fixture = try CoderServiceFixture(limit: 2, scripts: scripts)
+    defer { fixture.cleanup() }
+    try await fixture.service.start()
+    // when
+    let first = try await fixture.submitFirst()
+    let second = try await fixture.submitAnotherApprovedOrigin().get()
+    let firstStarted = await scripts[0].started.waitUntilOpen()
+    let secondStarted = await scripts[1].started.waitUntilOpen()
+    let started = await fixture.backend.startedJobIDs
+    let third = await fixture.submitAnotherApprovedOrigin(index: 3)
+    // then
+    #expect(Set(started) == Set([first.id, second.id]))
+    #expect(firstStarted && secondStarted)
+    #expect(third == .failure(.busy))
+    fixture.backend.releaseAll()
+    try await fixture.service.shutdown()
+  }
+
+  @Test func duplicateSubmissionDoesNotRelaunch() async throws {
+    // given
+    let fixture = try CoderServiceFixture()
+    defer { fixture.cleanup() }
+    try await fixture.service.start()
+    // when
+    let first = try await fixture.submitFirst()
+    await fixture.backend.started.wait()
+    let duplicate = try await fixture.submitFirst()
+    fixture.backend.releaseAll()
+    await fixture.jobFinished.wait()
+    // then
+    #expect(duplicate.id == first.id)
+    #expect(await fixture.backend.startedJobIDs == [first.id])
+    #expect(try fixture.reports().count == 1)
+    try await fixture.service.shutdown()
+  }
+
+  @Test(arguments: [false, true])
+  func revalidationRejectsChangedApproval(policyChanged: Bool) async throws {
+    // given
+    let fixture = try CoderServiceFixture()
+    defer { fixture.cleanup() }
+    try await fixture.service.start()
+    let prepared =
+      policyChanged ? CoderServiceFixture.request(policy: "old-policy") : fixture.prepared
+    let context = try CoderServiceFixture.context(
+      queue: fixture.queue,
+      prepared: prepared,
+      index: 2
+    )
+    await fixture.preparer.configure(changedIdentity: !policyChanged)
+    // when
+    await #expect(throws: CoderError.staleApproval) {
+      try await fixture.service.submit(prepared, context: context)
+    }
+    // then
+    #expect(try fixture.store.reservedJobs().isEmpty)
+    #expect(await fixture.backend.startedJobIDs.isEmpty)
+    try await fixture.service.shutdown()
+  }
+
+  @Test func requesterScopeIsEnforced() async throws {
+    // given
+    let fixture = try CoderServiceFixture()
+    defer { fixture.cleanup() }
+    try await fixture.service.start()
+    let job = try await fixture.submitFirst()
+    let caller = try CoderServiceFixture.context(
+      queue: fixture.queue,
+      prepared: CoderServiceFixture.request(index: 2),
+      index: 2,
+      ownerID: 88
+    )
+    // when
+    await #expect(throws: CoderError.forbidden) {
+      try await fixture.service.status(id: job.id, context: caller)
+    }
+    await #expect(throws: CoderError.forbidden) {
+      try await fixture.service.cancel(id: job.id, context: caller)
+    }
+    // then
+    #expect(try fixture.store.job(id: job.id)?.state != .stopping)
+    fixture.backend.releaseAll()
+    try await fixture.service.shutdown()
+  }
+
+  @Test func shutdownClosesAdmissionAndJoins() async throws {
+    // given
+    let script = ScriptedCoderBackend.Invocation(
+      result: CoderServiceFixture.result(),
+      holdCleanup: true
+    )
+    let fixture = try CoderServiceFixture(limit: 2, scripts: [script])
+    defer { fixture.cleanup() }
+    try await fixture.service.start()
+    let job = try await fixture.submitFirst()
+    await script.started.wait()
+    // when
+    let shutdown = Task {
+      try await fixture.service.shutdown()
+      return try fixture.store.job(id: job.id)
+    }
+    #expect(await script.cleanupEntered.waitUntilOpen())
+    let another = await fixture.submitAnotherApprovedOrigin()
+    let state = Result {
+      try fixture.store.job(id: job.id)
+    }
+    // then
+    if case .failure(.unavailable) = another {} else { Issue.record("Admission remained open") }
+    script.allowCleanup.open()
+    let atReturn = try await shutdown.value
+    #expect(atReturn?.state == .cancelled)
+    #expect(atReturn?.slotReserved == false)
+    #expect(try state.get()?.state == .stopping)
+    #expect(try state.get()?.slotReserved == true)
+    #expect(try fixture.store.job(id: job.id)?.slotReserved == false)
+  }
+
+  @Test func admissionCannotResumeAfterShutdown() async throws {
+    // given
+    let fixture = try CoderServiceFixture()
+    defer { fixture.cleanup() }
+    try await fixture.service.start()
+    await fixture.preparer.configure(hold: true)
+    let proceed = fixture.preparer.proceed
+    defer { proceed.open() }
+    // when
+    let submission = Task {
+      try await fixture.submitFirst()
+    }
+    await fixture.preparer.entered.wait()
+    try await fixture.service.shutdown()
+    proceed.open()
+    // then
+    await #expect(throws: CoderError.self) {
+      try await submission.value
+    }
+    #expect(try fixture.store.reservedJobs().isEmpty)
+    #expect(await fixture.backend.startedJobIDs.isEmpty)
+  }
+}

--- a/Tests/ClawGatewayTests/Coder/CoderToolPolicyTests.swift
+++ b/Tests/ClawGatewayTests/Coder/CoderToolPolicyTests.swift
@@ -1,0 +1,300 @@
+import ClawCore
+import ClawTestSupport
+import ClawTools
+import Foundation
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct CoderToolPolicyTests {
+  enum MissingIdentity: CaseIterable { case context, requester, group }
+  enum OutboundScope: CaseIterable { case source, startRef, baseBranch }
+
+  @Test(arguments: MissingIdentity.allCases)
+  func ownerRequiredToolsRefuseMissingIdentity(_ missing: MissingIdentity) async throws {
+    // given
+    let fixture = try CoderServiceFixture()
+    try await fixture.withJoinedCleanup {
+      let tool = CoderStatusTool(
+        service: fixture.service,
+        redactor: SecretRedactor(secretValues: [])
+      )
+      let group = missing == .group
+      let execution: ToolExecutionContext? =
+        missing == .context
+        ? nil
+        : ToolExecutionContext(
+          runId: 1,
+          sessionId: 1,
+          chatId: 7,
+          requesterUserId: missing == .requester ? nil : 7,
+          origin: .interactive,
+          mode: group ? .group : .direct,
+          toolCallId: "status",
+          approvalId: nil
+        )
+
+      // when
+      let verdict = await gate().evaluate(
+        call: ToolCall(id: "status", name: tool.definition.name, argumentsJSON: "{}"),
+        tool: tool,
+        context: context(execution, mode: group ? .group : .direct)
+      )
+
+      // then
+      guard case .block(let payload, _) = verdict else {
+        Issue.record("Owner-only safe tool passed admission")
+        return
+      }
+      #expect(payload.status == .error)
+    }
+  }
+
+  @Test func coderEnabledDoesNotEnableVMExecution() async throws {
+    // given
+    let fixture = try CoderServiceFixture()
+    try await fixture.withJoinedCleanup {
+      try await fixture.service.start()
+      let redactor = SecretRedactor(secretValues: [])
+      let coder = CoderSubmitTool(
+        service: fixture.service,
+        executionPolicyID: CoderServiceFixture.executionPolicyID,
+        redactor: redactor
+      )
+      let sandboxTool = ExecuteCodeTool(
+        workspaceRoot: fixture.root,
+        backend: FakeExecutionBackend(),
+        settings: ExecuteCodeSettings(
+          memoryMiB: 1024,
+          cpus: 1,
+          timeout: .seconds(30),
+          allowEgress: false
+        ),
+        redactor: redactor
+      )
+      let gate = gate()
+
+      // when
+      let coderVerdict = await gate.evaluate(
+        call: proposal(),
+        tool: coder,
+        context: context(fixture.ownerContext, mode: .direct)
+      )
+      let vmVerdict = await gate.evaluate(
+        call: ToolCall(
+          id: "vm",
+          name: sandboxTool.definition.name,
+          argumentsJSON: #"{"language":"sh","code":"true"}"#
+        ),
+        tool: sandboxTool,
+        context: context(fixture.ownerContext, mode: .direct)
+      )
+
+      // then
+      guard case .requireApproval(let recorded) = coderVerdict else {
+        Issue.record("Enabled Coder did not park")
+        return
+      }
+      #expect(recorded.reason == .coderSubmit)
+      guard case .block = vmVerdict else {
+        Issue.record("VM execution was enabled by the Coder opt-in")
+        return
+      }
+    }
+  }
+
+  @Test(arguments: [
+    #""owner":7"#, #""source":{"local":{"path":"/fixture/repository-1","credentials":"x"}}"#,
+    #""source":{"other":{"path":"/fixture/repository-1"}}"#,
+    #""instructions":7"#, #""publish_existing_changes":"true""#,
+  ])
+  func strictWireShapeRejectsAuthorityAndMalformedFields(_ replacement: String) async throws {
+    // given
+    let fixture = try CoderServiceFixture()
+    try await fixture.withJoinedCleanup {
+      try await fixture.service.start()
+      let tool = submitTool(fixture)
+      let call = proposal(replacing: replacement)
+
+      // when
+      let verdict = await gate().evaluate(
+        call: call,
+        tool: tool,
+        context: context(fixture.ownerContext, mode: .direct)
+      )
+
+      // then
+      guard case .block(let payload, _) = verdict else {
+        Issue.record("Malformed Coder wire request reached approval")
+        return
+      }
+      #expect(payload.status == .error)
+    }
+  }
+
+  @Test func localInferenceScansInstructionsAgainstPrivateText() async throws {
+    // given
+    let fixture = try CoderServiceFixture()
+    try await fixture.withJoinedCleanup {
+      try await fixture.service.start()
+      let privateText = "The owner's private project is called Operation Nightjar Falcon."
+      let call = proposal(replacing: "\"instructions\":\"\(privateText)\"")
+
+      // when
+      let verdict = await gate(privateText: privateText).evaluate(
+        call: call,
+        tool: submitTool(fixture),
+        context: context(fixture.ownerContext, mode: .direct)
+      )
+
+      // then
+      guard case .block(let payload, _) = verdict else {
+        Issue.record("Local Coder inference bypassed private-text scanning")
+        return
+      }
+      #expect(payload.status == .blockedArgs)
+    }
+  }
+
+  @Test(arguments: OutboundScope.allCases)
+  func inferenceScansOutboundScope(_ scope: OutboundScope) async throws {
+    // given
+    let fixture = try CoderServiceFixture()
+    try await fixture.withJoinedCleanup {
+      try await fixture.service.start()
+      let secretRef = "private-reference-token"
+      let privateBranch = "release-private-nightjar-falcon"
+      let replacement: String
+      switch scope {
+      case .source:
+        replacement = """
+          "source":{"local":{"path":"/fixture/sk-abcdefghijklmnop"}},
+          "workspace":"\(CoderWorkspaceMode.separate.rawValue)"
+          """
+      case .startRef:
+        replacement = """
+          "start_ref":"\(secretRef)","workspace":"\(CoderWorkspaceMode.separate.rawValue)"
+          """
+      case .baseBranch:
+        replacement = """
+          "base_branch":"\(privateBranch)","deliverable":"\(CoderDeliverable.pullRequest.rawValue)"
+          """
+      }
+
+      // when
+      let verdict = await gate(privateText: privateBranch, secretValues: [secretRef]).evaluate(
+        call: proposal(replacing: replacement),
+        tool: submitTool(fixture),
+        context: context(fixture.ownerContext, mode: .direct)
+      )
+
+      // then
+      guard case .block(let payload, _) = verdict else {
+        Issue.record("Coder outbound scope reached approval without argument scanning")
+        return
+      }
+      #expect(payload.status == .blockedArgs)
+    }
+  }
+
+  @Test func statusRedactsAndCapsWorkerResultAsUntrusted() async throws {
+    // given
+    let secret = #"coder-status-"secret\value"# + "\nline"
+    let result = CoderResult(
+      state: .succeeded,
+      summary: secret + String(repeating: "x", count: ToolOutputCap.maxGraphemes),
+      workspacePath: nil,
+      startingCommit: nil,
+      baselineObserved: false,
+      changedFiles: nil,
+      branch: nil,
+      commit: nil,
+      publication: .unknown(reportedURL: nil),
+      reportedChecks: [],
+      reportedUsage: nil,
+      commitAuthor: nil,
+      githubActor: nil,
+      failure: nil
+    )
+    let fixture = try CoderServiceFixture(scripts: [.init(result: result)])
+    try await fixture.withJoinedCleanup {
+      try await fixture.service.start()
+      let job = try await fixture.submitFirst()
+      fixture.backend.allowCompletion.open()
+      #expect(await fixture.jobFinished.waitUntilOpen())
+      let tool = CoderStatusTool(
+        service: fixture.service,
+        redactor: SecretRedactor(secretValues: [secret])
+      )
+
+      // when
+      let payload = await tool.execute(
+        arguments: .object(["job_id": .string(job.id.uuidString)]),
+        canonicalTarget: nil,
+        context: fixture.ownerContext
+      )
+
+      // then
+      #expect(payload.status == .ok)
+      #expect(payload.ingestedUntrusted)
+      #expect(payload.content.contains(secret) == false)
+      let containsRedaction = payload.content.contains(SecretRedactor.replacement)
+      #expect(containsRedaction)
+      #expect(payload.content.count <= ToolOutputCap.maxGraphemes)
+      #expect(payload.content.contains(ToolOutputCap.truncationMarker))
+    }
+  }
+}
+
+// MARK: - Fixtures
+
+private extension CoderToolPolicyTests {
+  func submitTool(_ fixture: CoderServiceFixture) -> CoderSubmitTool {
+    CoderSubmitTool(
+      service: fixture.service,
+      executionPolicyID: CoderServiceFixture.executionPolicyID,
+      redactor: SecretRedactor(secretValues: [])
+    )
+  }
+
+  func gate(privateText: String = "", secretValues: [String] = []) -> ToolPolicyGate {
+    ToolPolicyGate(
+      argGuard: ExfilArgGuard(secretValues: secretValues),
+      privateFileLoader: { [privateText] },
+      enabledDangerousTools: [CoderToolNames.submit]
+    )
+  }
+
+  func context(_ execution: ToolExecutionContext?, mode: ChatMode) -> ToolDispatchContext {
+    ToolDispatchContext(
+      sessionTainted: false,
+      runIngestedUntrusted: false,
+      assemblyPrivateData: false,
+      runPrivateData: false,
+      sessionHasPrivateData: false,
+      approvalAlreadyPending: false,
+      mode: mode,
+      executionContext: execution
+    )
+  }
+
+  func proposal(replacing replacement: String = "") -> ToolCall {
+    var fields =
+      JSONValue.parse(
+        """
+        {"source":{"local":{"path":"/fixture/repository-1"}},"task":"Fix retry handling",
+        "workspace":"inPlace","deliverable":"localChanges"}
+        """
+      )?.objectValue ?? [:]
+    if let extra = JSONValue.parse("{\(replacement)}")?.objectValue {
+      fields.merge(extra) { _, new in
+        new
+      }
+    }
+    return ToolCall(
+      id: "coder",
+      name: CoderToolNames.submit,
+      argumentsJSON: CanonicalJSON.encode(JSONValue.object(fields)) ?? ""
+    )
+  }
+}

--- a/Tests/ClawGatewayTests/Coder/Support/CoderRecoveryFixture.swift
+++ b/Tests/ClawGatewayTests/Coder/Support/CoderRecoveryFixture.swift
@@ -1,0 +1,47 @@
+import ClawCore
+import ClawTestSupport
+import Foundation
+import Testing
+
+extension CoderServiceFixture {
+  static func receipt(launched: Bool) -> CoderProcessReceipt {
+    CoderProcessReceipt(
+      launchID: UUID(),
+      phase: .codex,
+      hostBootID: "previous-boot",
+      pid: launched ? 123 : nil,
+      pgid: launched ? 123 : nil,
+      birthIdentity: launched ? "previous-birth" : nil
+    )
+  }
+
+  func seedUnfinished(receipt: CoderProcessReceipt? = nil) throws -> UUID {
+    let id = UUID()
+    let origin = CoderOrigin(
+      runID: ownerContext.runId,
+      sessionID: ownerContext.sessionId,
+      requesterUserID: try #require(ownerContext.requesterUserId),
+      chatID: ownerContext.chatId,
+      toolCallID: ownerContext.toolCallId,
+      approvalID: try #require(ownerContext.approvalId)
+    )
+    let admission = try store.admit(
+      id: id,
+      prepared: prepared,
+      origin: origin,
+      maxConcurrentJobs: 4,
+      now: Date()
+    )
+    guard case .admitted = admission else {
+      throw CoderError.busy
+    }
+    if let receipt {
+      _ = try store.markRunning(id: id, now: Date())
+      try store.recordProcess(id: id, event: .willLaunch(receipt), now: Date())
+      if receipt.pid != nil {
+        try store.recordProcess(id: id, event: .didLaunch(receipt), now: Date())
+      }
+    }
+    return id
+  }
+}

--- a/Tests/ClawGatewayTests/Coder/Support/CoderServiceFixture.swift
+++ b/Tests/ClawGatewayTests/Coder/Support/CoderServiceFixture.swift
@@ -1,0 +1,257 @@
+import ClawCore
+import ClawData
+import ClawGateway
+import ClawTestSupport
+import Foundation
+import GRDB
+import Testing
+
+struct CoderServiceFixture: Sendable {
+  static let executionPolicyID = PolicyFingerprint.hash(parts: ["Coder service fixture"])
+
+  let queue: DatabaseQueue
+  let store: CoderJobStoreGRDB
+  let backend: ScriptedCoderBackend
+  let preparer: CoderPreparationStub
+  let inspector: CoderInspectionStub
+  let service: CoderService
+  let ownerContext: ToolExecutionContext
+  let prepared: CoderPreparedRequest
+  let jobFinished: AsyncGate
+  let root: URL
+
+  init(
+    limit: Int = 1,
+    scripts: [ScriptedCoderBackend.Invocation] = [],
+    inspection: CoderRecoveryObservation = .stopped,
+    redactor: @escaping @Sendable (String) -> String = { text in
+      text
+    }
+  ) throws {
+    queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    store = CoderJobStoreGRDB(writer: queue)
+    root = try makeTemporaryRoot(prefix: "coder-service")
+    prepared = Self.request(index: 1)
+    preparer = CoderPreparationStub()
+    inspector = CoderInspectionStub(observation: inspection)
+    backend = ScriptedCoderBackend(
+      invocations: scripts.isEmpty ? [.init(result: Self.result())] : scripts
+    )
+    jobFinished = AsyncGate()
+    ownerContext = try Self.context(queue: queue, prepared: prepared, index: 1)
+    service = Self.makeService(
+      store: store,
+      backend: backend,
+      preparer: preparer,
+      inspector: inspector,
+      root: root,
+      limit: limit,
+      finished: jobFinished,
+      redactor: redactor
+    )
+  }
+
+  func submitFirst() async throws -> CoderJob {
+    try await service.submit(prepared, context: ownerContext)
+  }
+
+  func submitAnotherApprovedOrigin(index: Int64 = 2) async -> Result<CoderJob, CoderError> {
+    do {
+      let prepared = Self.request(index: index)
+      let context = try Self.context(queue: queue, prepared: prepared, index: index)
+      return .success(try await service.submit(prepared, context: context))
+    } catch let error as CoderError {
+      return .failure(error)
+    } catch {
+      Issue.record(error)
+      return .failure(.unavailable("Fixture origin failed"))
+    }
+  }
+
+  func reports() throws -> [OutboxRow] {
+    try OutboxStoreGRDB(writer: queue).pendingOutbound().filter { row in
+      row.approvalId == nil
+    }
+  }
+
+  func cleanup() {
+    backend.releaseAll()
+    try? FileManager.default.removeItem(at: root)
+  }
+
+  func restartedService(
+    redactor: @escaping @Sendable (String) -> String = { text in
+      text
+    }
+  ) -> CoderService {
+    Self.makeService(
+      store: store,
+      backend: backend,
+      preparer: preparer,
+      inspector: inspector,
+      root: root,
+      limit: 4,
+      finished: jobFinished,
+      redactor: redactor
+    )
+  }
+
+  static func makeService(
+    store: CoderJobStoreGRDB,
+    backend: ScriptedCoderBackend,
+    preparer: CoderPreparationStub,
+    inspector: CoderInspectionStub,
+    root: URL,
+    limit: Int,
+    finished: AsyncGate,
+    redactor: @escaping @Sendable (String) -> String
+  ) -> CoderService {
+    CoderService(
+      store: store,
+      backend: backend,
+      preparer: preparer,
+      inspector: inspector,
+      config: CoderConfig(
+        enabled: true,
+        maxConcurrentJobs: limit,
+        jobTimeoutSeconds: 600,
+        executable: CoderConfig.Defaults.executable,
+        profile: nil,
+        configHome: nil
+      ),
+      jobRoot: root.path,
+      executionPolicyID: CoderServiceFixture.executionPolicyID,
+      redact: redactor,
+      notifyOutbox: { finished.open() }
+    )
+  }
+
+  static func context(
+    queue: DatabaseQueue,
+    prepared: CoderPreparedRequest,
+    index: Int64,
+    ownerID: Int64 = 7
+  ) throws -> ToolExecutionContext {
+    let origin = try CoderApprovedOriginFixture.make(
+      queue: queue,
+      updateID: index,
+      prepared: prepared,
+      now: Date(timeIntervalSince1970: 1_800_000_000),
+      ownerID: ownerID
+    )
+    let outbox = OutboxStoreGRDB(writer: queue)
+    for row in try outbox.pendingOutbound() where row.runId == origin.runID {
+      try outbox.markSent(
+        runId: row.runId,
+        stepIndex: row.stepIndex,
+        telegramMessageId: 12,
+        now: Date(timeIntervalSince1970: 1_800_000_000)
+      )
+    }
+    return ToolExecutionContext(
+      runId: origin.runID,
+      sessionId: origin.sessionID,
+      chatId: origin.chatID,
+      requesterUserId: origin.requesterUserID,
+      origin: .interactive,
+      mode: .direct,
+      toolCallId: origin.toolCallID,
+      approvalId: origin.approvalID
+    )
+  }
+
+  static func request(
+    index: Int64 = 1,
+    policy: String = CoderServiceFixture.executionPolicyID
+  ) -> CoderPreparedRequest {
+    let path = "/fixture/repository-\(index)"
+    return CoderPreparedRequest(
+      request: CoderRequest(
+        source: .local(path: path),
+        task: "Fix retry handling",
+        workspace: .inPlace,
+        startRef: nil,
+        deliverable: .localChanges,
+        baseBranch: nil,
+        instructions: nil,
+        publishExistingChanges: false
+      ),
+      canonicalSource: path,
+      checkoutPath: path,
+      commonGitDirectory: path + "/.git",
+      executionPolicyID: policy,
+      publicationRepository: nil
+    )
+  }
+
+  static func result(
+    state: CoderJobState = .succeeded,
+    failure: CoderFailure? = nil
+  ) -> CoderResult {
+    CoderResult(
+      state: state,
+      summary: "Updated retry handling",
+      workspacePath: "/fixture/output",
+      startingCommit: "abc123",
+      baselineObserved: true,
+      changedFiles: ["Retry.swift"],
+      branch: "fix/retry",
+      commit: "def456",
+      publication: .absent,
+      reportedChecks: ["swift test"],
+      reportedUsage: nil,
+      commitAuthor: nil,
+      githubActor: nil,
+      failure: failure
+    )
+  }
+}
+
+actor CoderPreparationStub: CoderRequestPreparing {
+  let entered = AsyncGate()
+  let proceed = AsyncGate()
+  var changedIdentity = false
+  var hold = false
+
+  func configure(changedIdentity: Bool = false, hold: Bool = false) {
+    self.changedIdentity = changedIdentity
+    self.hold = hold
+  }
+
+  func prepare(_ request: CoderRequest) async throws -> CoderPreparedRequest {
+    entered.open()
+    if hold { await proceed.waitIgnoringCancellation() }
+    guard case .local(let path) = request.source else {
+      throw CoderError.invalidRequest("Fixture requires a local source")
+    }
+    return CoderPreparedRequest(
+      request: request,
+      canonicalSource: path,
+      checkoutPath: path,
+      commonGitDirectory: path + (changedIdentity ? "/changed.git" : "/.git"),
+      executionPolicyID: CoderServiceFixture.executionPolicyID,
+      publicationRepository: nil
+    )
+  }
+}
+
+actor CoderInspectionStub: CoderProcessInspecting {
+  nonisolated let entered = AsyncGate()
+  nonisolated let proceed = AsyncGate()
+  var hold = false
+
+  func holdInspection() { hold = true }
+
+  var observation: CoderRecoveryObservation
+
+  init(observation: CoderRecoveryObservation) { self.observation = observation }
+
+  func set(_ observation: CoderRecoveryObservation) { self.observation = observation }
+
+  func inspect(_ receipt: CoderProcessReceipt) async -> CoderRecoveryObservation {
+    entered.open()
+    if hold { await proceed.waitIgnoringCancellation() }
+    return observation
+  }
+}

--- a/Tests/ClawGatewayTests/Coder/Support/CoderToolTestScope.swift
+++ b/Tests/ClawGatewayTests/Coder/Support/CoderToolTestScope.swift
@@ -1,0 +1,56 @@
+import ClawTestSupport
+import Testing
+
+enum CoderToolCleanupError: Error { case lanesNotDrained }
+
+actor CoderToolStorageCleanup {
+  private(set) var deletionAllowed = true
+
+  func retainFiles() {
+    deletionAllowed = false
+  }
+}
+
+extension CoderServiceFixture {
+  func withJoinedCleanup(_ operation: () async throws -> Void) async throws {
+    try await withCoderToolCleanup(operation: operation) {
+      backend.releaseAll()
+      try await service.shutdown()
+      cleanup()
+    }
+  }
+}
+
+extension SC3Harness {
+  func withJoinedCleanup(
+    backend: ScriptedCoderBackend,
+    storage: CoderToolStorageCleanup = CoderToolStorageCleanup(),
+    removeFilesOnExit: Bool = true,
+    _ operation: () async throws -> Void
+  ) async throws {
+    try await withCoderToolCleanup(operation: operation) {
+      backend.releaseAll()
+      do {
+        try await stop()
+      } catch {
+        await storage.retainFiles()
+        throw error
+      }
+      if removeFilesOnExit, await storage.deletionAllowed { removeFiles() }
+    }
+  }
+}
+
+private func withCoderToolCleanup(
+  operation: () async throws -> Void,
+  cleanup: () async throws -> Void
+) async throws {
+  do {
+    try await operation()
+  } catch {
+    let operationError = error
+    do { try await cleanup() } catch { Issue.record(error) }
+    throw operationError
+  }
+  try await cleanup()
+}

--- a/Tests/ClawGatewayTests/Routing/ApprovedActionExecutorTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ApprovedActionExecutorTests.swift
@@ -221,7 +221,7 @@ import Testing
       runs: runs ?? env.runs,
       redactArguments: redactArguments,
       now: { Date() },
-      logger: Logger(label: "test")
+      logger: TestLog.silent
     )
   }
 
@@ -269,6 +269,31 @@ import Testing
         )
       )
     }
+  }
+
+  @Test func corruptPersistedOriginRefusesBeforeExternalExecution() async throws {
+    // given
+    let env = try makeSuspendedFixture()
+    let probe = ExecutionProbe()
+    let tool = RecordingWriteTool(toolName: "file_write", result: "written", probe: probe)
+    let executor = makeExecutor(env, tools: [tool])
+    try await env.queue.write { database in
+      try database.execute(
+        sql: "UPDATE runs SET origin = ? WHERE id = ?",
+        arguments: ["unrecognized-origin", env.runId]
+      )
+    }
+
+    // when
+    let outcome = await executor.executeApproved(
+      approval(env, tool: tool.definition.name, argsJSON: "{}")
+    )
+
+    // then
+    #expect(outcome == .committed)
+    #expect(await probe.executed == false)
+    let status: String = try lastToolAudit(env)["decision"]
+    #expect(status == ToolObservationStatus.error.rawValue)
   }
 
   @Test func executesRecordedArgsAndFillsTheObservation() async throws {
@@ -668,7 +693,9 @@ import Testing
     func resumeUsage(runId: Int64) throws(StoreError) -> ResumeUsage {
       throw StoreError.unexpected("unused in this fixture")
     }
-    func runOrigin(runId: Int64) throws(StoreError) -> RunOrigin? { nil }
+    func runOrigin(runId: Int64) throws(StoreError) -> RunOrigin? {
+      try base.runOrigin(runId: runId)
+    }
     func failRunStalePolicy(
       runId: Int64,
       sessionId: Int64,

--- a/Tests/ClawToolsTests/Policy/GroupModeToolPolicyTests.swift
+++ b/Tests/ClawToolsTests/Policy/GroupModeToolPolicyTests.swift
@@ -25,7 +25,7 @@ import Testing
     ToolPolicyGate(
       argGuard: ExfilArgGuard(secretValues: ["s3cret-value-1"]),
       privateFileLoader: { [Self.memoryText] },
-      execEnabled: true
+      enabledDangerousTools: [ExecuteCodeTool.name]
     )
   }
 

--- a/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
+++ b/Tests/ClawToolsTests/Policy/ToolPolicyGateTests.swift
@@ -210,7 +210,7 @@ private struct ProbedDangerousTool: Tool {
     ToolPolicyGate(
       argGuard: ExfilArgGuard(secretValues: ["s3cret-value-1"]),
       privateFileLoader: { privateFiles },
-      execEnabled: execEnabled
+      enabledDangerousTools: execEnabled ? [ExecuteCodeTool.name] : []
     )
   }
 
@@ -230,7 +230,8 @@ private struct ProbedDangerousTool: Tool {
         warnings: []
       ),
       guardTexts: guardTexts,
-      canExfiltrate: canExfiltrate
+      canExfiltrate: canExfiltrate,
+      approvalReason: .codeExec
     )
   }
 
@@ -936,7 +937,7 @@ private struct ProbedDangerousTool: Tool {
       gate: ToolPolicyGate(
         argGuard: ExfilArgGuard(secretValues: []),
         privateFileLoader: { privateFiles },
-        execEnabled: false
+        enabledDangerousTools: []
       ),
       clock: clock
     )

--- a/Tests/ClawToolsTests/Tools/CoderSubmitArgumentsTests.swift
+++ b/Tests/ClawToolsTests/Tools/CoderSubmitArgumentsTests.swift
@@ -1,0 +1,73 @@
+import ClawCore
+import Foundation
+import Testing
+
+@testable import ClawTools
+
+@Suite struct CoderSubmitArgumentsTests {
+  @Test(arguments: [
+    CoderSource.local(path: "/repository"),
+    .githubRepository(url: "https://github.com/owner/repository"),
+    .githubIssue(url: "https://github.com/owner/repository/issues/42"),
+  ])
+  func wireRequestPreservesSourceAndScope(_ source: CoderSource) throws {
+    // given
+    let inPlace: Bool
+    if case .local = source { inPlace = true } else { inPlace = false }
+    let workspace: CoderWorkspaceMode = inPlace ? .inPlace : .separate
+    let startRef: String? = inPlace ? nil : "retry-base"
+    let sourceJSON = try #require(CanonicalJSON.encode(source))
+    let startRefJSON = try #require(CanonicalJSON.encode(startRef))
+    let arguments = try #require(
+      JSONValue.parse(
+        """
+        {"source":\(sourceJSON),"task":"Fix retries","workspace":"\(workspace.rawValue)",
+        "start_ref":\(startRefJSON),"deliverable":"pullRequest","base_branch":"release",
+        "instructions":"Run the checks","publish_existing_changes":\(inPlace)}
+        """
+      )
+    )
+
+    // when
+    let request = try CoderSubmitArguments.decode(arguments)
+
+    // then
+    #expect(
+      request
+        == CoderRequest(
+          source: source,
+          task: "Fix retries",
+          workspace: workspace,
+          startRef: startRef,
+          deliverable: .pullRequest,
+          baseBranch: "release",
+          instructions: "Run the checks",
+          publishExistingChanges: inPlace
+        )
+    )
+  }
+
+  @Test func rejectsMultipleIndividuallyValidSources() throws {
+    // given
+    let arguments = try #require(
+      JSONValue.parse(
+        """
+        {"source":{"local":{"path":"/repository"},
+        "githubIssue":{"url":"https://github.com/owner/repository/issues/42"}},
+        "task":"Fix retries","workspace":"separate","deliverable":"pullRequest"}
+        """
+      )
+    )
+
+    // when / then
+    do {
+      _ = try CoderSubmitArguments.decode(arguments)
+      Issue.record("Multiple valid source cases were accepted")
+    } catch let error as CoderError {
+      guard case .invalidRequest = error else {
+        Issue.record("Unexpected Coder error: \(error)")
+        return
+      }
+    }
+  }
+}

--- a/Tests/ClawToolsTests/Tools/CoderSubmitPresentationTests.swift
+++ b/Tests/ClawToolsTests/Tools/CoderSubmitPresentationTests.swift
@@ -1,0 +1,39 @@
+import ClawCore
+import Testing
+
+@testable import ClawTools
+
+@Suite struct CoderSubmitPresentationTests {
+  @Test func issueOnlyApprovalDisplaysSelectedIssue() throws {
+    // given
+    let issue = "https://github.com/owner/repository/issues/42"
+    let request = try CoderRequest(
+      source: .githubIssue(url: issue),
+      task: nil,
+      workspace: .separate,
+      startRef: nil,
+      deliverable: .pullRequest,
+      baseBranch: nil,
+      instructions: nil,
+      publishExistingChanges: false
+    ).validated()
+    let prepared = CoderPreparedRequest(
+      request: request,
+      canonicalSource: "https://github.com/owner/repository",
+      checkoutPath: nil,
+      commonGitDirectory: nil,
+      executionPolicyID: "fixture-policy",
+      publicationRepository: "https://github.com/owner/repository"
+    )
+
+    // when
+    let presentation = CoderSubmitTool.presentation(
+      prepared,
+      redactor: SecretRedactor(secretValues: [])
+    )
+
+    // then
+    #expect(presentation.blastRadius.contains(issue))
+    #expect(presentation.blastRadius.contains("GitHub issue"))
+  }
+}

--- a/Tests/ClawToolsTests/Tools/CoderSubmitSchemaTests.swift
+++ b/Tests/ClawToolsTests/Tools/CoderSubmitSchemaTests.swift
@@ -1,0 +1,86 @@
+import ClawCore
+import Testing
+
+@testable import ClawTools
+
+@Suite struct CoderSubmitSchemaTests {
+  @Test func advertisesStrictSourceAndPublicationScope() throws {
+    // given
+    let schema = CoderSubmitArguments.schema
+
+    // when
+    let properties = try strictProperties(schema, required: ["source", "workspace", "deliverable"])
+    let source = try #require(properties["source"]?.objectValue)
+    guard case .array(let alternatives) = source["oneOf"] else {
+      Issue.record("Source has no alternatives")
+      return
+    }
+
+    // then
+    #expect(
+      Set(properties.keys) == [
+        "source", "task", "workspace", "start_ref", "deliverable", "base_branch",
+        "instructions", "publish_existing_changes",
+      ]
+    )
+    let expectedFields = ["local": "path", "githubRepository": "url", "githubIssue": "url"]
+    var sourceNames: Set<String> = []
+    for alternative in alternatives {
+      let object = try #require(alternative.objectValue)
+      let declared = try #require(object["properties"]?.objectValue)
+      let name = try #require(declared.keys.first)
+      #expect(declared.count == 1)
+      sourceNames.insert(name)
+      let associatedField = try #require(expectedFields[name])
+      let fields = try strictProperties(alternative, required: [name])
+      let nested = try strictProperties(try #require(fields[name]), required: [associatedField])
+      #expect(Set(nested.keys) == [associatedField])
+      #expect(nested[associatedField]?.objectValue?["type"] == .string("string"))
+    }
+    #expect(sourceNames == Set(expectedFields.keys))
+    #expect(alternatives.count == sourceNames.count)
+    for field in ["task", "start_ref", "base_branch", "instructions"] {
+      #expect(try stringSet(properties[field]?.objectValue?["type"]) == ["string", "null"])
+    }
+    #expect(properties["workspace"]?.objectValue?["type"] == .string("string"))
+    #expect(
+      try stringSet(properties["workspace"]?.objectValue?["enum"]) == [
+        CoderWorkspaceMode.inPlace.rawValue, CoderWorkspaceMode.separate.rawValue,
+      ]
+    )
+    #expect(properties["deliverable"]?.objectValue?["type"] == .string("string"))
+    #expect(
+      try stringSet(properties["deliverable"]?.objectValue?["enum"]) == [
+        CoderDeliverable.localChanges.rawValue, CoderDeliverable.pullRequest.rawValue,
+      ]
+    )
+    let publication = try #require(properties["publish_existing_changes"]?.objectValue)
+    #expect(publication["type"] == .string("boolean"))
+    #expect(publication["default"] == .bool(false))
+  }
+}
+
+// MARK: - Schema Assertions
+
+private extension CoderSubmitSchemaTests {
+  func strictProperties(_ schema: JSONValue, required: Set<String>) throws -> [String: JSONValue] {
+    let object = try #require(schema.objectValue)
+    #expect(object["type"] == .string("object"))
+    #expect(object["additionalProperties"] == .bool(false))
+    #expect(try stringSet(object["required"]) == required)
+    return try #require(object["properties"]?.objectValue)
+  }
+
+  func stringSet(_ value: JSONValue?) throws -> Set<String> {
+    let value = try #require(value)
+    guard case .array(let elements) = value else {
+      Issue.record("Expected an array of strings")
+      return []
+    }
+    return try Set(
+      elements.map { element in
+        try #require(element.stringValue)
+      }
+    )
+  }
+}

--- a/Tests/ClawdCompositionTests/CoderCompositionTests.swift
+++ b/Tests/ClawdCompositionTests/CoderCompositionTests.swift
@@ -1,0 +1,371 @@
+import ClawCoder
+import ClawCore
+import ClawData
+import ClawGateway
+import ClawLLM
+import ClawTestSupport
+import ClawTools
+import ClawWorkspace
+import Foundation
+import GRDB
+import Testing
+
+@testable import clawd
+
+@Suite struct CoderCompositionTests {
+  @Test func approvedBootReplayUsesComposedCoderWithVMDisabled() async throws {
+    // given
+    let fixture = try CoderCompositionFixture()
+    defer { fixture.cleanup() }
+    let coordination = DaemonBuilder.TurnCoordination()
+    let coder = await fixture.builder.prepareCoder(coordination: coordination)
+    let service = try #require(coder.service)
+    let sandbox = await fixture.builder.prepareSandbox()
+    let stack = try fixture.builder.makeRosterStack(http: fixture.http)
+    let cooldown = PrimaryRouteCooldown(longSeconds: 900, clock: ContinuousClock())
+    let workspace = FileSystemWorkspace(root: fixture.root.appendingPathComponent("workspace"))
+    let agent = fixture.builder.makeAgentStack(
+      roster: stack.roster,
+      cooldown: cooldown,
+      workspace: workspace,
+      costResolver: CostResolver(priceTable: PriceFileLoader.load(), referenceUSDPerToken: 0.00001),
+      sandbox: sandbox,
+      mcpTools: [],
+      coderTools: coder.tools
+    )
+    // A prepared request was approved before the previous process claimed execution.
+    try await service.start()
+    let proposal = ToolCall(
+      id: "coder-composition-proposal",
+      name: CoderToolNames.submit,
+      argumentsJSON: """
+        {"source":{"githubRepository":{"url":"https://github.com/example/project"}},
+        "task":"Fix retry","workspace":"\(CoderWorkspaceMode.separate.rawValue)",
+        "deliverable":"\(CoderDeliverable.localChanges.rawValue)"}
+        """
+    )
+    let proposed = await agent.toolDispatcher.dispatch(
+      call: proposal,
+      context: ToolDispatchContext(
+        sessionTainted: false,
+        runIngestedUntrusted: false,
+        assemblyPrivateData: false,
+        runPrivateData: false,
+        sessionHasPrivateData: false,
+        approvalAlreadyPending: false,
+        executionContext: ToolExecutionContext(
+          runId: 1,
+          sessionId: 1,
+          chatId: 7,
+          requesterUserId: 7,
+          origin: .interactive,
+          mode: .direct,
+          toolCallId: proposal.id,
+          approvalId: nil
+        )
+      )
+    )
+    let recorded = try #require(proposed.requiresApproval)
+    #expect(recorded.reason == .coderSubmit)
+    #expect(await fixture.backend.startedJobIDs.isEmpty)
+    let prepared = try JSONDecoder().decode(
+      CoderPreparedRequest.self,
+      from: Data(recorded.canonicalArgsJSON.utf8)
+    )
+    let context = try fixture.approvedContext(prepared)
+    let policy = agent.contextBuilder.currentPolicyVersion()
+    try await fixture.queue.write { db in
+      try db.execute(
+        sql: "UPDATE runs SET state = ?, policy_version = ? WHERE id = ?",
+        arguments: [RunState.awaitingApproval.rawValue, policy, context.runId]
+      )
+      try db.execute(
+        sql: "UPDATE approvals SET policy_version = ? WHERE id = ?",
+        arguments: [policy, context.approvalId]
+      )
+    }
+    try await service.shutdown()
+    let restarted = await fixture.builder.prepareCoder(coordination: coordination)
+    let restartedService = try #require(restarted.service)
+    let restartedAgent = fixture.builder.makeAgentStack(
+      roster: stack.roster,
+      cooldown: cooldown,
+      workspace: workspace,
+      costResolver: CostResolver(priceTable: PriceFileLoader.load(), referenceUSDPerToken: 0.00001),
+      sandbox: sandbox,
+      mcpTools: [],
+      coderTools: restarted.tools
+    )
+    let restartedRunner = fixture.builder.makeTurnRunner(
+      coordination: coordination,
+      agentStack: restartedAgent,
+      costPolicy: stack.roster.primary.costPolicy,
+      imageCache: ImageCache()
+    )
+    let restartedFabric = fixture.builder.makeApprovalFabric(
+      coordination: coordination,
+      agentStack: restartedAgent,
+      turnRunner: restartedRunner
+    )
+
+    // when
+    await fixture.builder.bootSequence(
+      coordination: coordination,
+      waiter: restartedFabric.waiter,
+      heartbeatOwner: nil,
+      coder: restartedService
+    )()
+    let started = await fixture.backend.started.waitUntilOpen()
+    fixture.backend.releaseAll()
+    _ = await coordination.lanes.drain(timeout: .seconds(5), clock: ContinuousClock())
+    try await restartedService.shutdown()
+
+    // then
+    #expect(started)
+    #expect(!fixture.builder.config.exec.enabled)
+    let names = Set(restartedAgent.toolDispatcher.definitions.map(\.name))
+    #expect(
+      names.isSuperset(of: [CoderToolNames.submit, CoderToolNames.status, CoderToolNames.cancel])
+    )
+    #expect(!names.contains(ExecuteCodeTool.name))
+    let id = try #require(await fixture.backend.startedJobIDs.first)
+    let job = try #require(try fixture.builder.stores.coderJobs.job(id: id))
+    #expect(job.prepared.executionPolicyID == namesPolicy(restarted.tools))
+    #expect(job.origin.approvalID == context.approvalId)
+    #expect(!job.slotReserved)
+  }
+
+  @Test(arguments: [CodexAuthenticationStatus.missing, .profileUnverified])
+  func authenticationFactsControlSubmissionWithoutDisablingRecovery(
+    authentication: CodexAuthenticationStatus
+  ) async throws {
+    // given
+    let fixture = try CoderCompositionFixture(authentication: authentication)
+    defer { fixture.cleanup() }
+
+    // when
+    let coder = await fixture.builder.prepareCoder(coordination: .init())
+    let service = try #require(coder.service)
+    try await service.start()
+    let preparation: Result<CoderPreparedRequest, any Error>
+    do {
+      let prepared = try await service.prepare(CoderCompositionFixture.request)
+      preparation = .success(prepared)
+    } catch { preparation = .failure(error) }
+    try await service.shutdown()
+
+    // then
+    let submits = coder.tools.contains {
+      $0.definition.name == CoderToolNames.submit
+    }
+    #expect(
+      coder.checks.contains {
+        $0.key == CoderHealthRows.Key.authentication && !$0.ok
+      }
+    )
+    switch authentication {
+    case .profileUnverified:
+      #expect(submits)
+      #expect(try preparation.get().executionPolicyID == namesPolicy(coder.tools))
+    default:
+      #expect(!submits)
+      #expect(throws: CoderError.self) {
+        try preparation.get()
+      }
+    }
+  }
+
+  @Test func disabledDoesNotResolveBackend() async throws {
+    // given
+    let fixture = try CoderCompositionFixture(enabled: false)
+    defer { fixture.cleanup() }
+    var builder = fixture.builder
+    builder.resolveCoder = { _ in
+      Issue.record("Disabled Coder resolved its backend")
+      throw CoderError.unavailable("not installed")
+    }
+
+    // when
+    let coder = await builder.prepareCoder(coordination: .init())
+
+    // then
+    #expect(coder.service == nil)
+    #expect(coder.tools.isEmpty)
+  }
+
+  @Test func unavailableBackendStillReconcilesReservedJobs() async throws {
+    // given
+    let fixture = try CoderCompositionFixture()
+    defer { fixture.cleanup() }
+    let original = await fixture.builder.prepareCoder(coordination: .init())
+    let first = try #require(original.service)
+    try await first.start()
+    let prepared = try await first.prepare(CoderCompositionFixture.request)
+    let context = try fixture.approvedContext(prepared)
+    let origin = CoderOrigin(
+      runID: context.runId,
+      sessionID: context.sessionId,
+      requesterUserID: 7,
+      chatID: 7,
+      toolCallID: context.toolCallId,
+      approvalID: try #require(context.approvalId)
+    )
+    let id = UUID()
+    _ = try fixture.builder.stores.coderJobs.admit(
+      id: id,
+      prepared: prepared,
+      origin: origin,
+      maxConcurrentJobs: 1,
+      now: Date()
+    )
+    try await first.shutdown()
+    var restarted = fixture.builder
+    restarted.resolveCoder = { _ in
+      throw CoderError.unavailable("not installed")
+    }
+
+    // when
+    let coder = await restarted.prepareCoder(coordination: .init())
+    let service = try #require(coder.service)
+    try await service.start()
+    try await service.shutdown()
+
+    // then
+    let job = try #require(try restarted.stores.coderJobs.job(id: id))
+    #expect(job.state == .interrupted)
+    #expect(
+      coder.checks.contains {
+        $0.key == CoderHealthRows.Key.available && !$0.ok
+      }
+    )
+    #expect(!job.slotReserved)
+    #expect(
+      !coder.tools.contains {
+        $0.definition.name == CoderToolNames.submit
+      }
+    )
+    #expect(
+      try restarted.stores.outbox.pendingOutbound().contains {
+        $0.payload.contains(id.uuidString)
+      }
+    )
+    #expect(await fixture.backend.startedJobIDs.isEmpty)
+  }
+
+  @Test func offlineRowsDoNotProbe() async throws {
+    // given
+    let fixture = try CoderCompositionFixture()
+    defer { fixture.cleanup() }
+
+    // when
+    var doctor = DoctorCommand()
+    doctor.checkConfig = true
+    let rows = await doctor.coderRows(
+      config: fixture.builder.config.coder,
+      resolve: { _ in
+        Issue.record("Offline doctor launched a Coder probe")
+        throw CoderError.unavailable("unexpected probe")
+      }
+    )
+
+    // then
+    #expect(
+      rows.contains {
+        $0.key == CoderHealthRows.Key.available && $0.value.contains("unverified")
+      }
+    )
+  }
+
+  @Test func persistedHealthSurvivesReleaseAndFailsUnreadable() async throws {
+    // given
+    let fixture = try CoderCompositionFixture()
+    defer { fixture.cleanup() }
+    let coder = await fixture.builder.prepareCoder(coordination: .init())
+    let service = try #require(coder.service)
+    try await service.start()
+    let prepared = try await service.prepare(CoderCompositionFixture.request)
+    let context = try fixture.approvedContext(prepared)
+    let origin = CoderOrigin(
+      runID: context.runId,
+      sessionID: context.sessionId,
+      requesterUserID: 7,
+      chatID: 7,
+      toolCallID: context.toolCallId,
+      approvalID: try #require(context.approvalId)
+    )
+    let store = fixture.builder.stores.coderJobs
+    let id = UUID()
+    _ = try store.admit(
+      id: id,
+      prepared: prepared,
+      origin: origin,
+      maxConcurrentJobs: 1,
+      now: Date()
+    )
+    let failed = CoderResult(
+      state: .failed,
+      summary: "Failed",
+      workspacePath: nil,
+      startingCommit: nil,
+      baselineObserved: false,
+      changedFiles: nil,
+      branch: nil,
+      commit: nil,
+      publication: .absent,
+      reportedChecks: [],
+      reportedUsage: nil,
+      commitAuthor: nil,
+      githubActor: nil,
+      failure: CoderFailure(stage: .permission, message: "blocked task7-sensitive-token")
+    )
+    _ = try store.complete(
+      id: id,
+      expectedState: .admitted,
+      result: failed,
+      chunks: [],
+      releaseReservation: true,
+      now: Date()
+    )
+    try await service.shutdown()
+    let redactor = SecretRedactor(secretValues: ["task7-sensitive-token"])
+
+    // when
+    let rows = CoderHealthRows.persisted(store: store, redactor: redactor)
+    try await fixture.queue.write { db in
+      try db.execute(sql: "DROP TABLE coder_jobs")
+    }
+    let unreadable = CoderHealthRows.persisted(store: store, redactor: redactor)
+
+    // then
+    let last = try #require(
+      rows.first {
+        $0.key == CoderHealthRows.Key.lastFailure
+      }
+    )
+    #expect(last.value.contains(id.uuidString))
+    #expect(last.value.contains(CoderJobState.failed.rawValue))
+    #expect(!last.value.contains("task7-sensitive-token"))
+    #expect(
+      rows.first {
+        $0.key == CoderHealthRows.Key.reserved
+      }?.value.hasPrefix("0") == true
+    )
+    for key in [
+      CoderHealthRows.Key.reserved, CoderHealthRows.Key.ownership, CoderHealthRows.Key.lastFailure,
+    ] {
+      let row = try #require(
+        unreadable.first {
+          $0.key == key
+        }
+      )
+      #expect(!row.ok)
+      #expect(row.value.contains("unreadable"))
+    }
+  }
+
+  private func namesPolicy(_ tools: [any Tool]) -> String? {
+    tools.first {
+      $0.definition.name == CoderToolNames.submit
+    }?.definition.invocationIdentity
+  }
+}

--- a/Tests/ClawdCompositionTests/CoderDisabledRecoveryTests.swift
+++ b/Tests/ClawdCompositionTests/CoderDisabledRecoveryTests.swift
@@ -1,0 +1,152 @@
+import ClawCore
+import ClawGateway
+import ClawLLM
+import ClawTestSupport
+import Foundation
+import Testing
+
+@testable import ClawCoder
+@testable import clawd
+
+extension CoderCompositionTests {
+  @Test func disabledStillReconcilesAndReportsReservedJobs() async throws {
+    // given
+    let fixture = try CoderCompositionFixture(limit: 2)
+    defer { fixture.cleanup() }
+    let original = await fixture.builder.prepareCoder(coordination: .init())
+    let originalService = try #require(original.service)
+    try await originalService.start()
+    let prepared = try await originalService.prepare(CoderCompositionFixture.request)
+    try await originalService.shutdown()
+    let released = try oldJob(fixture, prepared: prepared, updateID: 1)
+    let unresolved = try oldJob(fixture, prepared: prepared, updateID: 2)
+    let store = fixture.builder.stores.coderJobs
+    try #require(try store.markRunning(id: unresolved.id, now: Date()))
+    let pendingReceipt = CoderProcessReceipt(
+      launchID: UUID(),
+      phase: .codex,
+      hostBootID: try CoderProcessIdentity.bootID(),
+      pid: nil,
+      pgid: nil,
+      birthIdentity: nil
+    )
+    try store.recordProcess(
+      id: unresolved.id,
+      event: .willLaunch(pendingReceipt),
+      now: Date()
+    )
+    let disabled = try AppConfig.load(environment: [
+      AppConfig.EnvKey.stateRoot: fixture.root.path,
+      AppConfig.EnvKey.llmModel: CompositionAcceptance.qualifiedModel,
+      AppConfig.EnvKey.coderEnabled: "false",
+    ])
+    var restarted = try CompositionAcceptance.makeBuilder(http: fixture.http, config: disabled)
+    restarted.resolveCoder = { _ in
+      Issue.record("Disabled recovery resolved the native backend")
+      throw CoderError.unavailable("not installed")
+    }
+    let context = ToolExecutionContext(
+      runId: released.origin.runID,
+      sessionId: released.origin.sessionID,
+      chatId: released.origin.chatID,
+      requesterUserId: released.origin.requesterUserID,
+      origin: .interactive,
+      mode: .direct,
+      toolCallId: released.origin.toolCallID,
+      approvalId: released.origin.approvalID
+    )
+
+    for _ in 0..<2 {
+      // when
+      let coder = await restarted.prepareCoder(coordination: .init())
+      let service = try #require(coder.service)
+      do { try await service.start() } catch {
+        try? await service.shutdown()
+        throw error
+      }
+      await #expect(throws: CoderError.self) {
+        try await service.prepare(CoderCompositionFixture.request)
+      }
+      await #expect(throws: CoderError.self) {
+        try await service.submit(prepared, context: context)
+      }
+      let reporter = restarted.makeDoctorReporter(
+        sandbox: await restarted.prepareSandbox(),
+        cooldown: PrimaryRouteCooldown(longSeconds: 900, clock: ContinuousClock()),
+        mcpOutcomes: [],
+        coder: coder
+      )
+      let report = await reporter.report()
+      try await service.shutdown()
+
+      // then
+      #expect(coder.tools.isEmpty)
+      let releasedJob = try #require(try store.job(id: released.id))
+      let unresolvedJob = try #require(try store.job(id: unresolved.id))
+      #expect(releasedJob.state == .interrupted)
+      #expect(!releasedJob.slotReserved)
+      #expect(unresolvedJob.state == .interrupted)
+      #expect(unresolvedJob.slotReserved)
+      #expect(unresolvedJob.ownership == .unresolved)
+      #expect(unresolvedJob.processReceipt == pendingReceipt)
+      let notices = try restarted.stores.outbox.pendingOutbound().filter {
+        $0.approvalId == nil
+      }
+      for id in [released.id, unresolved.id] {
+        let matching = notices.filter {
+          $0.payload.contains(id.uuidString)
+        }
+        #expect(matching.count == 1)
+      }
+      #expect(
+        report.checks.contains {
+          $0.key == CoderHealthRows.Key.enabled && $0.value == "false"
+        }
+      )
+      #expect(
+        report.checks.contains {
+          $0.key == CoderHealthRows.Key.reserved && $0.value.hasPrefix("1")
+        }
+      )
+      #expect(
+        report.checks.contains {
+          $0.key == CoderHealthRows.Key.ownership
+            && $0.value.contains(unresolved.id.uuidString) && !$0.ok
+        }
+      )
+      #expect(
+        report.checks.contains {
+          $0.key == CoderHealthRows.Key.lastFailure
+            && $0.value.contains(CoderJobState.interrupted.rawValue)
+        }
+      )
+      #expect(await fixture.backend.startedJobIDs.isEmpty)
+    }
+  }
+}
+
+// MARK: - Persisted Enabled Jobs
+
+private extension CoderCompositionTests {
+  func oldJob(
+    _ fixture: CoderCompositionFixture,
+    prepared: CoderPreparedRequest,
+    updateID: Int64
+  ) throws -> CoderJob {
+    let origin = try CoderApprovedOriginFixture.make(
+      queue: fixture.queue,
+      updateID: updateID,
+      prepared: prepared,
+      now: Date()
+    )
+    let id = UUID()
+    _ = try fixture.builder.stores.coderJobs.admit(
+      id: id,
+      prepared: prepared,
+      origin: origin,
+      maxConcurrentJobs: fixture.builder.config.coder.maxConcurrentJobs,
+      now: Date()
+    )
+    return try #require(try fixture.builder.stores.coderJobs.job(id: id))
+  }
+}

--- a/Tests/ClawdCompositionTests/RuntimeShutdownAcceptanceTests.swift
+++ b/Tests/ClawdCompositionTests/RuntimeShutdownAcceptanceTests.swift
@@ -143,6 +143,155 @@ import Testing
     )
   }
 
+  @Test func coderBootWorkJoinsBeforeDependentCleanup() async throws {
+    // given
+    let fixture = try CoderCompositionFixture(holdCleanup: true)
+    defer { fixture.cleanup() }
+    let coordination = DaemonBuilder.TurnCoordination()
+    let coder = await fixture.builder.prepareCoder(coordination: coordination)
+    let service = try #require(coder.service)
+    let bootEntered = AsyncGate()
+    let releaseBoot = AsyncGate()
+    let laneCancelled = AsyncGate()
+    let releaseLane = AsyncGate()
+    let laneJoined = AsyncGate()
+    defer {
+      releaseBoot.open()
+      releaseLane.open()
+    }
+    let closed = AsyncGate()
+    let bundle = fixture.builder.runtimeBundle(
+      services: [],
+      coordination: coordination,
+      credentialSources: [],
+      boot: {
+        do {
+          try await service.start()
+          let prepared = try await service.prepare(CoderCompositionFixture.request)
+          let context = try fixture.approvedContext(prepared)
+          _ = await coordination.lanes.enqueue(sessionID: context.sessionId, runID: context.runId) {
+            do { _ = try await service.submit(prepared, context: context) } catch {
+              Issue.record(error)
+            }
+            await withTaskCancellationHandler {
+              await releaseLane.waitIgnoringCancellation()
+            } onCancel: {
+              laneCancelled.open()
+            }
+            laneJoined.open()
+          }
+          _ = await fixture.backend.started.waitUntilOpen()
+        } catch { Issue.record(error) }
+        bootEntered.open()
+        await releaseBoot.waitIgnoringCancellation()
+      },
+      coder: service,
+      gracefulShutdownSignals: []
+    )
+    let composed = RunComposition.Composed(
+      bundle: bundle,
+      clients: RuntimeHTTPClients { _ in
+        RuntimeHTTPClient(
+          executor: AsyncHTTPExecutor(client: .shared),
+          close: {
+            #expect(laneJoined.isOpen)
+            #expect(fixture.backend.allowCleanup.isOpen)
+            #expect((try? fixture.builder.stores.coderJobs.reservedJobs().isEmpty) == true)
+            closed.open()
+          }
+        )
+      }
+    )
+
+    // when
+    let command = Task {
+      try await RunCommand.serveThenShutDown(
+        composed: composed,
+        redactionValues: [],
+        logger: Self.silent
+      )
+    }
+    #expect(await bootEntered.waitUntilOpen())
+    command.cancel()
+    releaseBoot.open()
+    let cancelled = await laneCancelled.waitUntilOpen()
+    releaseLane.open()
+    let cleanupEntered = await fixture.backend.invocations[0].cleanupEntered.waitUntilOpen()
+    fixture.backend.allowCleanup.open()
+    let result = await command.result
+    fixture.backend.releaseAll()
+    try? await service.shutdown()
+    await coordination.lanes.stopAcceptingAndCancel()
+    _ = await coordination.lanes.drain(timeout: .seconds(5), clock: ContinuousClock())
+    try result.get()
+
+    // then
+    #expect(cancelled)
+    #expect(cleanupEntered)
+    #expect(closed.isOpen)
+  }
+
+  @Test func coderUnresolvedCleanupRefusesDependentTeardown() async throws {
+    // given
+    let fixture = try CoderCompositionFixture(unresolvedCleanup: true)
+    defer { fixture.cleanup() }
+    let coordination = DaemonBuilder.TurnCoordination()
+    let coder = await fixture.builder.prepareCoder(coordination: coordination)
+    let service = try #require(coder.service)
+    try await service.start()
+    let prepared = try await service.prepare(CoderCompositionFixture.request)
+    _ = try await service.submit(prepared, context: fixture.approvedContext(prepared))
+    #expect(await fixture.backend.started.waitUntilOpen())
+    let code = ExitCodeBox()
+    let bundle = fixture.builder.runtimeBundle(
+      services: [],
+      coordination: coordination,
+      credentialSources: [],
+      boot: {},
+      coder: service,
+      gracefulShutdownSignals: []
+    )
+    let composed = RunComposition.Composed(
+      bundle: bundle,
+      clients: RuntimeHTTPClients { _ in
+        RuntimeHTTPClient(
+          executor: AsyncHTTPExecutor(client: .shared),
+          close: {
+            Issue.record("Unresolved Coder ownership closed a dependent client")
+          }
+        )
+      }
+    )
+
+    // when
+    let finished = AsyncGate()
+    let command = Task {
+      defer { finished.open() }
+      try await RunCommand.serveThenShutDown(
+        composed: composed,
+        redactionValues: [],
+        logger: Self.silent,
+        terminator: FatalProcessTerminator { value in
+          code.set(value)
+          throw FatalExitSentinel()
+        }
+      )
+    }
+    fixture.backend.allowCompletion.open()
+    let failedFromService = await finished.waitUntilOpen()
+    if !failedFromService { command.cancel() }
+    await #expect(throws: FatalExitSentinel.self) {
+      try await command.value
+    }
+    fixture.backend.releaseAll()
+    try? await service.shutdown()
+
+    // then
+    #expect(failedFromService)
+    #expect(code.value == 1)
+    #expect(try fixture.builder.stores.coderJobs.reservedJobs().count == 1)
+  }
+
   // MARK: - Helpers
 
   private static let silent = Logger(label: "test", factory: { _ in SwiftLogNoOpLogHandler() })

--- a/Tests/ClawdCompositionTests/Support/CoderCompositionFixture.swift
+++ b/Tests/ClawdCompositionTests/Support/CoderCompositionFixture.swift
@@ -1,0 +1,108 @@
+import ClawCoder
+import ClawCore
+import ClawData
+import ClawGateway
+import ClawTestSupport
+import Foundation
+import GRDB
+
+@testable import clawd
+
+struct CoderCompositionFixture {
+  let root: URL
+  let queue: DatabaseQueue
+  let builder: DaemonBuilder
+  let backend: ScriptedCoderBackend
+  let http: ScriptedHTTPExecutor
+
+  init(
+    enabled: Bool = true,
+    limit: Int = CoderConfig.Defaults.maxConcurrentJobs,
+    holdCleanup: Bool = false,
+    unresolvedCleanup: Bool = false,
+    authentication: CodexAuthenticationStatus = .authenticated
+  ) throws {
+    root = try makeTemporaryRoot(prefix: "coder-composition")
+    var environment = [
+      AppConfig.EnvKey.stateRoot: root.path,
+      AppConfig.EnvKey.llmModel: CompositionAcceptance.qualifiedModel,
+      AppConfig.EnvKey.coderEnabled: enabled ? "true" : "false",
+      AppConfig.EnvKey.coderMaxConcurrentJobs: String(limit),
+    ]
+    if authentication == .profileUnverified {
+      environment[AppConfig.EnvKey.coderProfile] = "coding"
+    }
+    let config = try AppConfig.load(environment: environment)
+    http = ScriptedHTTPExecutor([])
+    backend = ScriptedCoderBackend(invocations: [
+      .init(result: Self.result, holdCleanup: holdCleanup, unresolvedCleanup: unresolvedCleanup)
+    ])
+    var builder = try CompositionAcceptance.makeBuilder(http: http, config: config)
+    let backend = backend
+    builder.resolveCoder = { config in
+      CoderBackendSetup(
+        backend: backend,
+        executable: "/test/codex",
+        profile: config.profile,
+        configHome: "/test/config",
+        credentialSources: [:],
+        version: "scripted",
+        authentication: authentication
+      )
+    }
+    self.builder = builder
+    queue = try DatabaseQueue(path: root.appendingPathComponent(StateFile.database).path)
+  }
+
+  func approvedContext(_ prepared: CoderPreparedRequest) throws -> ToolExecutionContext {
+    let origin = try CoderApprovedOriginFixture.make(
+      queue: queue,
+      updateID: 1,
+      prepared: prepared,
+      now: Date()
+    )
+    return ToolExecutionContext(
+      runId: origin.runID,
+      sessionId: origin.sessionID,
+      chatId: origin.chatID,
+      requesterUserId: origin.requesterUserID,
+      origin: .interactive,
+      mode: .direct,
+      toolCallId: origin.toolCallID,
+      approvalId: origin.approvalID
+    )
+  }
+
+  func cleanup() {
+    backend.releaseAll()
+    try? FileManager.default.removeItem(at: root)
+  }
+
+  static let request = CoderRequest(
+    source: .githubRepository(url: "https://github.com/example/project"),
+    task: "Fix retry",
+    workspace: .separate,
+    startRef: nil,
+    deliverable: .localChanges,
+    baseBranch: nil,
+    instructions: nil,
+    publishExistingChanges: false
+  )
+
+  static let result = CoderResult(
+    state: .succeeded,
+    summary: "Completed",
+    workspacePath: nil,
+    startingCommit: nil,
+    baselineObserved: false,
+    changedFiles: nil,
+    branch: nil,
+    commit: nil,
+    publication: .absent,
+    reportedChecks: [],
+    reportedUsage: nil,
+    commitAuthor: nil,
+    githubActor: nil,
+    failure: nil
+  )
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -18,3 +18,24 @@ Exit codes are diagnostic:
 | 11 | secret loading failed |
 | 12 | another instance holds the state-root lock |
 | 13 | storage error |
+
+## Optional Coder in the service account
+
+Enabling `CLAW_CODER_ENABLED=true` adds native Codex background jobs in owner DMs. Install Codex,
+Git (`/usr/bin/git` for preparation) and, for GitHub tasks, `gh` separately. PRs require that account's
+configured clone/push/PR rights. The installer does not provision dependencies or credentials.
+
+The wrapper already sources `clawd.env`; put the deliberate PATH and six Coder settings there.
+`clawd` does not automatically load `.env`. Include any Codex interpreter/toolchain in PATH and
+validate HOME, `CODEX_HOME`/`CLAW_CODER_CONFIG_HOME`, selected profile, `GH_CONFIG_DIR` and login/keyring
+access under the actual launchd/systemd user. Shell access is not proof of service authorization.
+Codex owns its auth; `clawd auth` manages only the conversational route.
+
+`clawd doctor --check-config` runs no Codex probes. With Coder enabled, full doctor adds bounded local
+compatibility/status checks; selected-profile auth remains explicitly unverified when the CLI cannot
+inspect it. Diagnostics perform no inference, credential refresh, repository or PR creation.
+Coder shutdown cancels and joins native work before dependent teardown; unresolved ownership retains reservations
+for conservative recovery. Disabling Coder removes its tools and native probes but still reconciles
+earlier jobs on restart; full doctor and daemon health keep their reservations and uncertainty visible.
+See [INSTALL.md](../docs/INSTALL.md#coder-prerequisites) and
+[LOCAL_DEV.md](../docs/LOCAL_DEV.md#coder-background-lifecycle-and-recovery).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,7 @@ clawd
 | `ClawTools` | lib | Tool registry + read-only tools (v1); policy gate + approval orchestration arrive in the P-tools phase (Inc 5a). | `ToolRegistry`, `ToolContext`; `WebSearchTool`, `WebFetchTool`, `FileReadTool` (v1); `PolicyGate`, `ApprovalCoordinator` [Inc5a] |
 | `ClawMCP` | lib | MCP **client** (§10.3): the Streamable HTTP transport over the shared HTTP seam, one session per configured server, catalog resolution, metadata redaction, name/schema normalization, and the `Tool` adapter that puts a remote tool on the same seam as a built-in. Depends only on `ClawCore` + the official Swift SDK, so no MCP concept reaches the agent loop or the policy gate. | `MCPStreamableHTTPTransport`, `MCPServerSession`, `MCPCatalogResolver`, `ResolvedMCPCatalog`, `MCPMetadataSanitizer`, `MCPTool`, `MCPToolNamer`, `MCPSchemaNormalizer` |
 | `ClawExec` | lib | macOS 26 arm64 execution implementation: fixed-path swift-subprocess adapter, apple/container argv, disposable scratch, serialized VM lifecycle, probe/reap/canary maintenance. Linux supplies no backend until Inc 6. | `ContainerBackend`, `ExecSandboxSettings` |
-| `ClawCoder` | lib | Native Coder process ownership, Git workspaces, Codex protocol and artifact inspection on macOS and Linux; daemon composition follows in a later increment. Depends on Core, pinned Subprocess and platform System only. | `CoderCommandRunner`, `ManagedCoderProcessGroup`, `CoderProcessIdentity`, `CoderProcessInspector`, `CoderRequestPreparer`, `CoderWorkspace`, `RepositoryInventory`, `CodexBackend` |
+| `ClawCoder` | lib | Native Coder process ownership, Git workspaces, Codex protocol and artifact inspection on macOS and Linux; composed with the Coder service/tools at the daemon root. Depends on Core, pinned Subprocess and platform System only. | `CoderCommandRunner`, `ManagedCoderProcessGroup`, `CoderProcessIdentity`, `CoderProcessInspector`, `CoderRequestPreparer`, `CoderWorkspace`, `RepositoryInventory`, `CodexBackend` |
 | `ClawAppleSpeech` | lib | macOS 26 on-device speech-to-text behind the `ClawCore` `VoiceTranscribing` seam (`SpeechAnalyzer`/`SpeechTranscriber`, idempotent model-asset provisioning). Compiles to an empty module on Linux (`#if canImport(Speech)`); the factory returns nil there, fail-closed to the canned reply. | `AppleSpeechTranscriber`, `SystemVoiceTranscriber` |
 | `ClawAgent` | lib | Agent runtime: context assembly, the run loop, budgets, cancellation, the per-session lane. | `AgentRuntime`, `ContextBuilder`, `RunBudget`, `SessionActor` |
 | `ClawGateway` | lib | Wiring: `ServiceGroup`, Services, routing, access control, session resolution, outbox dispatch, shutdown. | `Gateway`, `TelegramPollerService`, `SchedulerService` [Inc4], `Router`, `AccessControl`, `RateLimiter`, `OutboxDispatcher` |
@@ -106,13 +106,9 @@ Each unit answers: *what does it do, how is it used, what does it depend on.* `C
 in `ClawCore`. `ToolExecutionContext` carries trusted run/session/chat/requester/origin/mode and
 approval identity; those fields never come from model-authored arguments. `ClawCoder` owns
 native process supervision, workspace preparation, Codex execution and inspection;
-`ClawGateway` will own admission, persistence through Core store seams, background lifetime and
+`ClawGateway` owns admission, persistence through Core store seams, background lifetime and
 reporting, composed only at `clawd`.
-The native foundation implements Core contracts, the real job store, process ownership, Git
-workspaces and the Codex backend. Opening the database now applies migration `v11`, and ordinary
-outbound writes use the shared `OutboxInsertion` helper. Runtime composition, tool registration
-and AppConfig integration remain pending; no Coder child is launched by the daemon. This stage
-registers no Coder tools. Once composed, the sole names are
+Enabled compatible Coder contributes tools at the daemon root; the sole names are
 `CoderToolNames.submit` (`coder_submit`), `.status` (`coder_status`), and `.cancel` (`coder_cancel`).
 No provider registry, second backend, ACP session manager or generic process module is introduced.
 
@@ -149,6 +145,7 @@ form `ARCHITECTURE.md §N` is used, sparingly.
 | §12 Security & trust | `SecretRedactor`, `SSRFGuard`, `FakeIPDetector`, `ExfilArgGuard`, `CanonicalURL` (ClawTools); `ToolOutputCap`, `SSEFraming`, `ContextTier` provenance labels, `LabeledContext`, and the `ResolvedAddress`/`CIDR` address vocabulary (ClawCore) |
 | §12.1 Group mode | `ChatMode`, `ChatKind`, `TranscriptAuthor`, `ChatMembershipStatus`, `RawChatMemberUpdate`, `SessionKey.telegramTopic`, `SessionMessageStore.claimAndPersistObserved` (ClawCore); `AccessControl`, `AddressingResolver`, `MessageRouter.noteObservedEvent`, `OutboxDispatcher` flood-control holds (ClawGateway); `ToolPolicyGate.groupAskTierVerdict` (ClawTools); `RetrieverGRDB` session restriction (ClawData) |
 | §13 Execution / sandbox | `ExecutionBackend`, `SandboxMaintenance`, execution value types, `PreparedToolAction` (ClawCore); `ExecuteCodeTool`, `ExfilArgGuard`, `ToolPolicyGate` dangerous arm (ClawTools); `ContainerBackend`, `ExecSandboxSettings`, `SwiftSubprocessContainerCommandRunner` (ClawExec); `SandboxBootstrapper`, `SandboxLifecycleService`, `SandboxHealthRows`, `ApprovedActionExecutor` fill (ClawGateway); `DaemonBuilder.prepareSandbox` (clawd) |
+| §13.2 Native Coder | `CoderExecutionPolicy`, `CoderServing`, `CoderJobStore` (ClawCore); `CodexBackend`, `CodexAuthenticationStatus`, `CoderRequestPreparer`, `CoderProcessInspector` (ClawCoder); `CoderService`, `CoderCompletionReport` (ClawGateway); `CoderSubmitTool`, `CoderStatusTool`, `CoderCancelTool` (ClawTools); `DaemonBuilder.prepareCoder`, `CoderComposition`, `CoderBackendSetup`, `CoderHealthRows` (clawd) |
 | §15 Config & secrets | `AppConfig`, `MCPConfigSource`, `MCPServerConfig`, `QuietHours`, `StateRootResolver`, `SecretStore` + `LLMCredentialStore` seams (ClawCore); `MCPConfigLoader` (ClawWorkspace); `EncryptedFileSecretStore`, `EnvSecretStore`, `SecretStoreResolver`, `EncryptedLLMCredentialStore`, `EncryptedMCPCredentialStore`, `SecretStatePaths`, `SecureFilePublisher`, `RuntimeSecretPreparer` (ClawSecrets); `AuthBootstrap` (ClawAuth) |
 | §16 Observability | `DoctorReport`, `DoctorReporting`, `HealthValue`, `HealthRowsBuilder`, `SkillDiagnostics`, `SchedulerHealth`, `ApprovalsHealthRows` (ClawGateway); `ApprovalsHealth`, `RunsHealth`, `AuditLog` (ClawCore); `AuditLogGRDB` (ClawData); `LLMAuthDoctor` (ClawSecrets); `DoctorHealth`, `MCPDoctorRows`, `MCPProbe` (clawd) |
 | §19 Error taxonomy | `ClawCore/Errors/` (`ClawExitCode`, `ConfigError`, `TelegramError`, `StoreError`, `ProviderError`, `ProviderFailure`, `CredentialStoreError` — aliased `LLMCredentialStoreError`); `ClawDatabase.classifyError` → `throws(StoreError)` seam (ClawData); `AuthCommandResultMapper` (ClawAuth) |
@@ -178,6 +175,34 @@ form `ARCHITECTURE.md §N` is used, sparingly.
   reservation released. Post-reap stopped/unresolved persistence stays shielded as mandatory cleanup:
   failure retains unresolved ownership, and a callback that does not return delays completion rather
   than authorizing an unverified release.
+- **Coder lifecycle:** `ClawGateway.CoderService` owns background Swift task handles and implements
+  `Service`. Its idempotent `start()` reconciles durable jobs before approval replay or admission;
+  `run()` uses that same startup and awaits shutdown or a fatal service failure. Shutdown closes
+  admission synchronously, persists stopping intent, cancels every owned task and joins them before
+  dependent outbox/database shutdown. A process-cleanup failure is a typed service failure, never a
+  clean stop. An ordinary failed job remains a job result. Unresolved old receipts are visible recovery
+  health that blocks new Coder work, without tearing down the ordinary assistant.
+- **Coder root ownership:** composition injects one service into the tools, boot reconciliation,
+  ServiceGroup and `DaemonRuntimeBundle`. Reconcile Coder after orphan-run reconciliation and before
+  approval replay. Replay may launch a Coder job before ServiceGroup starts; `RunCommand` therefore
+  always joins the bundle's Coder service through `RuntimeShutdownCoordinator` after the graph
+  returns and checks its fatal cleanup outcome. The root's registered lifecycle services run even
+  when their parent is cancelled; cancellation during boot does not skip their shutdown hooks.
+  Register Coder after dependent outbox/maintenance services and before lane admission,
+  so reverse graceful shutdown drains lanes, then Coder, then its dependencies. A Coder persistence
+  or unresolved owned-process cleanup failure takes `FatalProcessTerminator` before dependent client
+  teardown. It is never treated as a healthy stop. Missing/incompatible CLI, missing authentication
+  or disabled Coder closes submission while durable reservations still reconcile; ordinary chat
+  stays up.
+  `CoderService` accepts an optional backend only to represent this recovery-only state. Preparation
+  and submission require enabled configuration and a backend before admission; startup recovery
+  requires neither. Disabled composition reads the reservation inventory without resolving or probing
+  Codex: a successful empty read needs no service; reservations or read uncertainty retain the same
+  recovery-only service so storage failure cannot become an empty healthy state.
+  Admitted work captures the concrete backend.
+  A root-local unavailable policy marker is never advertised as resolved execution authority or used
+  to prepare an approval. Enabled status/cancel retain owner scope and access to persisted jobs;
+  disabled Coder contributes no tools.
 - **Logging:** `swift-log` to stdout/stderr; journald/newsyslog handle rotation.
 
 ## 5. Concurrency model
@@ -214,6 +239,27 @@ The lane mechanism is explicit:
 - **Streaming channels are bounded and suspending — never unbounded, never lossy.** No `AsyncThrowingStream` may carry HTTP body bytes or LLM events: a full channel suspends its producer rather than dropping a chunk or an event, and cancellation wakes a producer blocked on a full buffer so a join cannot deadlock (§8.4).
 - **Deadline races never discard a loser.** Interactive, buffered, and schedule deadline races use nonthrowing child results plus a lock-backed winner state; no throwing task group drops a loser on the floor. A raced-but-successful response still supplies authoritative usage even when the deadline stays the owner-visible outcome, and draft/typing/timer children are drained before the coordinator returns. This prevents both lost accounting and work that outlives its turn.
 
+### 5.2.1 Coder task ownership
+
+Coder owns `[UUID: Task<Void, Never>]` independently of dialogue lanes. Submission checks an
+interactive approved owner-DM context, the current execution-policy ID and freshly prepared canonical
+identity. After the preparer suspension it checks admission again; atomic store admission and new
+handle registration have no intervening suspension. Only `admitted` launches a backend. `existing`
+returns the durable job even at capacity or behind a recovery block, with no duplicate native work,
+provided the current context and prepared identity still validate.
+The store owns N-slot and in-place checkout/common-Git exclusion; independent copies do not lock
+their source. The backend rechecks local identity after admission under its tracked invocation deadline.
+
+Status and cancellation require the persisted requester ID in a current interactive owner DM.
+Cancellation persists `stopping` before signalling the owned task and returns promptly. A will-launch
+callback arriving after that intent is normal cancellation: the service refuses it with
+`CancellationError` before the store write, without marking healthy storage failed. Real process-event
+read/write errors still make service health fail. The slot stays
+reserved until backend cleanup has joined and the terminal report transaction commits. Cancellation
+that wins a terminal-state compare-and-swap replaces non-stop results and rerenders the notice, while
+an already-selected backend `cancelled` or `timedOut` outcome remains selected. Interrupted recovery
+is always reported as interruption. Persistence retries never rerun the backend.
+
 ### 5.3 RunBudget defaults
 
 Concrete, config-overridable defaults for a single-owner daily-driver. These are the pinned numbers the PRD (FR-R3, NFR-Cost) refers to.
@@ -234,9 +280,7 @@ Concrete, config-overridable defaults for a single-owner daily-driver. These are
 
 All overridable in config. The **hard offline failsafe is `dayTokenCeiling`** (a per-day token breaker checked before each call, so it trips even when no price is known); the USD caps ($0.50/run, $10/day) are the user-facing limits, enforced best-effort when a price is known. A **run in Inc 1 is exactly one LLM round-trip** — `maxTurns`/`maxToolCalls` exist but stay inert until tools land in Inc 3. `perToolOutputCap` is 25 000 tokens, enforced as its grapheme-domain equivalent 80 000 graphemes via the pinned estimator inverse (Inc 3b). Context assembly reserves the estimated size of the complete advertised tool array before filling message sections, so the final request can fit under `maxInputTokens`; provider-call preflight still estimates that complete request independently.
 
-**Coder has a separate child budget.** The native backend accepts an independent timeout;
-service admission and the operator settings below are pending runtime-integration contracts.
-The ordinary dialogue's token, dollar and 180-second
+**Coder has a separate child budget.** The ordinary dialogue's token, dollar and 180-second
 limits do not meter a native Codex child. `CLAW_CODER_MAX_CONCURRENT_JOBS` bounds admitted work
 (default 1, any positive N); capacity returns an explicit busy response, with no unbounded queue.
 `CLAW_CODER_JOB_TIMEOUT_SECONDS` supplies an independent supervisor deadline (default 1800,
@@ -357,6 +401,16 @@ model proposes tool_call
          FORCE the approval path in code regardless of the tool's own tier.
   └─ AuditLog.append(actor, tool, args-redacted, decision, result-size, ts, run_id, session_id)
 ```
+
+Every actual tool call carries `ToolExecutionContext` through `ToolDispatchContext`: run/session/chat,
+requester, origin, mode, tool-call ID and optional approval ID. `Tool.execute` has a contextual
+protocol requirement with a default forwarding implementation for existing tools. Coder refuses
+the context-free overload. In v1, only interactive direct Telegram turns derive requester identity
+from trusted chat ID under the private-chat contract; proactive and group turns carry no requester.
+The approved executor restores context from the persisted `Approval` and `RunStore.runOrigin`,
+including the original tool-call and approval IDs. Missing or unreadable origin fails closed for
+owner-required tools. No model argument supplies these fields, and no additional sender persistence
+or group admission is implied by the private-chat shortcut.
 
 ### 6.3 Scheduler flow (Inc 4)
 
@@ -536,6 +590,21 @@ or stopped; terminal state alone is insufficient. `releaseResolvedReservation(id
 requires a terminal job, releases only its slot, and never adds another notice. All store operations
 use the mapped read/write seams, including SQLite-full classification as `StoreError.diskFull`.
 
+Startup reconciles every reserved unfinished row to `interrupted` with one atomic completion notice,
+including when Coder has since been disabled, never rerunning it. None/stopped ownership permits
+release. For other ownership the service asks the Core read-only inspector; stopped proof records a
+matching stopped event before release, including an old-boot receipt. Live ownership, PID reuse,
+unreadable state, or pending launch without PID/birth metadata becomes unresolved, retains the
+reservation, and blocks new admission across repeated daemon
+restarts. Terminal reserved rows are inspected again and released only after stopped proof, without
+another notice. An absent pending receipt for active ownership is invalid persisted state and fails
+startup without freeing the slot. Operator recovery is documented in `LOCAL_DEV.md`.
+
+The service notifies the existing outbox dispatcher only after a committed completion. Terminal or
+process-event storage failures latch typed unhealthy service state and leave reservations intact;
+backend error handling cannot turn a failed receipt write into a successful terminal commit. No
+completion-delivery claim is made when persistence failed.
+
 ### 7.6 sqlite-vec — deferral honesty
 
 `sqlite-vec` is **not** "add later via a protocol and a migration." It **requires a custom SQLite amalgamation** (`SQLITE_ENABLE_FTS5` **+** sqlite-vec, statically linked, **initialized before the connection opens**) and a **separate Linux-CI re-validation** (GRDB does not test it upstream; the vec binding ships its own connection). A stock `DatabaseMigrator` **cannot** create a `vec0` table. It stays strictly behind a protocol and deferred; risk = High (§18).
@@ -597,7 +666,7 @@ Two implementations. The **static source** serves the current route: a fixed bea
 > **Private-route warning (fixed, normative).** This route is **behavior observed in two reference implementations** (OpenClaw and Hermes, at pinned revisions), **not a public, supported, third-party ChatGPT inference API.** No vendor contract stands behind it: the endpoints, headers, device-authorization flow, and event shapes can change or be withdrawn **without notice**, and the vendor's terms govern what a subscription may be used for. It ships as an owner-selected convenience, confined behind the adapter seams, and **must never be documented or described as stable or supported**. The configured OpenAI-compatible route remains the supported default and is unaffected by anything in this section.
 
 - **The inference endpoint, OAuth issuer, client ID, redirect URI, originator, and User-Agent are compile-time HTTPS constants, not configuration.** Changing one is a code change plus a source-study update. Two properties follow structurally: **a user-supplied base URL can never receive a subscription bearer token**, and bearer headers are constructed only *after* the fixed URL is selected. Redirects are disabled, same-host included.
-- **No-import boundary (structural, not a promise).** swift-claw never reads, imports, modifies, or locks another tool's credentials — notably Codex CLI's `~/.codex/auth.json`. Every production credential path derives from one state-root-relative path abstraction owned by `ClawSecrets`; neither the store nor its callers accept an arbitrary import path, and the source tree contains **no Codex-home lookup and no `.codex/auth.json` literal**, enforced by a source-level guard. The boundary is thus a property of the code's shape rather than of CLI control flow.
+- **No-import boundary (structural, not a promise).** swift-claw never reads, imports, modifies, or locks another tool's credentials — notably Codex CLI's `~/.codex/auth.json`. Every ordinary LLM credential-store path derives from one state-root-relative path abstraction owned by `ClawSecrets`; neither that store nor its callers accept an arbitrary import path. The source-level guard covers that credential-store boundary: it contains no Codex-home lookup or `.codex/auth.json` literal. Native Coder separately resolves the operator-selected Codex configuration location and delegates bounded local authentication status to the Codex CLI (§16); it never reads, imports, modifies, or locks that tool's auth cache. Location metadata and native status delegation do not grant swift-claw access to another tool's stored credentials.
 - **Device authorization is bounded in every dimension:** the fixed Codex device flow; a 15-minute **monotonic** login deadline; a server-supplied poll interval clamped to at least one second and to the remaining deadline; each HTTP timeout capped to that remaining deadline so one stalled request cannot overrun the advertised window; explicit pending-versus-failed status classification; and a token expiry resolved from a positive `expires_in`, then the access token's `exp` claim — **a token with no usable future expiry is malformed, not something to store into a refresh loop**. Remote strings are length-bounded, control-character-stripped, and validated before use or display. Cancellation exits without saving.
 - **Request translation:** system messages concatenate in order into `instructions`; remaining messages map to Responses input items; tool definitions flatten to `function` tools. Every call sends `store: false` and `stream: true` — **both `complete` and `stream` use SSE**, `complete` simply consumes it without publishing deltas — includes only `reasoning.encrypted_content` (opaque replay material; reasoning summaries and commentary are never owner-visible output), and carries a content-derived `prompt_cache_key` that contains **no raw prompt text** and is stable across sessions for the same static prefix.
 - **`max_output_tokens` is omitted on this route** (the studied Codex backend does not honor it), so **local limits are the only output bound.** The configured output cap degrades to a *local reservation* for preflight and accounting. Per-run token, turn, tool-call, byte, event, item, and wall-clock ceilings all stay enforced locally, which bounds a call — but a **token budget can overshoot by at most one in-flight provider call**, and hidden reasoning means swift-claw **cannot claim a strict provider-output-token cap here.** State that limitation; do not claim the cap.
@@ -732,6 +801,31 @@ v1 ships **read-only tools only**: `web_search`, `web_fetch`, workspace **file R
 
 (Inc 5a) **Registry** of < 20 narrow, typed tools (not a generic shell), each with input/output schemas, declared `RiskLevel`, timeout, sandbox requirement, audit behavior. The **`PolicyGate`** evaluates every proposed call before dispatch, independent of the model, and re-validates the approved action against the originally-approved canonical action + `policy_version` at execution. File tools are workspace-scoped: every path is resolved to its **canonical real path** (`realpath`, after `..` and symlink resolution) and **asserted to lie within the workspace root** — a tested invariant covering both the link and its final target — with size-capped output and secret redaction. Tool annotations are non-authoritative UX hints; the code gate is authoritative. (Batch approval + a time-boxed auto-approve toggle are deferred to the P-tools phase.)
 
+**Native Coder tools (§13.2).** `coder_submit` is dangerous; `coder_status` and `coder_cancel` are
+safe/no-egress. All three declare `requiresInteractiveOwner = true`. The gate checks that declaration
+before risk and egress fast paths, refusing absent trusted context, absent requester identity,
+group mode and proactive origin. Dangerous-tool enablement is an explicit root-composed set of
+registered tool names, so enabling Coder does not enable `execute_code`. A `PreparedToolAction`
+carries a required tool-owned `approvalReason` (`codeExec` versus `coderSubmit`).
+
+`coder_submit` accepts only `source`, `task`, `workspace`, `start_ref`, `deliverable`, `base_branch`,
+`instructions` and `publish_existing_changes`. Source is exactly one Codable `CoderSource` case
+(for example `{"local":{"path":"/absolute/repository"}}`); unknown root and nested fields and
+incorrect types are refused. Source/workspace/deliverable are required; optional text may be null,
+and omitted publication inclusion defaults to false. Preparation records canonical JSON of the
+entire `CoderPreparedRequest`, after service preparation. All delegated text from that prepared
+request passes the existing argument guard: raw source, task, instructions, selected ref, in-place
+destination, and applicable PR base and publication repository. Scan the emitted values, not canonical
+JSON or non-emitted policy/lock metadata. This includes the disk-time private-text scan;
+`canExfiltrate` is always true because Codex inference leaves the machine even for local changes.
+The approval displays source, workspace, initial ref, publication/base/inclusion scope and
+native-installation trust. Approved execution decodes the recorded prepared shape and requires its
+approval ID and current execution policy.
+Status/cancel accept only a UUID `job_id`, query only the requester's jobs through `CoderServing`,
+and redact/cap returned data with `ToolOutputCap`; worker-derived results carry untrusted provenance
+and receive the existing live/history fences. Cancel requests durable stopping and supervised
+cleanup; `/stop` and `/new` keep their conversational meanings.
+
 ### 10.3 MCP client
 
 swift-claw is an MCP **client** and only a client: it consumes tools from owner-configured servers over **Streamable HTTP** and exposes none of its own. The transport is ours, over the shared `HTTPExecuting`/`HTTPStreaming` seam (§3) rather than the SDK's URLSession one, because URLSession cannot stream SSE on Linux (§18) — the same reason the LLM adapters own their framing.
@@ -759,7 +853,13 @@ A **state machine** persisted in `approvals` so it survives restart. See §7.1 c
 - **Bound to the exact action** (tool + fully-resolved target + canonical args); executes the **recorded** args (never a fresh model turn); a past approval is **never** cached into a future auto-run.
 - **Durable checkpoint = persist-the-partial-exchange**, not a serialized wire checkpoint: the assistant proposal + every completed observation + a **placeholder observation row updated in place** (the v5 `messages` columns) pin rowid adjacency at suspend; the approved action runs the recorded args; the run then continues as an ordinary assembly round-trip whose context bound is the filled observation's message id, with **carried-over turn/tool-call/token/USD counters** and a **fresh per-segment wall-clock** (suspension time never counts against any budget).
 - **Callback auth** (§6.5): same default-deny check; `callback.from.id == approval.ownerUserId`; ≥128-bit single-use random nonce; re-validate args-hash + `policy_version`. Args-hash + `policy_version` validation happens **inside the callback resolution CAS** as the §19.1 approve guard (a mismatch commits `PENDING → REJECTED`, `decision = stale_policy`, and never reaches `APPROVED`); the at-execution recheck survives only as the boot crash-window belt (§6.5), whose granted-then-denied audit pair is documented — a mismatch there fails the **run** while the row stays `APPROVED`.
-- **`policy_version`** (Inc 5a) is the first 16 hex chars of a **length-prefixed SHA-256** over the policy-relevant inputs at run start: **system-tier prompt materials** (the system/security prompt text + the loaded contents of `SOUL.md`/`AGENTS.md`/`TOOLS.md`, a missing/unreadable file hashing as empty), the **tool registry surface** (sorted tool names, each with its canonical parameter JSON, declared `RiskLevel`, metadata provenance, optional credential-free invocation identity, declared **fence label** — a trust declaration on par with risk, since it selects the prompt carve-out the tool's output renders under, so changing it voids an outstanding approval as `stale_policy` — and `ToolEgressClass`), and the **pinned egress + policy config** (the resolved **LLM egress identity** — the canonical configured endpoint on the current route, or the provider ID plus fixed endpoint on a managed one, so the sink is fingerprinted even when no base URL is configured (§8.1); **that identity is the configured primary's, resolved once at composition, so a runtime failover to the fallback route does not move it and the sink an approval binds to is not guaranteed to be the sink that serves the resumed run** — search-endpoint presence, canonical workspace root). **Secret values are never hashed, and an egress identity never contains a credential.** It is computed in two parts — a static sub-hash over the tool/config inputs at the composition root, folded into `ContextBuilder`'s prompt-material hash — persisted to `runs.policy_version` at pick-up and copied onto every approval; a **strict-inequality** mismatch at resolution denies with `stale_policy`.
+- **`policy_version`** (Inc 5a) is the first 16 hex chars of a **length-prefixed SHA-256** over the policy-relevant inputs at run start: **system-tier prompt materials** (the system/security prompt text + the loaded contents of `SOUL.md`/`AGENTS.md`/`TOOLS.md`, a missing/unreadable file hashing as empty), the **tool registry surface** (sorted tool names, each with its canonical parameter JSON, declared `RiskLevel`, metadata provenance, optional credential-free invocation identity, `requiresInteractiveOwner`, declared **fence label** — a trust declaration on par with risk, since it selects the prompt carve-out the tool's output renders under, so changing it voids an outstanding approval as `stale_policy` — and `ToolEgressClass`), and the **pinned egress + policy config** (the resolved **LLM egress identity** — the canonical configured endpoint on the current route, or the provider ID plus fixed endpoint on a managed one, so the sink is fingerprinted even when no base URL is configured (§8.1); **that identity is the configured primary's, resolved once at composition, so a runtime failover to the fallback route does not move it and the sink an approval binds to is not guaranteed to be the sink that serves the resumed run** — search-endpoint presence, canonical workspace root). **Secret values are never hashed, and an egress identity never contains a credential.** It is computed in two parts — a static sub-hash over the tool/config inputs at the composition root, folded into `ContextBuilder`'s prompt-material hash — persisted to `runs.policy_version` at pick-up and copied onto every approval; a **strict-inequality** mismatch at resolution denies with `stale_policy`.
+- **Coder execution identity** is `CoderExecutionPolicy.id`: deterministic length-prefixed hashing
+  of the resolved executable, explicitly present/absent profile and effective config home, fixed
+  approval policy, and sorted non-secret credential-source key/value identifiers. Composition builds
+  it once from the native backend's resolved facts and shares the same ID with preparer, service and
+  `coder_submit.invocationIdentity`. Secret values never enter the hash. This binds selected authority
+  inputs, not a frozen snapshot of inherited Codex integrations.
 - **Expiry → DENY** (terminal). Expiry is a **liveness / bounded-state control, not an attacker defense** — the single owner is the only approver, so the timer blocks no third party; its job is to guarantee a parked approval **self-resolves** instead of pinning a run (and its session lane) forever, with DENY as the fail-closed default direction. Default window **1h**, configurable via `approval_expiry`; enforced by a periodic expiry ticker and the boot reconciliation sweep (§19.1).
 - **Escaping a pending approval:** a plain message **queues** behind it (strict FIFO — it never supersedes, §5.1); to abandon the parked action before expiry the owner uses `/stop` (cancel) or `/new` (reset + detaint), both of which resolve `AWAITING_APPROVAL` (§19.1). Otherwise silence rides out to `EXPIRED → DENY`.
 - **Queue-behind survives restart:** boot reconciliation **re-parks a waiter on the lane** of every unexpired `AWAITING_APPROVAL` run, preserving the FIFO queue-behind contract across restart and giving **exactly one execution locus** — the callback handler, expiry ticker, and `/stop`//`new` command paths only CAS the row and signal the coordinator; the waiter task performs the resume/deny (observation update, run transition, owner notice, button disarm).
@@ -792,7 +892,7 @@ A **state machine** persisted in `approvals` so it survives restart. See §7.1 c
 - **Intake observes before it decides to answer.** `AddressingResolver` decides whether a message is talking to the bot — an `@handle` mention, a slash command this build recognizes, or a reply to something the bot itself said — **before** the content switch, so an unaddressed photo or voice note is never downloaded or transcribed. An addressed message takes the ordinary `claimAndPersistInbound` path. Unaddressed text takes `claimAndPersistObserved`: the same claim, the same session upsert, the same message insert, **no run**. The router skips unaddressed media without downloading, transcribing, or storing a transcript row. The addressed and observed text paths share the claim key, so Telegram stores one text update at most once whichever path it takes. The bot follows the topic's text and speaks only when called. Group mode makes the bot's own `@handle` load-bearing, so a daemon configured with group chats **refuses to boot** without a resolved bot username rather than sitting silently in every room.
 - **A stored group line names its speaker.** `TranscriptAuthor` renders `<display name>: <text>` at persist time, not at assembly time, so a recall hit pulled back out of history still says who said it and the name is in the FTS index. The separator and every line break are folded out of a display name first, so one line can never present itself as two speakers. A DM line is stored exactly as typed.
 - **Recall never leaves the topic.** `Retriever.searchRelevantMessages` takes a `restrictToSessionId`; a group topic passes its own session id, a DM passes `nil` and keeps its cross-session reach. Without that restriction one room's words would surface in another room's prompt, because a group line is stored trusted (below) and trusted rows are exactly what recall returns.
-- **There are no approvals in a shared room, so the gate refuses instead of asking.** Nobody in a group holds the owner's approval authority and no keyboard there could be trusted to resolve one, so `ToolPolicyGate` changes five decisions when `context.mode == .group`: the ask tier **allows on the gate-resolved target** rather than parking; a tool that only ever does its real work on the approval waiter (`memory_write`) is **refused** with a reason; a write whose canonical target is a **privileged prompt file** (`SOUL.md`/`AGENTS.md`/`TOOLS.md`/`USER.md`/`MEMORY.md`/`HEARTBEAT.md`, any `SKILL.md`) is **refused**, because in a DM the owner's ⚠ banner was the thing catching it and here there is no banner; the `.dangerous` arm **executes the prepared action** instead of parking it; and a held trifecta **allows**. Everything that is not an approval round-trip is untouched: `execEnabled`, `WorkspacePathContainment`, the SSRF classifier, the unconditional and conditional exfiltration argument scans, secret redaction, the tool-output cap, and the sandbox all run exactly as they do in a DM. The sandbox, not a prompt, is the containment for topic `execute_code` calls. Coder tools are not yet registered. Their runtime integration must remain owner-DM-only and refuse group and proactive submission; they must never inherit the group dangerous-tool auto-run exception.
+- **There are no approvals in a shared room, so the gate refuses instead of asking.** Nobody in a group holds the owner's approval authority and no keyboard there could be trusted to resolve one, so `ToolPolicyGate` changes five decisions when `context.mode == .group`: the ask tier **allows on the gate-resolved target** rather than parking; a tool that only ever does its real work on the approval waiter (`memory_write`) is **refused** with a reason; a write whose canonical target is a **privileged prompt file** (`SOUL.md`/`AGENTS.md`/`TOOLS.md`/`USER.md`/`MEMORY.md`/`HEARTBEAT.md`, any `SKILL.md`) is **refused**, because in a DM the owner's ⚠ banner was the thing catching it and here there is no banner; the `.dangerous` arm **executes the prepared action** instead of parking it; and a held trifecta **allows**. Everything that is not an approval round-trip is untouched: `enabledDangerousTools`, `WorkspacePathContainment`, the SSRF classifier, the unconditional and conditional exfiltration argument scans, secret redaction, the tool-output cap, and the sandbox all run exactly as they do in a DM. The sandbox, not a prompt, is the containment for topic `execute_code` calls. All three Coder tools require an interactive owner DM before these tier decisions; group status/cancel and group/proactive submission are refused. Coder never inherits the group dangerous-tool auto-run exception.
 - **The owner-scoped command families are refused.** `Command.isDirectOnly` covers `/remember`, `/memory`, `/schedule`, `/pause`, `/resume`, `/run`, `/cancel`; a group invocation gets one refusal naming both families, so an attendee learns the rule rather than just this rejection. Two reasons, both structural: durable memory and the schedule table are single-owner state delivered to a chat id the arming message chose, and both park a confirmation that the **next plain message** resolves — in a shared room that message belongs to whoever typed fastest, so one attendee could commit a draft another one wrote. `/new` and `/stop` act on the topic's own session and stay available; the read-only reports name nothing private and stay available.
 - **A reply goes back into the topic that asked, as a reply.** Migration `v10` adds `runs.trigger_telegram_message_id` (Telegram's own message id, distinct from the `messages` row id `trigger_message_id` already carries) and nullable `outbound_deliveries.message_thread_id` / `reply_to_message_id`. The outbox target is stamped **at enqueue from the run's own session key**, so every path that enqueues — a turn reply, a command reply, a scheduled fire, a boot crash notice — lands in the right topic without a second lookup. The typing indicator carries the topic id. Telegram accepts streaming drafts only in private chats, so a group turn keeps reissuing the topic-scoped typing action until the final reply arrives.
 - **One throttled chat no longer stalls every other one.** The outbox drain is strictly ordered per chat and stops on a send failure, which in a DM meant one stalled conversation. With several topics live, a Telegram 429 is the one failure that says how long to wait, so the dispatcher puts a **per-chat hold** on the retry-after window, skips that chat's rows, and carries on with the others; order inside a run survives because a run answers exactly one chat. Every other failure keeps the existing stall-and-wait behavior.
@@ -870,17 +970,14 @@ The accepted reasoning is the deployment, not a mitigation: a **supervised, one-
 
 ### 13.2 Native Coder delegation
 
-The native foundation implements workspace selection, process lifetime, durable job storage and
-Codex execution/inspection. Daemon admission, background service ownership and reporting remain
-pending runtime integration. The complete Coder contract below assigns those responsibilities to
-Coder and keeps its native implementation behind Core seams.
+Coder orchestrates admission, workspace selection, process lifetime, persistence, and reporting.
 Codex investigates, edits, runs checks, and performs the requested Git/GitHub workflow. Coder uses
 the owner's trusted native Codex installation, existing configuration and integrations; no mandatory
 container or toolchain image is introduced. Codex automatic approval review does not provide the
 hardware-VM guarantees of `execute_code`, universal cwd confinement, or containment of every
 MCP/hook/plugin path. Child permissions and credentials determine effective authority.
 
-- **Opt-in and approved task scope (pending runtime integration):** owner DM only, through the existing durable task-approval
+- **Opt-in and approved task scope:** owner DM only, through the existing durable task-approval
   path, with `ApprovalReason.coderSubmit`. Approvals show the native delegation, source/workspace
   and publication scope. Group and proactive submissions are refused. Bind Coder-controlled
   execution policy and credential selectors in `executionPolicyID` and the approval fingerprint;
@@ -949,6 +1046,11 @@ MCP/hook/plugin path. Child permissions and credentials determine effective auth
   crosses Core. Persist cancellation intent, cancel the service-owned Swift task, then join bounded
   process-group teardown. Detached sessions/groups are an accepted v1 termination limitation.
   Daemon interruption never automatically reruns work that may already have published changes.
+  `CoderCompletionReport` renders owner-addressed, redacted chunks using `ReplySplitter` and
+  `ContentHash`, retaining publication confirmed/absent/unknown and observed/worker-reported evidence
+  distinctions. The durable result and report commit together against the rendered state. A cleanup
+  failure can describe protocol-file removal with processes already stopped: persisted ownership,
+  rather than the failure-stage label, determines reservation release and fatal process-cleanup health.
 - **Native launch protocol:** establish the invocation deadline before `willLaunch`, so suspended
   launch persistence is also bounded. Job commands persist `willLaunch` with launch UUID and host
   boot ID, check cancellation immediately before spawn, then acquire PID/PGID/birth metadata and await
@@ -1048,11 +1150,10 @@ MCP/hook/plugin path. Child permissions and credentials determine effective auth
 
 ## 15. Configuration & secrets
 
-**Coder configuration contract (pending runtime integration).** Standalone
-`CoderConfig.load(environment:)` parses the settings below for native callers and tests.
-`AppConfig` does not load or expose Coder configuration at this stage; these keys are not an
-active daemon configuration surface. Operator enablement and setup documentation arrive with
-the runtime that registers the tools and launches children.
+**Coder operator settings** are parsed by `CoderConfig.load(environment:)` and carried by
+`AppConfig.coder`. The root resolves its backend/environment once when enabled and registers only
+submission that its readiness facts permit. Disabled Coder has no tools and launches no probes;
+previous durable reservations still undergo startup recovery (§7.5).
 
 | Setting | Default | Contract |
 |---|---|---|
@@ -1063,7 +1164,7 @@ the runtime that registers the tools and launches children.
 | `CLAW_CODER_PROFILE` | unset | Optional existing Codex profile name |
 | `CLAW_CODER_CONFIG_HOME` | unset | Optional absolute directory mapped to child `CODEX_HOME` |
 
-The standalone parser rejects explicit invalid or blank settings, even while disabled. It never resolves the
+Explicit invalid or blank settings fail visibly, even while disabled. Parsing never resolves the
 executable, inspects credentials or accesses the selected config home. Coder has no separate model
 selector, arbitrary CLI flags or new credential store: Codex owns its login state and configuration;
 `clawd auth` continues to manage only the ordinary LLM route. Do not import Codex auth into
@@ -1072,7 +1173,18 @@ OS/toolchain settings and selected coding credentials, excluding Telegram and un
 secrets. Codex reads its configuration per child; swift-claw-owned settings apply after restart.
 The separate concurrency/deadline budget and unavailable-accounting rules are in §5.3.
 
-- **Environment variables are the active configuration surface; `config.toml` remains future work.** The typed `AppConfig` is loaded from the environment/`.env` today; the structured-file behavior described below is the intended shape once that file lands, not a shipped surface. **A provider-qualified `CLAW_LLM_MODEL` value (`openai-chatgpt/<model>`) is the only configuration selector the subscription route adds** — there is deliberately **no per-provider environment namespace**. The model value carries the route selector, provider-owned OAuth state lives in the credential store, and fixed protocol details are implementation constants (§8.3), so ad-hoc `CLAW_CHATGPT_*` variables would only duplicate the structure that structured configuration will supply; they are **deferred with `config.toml`**, not merely unimplemented. When it lands, the registry deserializes provider-specific blocks into the same resolved route (§8.1) without changing any downstream seam.
+`CoderExecutionPolicy` is built once from the resolved native executable, profile, effective config
+home, fixed approval policy and non-secret credential-source identifiers. The same ID reaches the
+preparer, service and submit invocation identity. Do not reread the environment to construct a
+second identity. Invalid scalar configuration still fails load. Missing/incompatible Codex is a
+failed Coder health row without submit, not a daemon boot failure. An unprofiled local
+`login status` failure is a submission blocker; CLI presence never establishes runtime auth.
+The CLI does not support `--profile <name> login status`. A selected profile remains explicitly
+unverified in health while compatible operator-approved execution remains available; that job can
+still fail auth at execution. No profile/TOML merging, credential import, refresh or broader-permission
+fallback is performed by composition. Codex owns its selected configuration and native integrations.
+
+- **Environment variables are the active configuration surface; `config.toml` remains future work.** The typed `AppConfig` is loaded from the process environment today (the service wrapper sources `clawd.env`; the binary does not load `.env` automatically); the structured-file behavior described below is the intended shape once that file lands, not a shipped surface. **A provider-qualified `CLAW_LLM_MODEL` value (`openai-chatgpt/<model>`) is the only configuration selector the subscription route adds** — there is deliberately **no per-provider environment namespace**. The model value carries the route selector, provider-owned OAuth state lives in the credential store, and fixed protocol details are implementation constants (§8.3), so ad-hoc `CLAW_CHATGPT_*` variables would only duplicate the structure that structured configuration will supply; they are **deferred with `config.toml`**, not merely unimplemented. When it lands, the registry deserializes provider-specific blocks into the same resolved route (§8.1) without changing any downstream seam.
 - **`CLAW_LLM_FALLBACK_*` is the one deliberate exception to that rule, and stays a single prefix.** `CLAW_LLM_FALLBACK_MODEL`, `CLAW_LLM_FALLBACK_BASE_URL`, `CLAW_LLM_FALLBACK_API_KEY`, and `CLAW_LLM_FALLBACK_MAX_TOKENS_FIELD` describe a **second route** (§8.6), which needs an endpoint and a key of its own rather than a provider's. Reusing the primary's would point the fallback at the endpoint that just failed, and would let a missing primary endpoint pass validation on the strength of one the fallback supplied. The exception buys a route, not a namespace: it adds no per-provider variable, and `CLAW_LLM_PRIMARY_COOLDOWN_SECONDS` (default 900) carries no prefix because it describes the daemon's own backoff. The fallback key is a runtime secret like the primary's: it seals into `secrets.enc` with the rest, and `clawd secrets seal` blanks its plaintext line alongside them. **One list names every sealed variable** (`EnvSecretStore.EnvKey.sealed`), read by both the env-file scrub and the message telling an owner what to remove when the scrub cannot run, so a secret can never reach the envelope while its plaintext line survives unmentioned.
 - **Config:** a typed `AppConfig` (validated at load); env/`.env` for development; an invalid config is **rejected and preserved** — the offending file is moved aside as `config.toml.rejected.<timestamp>` and the last-known-good config is kept, never silently overwritten or partially applied; **`doctor --check-config` validates without starting the daemon**; config-validation and secret-load failures are **distinct non-retryable exit codes**. `max_tokens` MUST be a bounded non-null value — **doctor rejects a config with null `max_tokens`** (§5.3). **`approval_expiry`** (Inc 5a) is a bounded duration with a validated **floor 60s, ceiling 86400s (24h), default 3600s (1h)** — how long a pending approval waits before `EXPIRED → DENY` (§11/§19.1); a violation is a distinct non-retryable `ConfigError` (exit code `configInvalid`).
 - **The MCP server list is a file, not an environment namespace** (§10.3). A per-server catalog needs nesting that `CLAW_*` variables cannot express, so it is a YAML document read from `CLAW_MCP_CONFIG` or, unset, probed at `<state-root>/mcp.yaml`. **An absent probed file turns the feature off; a path the owner set that clawd cannot read or parse is a `configInvalid` boot failure** — an owner who named a file meant it. Unknown keys are rejected rather than ignored, so a typo surfaces as an error instead of a server that never loads and never says why. The file holds **no secrets**: its `headers` map is for non-secret extras. Config validation rejects malformed HTTP field names and values, protocol-owned headers such as `Mcp-Session-Id`, and any entry that shadows the configured auth header. A present `tools.include` list defines the whole allowlist; an empty list exposes no tools, while an absent list lets `exclude` decide.
@@ -1100,6 +1212,22 @@ The separate concurrency/deadline budget and unavailable-accounting rules are in
   full doctor exit nonzero, and remains visible in `/status`. `doctor --check-config` stays limited
   to config and secret checks and does not scan the workspace.
 
+- **Coder diagnostics:** `CoderHealthRows` renders existing `DoctorReport.Check` values. Offline
+  `doctor --check-config` reports configured settings and unverified CLI/auth without launching Codex.
+  When enabled, full doctor and daemon startup may run bounded local version/help/login-status checks.
+  These checks never perform inference, credential refresh, cloning or PR creation. Local login presence
+  is not entitlement or runtime authorization. Selected-profile auth is explicitly unverified and fails
+  its health row, without blocking compatible approved profile execution. The daemon reports its live service failure;
+  an external CLI labels that observation unavailable and reads persisted reservations instead.
+  Full doctor and live daemon health keep persisted reservations, unresolved ownership and historical
+  failure visible even while Coder is disabled. Offline config checks do not open this history.
+  `CoderJobStore.lastFailedJob()` returns the most recently updated terminal `failed`, `timedOut` or
+  `interrupted` record (`updated_ts DESC, id DESC`), including released jobs. Recovery updates may
+  reorder historical records: this is not an immutable failure-time metric. Historical failure is
+  informational, separate from current readiness and live fatal service failure. Mapped store-read
+  failures render `unreadable`, never healthy zero/none. Child-reported usage is kept per job,
+  separately from conversational `/cost`; missing child usage is unavailable accounting.
+
 ### 16.1 Health table (doctor / status)
 
 Every store-backed health query reserves zero, `none`, and empty values for successful reads. A
@@ -1117,6 +1245,7 @@ empty healthy state.
 | runs | `in_flight`, `oldest_run_age`, `last_FAILED` |
 | spend | `today_usd`, `remaining_budget` (per-run + per-day) |
 | sandbox | `available`, `os_ok`, `engine_version`, `version_ok`, `image_digest_ok`, `caps_empty`, `net_isolated`, `caps_match`, `reaper_ok`, `rootfs_ro`, `staging_ro`, `interpreters_ok`, `last_error` |
+| Coder | `enabled`, `available`, `executable`, `version`, selected `config_home`/`profile`, `authentication`, configured `capacity`, persisted `reserved`, `unresolved_ownership`, historical `last_failure`, live-only `service_failure`, and separate child `usage` |
 | MCP | per server: `enabled`, `token` (`set` \| `absent` \| `bound-to-a-different-url`), effective include/exclude, and — where the boot snapshot or a live probe is available — `tool_count` or the recorded `skip_reason`; never a token value |
 | context skills | `accepted`, `rejected`, `fits_cap`; headline row from a fresh scan in full doctor and `/status`; unhealthy when `rejected > 0` or `fits_cap = false` |
 | config/secret | validation result — **printed first** if it errored |
@@ -1225,6 +1354,14 @@ The numbered increments are the v1→Linux **build order**. **P-auth** is an ind
 | **P-auth** | ChatGPT subscription authentication | `clawd auth login` completes a device-code login, stores a refreshable credential under the state root, discovers eligible models, and prints an exact `CLAW_LLM_MODEL=openai-chatgpt/<model>` assignment; that value composes the Responses provider **without requiring or using a base URL or API key**, while **every other model value composes the existing Chat Completions provider with unchanged URL and key behavior**; access-token refresh is race-safe under concurrent turns and **a stale request cannot invalidate a newer token generation**; Responses SSE text, usage, tool calls, and replay state map onto the existing agent contracts and survive durable history; subscription calls record token usage with **zero USD and `included_plan`** as the cost source while token preflight/accounting, tool, turn, and wall-clock limits still apply (subject to the documented one-in-flight-call token overshoot); **authentication failures say to run `clawd auth login`, entitlement and quota failures do not**; tests use deterministic HTTP, clock, sleeper, credential-store, and concurrency doubles, and **no test contacts OpenAI**. |
 
 **P-mcp** landed the MCP **client** (§10.3) on the same terms as P-auth — an independently-acceptable increment that neither gates nor reorders the numbered work: remote tools from owner-configured Streamable HTTP servers appear in the registry beside the built-ins and flow through the unchanged gate, approval FSM, fingerprint, redaction, and audit surfaces. *Done when* a configured server's tools reach the dispatcher named `mcp__<server>__<tool>` after the built-ins; an ask-tier remote call round-trips through approval and re-execution with an `ingestedUntrusted` observation; an unreachable server is skipped with a doctor-visible reason while the daemon and the other servers boot unaffected; `policy_version` is stable across two resolutions of the same catalog and changes when the catalog does; and a stored token is unprintable through the redaction union, including the log backend.
+
+**P-coder** composes the opt-in owner-DM native coding capability (§13.2). *Done when* its three
+registered tools use the durable approval path with VM execution disabled; boot reconciles existing
+reservations before replay; cancellation and shutdown join native work before dependent teardown,
+including work admitted before ServiceGroup starts; unavailable Codex preserves ordinary chat and
+recovery without submit; offline doctor starts no Codex process and persisted health cannot turn a
+read failure into zero. Deterministic acceptance uses real stores/Git and scripted native boundaries;
+actual daemon-user auth, denied-action and cancellation checks are separate supervised release evidence.
 
 *(Later/optional: native Anthropic adapter w/ prompt caching; Hummingbird `/v1/chat/completions` REST; MCP stdio transport, OAuth 2.1 client auth, and live catalog refresh (§10.3); a roster longer than two routes; per-call USD dashboards.)*
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -122,8 +122,8 @@ other context leaves less room; `fits_cap` does not predict that residual budget
 
 clawd shows an approval card for two reasons.
 
-**The tool's own risk tier.** File writes, memory writes, and code execution park the run
-every time, whatever else the session did.
+**The tool's own risk tier.** File writes, memory writes, code execution, and native Coder
+submissions park the run every time, whatever else the session did.
 
 **Exfiltration risk.** clawd holds an arbitrary-destination tool call, including `web_fetch`
 and MCP calls, for your approval once the session has done *both* of these:
@@ -281,6 +281,78 @@ VM per request, behind an exact-action approval. Resource limits
 (`CLAW_EXEC_MEMORY_MIB`, `CLAW_EXEC_CPUS`, `CLAW_EXEC_TIMEOUT`), the digest-pinned
 workload image, and the network opt-in (`CLAW_EXEC_ALLOW_EGRESS`) are documented in
 [`.env.example`](../.env.example) and [LOCAL_DEV.md](LOCAL_DEV.md).
+
+## Coder configuration
+
+Set `CLAW_CODER_ENABLED=true` to expose `coder_submit`, `coder_status` and `coder_cancel` in owner
+DMs. Submission always uses the durable Telegram approval path, then runs in the background through
+your native Codex installation and its configured integrations. v1 is owner DM only.
+`execute_code` keeps the VM sandbox described above.
+
+| Variable | Default / accepted value |
+|---|---|
+| `CLAW_CODER_ENABLED` | `false`; strict boolean (`true`/`false`, `yes`/`no`, `on`/`off`, `1`/`0`) |
+| `CLAW_CODER_MAX_CONCURRENT_JOBS` | `1`; any positive integer |
+| `CLAW_CODER_JOB_TIMEOUT_SECONDS` | `1800`; integer seconds from 1 through 86400 |
+| `CLAW_CODER_EXECUTABLE` | `codex`; program name or absolute executable path, without command arguments |
+| `CLAW_CODER_PROFILE` | Unset; optional existing Codex profile name |
+| `CLAW_CODER_CONFIG_HOME` | Unset; optional absolute directory for the child's `CODEX_HOME` |
+
+Omit optional settings to use defaults; explicit blank or invalid settings fail configuration even
+with Coder disabled. Parsing does not check the executable, credentials or directory. These settings
+apply after daemon restart. The backend child uses Codex-owned login/configuration, separately from
+`clawd auth`; its working directory and profile are not isolation boundaries. Coder's concurrency
+bound and timeout do not impose a hard dollar cap. Child-reported usage belongs to the Coder result,
+not ordinary provider accounting; missing usage means accounting is unavailable.
+
+The backend resolves the selected executable once against its child `PATH`; an explicit absolute
+path never falls back to another binary. It checks `--version` and `exec --help` before inference
+and refuses installations missing the required automatic-review/schema flags. The validated recipe
+uses `exec --approve-for-me` with `approval_policy="on-request"`; a refusal never triggers a broader
+permission mode. See the [backend recipe](LOCAL_DEV.md#codex-backend-development).
+
+The child receives basic OS/toolchain and locale settings plus `CODEX_HOME`, `GH_CONFIG_DIR`,
+`GH_HOST`, `GH_TOKEN`, `GITHUB_TOKEN`, and `SSH_AUTH_SOCK` when selected. Telegram tokens, ordinary
+LLM provider keys, and other `CLAW_*` values are excluded. The config-home override changes only
+the child's `CODEX_HOME`. Existing Codex integrations can use their own credentials and remain
+part of the trusted installation. swift-claw never imports that login state into `clawd auth`.
+Interactive-shell access is not proof that launchd/systemd has the same PATH or authorization.
+
+Local paths refer to the daemon machine. In-place accepts dirty work; a separate copy is ref-only,
+with no uncommitted overlay. PRs require your configured repository rights; local PR preparation
+refuses an origin whose fetch and push URLs name different repositories, including a preconfigured
+fork push URL. Use an explicit GitHub source or an unambiguous origin. There is no automatic
+apply-back or rollback, and no automatic dependency provisioning. N is configurable; full means busy,
+without a queue. Completion uses existing outbox retries and needs no new LLM turn. Ask to inspect or
+cancel a job by its UUID; `/stop` only stops the conversation turn. Child billing is separate from
+conversational `/cost`, and Coder's limit/timeout cannot enforce a hard dollar cap.
+
+Disabled Coder contributes no tools, admits no work and launches no probes. On restart it still
+reconciles jobs admitted while enabled: unfinished jobs become interrupted with one completion notice,
+and uncertain process ownership retains its reservation. Missing/incompatible Codex leaves the
+assistant available with a failed Coder health row and no submit tool. An unprofiled local login-status
+failure blocks submit; authenticate Codex under the daemon user and restart. `doctor --check-config`
+performs no Codex probe and labels enabled runtime availability/authentication unverified. While Coder
+is enabled, full doctor and startup run bounded local version/help/status checks without inference,
+credential refresh, repository creation or publication. CLI compatibility and a present local login
+do not prove runtime authorization.
+Codex CLI cannot inspect a selected profile's authentication through `login status`: that health row
+is explicitly unverified and fails doctor, while compatible operator-approved profile jobs remain
+available. A profile can still fail authentication during execution; clawd does not refresh/import
+credentials or retry with broader permissions. An owner who accepts that limitation can start `clawd run`
+directly even when doctor withholds its healthy-start hint.
+
+The running daemon reports live fatal service failures separately from the persisted reservation
+count, unresolved ownership and last terminal failure. An external doctor labels live-only observations
+unavailable and reads persisted reservations. These historical rows remain visible in full doctor and
+daemon health with Coder disabled; `--check-config` does not read job history.
+Unreadable storage is a failed row, never a healthy zero.
+`coder.last_failure` is the most recently updated failed/timed-out/interrupted record, including
+released jobs; recovery updates can reorder it. It is historical evidence, separate from current
+CLI/auth availability. Child-reported checks/usage remain in each job's result.
+
+Interrupted jobs are never automatically rerun. Unresolved process ownership retains its slot across
+daemon restarts; see the [operator recovery path](LOCAL_DEV.md#coder-background-lifecycle-and-recovery).
 
 ## MCP servers
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -238,6 +238,34 @@ fails config validation with exit 10. Then:
 This route is unofficial and vendor-dependent; details and caveats in
 [LOCAL_DEV.md](LOCAL_DEV.md#chatgpt-subscription-auth).
 
+## 9. Optional coding tasks
+
+Install a compatible native Codex CLI and Git on the daemon machine. GitHub work also needs `gh`
+and repository rights to clone, push and create the requested PR. Authenticate those tools as the
+service account and configure its PATH; [INSTALL.md](INSTALL.md#coder-prerequisites) explains the
+service context. `clawd auth login` manages the conversation model, not Coder's login.
+
+Set `CLAW_CODER_ENABLED=true` in `~/.swift-claw/clawd.env`, source it as in step 2, and run
+`clawd doctor`. The Coder rows distinguish CLI compatibility, local login and profile authentication
+that cannot be verified without running a task. Restart the daemon to expose the three Coder tools.
+
+In your private bot DM:
+
+> Use Coder in `/home/me/projects/my-app` to fix the parser test in place and leave local changes.
+
+> Use Coder to resolve `https://github.com/my-org/my-app/issues/42` in a separate copy and open a pull request.
+
+Local paths refer to the daemon machine. In-place accepts dirty work; a separate copy is ref-only
+and does not copy uncommitted changes. A PR requires configured repository rights. There is no
+automatic apply-back or rollback. Review the task approval; after admission, you can continue chatting
+while the job runs. Ask for status or cancellation using the returned UUID. `/stop` cancels the current
+conversation turn; cancel the Coder job explicitly to stop its native worker.
+
+N is configurable with `CLAW_CODER_MAX_CONCURRENT_JOBS` (default 1), and full means busy. Completion
+uses existing outbox retries, without another LLM turn. Child billing and child-reported usage are
+separate from conversational `/cost`. v1 is owner DM only. The six settings, limits and authentication
+caveats are in [CUSTOMIZATION.md](CUSTOMIZATION.md#coder-configuration).
+
 ## Troubleshooting
 
 - **Exit codes are diagnostic:** 10 invalid config, 11 secret loading failed, 12 another

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -145,6 +145,32 @@ mkdir -p ~/.config/systemd/user && cp swift-claw.service ~/.config/systemd/user/
 systemctl --user enable --now swift-claw.service
 ```
 
+### Coder prerequisites
+
+Coder is optional and off by default. Install a compatible native Codex CLI and Git separately;
+GitHub sources and PRs also require the GitHub CLI (`gh`) and the account's repository rights.
+The installer does not provision these tools, their dependencies, repository access or credentials.
+The result schema is embedded in `clawd`; there is no extra schema resource to install.
+
+Both service units run under your user account, but do not inherit an interactive shell's PATH or
+login environment. The existing `run-clawd.sh` sources `~/.swift-claw/clawd.env` (or `CLAW_ENV_FILE`);
+`clawd` itself does not load `.env` files. Put a deliberate PATH with Codex, Git, `gh`, and any CLI
+interpreter/toolchain in that file, or use an absolute `CLAW_CODER_EXECUTABLE`. Native preparation
+requires `/usr/bin/git`. Authenticate Codex and GitHub under the actual daemon account, with its HOME,
+selected `CODEX_HOME` (`CLAW_CODER_CONFIG_HOME`), profile and `GH_CONFIG_DIR`. A terminal login does not
+prove that launchd/systemd can read the same auth source or keyring. `clawd auth` is independent.
+
+Set `CLAW_CODER_ENABLED=true` and run `clawd doctor` under those same settings before starting the
+daemon; `--check-config` stays offline
+and does not check Codex authentication. Full doctor uses local CLI checks, not inference or credential
+refresh. Selected-profile authentication can remain explicitly unverified; see
+[CUSTOMIZATION.md](CUSTOMIZATION.md#coder-configuration). The supervised daemon auth/denial/cancellation
+validation procedure is in [LOCAL_DEV.md](LOCAL_DEV.md#coder-background-lifecycle-and-recovery).
+
+To stop new Coder tasks, set `CLAW_CODER_ENABLED=false` and restart. Disabled startup performs no
+Codex probes and exposes no Coder tools, but still reconciles earlier jobs and reports retained
+reservations in full doctor and daemon health. Follow the recovery procedure for unresolved ownership.
+
 ### Staying on after logout
 
 - **Linux:** `sudo loginctl enable-linger $USER` lets the user manager run without a

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -557,8 +557,9 @@ section and this checklist before the new digest ships.
 
 ## Coder workspace development
 
-The native process runner and Git workspace preparation are implemented internally; coding tools
-are not exposed in this increment; the native backend can be exercised by its CLI fixtures.
+The native process runner and Git workspace preparation back the opt-in Coder tools. Local paths
+refer to the daemon machine; native tools and their dependencies must already be installed.
+The backend can be exercised without inference through its CLI fixtures.
 Run the workspace fixtures with:
 
 ```bash
@@ -593,8 +594,8 @@ tracking, including preparation and inspection.
 
 ## Codex backend development
 
-`ClawCoder.CodexBackend` implements one admitted task. Telegram tools and daemon composition arrive
-in later increments. Run the unmanaged CLI fixture against real temporary Git repositories with:
+`ClawCoder.CodexBackend` implements one admitted task, composed at the daemon root with the Coder
+service and its three Telegram-facing tools. Run the unmanaged CLI fixture against real temporary Git repositories with:
 
 ```bash
 swift test --filter CodexBackendTests
@@ -639,7 +640,137 @@ to establish that repository's default. The GitHub actor is the confirmed PR's a
 the Git commit author. Missing or unverifiable publication after possible execution remains unknown;
 a requested PR with unknown publication cannot be an unqualified success.
 
-The child environment and inherited installation trust are specified in
-[ARCHITECTURE.md §13.2](ARCHITECTURE.md#132-native-coder-delegation). The daemon does not yet
-compose this backend or load Coder settings. Operator setup and live service validation arrive
-with that runtime integration.
+The child environment and inherited installation trust are documented in
+[CUSTOMIZATION.md](CUSTOMIZATION.md#coder-configuration). Configure a service-visible PATH (including
+any interpreter used by the selected CLI) and existing Codex/gh authorization under the actual service
+account before live validation. CLI presence and a foreground login are insufficient proof. Keep
+paid probes, denied-action checks and cancellation probes in a dedicated temporary state root; the
+scripted suite does not use or validate your personal daemon credentials.
+
+## Coder background lifecycle and recovery
+
+`ClawGateway.CoderService` supplies background task ownership over the Core seams. The daemon root
+injects the same instance into the tools, boot reconciliation, service graph and fallback shutdown.
+Its `start()` finishes before approval replay or new admission; `run()` participates in the service
+graph and `shutdown()` closes admission, persists cancellation and joins all owned backend work
+before outbox/database close. Approval replay can start work before ServiceGroup starts, so command
+fallback joins that same service and checks its cleanup failure. The current lifecycle graph still
+starts its registered services when the parent was cancelled during boot. Unresolved cleanup exits
+without closing dependent clients underneath owned work.
+Run the real-store, scripted-backend tests without inference or GitHub access:
+
+```bash
+swift test --filter 'CoderServiceTests|CoderRecoveryTests|CoderCompositionTests|RuntimeShutdownAcceptanceTests'
+```
+
+Enable Coder in the already-sourced `clawd.env`; no additional loader is used. `clawd doctor
+--check-config` launches no Codex process. Full doctor and daemon startup use bounded local
+`--version`, `exec --help` and unprofiled `login status` checks. These do not run inference, refresh
+credentials, clone a repository or create a PR. Missing base login blocks unprofiled submission.
+The CLI rejects `--profile <name> login status`; selected-profile authentication is explicitly
+unverified in health while compatible approved jobs remain available. Profile-specific auth may fail
+at execution. Do not infer profile readiness from the base login or import/merge authentication state.
+
+For supervised live validation, use a dedicated temporary state root and an already-authorized
+repository under the actual service user, HOME, PATH and selected Codex/GitHub auth context. Check the
+local health facts first, then verify an approved daemon task, a denied native action and cancellation
+through its cleanup receipt. Retain sanitized argv, exit/outcome and publication evidence; never dump
+credentials, prompts or raw protocol output. A prior foreground success is not proof of daemon auth.
+These live checks can incur child billing and are separate from the deterministic suite.
+
+Ask in the owner DM to cancel `Coder job <UUID>`; `/stop` cancels the conversational turn, not an
+already-admitted job. Completion uses existing outbox retries without another LLM turn. Child-reported
+usage is kept with that job, separate from `/cost`; missing usage is unavailable accounting. Coder's
+concurrency/timeout settings are not a hard dollar cap. v1 is owner DM only; full capacity returns busy.
+
+Full doctor and daemon health read persisted reservations and the most recently updated
+failed/timed-out/interrupted record, including released jobs and history from enabled runs when Coder
+is now disabled. `doctor --check-config` does not read job history. Recovery can update the record
+ordering; the timestamp is not immutable failure time. The CLI labels live service observations
+unavailable, and failed storage reads as unreadable rather than zero/none. Current CLI/auth health
+is separate from historical failure.
+
+Cancellation returns a stopping job promptly, while its slot remains reserved through joined cleanup
+and terminal persistence. The configured N slots allow independent jobs to run concurrently; a full
+service returns busy. In-place checkout/common-Git identity conflicts return workspace busy even if
+capacity remains. These locks coordinate only Coder's own jobs, not external editors or agents.
+
+On daemon restart, unfinished tasks become interrupted and produce one durable completion notice,
+even when `CLAW_CODER_ENABLED=false`. Disabling removes the tools and prevents admission and native
+probes; read-only ownership inspection and durable recovery still run for previous reservations.
+They are never rerun automatically: a task may already have pushed commits or opened a PR. Review its
+workspace and publication evidence before submitting a fresh approval. None/stopped process ownership
+releases its slot. A read-only inspection that proves the recorded group stopped also permits release;
+a missing leader by itself is insufficient. Pending launch without PID/birth metadata, live owned
+members, PID reuse or unreadable process state retains the reservation and blocks new Coder admission.
+The rest of the assistant can remain available. A second daemon restart does not clear uncertainty.
+
+For operator recovery:
+
+1. Stop the daemon using the service commands in [INSTALL.md](INSTALL.md#4-running-as-a-service).
+   Inspect the retained job and its `process_receipt_json` in `coder_jobs` under the selected state
+   root's `claw.sqlite`; record the job UUID, phase, host boot ID, PID/PGID and birth identity.
+   Preserve the job's private directory at `<state-root>/coder/jobs/<UUID>/` and inspect its work.
+2. Compare the receipt with current host/process evidence. Terminate only processes whose ownership
+   you have identified; a matching numeric PID or PGID alone is insufficient because IDs are reused.
+   Do not signal an unrelated process or assume an absent leader means its group is empty.
+3. Once the recorded group is verified empty, start the daemon again; Coder may remain disabled.
+   Read-only startup reconciliation records stopped ownership and releases the existing terminal
+   reservation without a second notice.
+   If a crash happened between spawn and receipt persistence and ownership cannot be established,
+   restart the host: a changed boot ID proves that the old-boot processes cannot survive.
+
+Do not delete/forget job rows or manually reset reservations to bypass recovery. If the pending launch
+receipt itself is missing or storage is unreadable, retain the state root and diagnose the storage
+failure; no process identity can safely be invented. Process-event or terminal/outbox write failures
+are unhealthy service outcomes and retain reservations without claiming a completion was delivered.
+A failed protocol-file deletion can coexist with proved stopped processes: it remains a visible job
+cleanup diagnostic, while process ownership determines whether a reservation can be released.
+
+### Background completion acceptance
+
+Run the complete owner-DM path without native inference or publication:
+
+```bash
+swift test --filter CoderDoneWhenTests
+```
+
+This scenario uses the real router, durable approval, Coder service, SQLite stores and outbox
+dispatcher with scripted LLM, native backend and Telegram boundaries. After approval it holds the
+backend, observes an ordinary reply in the same conversation, then releases the backend and verifies
+the saved result and automatic completion delivery to the authenticated origin without another LLM
+turn. Replaying the outbox wake keeps one completion row; failed network delivery retains the
+existing at-least-once retry semantics.
+
+### Live validation recorded on 2026-09-07
+
+**The required native-denial evidence gap (V1) is closed.** The first supervised attempt on
+2026-09-06 at 22:00 UTC remains historically inconclusive: its retained evidence lacked a refusal
+tied to the requested command. One later authorized native job at 23:09:51–23:10:26 UTC supplied
+the exact touch-command rejection from native `codex_core::tools::router` stderr. This establishes
+native execpolicy denial; the worker's wording does not establish a separate Guardian decision.
+Both attempts occurred on September 7 in Europe/Istanbul.
+
+The later run used actual CoderService, CodexBackend and GRDB under a temporary `gui/502`
+LaunchAgent on macOS 26.6.2 as `jetbrains` (UID 502), with Codex CLI 0.153.4, default
+`/Users/jetbrains/.codex` and no named profile. The unchanged installed `run-clawd.sh` loaded a
+separate `CLAW_ENV_FILE` containing the explicit PATH candidate recorded in the audit. That concrete
+recipe passed local Codex login, native execution, and `gh` keyring/authenticated API checks.
+The first service's default PATH could not resolve Codex, `gh` or Node; the tested candidate was
+never installed into production configuration. Production enablement and deployment were excluded,
+so this is no claim that the current installed service configuration is ready.
+
+The job persisted failed/permission with one new completion outbox row at its fixture-approved
+origin, retained the exact file contents, and released its reservation after owned work stopped.
+A transparent observer was the selected executable and approval identity; it forwarded the real
+CLI's production argv, schema, environment and finite stdin in the same process group. No Telegram
+network delivery ran in the live probe; the deterministic acceptance above owns that boundary.
+Independent evidence review passed. The unique rule, LaunchAgent and private controls/protocol files
+were removed, all recorded owned groups were empty, and service shutdown joined.
+
+The original foreground cancellation harness passed through the actual service, native backend,
+process group and SQLite store with a harmless long-running external CLI fixture: its descendant
+stopped, work remained, and both the N=1 capacity slot and checkout reservation were reused.
+This was not paid inference cancellation. Historical draft PR #182 remains the publication baseline;
+the service checks created no new push or PR. Exact recipes, evidence and review/validation closure
+are in the [resumed evidence append](research/coder-capability-audit-2026-09-06.md#11-resumed-validation-and-final-review-closure).

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -47,10 +47,7 @@ Why Swift: one self-contained binary per platform with no runtime to install und
 - **NG9.** A provider *pool* and per-call USD attribution dashboards. v1 routes over at most two owner-configured routes — a primary and one optional fallback (FR-R3) — with no credential pools, no weighted or model-aware routing, and no automatic provider discovery; and it has a USD spend **breaker**, not a dashboard.
 - **NG10.** *(bounds FR-P5)* **Sharing or importing another tool's credentials** — notably Codex CLI's `~/.codex/auth.json` — or supervising Codex as the ordinary LLM provider route, multiple accounts, credential pools, live credential mutation while the daemon runs, and subscription providers other than ChatGPT. Also out: **a per-provider environment-variable namespace** (`CLAW_CHATGPT_*` and the like) and a configurable subscription endpoint or client identity. Subscription auth adds exactly **one** configuration selector — a provider-qualified model value — and structured configuration (`config.toml`) stays deferred; it is the mechanism a future provider's own settings will use.
 
-**Generic Coder is a separate opt-in capability under construction.** The native foundation
-implements contracts, durable jobs, process ownership, Git workspaces and the Codex backend.
-Daemon composition and operator enablement remain pending. Its complete product contract
-delegates an approved owner-DM task to the
+**Generic Coder is a separate opt-in capability.** It delegates an approved owner-DM task to the
 native personal Codex installation, which retains its own credentials and integrations. Coder
 supervises workspace selection, admission, child lifetime, persistence and reporting; Codex performs
 the coding and requested Git/GitHub workflow. In-place work accepts uncommitted changes; separate
@@ -306,6 +303,16 @@ Each criterion is backed by an **automated acceptance test** (per-requirement ve
   `/skills` returns every accepted descriptor and rejection from a fresh scan without starting a
   turn. Full `clawd doctor`, its JSON form, and `/status` report the same fresh accepted count,
   rejected count, and absolute-cap fit; warnings or overflow fail the headline row.
+
+- **SC11 (P-coder).** With Coder enabled and VM execution disabled, an approved owner-DM task reaches
+  the configured native Codex installation using its existing integrations. Local in-place tasks
+  accept dirty work; separate copies start from refs. Configurable N capacity returns busy when full.
+  Status/cancel use the job UUID; completion is durably delivered through existing outbox retries
+  without another LLM turn. Shutdown joins owned work before dependent teardown, and restart reports
+  interruption without automatic rerun. Missing/incompatible CLI preserves ordinary chat and durable
+  recovery without submit. Doctor distinguishes compatibility, auth uncertainty, persisted reservations
+  and unreadable storage; child billing remains separate from conversational `/cost`. No automatic
+  apply-back/rollback, queue, conference admission or dependency provisioning is implied.
 
 ## 11. Constraints & assumptions
 

--- a/docs/research/coder-capability-audit-2026-09-06.md
+++ b/docs/research/coder-capability-audit-2026-09-06.md
@@ -1,0 +1,864 @@
+# Generic Coder capability: independent audit and design inputs
+
+**Date:** 2026-09-06
+
+**Status:** research for brainstorming; not an approved design or implementation plan.
+
+**Repository examined:** `main` at `d47151764c74ae2b87799d2de58912f3b08b4283`.
+
+This supplements [the September 5 study](coder-capability-2026-09-05.md). It distinguishes
+verified implementation facts, version-specific observations, and proposed product choices.
+`docs/ARCHITECTURE.md` remains normative.
+
+The subsequent local design draft collects accepted product decisions and the proposed technical
+contract. It lives under the repository's intentionally ignored `docs/superpowers/specs/` working
+directory, not in the normative specification or an implementation plan.
+
+## Product scope established in this discussion
+
+- Coder is a general swift-claw capability: delegate a repository coding task and return its result.
+- Codex headless is the first backend. A small internal seam should permit replacement without
+  making the product contract depend on Codex terminology.
+- Conference participants, cases, scoring, and submission tracking do not define this capability.
+- A branch, commit, or PR can be an artifact; publishing is not the definition of successful coding.
+- **GitHub integration and automated PR creation are required in v1.** The owner explicitly
+  rejected deferring them. Local-only coding remains useful; publication is selected for the
+  particular request rather than required for every coding task.
+- **The owner explicitly requires both workspace modes in v1, selected for each launch:** editing
+  the supplied directory in place, and producing changes in a separate working copy.
+- **The owner accepted end-to-end delegation to Codex:** Coder orchestrates the job; Codex carries
+  out the repository workflow, including Git and GitHub PR operations. A separate Swift publisher
+  is not part of the initial approach.
+- **In-place execution must support existing uncommitted work.** The owner supplied a concrete
+  acceptance scenario: fix a bug in changes already made by the owner or another agent before
+  those changes have been committed. A blanket clean-checkout prerequisite excludes this scenario.
+- **Three source forms are accepted for v1:** an explicit local path, a GitHub repository URL,
+  or a GitHub issue URL. A remote project is obtained as part of the task; a manual clone is not
+  a prerequisite.
+- The owner accepted existing Codex configuration by default with optional overrides, background
+  task status/cancellation/completion, and preserving origin-based delivery for future group topics.
+- The owner requires a configurable N-task concurrency limit in generic Coder v1. A fixed
+  one-task-only implementation would not support the intended event use. A default of 1, the
+  proposed 30-minute per-job deadline, and busy-versus-queue handling remain design defaults to
+  review rather than independently accepted product requirements.
+- After independent design review, the owner accepted conversational-model-dependent cancellation,
+  managed-process-group-only teardown, and pending notification retry on later outbox activity or
+  restart. Neither deterministic control commands nor a general delivery retry timer is required
+  for v1. PR construction remains delegated to Codex without a mandatory independent splitting of
+  pre-existing committed history; the task remains the publication scope. Publication-head
+  uniqueness is still recommended for N jobs, but is not an owner-declared release blocker.
+
+Support for Xcode builds, the execution boundary, the mechanics of preserving/comparing initial
+dirty state, and the details/defaults of publication remain open product decisions. Accepting an
+initially dirty in-place workspace and supporting GitHub/PR are established product requirements.
+
+The owner subsequently questioned the implementation cost of installing Codex and project
+dependencies in a container. The revised recommendation is to begin with the operator's installed
+Codex and local development tools, with a deliberately specified host execution policy. This is
+a candidate response to that concern, not an approved relaxation of the existing VM guarantees.
+
+## Method and limits
+
+Three independent readers examined current swift-claw integration, the Codex runtime contract, and
+workspace/Git behavior. The coordinator re-read the principal tool, lane, approval, scheduler,
+outbox, and architecture contracts. We fetched official OpenAI, Git, and Apple documentation.
+
+Local CLI checks used `codex-cli 0.153.4`. Git experiments used version 2.55.0 and disposable
+repositories outside the project. No coding-model invocation, account mutation, credential read,
+remote Git write, or product implementation was performed. Current online documentation can
+describe behavior newer than the installed binary; documentation is not an isolation test.
+
+## 1. Background execution is justified, but the timeout argument needs correction
+
+The chat run's default budget is 180 seconds (`Sources/ClawCore/LLM/RunBudget.swift:59`). The
+runtime checks it before tool dispatch (`Sources/ClawAgent/Runtime/AgentRuntime.swift:477`);
+this is not an enclosing timeout that mechanically prevents every longer tool execution.
+
+The previous study's 50-second maximum is not a fixed contract. `ExecuteCodeTool.timeout` adds
+20 seconds to a configurable execution timeout; the latter permits up to 300 seconds
+(`Sources/ClawTools/Tools/ExecuteCodeTool.swift:73`,
+`Sources/ClawCore/Config/ExecConfig.swift:191`). MCP timeouts are configurable too.
+
+Likewise, cancel-and-abandon is path-specific. Ordinary dispatcher execution uses that race, but
+approved DM execution directly awaits the tool
+(`Sources/ClawGateway/Approval/ApprovedActionExecutor.swift:140–145`).
+
+The decisive product argument survives: session work chains behind its predecessor
+(`Sources/ClawAgent/Runtime/SessionLaneRegistry.swift:61–102`). Waiting for a long coding task
+occupies that lane. An independently supervised job keeps the conversation responsive and makes
+status, cancellation, shutdown, and restart behavior explicit. It need not change the conversational
+FIFO contract or increase its budget.
+
+**Recommendation:** make the tool submit a durable job and promptly return its ID. Keep job
+execution outside the conversation lane. Cancellation must own process termination; changing a
+database row to failed after restart does not terminate an orphan.
+
+## 2. Submission and completion need real integration work
+
+The current `Tool.execute(arguments:canonicalTarget:)` signature receives neither authenticated
+origin nor run/session/chat/tool-call identity
+(`Sources/ClawCore/Domain/Tools/ToolContracts.swift:308–329`). A persisted background job needs
+trusted routing and deduplication data supplied by runtime code, not by model-authored arguments.
+
+`TurnEnqueuer` only schedules an already-persisted PENDING agent run. It is not a generic durable
+completion API (`Sources/ClawGateway/Turn/TurnEnqueuer.swift:5–32`). Scheduler firing provides a
+useful transaction pattern, but resets/detaints a session and inserts its confirmed prompt as trusted
+input (`Sources/ClawData/Stores/Scheduling/ScheduledJobStoreGRDB.swift:287–304`). A Coder result
+must not inherit either behavior: it is external output and must not reset the owner's chat.
+
+The existing outbox is keyed by agent run (`Sources/ClawCore/Persistence/OutboxStore.swift:3–12`).
+Durably finishing a coding job and reporting it therefore needs an explicit identity/delivery
+contract whichever presentation we choose.
+
+**Smaller candidate:** deliver a deterministic, redacted completion report through the durable
+delivery path. An additional LLM turn to interpret every result is optional. If later conversation
+uses the report, preserve its untrusted provenance. Define whether `/stop` cancels a coding job and
+whether `/new` affects eventual delivery; existing commands only cancel conversational lane work.
+
+## 3. `exec --json` is a suitable first adapter, not the only credible transport
+
+Local help confirms JSONL output, final-message output, output schemas, ephemeral execution, and
+the config/rules switches. Official documentation describes these as automation surfaces. It also
+shows why a schema is useful for a predictable report shape.
+[Source: non-interactive mode](https://learn.chatgpt.com/docs/non-interactive-mode).
+
+App-server has a stable protocol subset as well as experimental features; the CLI still labels
+the command experimental. It is worth reconsidering when steering, interactive approval exchange,
+or persistent conversation ownership becomes a requirement. One process per job is possible with
+either transport, so that is not an exclusive advantage of `exec`.
+[Source: App Server](https://learn.chatgpt.com/docs/app-server).
+
+**Recommendation:** one controlled native executable invocation per coding job; bounded progress
+and diagnostics; final report; timeout/cancellation; process termination outcome. Avoid generic
+session creation, resume/fork, backend capabilities negotiation, and opaque settings extension
+machinery until a requirement uses them. Backend-specific configuration can live in the concrete
+adapter constructed at the composition root.
+
+The npm launcher's signal handling supports the earlier study's explanation of its observed
+misleading exit status (`@openai/codex/bin/codex.js:255–295` in the installed package). This audit
+inspected the launcher but did not repeat the live Codex termination experiment. A supervisor still
+needs bounded process-group teardown and stream draining. A successful exit cannot override an
+already-selected cancellation outcome. Process groups alone do not contain descendants that escape
+the group.
+
+## 4. Completion, changes, and verification are different facts
+
+`turn.completed` plus exit zero establishes execution completion, not satisfaction of an arbitrary
+coding task. A structured final report is still the worker's account of what happened.
+
+An empty `git status --porcelain` is not a no-op test. In the disposable reproduction, the worker-like
+edit was committed: porcelain became empty while the captured base-to-final comparison still
+contained `file.txt`. Git status describes differences relative to the current index/HEAD.
+[Source: git status](https://git-scm.com/docs/git-status).
+
+**Recommendation:** report separately the execution outcome, actual changes relative to the
+captured starting state, and checks with their evidence. Include committed changes, remaining
+tracked edits, and new files. An initially dirty workspace needs a pre-run baseline; comparing only
+with HEAD attributes existing work to Coder. If comparison fails, say it is unavailable instead of
+reporting no changes. Do not infer test success from the final narrative.
+
+Keep useful partial changes after cancellation or failure. The earlier study's suggestion to
+delete an unusual Git workspace is inappropriate for in-place editing and can discard the owner's
+work. Automated publication can have stricter readiness checks without defining every coding run.
+
+## 5. Workspace separation is independent of process containment
+
+| Workspace choice | What it provides | What it does not provide |
+| --- | --- | --- |
+| In place | Edits where the owner asked; can include existing local state | Protection from overwriting existing work or concurrent external edits |
+| Linked worktree | Separate working files and branch | Separate repository configuration/refs/object store, or automatic inclusion of dirty source files |
+| Independent clone | Separate repository metadata; standalone result | Process confinement; dirty source state unless deliberately copied; independent object storage if hardlinks/alternates remain |
+
+Disposable experiments reproduced three relevant behaviors:
+
+1. A local clone and its source shared packed-object inodes. Altering the clone's pack after
+   changing its mode also damaged the source; `git fsck` exited 30. A clone made with
+   `--no-hardlinks` had distinct object inodes. Objects are immutable by Git convention, not by
+   protection against arbitrary same-user writes. [Source: git clone](https://git-scm.com/docs/git-clone).
+2. Setting a harmless configuration key inside a linked worktree changed what the original
+   checkout read. This sharing is documented. Worktree registration/cleanup recovery is also
+   documented; it does not justify categorically rejecting worktrees.
+   [Source: git worktree](https://git-scm.com/docs/git-worktree).
+3. A harmless configured fsmonitor command ran during plain `git status`. Same-user ownership
+   does not make repository configuration trustworthy. Git inspection is not automatically free of
+   execution effects. [Source: git config](https://git-scm.com/docs/git-config).
+
+These experiments tested Git topology without a Codex sandbox. Effective sandbox permissions can
+prevent the writes they used. The useful boundary rule is: **do not give repository-controlled code
+or configuration more authority during inspection/publication than it had while editing.** Git
+can run within the same controlled boundary; a fresh pathname alone does not make imported content
+trusted. The v1 publisher needs an explicit import and credential design wherever its authority
+exceeds the coding process's authority.
+
+**Implications of the owner's two-mode requirement:** resolve and report the actual target path;
+serialize conflicting Coder jobs by canonical workspace identity; define initial-state handling;
+retain the result. An in-place request should not silently switch the owner's branch to honor a
+base-branch field. A base reference belongs naturally to separate-copy preparation. Coder's own
+lock cannot prevent an editor or unrelated process from changing an in-place workspace.
+
+**Dirty in-place scenario:** the current files, including relevant uncommitted changes, are the
+input to the coding task. Codex can fix a defect within that existing work and leave the resulting
+files for review. A comparison with the pre-run state describes changes during the run; it cannot
+prove human-versus-agent authorship when another writer runs concurrently. Snapshot mechanics are
+still to be designed and do not imply stashing or committing the owner's work as a prerequisite.
+
+Editing and publication scope are distinct. A local bugfix request does not by itself authorize
+committing all pre-existing work. If a PR is requested, its agreed scope may include the original
+uncommitted feature together with the fix; a fix that depends on that feature cannot necessarily
+be published as a standalone change against the base branch. Do not promise automatic semantic
+separation of overlapping edits. For a separate-copy run, whether to include source uncommitted
+work remains an explicit initial-state choice rather than silently omitting the reported bug.
+
+Mirrors and clone caches are not prerequisites for these workspace modes. The required v1 PR path
+does need branch/commit/push handling, GitHub authorization, and PR creation, but those operations
+can be performed by Codex using the installed Git and GitHub CLI. A custom Swift publisher is a
+separate design choice, not a requirement implied by supporting PRs. The choice of worktree versus
+independent clone should follow the execution boundary and result workflow, not the conference's
+anticipated concurrency.
+
+## 6. Native Codex isolation deserves a version-pinned check
+
+Current official documentation describes read-only protection for `.git`, including a linked
+worktree's resolved Git directory, and for `.codex`/`.agents` under writable roots. Thus the earlier
+study's unrestricted shared-Git-write claim needs an effective-permissions qualification.
+[Source: protected paths](https://learn.chatgpt.com/docs/agent-approvals-security#protected-paths-in-writable-roots).
+
+Beta permissions support restricting command reads and writes, not just workspace writes. They do
+not compose with legacy sandbox settings: passing `--sandbox` selects the older system. Network
+domain restrictions also require an active proxy; merely enabling networking is insufficient.
+[Source: permissions](https://learn.chatgpt.com/docs/permissions).
+
+Those controls concern local commands. Model traffic, MCP, hooks, plugins, inherited guidance, and
+the Codex process itself need separate consideration. A workspace-write flag is not proof that the
+entire integration cannot read host secrets. `--ignore-rules` does not mean ignore `AGENTS.md`;
+`--ignore-user-config` help promises skipping user config, so its previously observed wider scope
+must not become an untested guarantee. Project configuration and instruction discovery are distinct.
+[Sources: configuration](https://learn.chatgpt.com/docs/config-file/config-basic#configuration-precedence),
+[instruction discovery](https://learn.chatgpt.com/docs/agent-configuration/agents-md#how-codex-discovers-guidance).
+
+Keep authentication owned by Codex/operator provisioning. The adapter need not parse another
+program's auth cache or implement OAuth refresh. Official guidance favors API keys for automation
+and documents advanced account-auth provisioning with restrictions. A login-status probe establishes
+local availability, not that the next provider request will succeed.
+[Source: authentication](https://learn.chatgpt.com/docs/auth).
+
+Any execution choice must explicitly reconcile `ARCHITECTURE.md` §12/§13 and PRD FR-X1/FR-X2.
+Do not silently weaken `execute_code`'s existing VM profile to make Coder fit.
+
+## 7. Execution environment and Xcode compatibility
+
+Apple's container tool runs **Linux** guests, whereas Xcode's supported host platform is macOS.
+Therefore the existing Linux VM approach cannot itself run an Xcode build; an iOS build requirement
+needs access to an appropriate macOS execution environment.
+[Sources: Apple container](https://opensource.apple.com/projects/container/),
+[Xcode system requirements](https://developer.apple.com/xcode/system-requirements/).
+
+The viable approaches have different scope:
+
+- **Native macOS Codex with deliberately restricted permissions:** recommended first candidate
+  for local tools, both workspace modes, and lower setup cost. It needs demonstrated containment
+  and an explicit architecture decision about trusting that boundary.
+- **A new Linux VM Coder profile:** aligned with hardware isolation for Linux-compatible projects,
+  but requires a writable workspace, toolchain image, credentials/network design, and does not
+  supply Xcode. It is not a reuse of today's readonly `execute_code` profile unchanged.
+- **A separate macOS worker/VM:** can combine a macOS toolchain with stronger isolation, but adds
+  provisioning and workspace transport. Consider if required guarantees rule out the first option.
+
+## 8. Minimal product direction to discuss
+
+A local, opt-in, owner-DM Coder job with an explicit workspace mode, task and optional instructions;
+a small one-job backend seam in `ClawCore`; a Codex implementation in a sibling target; durable
+status, cancellation, retained changes, and completion delivery. The runtime owns origin, limits,
+process lifecycle, and result evidence. V1 supports both a local result and a published GitHub PR.
+Workspace mode (in-place/separate copy) and delivery choice (local changes/PR) are distinct inputs.
+
+### Project source and the local execution directory
+
+Separate the requested source from the eventual checkout. A local path refers to a directory on
+the execution host. A GitHub repository URL identifies the project; it still needs a task supplied
+by the request or conversation. A GitHub issue URL identifies both the repository and contextual
+problem description. It does not necessarily specify a starting branch or PR base.
+
+For a remote source without an explicitly selected existing checkout, the proposed v1 default is
+a fresh job-owned directory. Coder allocates the directory and binds the requested source and
+publication scope. Codex can obtain the repository with `git clone`/`gh repo clone`, read the issue
+with `gh issue view`, and execute the task through PR creation. This keeps the accepted end-to-end
+delegation model and needs neither a custom GitHub API client nor a repository mirror cache.
+[Sources: cloning](https://cli.github.com/manual/gh_repo_clone),
+[reading an issue](https://cli.github.com/manual/gh_issue_view).
+
+The local Codex 0.153.4 help exposes `--skip-git-repo-check`, permitting an invocation to begin in
+the allocated directory before a clone exists. This is a bootstrap candidate to validate in an
+implementation probe, not filesystem containment. The chosen execution profile must still enforce
+the permitted workspace. Explicitly selecting an existing local checkout is required for in-place
+work; do not silently discover and reuse an arbitrary matching repository on the host.
+
+Use the requested base when supplied, otherwise resolve the repository's default branch. Record
+the resolved checkout, actual starting commit, and intended PR repository/base; make any repository
+redirect or fork mapping visible. A source URL and an actual commit are not interchangeable.
+
+Use the configured owner's GitHub identity. It needs read access for a private source; publication
+may use a branch in that repository or a fork when permitted by the task and account. If neither
+route is available, retain the available result and report the access blocker. A submitted URL
+does not grant credentials or authorize a different Telegram sender: current single-owner intake
+rules remain unchanged. Issue text, comments, and repository content are untrusted task data, not
+authority to replace the source, credential profile, or allowed operations.
+
+### Who performs Git and GitHub operations?
+
+The owner challenged the initial recommendation to implement publication separately from Codex.
+There are three materially different choices:
+
+| Approach | Benefit | Cost |
+| --- | --- | --- |
+| Swift GitHub client plus deterministic publication workflow | Typed API errors and explicit publication transitions | New integration and workflow beyond delegating a coding task |
+| Fixed orchestration commands using existing `git`/`gh` | Predictable publication steps without implementing Git or GitHub APIs | Still owns branch, dirty-state, no-op, failure/recovery, and credential rules |
+| Codex performs editing through PR creation using `git`/`gh` | Smallest first integration; uses the coding agent's existing workflow abilities | Less deterministic sequencing and ambiguous partial publication after interruption |
+
+**Accepted direction for this single-owner v1:** use the third approach. The reason is the
+current requirement for general task delegation, not simply that the coding agent can invoke Git.
+Do not add a separate publisher until deterministic publication or credential separation becomes a
+concrete requirement. The second approach is a valid alternative, not inherently reinventing Git.
+
+Coder owns the authorized scope, selected/prepared workspace, runtime configuration, process
+lifecycle, durable status, and delivery of the result. Codex performs the requested repository work,
+including branch/commit/push/PR where authorized. Keep lightweight artifact checks separate from
+the worker's narrative. On this machine, `gh 2.98.0` is installed; `gh pr create --help` confirms
+non-interactive arguments and a returned PR URL.
+[Source: gh pr create](https://cli.github.com/manual/gh_pr_create).
+
+Publication must retain its own outcome in the report even when Codex performs it. A cancelled or
+crashed process may already have pushed or opened a PR. Preserve local work and report publication
+as confirmed, absent, or unknown according to available evidence; do not automatically rerun an
+ambiguous task. A follow-up attempt can use the retained workspace and known artifacts. Guaranteed
+automatic recovery or exactly-once publication is not established by this design.
+
+Delegation authorizes a scope of work rather than each later Git command. Workspace, runtime, and
+credential permissions must enforce the actual boundary. Prompt instructions are not enforcement,
+and swift-claw cannot claim it inspects or independently approves every child command. Giving the
+child publishing credentials also gives it their effective authority; rejecting that trust model
+would be a concrete reason to choose separate publication instead.
+
+### GitHub credentials and identity
+
+Authentication determines which account/app acts on GitHub. Git author/committer metadata is a
+separate setting; changing `user.name` does not authenticate a bot. GitHub links commit attribution
+using the commit email. A GitHub App installation token identifies the app's bot account, while
+user credentials can authorize user actions.
+[Sources: GitHub App identities](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps),
+[commit identity](https://docs.github.com/en/account-and-profile/how-tos/email-preferences/setting-your-commit-email-address).
+
+The initial integration can consume an operator-provisioned credential profile rather than build
+GitHub App registration/token renewal. GitHub CLI supports environment-supplied authentication;
+Git push also needs its own compatible credential configuration. Select identity outside the task
+text and never put raw credentials into prompts. Exact secret delivery, scopes, and renewal remain
+design work.
+[Source: GitHub CLI environment](https://cli.github.com/manual/gh_help_environment).
+
+### Operator setup is persistent configuration
+
+The proposed operator experience is one-time setup per swift-claw installation, followed by reuse
+for each job. The owner accepted reusing existing Codex settings by default, with optional settings
+for swift-claw. This is the accepted product default for the current single-owner deployment:
+avoid requiring a second configuration and login just to delegate the first coding task. A selected
+profile is persistent; it is not recreated or authenticated manually for every task.
+
+Reuse Codex's configuration loading rather than implement a second TOML merger or profile manager.
+The installed CLI exposes `--profile` as a layer over user configuration and `--config` overrides.
+Official precedence places CLI overrides first, then trusted project configuration, selected
+profile, user configuration, system configuration, and defaults. A named profile is therefore not
+an independent configuration home or an isolation boundary. Optional overrides should describe
+only what differs; exact supported settings remain implementation-design work.
+[Source: configuration precedence](https://learn.chatgpt.com/docs/config-file/config-basic#configuration-precedence).
+
+Existing settings means the Codex configuration home available to the daemon's OS user, not the
+transient settings of an open desktop conversation or an arbitrary interactive shell. Diagnose the
+selected source without exposing secrets. Inherited preferences may change between jobs. Coder
+must still bind its protocol/output settings, workspace, operational limits, and execution policy
+explicitly; inherited configuration cannot silently expand admitted authority. Compatibility of
+inherited MCP servers, hooks, and rules with the selected native execution policy still needs to
+be established. This preference decision does not approve unrestricted access or a trust profile.
+
+Keep non-secret settings such as the executable, profile selection, and default limits in the
+existing environment-based configuration. `docs/LOCAL_DEV.md` documents `clawd.env`; the daemon
+reads environment variables and does not automatically source that file itself. Configuration
+owned by swift-claw takes effect at restart in this proposed v1; Codex loads its own inherited
+configuration when each child starts. No per-job settings wizard or swift-claw hot-reload subsystem
+is needed.
+
+Reuse the existing secret mechanism for any static GitHub/API credentials owned by swift-claw:
+environment input for development/setup and the encrypted `ClawSecrets` backend for persistent
+deployment. This requires deliberately adding any new secret to the sealed/redacted set, not
+assuming today's implementation already handles it. Codex-managed login state remains owned by
+Codex; swift-claw configures its use without importing it into the LLM credential store. Revoked or
+expired credentials can still require renewal or a new login. Ordinary job requests carry only the
+repository/task/workspace/result choices, not raw credentials or executable configuration.
+
+Main does not yet express this admission policy: `ToolDispatchContext` has no proactive-origin
+input or `requiresInteractiveRun` flag. The dangerous gate uses the shared `execEnabled` switch,
+hardcodes the `.codeExec` approval reason, and executes dangerous tools without approval in groups
+(`Sources/ClawCore/Domain/Tools/ToolDispatching.swift:5–35`,
+`Sources/ClawTools/Policy/ToolPolicyGate.swift:387,438–454`). Registering Coder alone would not
+enforce owner-DM-only operation; this needs explicit policy work.
+
+The delegation split is accepted; the detailed host execution policy, exact Swift API, and job
+lifecycle have not yet been approved as an implementation design. The two workspace modes and
+GitHub/PR publication are accepted v1 scope. A second backend, resume/steering, conference workflows,
+and generic capability negotiation can be evaluated later.
+
+`host-bash-tool` is unmerged at `7659cb14`. It has reusable process-lifecycle work, but its current
+runner returns captured output at completion and offers inherited-environment filtering rather
+than an explicit clean environment. It is not a ready-made streaming Coder runner, and importing
+the entire branch would import unrelated changes. Reuse/extract the required primitive if its
+contract fits; do not make that whole feature a prerequisite.
+
+Before implementation, resolve Xcode support, initial-state capture and publication semantics,
+the execution/trust profile, cancellation semantics, publication authorization/target handling,
+and completion presentation. Then record accepted normative changes in `docs/ARCHITECTURE.md`,
+including trusted submission identity, job lifecycle/delivery,
+DM/proactive/group policy, child budget visibility, and configuration/health checks.
+
+## 9. Compact contract proposal for the next design discussion
+
+This section collects a candidate contract; accepting the source forms does not approve all of its
+implementation details or the host execution policy.
+
+### Task input
+
+- **Source:** local repository path, GitHub repository URL, or GitHub issue URL. Issue resolution
+  produces repository identity plus task context; it does not introduce a second execution engine.
+- **Task:** the owner's requested outcome, informed by the supplied issue when applicable.
+- **Workspace selection:** edit an explicitly supplied local checkout in place, or use an isolated
+  working copy. In-place uses the current files. An isolated local copy can start from a selected
+  ref or current local state; remote sources start from a selected/default repository ref.
+  Snapshot rules for tracked, untracked, and ignored files still need an explicit decision;
+  neither copying secrets/build caches nor silently dropping required source files is acceptable.
+- **Desired result:** local changes or a GitHub PR. Both use the same backend job mechanism.
+- **Additional instructions:** optional task constraints, separate from runtime access policy.
+
+Authenticated origin, session/run/tool-call identity, deduplication key, runtime permissions,
+credential selection, and operational limits come from trusted runtime context/configuration.
+They are not model-authored task fields. An in-place selection without a local checkout is invalid;
+the adapter must not silently substitute some discovered directory.
+The publication scope must also specify whether existing uncommitted work belongs in the requested
+commit/PR. Capturing a baseline does not grant permission to publish that work or reliably attribute
+changes made by concurrent external writers.
+
+### Lifecycle and ownership
+
+The owner accepted the proposed user experience: background execution while conversation remains
+available, task status/cancellation, an automatic completion report, retained partial changes, and
+no automatic rerun after a daemon interruption. The store and process details below remain design
+candidates, not implemented behavior.
+
+After the required authorization, admission records a job and promptly returns its ID. The existing
+approval flow can park the conversational lane while awaiting the owner; the responsiveness promise
+applies to admitted coding execution, not to removing that approval step. A service owns the claimed
+job and native Codex process outside the conversational lane. The request fixes the
+authorized task scope; Codex chooses implementation commands and performs the repository workflow.
+Status and cancellation address the job ID. Completion uses durable delivery, without requiring a
+second model call simply to announce the outcome.
+
+The minimal integration candidate keeps a Coder task distinct from the conversational `runs` FSM.
+Persist the trusted origin run and tool-call identity at admission; compose the worker as a
+`Service` at the daemon root. Status and cancellation are short ordinary tools, so natural-language
+requests use the existing assistant flow. Preserve `/stop` as conversational-turn cancellation;
+stopping a Coder task explicitly selects that task. A cancellation request is not evidence that
+the supervised process has stopped, and neither cancellation nor failure implies a Git rollback.
+
+Reuse the current Telegram outbox for completion. An independent code review found that existing
+outbox insertion can target a completed origin run and already allocates the next chunk indices
+inside a write transaction (`RunStoreGRDB+Helpers.swift`, `insertOutbox` and
+`nextOutboxStepBase`). Add one atomic store operation that transitions the Coder task to terminal
+and inserts its bounded, sanitized completion report against that origin run; a repeated terminal
+transition does not insert another report. Then wake the existing dispatcher. Separately saving
+the result and subsequently calling `claimOutbound` would leave a lost-notification crash window.
+This reuses the existing at-least-once delivery contract rather than claiming exactly-once Telegram
+delivery. The report is external-worker data, never a newly trusted scheduled prompt.
+
+Proposed failure defaults: preserve partial work; bound process teardown; mark interrupted jobs
+after daemon restart; do not automatically repeat a job whose remote effects are uncertain.
+These are suggested operating defaults, not established guarantees of the current implementation.
+Restart notification uses the same terminal-and-outbox transaction. Database recovery alone does
+not establish termination of an orphaned Codex process; process ownership/reconciliation must be
+designed separately. The initial user experience needs task admission, status/cancel, and a final
+report; live terminal streaming and an interactive resume protocol are not required for it.
+
+The later concurrency requirement applies to the same service: atomically reserve up to the
+configured N active job slots. Startup, cancellation/draining and unreconciled surviving processes
+must be included in capacity accounting; changing a row to interrupted is not process termination.
+Independently reject in-place conflicts using canonical checkout/common-Git-directory identity;
+separate job-owned clones may run concurrently. Per-job deadlines remain independent of N.
+
+### Future group/topic delivery
+
+The owner asked how conference participants could later receive completion in the requesting
+Telegram topic. Existing `DeliveryTarget` already represents chat, optional forum topic, and the
+triggering message; `outboxTarget` derives the topic/reply from the origin run's persisted session
+and trigger. The Coder completion route should preserve that origin instead of hardcoding an
+owner-DM destination. Telegram addressing belongs in the swift-claw submission/delivery layer,
+not in the repository-task contract passed to Codex.
+
+Topic delivery does not enable group execution by itself. Architecture section 12.1 currently
+allows configured rooms as shared sessions, not isolated participant conversations; its dangerous
+tool path can run without owner approval and relies on the existing VM boundary. An event adapter
+must deliberately admit Coder jobs under an event execution policy rather than inherit this branch
+accidentally. The current owner-DM v1 scope is not expanded merely by this future-use discussion.
+
+For a future event, bind the sender's verified numeric identity and the originating conversation
+to each submitted job in trusted code. A topic is the shared reply destination; a participant's
+submission receives its own working copy, branch, and coding context containing the selected case
+and that submission. Do not pass the whole shared topic as if it were one participant's solution.
+Submission-to-case mapping, access to allowed event repositories, participant/operator cancellation
+rights, and limits belong to event orchestration. Use the separately configured event deployment
+required by architecture section 12.1; inheriting a personal daemon's credentials is not part of
+the group-delivery proposal. These are future design inputs, not approved event implementation.
+
+### Result
+
+Keep execution disposition distinct from satisfaction of the requested task. The result includes
+the worker's summary, actual workspace, changes relative to the starting state when observable,
+available branch/commit/PR artifacts, checks with their evidence, and any failure reason/stage.
+Unknown publication or unavailable comparison stays explicit. A successful process exit or a
+well-formed worker report alone cannot establish that the requested fix or PR succeeded.
+
+Source resolution, checkout preparation, and final artifact verification remain subordinate to
+this one task lifecycle. A backend replacement must not require conference entities or a new
+publication subsystem. The next design step must settle the native execution/credential profile
+and concrete persistence/delivery seams before implementation planning.
+
+## 10. Task 8 supervised validation evidence
+
+This append records actual execution on **2026-09-06 22:00:18–22:05:02 UTC** (2026-09-07 in
+Europe/Istanbul), against reviewed Task 7 commit `4340eb267733b4ece966b5dea1b3ff4d757eae71` on
+`generic-coder`, in `/Users/jetbrains/Developer/swift-claw-worktrees/main-session-20260906`.
+Host: macOS 26.6.2 (25G83). Native CLI: `codex-cli 0.153.4`. GitHub CLI's service version command
+exited zero; supplemental foreground inspection retained `gh version 2.98.0 (2026-08-20)`.
+The earlier audit above is preserved verbatim; this is new evidence rather than a rewrite of its
+historical design discussion.
+
+**Outcome: A passed in a controlled temporary service environment; B ran once but is inconclusive
+for actual command-correlated denial; C passed. Required denial validation remains incomplete, so
+these results do not establish release readiness.** No production service/configuration or credential
+files were changed, no inference retry or broader permission fallback ran, and no new publication
+was attempted.
+
+### A — service account authorization
+
+An actual temporary LaunchAgent in `gui/502` ran as UID 502, USER/LOGNAME `jetbrains`, HOME
+`/Users/jetbrains`. Its private wrapper sourced `${CLAW_ENV_FILE:-$HOME/.swift-claw/clawd.env}` under
+`set -a`, matching the installed wrapper contract, then executed the private helper. It never started
+clawd or Telegram. Label:
+`com.ivanmagda.swift-claw.coder-probe.6e81373b-91b0-439f-a968-2d5414ddf772`.
+Private control root: `/tmp/swift-claw-coder-probes.vmrmm2wj`.
+
+The unmodified installed service PATH resolved none of `codex`, `gh` or `node`. Only the temporary
+probe selected:
+
+```text
+PATH=/Users/jetbrains/.nvm/versions/node/v24.4.1/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+Codex executable=/Users/jetbrains/.nvm/versions/node/v24.4.1/bin/codex
+CODEX_HOME=/Users/jetbrains/.codex
+profile=unset
+GH_CONFIG_DIR=/Users/jetbrains/.config/gh
+```
+
+Child environment used the production `CodexInvocation.environmentKeys` allowlist, excluding
+unrelated CLAW/Telegram/provider keys. SSH socket presence came from launchd; no interactive socket
+or auth-file contents were copied. Each read-only command had no TTY, `/dev/null` stdin and a
+20-second guard. Every command below exited zero without timeout:
+
+- `/usr/bin/id -u` and `/usr/bin/id -un`: 502 / jetbrains.
+- Selected `codex --version`, `codex exec --help`, `codex login status`: version above, required flags
+  present, local ChatGPT authentication present.
+- `/opt/homebrew/bin/gh --version` and `gh auth status --active --hostname github.com`: installed CLI,
+  authenticated `ivan-magda` via keyring.
+- `gh api user --jq .login`: `ivan-magda`.
+- `gh api repos/ivan-magda/swift-claw --jq '{full_name,default_branch,permissions}'`: repository
+  `ivan-magda/swift-claw`, default `main`, admin/maintain/pull/push/triage true.
+- `/usr/bin/git -c core.hooksPath=/dev/null ls-remote --exit-code https://github.com/ivan-magda/swift-claw.git HEAD`,
+  with `GIT_TERMINAL_PROMPT=0` and `GCM_INTERACTIVE=Never`: HEAD
+  `d47151764c74ae2b87799d2de58912f3b08b4283`.
+- `gh pr view 182 --repo ivan-magda/swift-claw --json url,state,isDraft,headRefName,headRefOid,baseRefName`:
+  [PR #182](https://github.com/ivan-magda/swift-claw/pull/182) still open/draft, base `main`, head
+  `codex/coder-smoke-timeout-doc-20260906-9fy3sqxw`, commit
+  `74191294df5875c7f97aae7e374bbd566caa357c`.
+
+This newly establishes service-context local login/keyring/API access with that temporary PATH.
+Local status is not provider execution; GitHub API permissions are not a push test; public
+`ls-remote` establishes public readability. PR #182's earlier 254.881-second foreground
+clone/edit/lint/commit/push/draft-PR run remains the publication evidence. The service only inspected
+that existing PR; no new service-context push or PR was attempted. Installed PATH/interpreter setup
+remains an operator follow-up.
+
+### B — native denial attempt, inconclusive
+
+One exclusive mode-0600 rule was created at
+`/Users/jetbrains/.codex/rules/swift-claw-denial-swift-claw-coder-probes.vmrmm2wj.rules`.
+It forbade only `/usr/bin/touch` or `touch` with the exact argument
+`/tmp/swift-claw-coder-probes.vmrmm2wj/denial-repository/denied-marker`.
+The free `codex execpolicy check --rules <rule> -- <executable> <marker>` returned `forbidden` for
+both executable spellings; the `denied-marker-other` control matched no rule. Evaluator results
+alone do not prove execution-time refusal.
+
+The one native invocation ran inside the same LaunchAgent at 22:00:50.688352–22:01:24.383493 UTC
+(about 33.695 seconds), with finite stdin, no TTY, a 360-second outer guard, PID/PGID 60642, and:
+
+```text
+/Users/jetbrains/.nvm/versions/node/v24.4.1/bin/codex exec --json --approve-for-me -c 'approval_policy="on-request"' --skip-git-repo-check --ephemeral --color never -C /tmp/swift-claw-coder-probes.vmrmm2wj/denial-repository --output-schema /tmp/swift-claw-coder-probes.vmrmm2wj/schema.json -o /tmp/swift-claw-coder-probes.vmrmm2wj/native-result.json -
+```
+
+The schema matched `Sources/ClawCoder/Codex/CodexResult.schema.json`. This direct CLI probe exercised
+the external native contract, not CoderService. Its finite input requested a retained file, then
+exactly the forbidden touch command, stopping after denial without substitution, escalation, commit,
+push or PR. The isolated local in-place repository had no remote.
+
+Retained facts: exit zero; `thread.started`, `turn.started`, retained-file `command_execution`
+with exit zero, then `turn.completed`; schema-valid final status `blocked`; worker-reported branch
+and base `probe-denial`, null starting commit/commit/PR, changed file `retained.txt`. Independent
+inspection found branch `probe-denial`, unborn HEAD (`rev-parse --verify HEAD` exit 128), no remotes,
+only untracked `retained.txt` with exact contents `retained`, and no denied marker.
+
+**No command-execution event for the denied touch or direct tool/policy refusal tied to that command
+remains in the evidence.** Final narration reported the rule's rejection, while stderr extraction
+retained only broad error/denied categories. Transient raw stderr was already discarded; no retry
+was run. Blocked-result handling and retained work were observed, but native refusal execution is
+unproven. This attempt cannot satisfy the required denial check.
+
+No live members of PGID 60642 remained after exit; no timeout or emergency cleanup occurred. The
+exact unique rule was removed, and private schema/report/control files were deleted after sanitized
+extraction. Existing config/profile/auth/rules were outside the mutation scope; they were not
+snapshotted or hashed.
+
+### C — real Coder service cancellation and reservation reuse
+
+A foreground scratch executable under UID 502 used actual `CoderService`, `CodexBackend`,
+`CoderRequestPreparer`, `CoderProcessInspector`, `CoderJobStoreGRDB`, file-backed migrated GRDB and
+`CoderApprovedOriginFixture`. It ran a harmless external CLI fixture that wrote retained work,
+forked real `/bin/sleep 300`, emitted readiness and waited. The second invocation wrote `reused.txt`
+and a valid success report. No inference, network or Telegram delivery ran; this proves native
+process cancellation through Coder, not cancellation of a paid inference.
+
+The scratch program linked existing Task 7 objects in an agreed stable host-build window (standalone
+compile exit zero, 0.899 seconds). Runtime argv was:
+
+```text
+/Users/jetbrains/Developer/swift-claw-worktrees/main-session-20260906/.superpowers/sdd/2026-09-06-generic-coder/task8-cancellation/probe /tmp/swift-claw-coder-cancellation.ytlfrf9v /Users/jetbrains/Developer/swift-claw-worktrees/main-session-20260906/.superpowers/sdd/2026-09-06-generic-coder/task8-cancellation/fake-codex.sh
+```
+
+Runtime 22:04:02.624011–22:04:04.717114 UTC, exit zero, empty stderr, no timeout. The outer guard
+was 90 seconds; readiness/state guards were 30 seconds, backend timeout 120 seconds and capacity
+N=1. It selected a private empty config home, real user HOME, `/usr/bin:/bin` PATH and no credential
+environment. This was foreground, not a LaunchAgent authorization check.
+
+Private state root `/tmp/swift-claw-coder-cancellation.ytlfrf9v` retained `claw.sqlite`, `coder/jobs`
+and `repository/`, with owner-only root/repository permissions. The request used the local in-place
+checkout, localChanges, no ref/base/instructions and no existing-change publication. The real
+approved-origin fixture established separate owner-DM approval/run/tool-call identities for each job.
+
+- Job `25898636-5C0C-4088-BB29-89EA7FE26A30` reached running/owned/reserved with Codex-phase PID/PGID
+  62175; descendant PID 62176 was live in that group, and the real inspector returned `liveOwned`.
+- One `CoderServing.cancel(id:context:)` call produced a separate acknowledgement, followed by
+  persisted cancelled/stopped/unreserved state. The original receipt inspector returned `stopped`,
+  the descendant was absent, and reserved count was zero without a preceding manual group signal.
+  `retained.txt` still held `retained` plus newline.
+- The same canonical checkout/common Git directory admitted distinct job
+  `11ADA2FF-873C-4873-BDC2-DAA755DE5D72` at N=1; it succeeded with observed `reused.txt`, absent
+  publication and released reservation. Both capacity and checkout ownership were reusable.
+- Service shutdown joined successfully with no reservations. Final snapshots found no live members
+  of cancellation group 62175 or the second job's final inspection group 62196. No exact child
+  termination signal is claimed by the public result/receipt API.
+
+Independent Git inspection found branch `probe-cancellation`, unborn HEAD, no remotes and only
+fixture/retained/reuse files. No commit or publication was created; retained work remains for inspection.
+
+### Cleanup and evidence retention
+
+`launchctl bootstrap gui/502 <private-plist>`, pre-cleanup `print` and exact-label `bootout` exited
+zero. Final `print` of the removed unique label exited 113 at 22:05:02 UTC. Private wrapper/helper/
+plist/stdout/stderr were removed, the exact rule was absent, all owned groups were empty, and
+Coder shutdown/reservation settlement passed. Retained repositories and sanitized receipts remain;
+no production service/configuration changes require rollback.
+
+The complete sanitized report and command/result JSON remain under the ignored
+`.superpowers/sdd/2026-09-06-generic-coder/` directory (`task-8-live-validation-report.md`,
+`task8-live-evidence/{A,B,supervisor,C-supervisor,final-verification}.json`). C's sanitized state
+snapshots remain in its private root. Raw auth, full environments, prompts and reasoning logs were
+not retained. Required follow-up remains direct command-correlated denial evidence and the installed
+service PATH setup; this append does not mark those checks complete.
+
+## 11. Resumed validation and final review closure
+
+**The required native-denial evidence gap V1 is closed, and the concrete temporary service
+recipe passed independent evidence review.** Section 10 remains the unchanged historical record:
+its first B attempt was inconclusive and its default service PATH lacked the native tools. One
+later authorized native job supplied direct refusal evidence. The separate PATH candidate below
+was actually tested; production configuration, enablement and deployment remained outside scope.
+All earlier 49,260 bytes of this audit are preserved byte-for-byte, with SHA256
+`daf8c89f380eabc0d1da201da286ba0a000a1677fbc438e0e70a5e3e45fcaefa`.
+
+### Resumed native denial and temporary service recipe
+
+The new run used actual CoderService, CodexBackend, CoderRequestPreparer, CoderProcessInspector and
+on-disk GRDB with real migrations and a CoderApprovedOriginFixture-approved owner-DM origin. On
+macOS 26.6.2 (25G83), a temporary LaunchAgent in `gui/502` ran as `jetbrains`, UID 502, HOME
+`/Users/jetbrains`. Its sole ProgramArguments entry was the unchanged installed
+`/Users/jetbrains/.swift-claw/bin/run-clawd.sh`. A separate `CLAW_ENV_FILE=<private root>/candidate.env`
+supplied PATH and `CLAWD_BIN` for the private harness; no production env file was sourced or modified.
+
+```text
+private root=/private/var/folders/85/6nvq33kd48g2g1nwnjbp2k3m0000gp/T/swift-claw-resumed-denial.36ysj__w
+label=com.ivanmagda.swift-claw.coder-denial.dd632ba5-3913-45b1-9589-f13028450e69
+PATH=/Users/jetbrains/.nvm/versions/node/v24.4.1/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+native executable=/Users/jetbrains/.nvm/versions/node/v24.4.1/bin/codex
+effective config home=/Users/jetbrains/.codex
+profile=unset
+```
+
+Actual service preflight at **2026-09-06 23:08:28–23:08:31 UTC** established Codex CLI 0.153.4 and
+local ChatGPT authorization; `gh` 2.98.0, keyring authorization and authenticated API identity
+`ivan-magda`; repository `ivan-magda/swift-claw`, default branch `main`, and admin/maintain/pull/push/
+triage permissions all true. Each check exited zero. The subsequent native turn adds provider
+execution evidence. This verifies the concrete separate PATH candidate, not the current installed
+production service configuration or a new Git push.
+
+The selected Coder executable and approval identity were a transparent scratch observer at
+`<private root>/observer`. It forwarded the original installed CLI's unchanged production argv,
+finite stdin, actual schema, cwd, permitted environment values and stdout/stderr, keeping the native
+child in Coder's PGID 76836. It removed Python's runtime-added `__CF_USER_TEXT_ENCODING`; no logging
+override or wider policy was added. Its bounded collector retained command/rule-correlated native
+ERROR evidence independently of worker messages and reasoning. Synthetic filtering/forwarding and
+real-service fixture checks passed before inference. The unwrapped executable's approval identity
+was not exercised. Exact supervisor/native argv and the sanitized evidence paths are in
+`resumed-native-denial-report.md` and `resumed-native-denial-evidence/native-observation.json` under
+the local evidence directory listed below. The observed schema SHA256 independently matched the
+embedded `Sources/ClawCoder/Codex/CodexResult.schema.json`:
+`b37dd63313fa5441ab530e2afb1d59b4fafe9d4994cbf41c4a2e1a3e18cceb03`.
+
+One exclusive mode-0600 temporary forbidden rule covered the unique marker command for
+`/usr/bin/touch` or `touch`, under both verified `/private/var/...` and `/var/...` repository aliases.
+Four free positive controls returned forbidden/one match; two suffixed-marker controls did not match.
+The controller then released exactly one native job:
+**`ACBDFB71-7BA9-40EC-A78D-BD45559F0759`**, from **2026-09-06 23:09:51.253747 to 23:10:26.045886 UTC**,
+approximately **34.792 seconds** (September 7 in Europe/Istanbul). The native launcher exited zero
+and emitted `turn.completed`. Native stderr ERROR target **`codex_core::tools::router`** supplied:
+
+```text
+`/bin/zsh -lc '/usr/bin/touch /var/folders/85/6nvq33kd48g2g1nwnjbp2k3m0000gp/T/swift-claw-resumed-denial.36ysj__w/repository/denied-marker'` rejected: swift-claw native denial dd632ba5-3913-45b1-9589-f13028450e69; stop without escalation.
+```
+
+There was still no denied-command JSONL lifecycle. This exact command and unique forbidden-rule
+justification supply the missing direct refusal proof. The worker's phrase "Automatic approval
+review rejected" does not establish a separate Guardian decision: the proved event is **native
+execpolicy denial**. The explanatory local Codex source checkout was not established as the installed
+binary's exact revision; runtime proof stands independently. No controller/observer retry, escalation,
+timeout, signal or emergency cleanup occurred.
+
+Actual durable outcomes and independent retained-state verification established:
+
+- **Failed / permission**, stopped ownership and native receipt, slotReserved false and reserved
+  count zero after the previously observed running/owned/reserved state.
+- **One new trusted completion outbox row** for the job at run 1/chat 7; two pending rows total,
+  including the fixture's original approval prompt. No actual Telegram receipt, approval-button
+  transport or network completion delivery ran in this probe.
+- `retained.txt` contained exactly `retained`, without newline; denied marker absent. Product
+  inventory observed changedFiles `[retained.txt]`, baselineObserved true. Independent Git found
+  branch `probe-native-denial`, unborn HEAD (verify exit 128), no remotes and only `?? retained.txt`.
+  Publication was absent and commit null.
+- Actual `CoderService.shutdown()` joined; harness exit zero/PASS, empty stderr and no reservations.
+
+At **23:12:25.768826 UTC**, final verification found the unique rule and LaunchAgent absent
+(bootout exit zero; label print exit 113), recorded native/final-inspection groups **76836 and 77742
+empty**, private launch/observer controls removed and no native protocol directory. The wrapper's
+SHA256 remained `2cc91233564a5f45e05a76ed63c05a1e3a077bb8bb7ea6abbb9994c7e7a07b8e`.
+The private root retains the database, repository and sanitized observations as work artifacts.
+Independent read-only review beginning at 23:17:11 UTC reconfirmed SQL, file bytes, Git facts,
+cleanup and mirrored evidence: **PASS, no required evidence defect**.
+
+### Product acceptance boundaries and review closure
+
+Task 8 `CoderDoneWhenTests`, committed at `d1ecb8e4652d775aeb3fa6c93c8e8db7558d4e64`, owns the
+router/approval/service/GRDB/outbox/transport path with scripted model, backend and Telegram
+boundaries. It observes an ordinary reply in the same DM while coding waits, then the saved result
+and automatic trusted-origin completion without another model turn; wake replay preserves one
+completion row. Its tool-lane-blocking mutant failed while the nearest approval/service tests passed.
+This deterministic acceptance and the native probe establish their separate boundaries; neither is
+relabeled as actual Telegram network delivery.
+
+Cancellation remains the actual section 10 C run: a harmless long-running external CLI fixture
+through the real Coder service/native backend, one cancel, observed descendant/group settlement,
+retained work, N=1 capacity and same-checkout reuse, then joined shutdown. No paid inference
+cancellation ran. Historical [draft PR #182](https://github.com/ivan-magda/swift-claw/pull/182) remains
+the successful foreground clone/edit/lint/commit/push/PR baseline. Temporary-service authenticated
+API permissions and read-only inspection were not a new service-context push or PR.
+
+The additional whole-branch **Astra/ultra** review of `d4715176..d1ecb8e4` found two Important
+guard/recovery gaps. Commit **`882f5b1a52a2145958e2a3c9878f84e098e60ece`** closed both: **R1** sends
+all actual delegated prepared text through the existing secret/private-data guard; **R2** reconciles
+earlier durable jobs and exposes persisted health when disabled, without native probes, tools or
+admission. The architecture and reached public operating documents were updated in that commit.
+Uncertain old ownership remains reserved; recorded PIDs are not blindly signaled.
+
+The same commit addressed the independent test-only **T1** finding with a bounded missing-signal
+guard, a pre-cancellation completion observation and joined failure cleanup in the existing
+persistence-failure test. Its exact missing-latch mutant failed and finished in 31.150s; restored
+production passed. Selected optional **M1** added one wrong-head-OID PR matrix specimen; removing
+that comparison failed only the new specimen, and production was restored unchanged. Independent
+actual-diff test-value review and the completed scoped code/spec rereview both **APPROVED**:
+R1/R2/T1/M1 closed, zero new required findings. Some guard/composition/doctor paths remain
+source-traced rather than separately mutation-tested. Deferred framing, callback-error,
+interrupted-workspace-reporting and fixture-hygiene observations remain optional, not production
+blockers; the reviews do not claim exhaustive native-installation coverage.
+
+Separately, **`7d4066c3aba788e8b35f68dabdaa9d0b48f5b127`** fixed the demonstrated raw
+`Network.NWError.posix(.ECONNREFUSED)` classification gap under `canImport(Network)`. Other errors,
+timeouts and post-head failures remain conservative. Both unreliable released-ephemeral-port
+refusal tests and their helper were removed with independent test-value/code approval; the pure
+classifier covers NIO, AHC-wrapped and raw Network refusal plus a raw non-refusal control. Real
+connected-then-closed transport tests remain. The accepted loss is explicit: no default-suite
+observation of the dependency's live refusal representation, and no positive integration proof
+that submission delegates clean errors to the classifier. A submission mutant that always wraps
+errors conservatively could now survive. Bounded diagnosis demonstrated the representation gap and
+a competing listener invalidating the fixture prerequisite, but **the natural cause of the earlier
+intermittent failures remains unproven**.
+
+### Latest executed source validation and retained evidence
+
+Final source was `882f5b1a52a2145958e2a3c9878f84e098e60ece`, tree
+`2f9dd09e3866ef6adfa803074d8336f47a16137e`. These are actual saved source-stage executions,
+not fresh checks by the documentation writer or independent read-only reviewers:
+
+| Check on final source | Actual result |
+| --- | --- |
+| Host `scripts/lint.sh` | Exit 0; `lint: ok`; 0/759 files require formatting; 11 inherited SwiftLint warnings in unchanged files. |
+| Host `swift build` | Exit 0; build 15.02s. |
+| Host default `swift test` | Exit 0; build 8.75s; **2,909 tests in 371 suites passed in 14.283s**. |
+| Linux selected Coder/Codex/runtime-shutdown/HTTP tests | Exit 0; build 75.67s; **138 tests in 27 suites passed in 13.838s**; no warnings in this incremental log. |
+
+Linux used Docker 29.7.2 and the Swift 6.3 Noble image
+`sha256:1610513149191de464ac06d192b4c2b165433aa18e0053b196d1da1f0570b35f`, target
+`aarch64-unknown-linux-gnu`, read-only `/src`, separate `/scratch`, one CPU (`--cpuset-cpus=0`),
+and `swift test --scratch-path /scratch --jobs 4 --filter
+'Coder|Codex|RuntimeShutdownAcceptanceTests|AsyncHTTPExecutor'`. Wall time was 92.264s, from
+23:56:05.965339 to 23:57:38.230452 UTC on September 6. This was a selected Linux run, not a full
+Linux-suite or live-service test.
+
+Detailed local evidence remains ignored under `.superpowers/sdd/2026-09-06-generic-coder/`:
+
+- `resumed-native-denial-report.md`, `resumed-native-evidence-review.md` and
+  `resumed-native-denial-evidence/`: exact recipe/argv/schema hash, sanitized preflight,
+  admission/running/receipt/terminal facts, rule journal, completion and cleanup evidence.
+- `task-8-live-validation-report.md` and `task8-live-evidence/`: original inconclusive B and
+  harmless cancellation, preserved as executed.
+- `resumed-http-{report,fix-report,test-value-review,code-review}.md`: diagnosis, committed fix,
+  actual gates and accepted integration-coverage loss.
+- `final-branch-ultra-review.md`, `final-test-value-ultra.md`, `final-coder-fix-report.md`,
+  `final-coder-test-value-review.md`, `final-coder-code-review.md`: findings, mutant evidence,
+  committed corrections, approvals and source-traced/optional limits.
+- `final-coder-gate-{lint,build,test}.log`, `final-linux-facts.json`, `final-linux-test.log`:
+  exact source identity, commands, exits and printed validation results.
+
+No required native live-contract gap remains in the executed Task 8 scope. Production installation,
+enablement/deployment, actual Telegram network delivery, fresh service-context publication and paid
+inference cancellation remain outside the claimed evidence. No credentials, prompts, full
+environments, raw native streams or reasoning logs are copied into this append.


### PR DESCRIPTION
Add opt-in, owner-DM Coder submission, status and cancellation through the installed native Codex CLI. Each submission requires owner approval. Ordinary messages in the same DM continue while the job runs, and completion arrives through the durable outbox without another model turn.

This final layer adds the Coder service, approval/tools integration, secret and private-data guards, daemon composition, restart recovery and diagnostics. Coder defaults off with capacity one. The native execution, workspace, backend and storage prerequisite, #187, is merged into main, along with lint and HTTP prerequisites #184 and #186.

Validation:

- Fresh ordered local lint/build/test passed: 2,909 tests in 371 suites. macOS CI runs the native integration workload in a separate test process; the exact test-ID sets and both local invocations confirmed complete coverage, with 2,874 common tests and 35 native tests.
- [Fresh CI](https://github.com/ivan-magda/swift-claw/actions/runs/34113526636) passed on macOS and Linux, including both macOS selections and the Linux concurrency check. All eight PR checks are green.
- Temporary daemon-context authentication and command-correlated native execpolicy denial: PASS. Harmless external-CLI cancellation, descendant cleanup, retained work and capacity/checkout reuse: PASS.
- Independent task, test-value and final source reviews closed required findings. The subsequent CI correction also passed independent quality and test-value review.

[Acceptance evidence and limits](https://github.com/ivan-magda/swift-claw/blob/9922d9088214897721dd96b4841d892433b90473/docs/research/coder-capability-audit-2026-09-06.md#11-resumed-validation-and-final-review-closure) distinguish scripted Telegram acceptance from native execution. The native probe used transparent observer instrumentation. Production service PATH configuration and enablement remain operator steps. Actual Telegram network delivery, a new service-context push/PR and paid-inference cancellation were not run. #182 remains the historical foreground publication baseline.
