### PR TITLE
chore(lint): Enforce multiline guard bodies

### DIFF
--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "301858e56e10c2431bada25a53d5ae90330449d0a5324df4196d944f69f91815",
+  "pins" : [
+    {
+      "identity" : "swiftformat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/SwiftFormat.git",
+      "state" : {
+        "revision" : "2226e9d89bf05a604cc985bab3dccb44ff7c8ee3",
+        "version" : "0.62.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+  name: "BuildTools",
+  dependencies: [
+    .package(
+      url: "https://github.com/nicklockwood/SwiftFormat.git",
+      exact: "0.62.1"
+    )
+  ],
+  targets: [
+    .target(name: "BuildTools")
+  ]
+)

--- a/BuildTools/Sources/BuildTools/Empty.swift
+++ b/BuildTools/Sources/BuildTools/Empty.swift
@@ -1,0 +1,1 @@
+enum BuildTools {}

--- a/BuildTools/guard-bodies.swiftformat
+++ b/BuildTools/guard-bodies.swiftformat
@@ -1,0 +1,6 @@
+# Apple swift-format owns general layout. This pass supplies only the guard-body
+# rule that Apple swift-format cannot express.
+--rules wrapGuardStatementBodies
+--indent 2
+--linebreaks lf
+--swift-version 6.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,9 @@ SwiftPM package, executable `clawd`. The dependency graph is a layered DAG: **se
 
 ## Code style
 
-- **Lint gate = `scripts/lint.sh`** over `Sources`, `Tests`, `Package.swift`. Run `scripts/lint.sh --fix`, read the diff it produced, then `scripts/lint.sh` to check. Both tools must pass before committing (CI enforces it). `.swift-format` and `.swiftlint.yml` hold the exact rules, and are the source of truth for identifier limits and the domain exceptions they allow.
-- **Two shapes `--fix` never converges on**, both of which then fail the gate: the `{` of a multi-line `if let X, cond {` — use `guard … else {`, or keep the condition on one line — and a single line over width 100, where you hoist a subexpression into a named local first.
-- **Guard bodies are always multiline** — never `guard condition else { return }`.
+- **Lint gate = `scripts/lint.sh`** — three tools: Apple swift-format owns general layout (`.swift-format`), a targeted SwiftFormat pass owns the layout rules Apple cannot express (`BuildTools/guard-bodies.swiftformat`), and SwiftLint owns correctness and idiom (`.swiftlint.yml`, also the source of truth for identifier limits and the domain exceptions they allow). Run `scripts/lint.sh --fix`, read the diff it produced, then `scripts/lint.sh` to check. All three must pass before committing (CI enforces it).
+- **Guard bodies are always multiline** — never `guard condition else { return }`. `--fix` expands it for you; the gate rejects it if you skip that.
+- **A line over width 100 is the one shape `--fix` never converges on** — hoist a subexpression into a named local first.
 - **Closure bodies go on their own line** — break after `in`, even for a single expression. The lint gate does not enforce this one.
 - **Tests follow Given-When-Then** — separate the body with `// given` / `// when` / `// then` sections (AAA equivalent).
 - **Comments: signal, not noise.** `///` is 1–2 lines of contract the signature can't express; `//` is for a constraint invisible in the code *and* not tied to the current change. Rationale for a change goes in the commit and the PR, never beside the code. Never cite a bare `§N` — write the why in place, or use the full `ARCHITECTURE.md §N` only where code would otherwise read as a bug (the durable direction is docs→code; see the `ARCHITECTURE.md` §3.1 code map).

--- a/Sources/ClawAgent/Runtime/AgentRuntime.swift
+++ b/Sources/ClawAgent/Runtime/AgentRuntime.swift
@@ -667,7 +667,9 @@ private extension AgentRuntime {
   /// owed when that window had lapsed rather than been cleared, so exactly one turn tells the owner
   /// the primary is carrying traffic again.
   func primaryRecoveryNotice(binding: LLMRouteBinding) async -> RouteNotice? {
-    guard let cooldown else { return nil }
+    guard let cooldown else {
+      return nil
+    }
     let lapsed = await cooldown.recordSuccess()
     return lapsed ? .restored(route: binding.configuredReference) : nil
   }

--- a/Sources/ClawAuth/Credentials/ChatGPTCredentialSource.swift
+++ b/Sources/ClawAuth/Credentials/ChatGPTCredentialSource.swift
@@ -371,7 +371,9 @@ private extension ChatGPTCredentialSource {
   }
 
   func append(_ value: String, to values: inout [String]) {
-    guard values.contains(value) == false else { return }
+    guard values.contains(value) == false else {
+      return
+    }
     values.append(value)
   }
 }
@@ -436,7 +438,9 @@ private extension ChatGPTCredentialSource {
   }
 
   nonisolated static func isWorthRetrying(_ error: any Error) -> Bool {
-    guard case .transport = error as? ChatGPTOAuthFailure else { return false }
+    guard case .transport = error as? ChatGPTOAuthFailure else {
+      return false
+    }
     return true
   }
 

--- a/Sources/ClawCore/Transport/StreamTerminationOwner.swift
+++ b/Sources/ClawCore/Transport/StreamTerminationOwner.swift
@@ -105,7 +105,9 @@ final class StreamTerminationOwner<Element: Sendable, Termination: Sendable>: Se
   /// Runs once, as the producer's last act, so a resumed joiner knows the transfer has stopped and
   /// every transfer nested inside it with it.
   func finish(reporting termination: Termination) {
-    guard let commit = commit(termination) else { return }
+    guard let commit = commit(termination) else {
+      return
+    }
     // Caching before closing is what resolves the terminal-versus-cancellation race: a consumer that
     // sees the channel end can always read whatever a completed commit reserved before the close, so
     // the outcome — never the timing of the last element — decides what it saw.
@@ -135,7 +137,9 @@ private extension StreamTerminationOwner {
   /// Returns nil for a second report, which is how the first outcome stays the only one.
   func commit(_ termination: Termination) -> Commit? {
     state.withLock { current -> Commit? in
-      guard current.terminal == nil else { return nil }
+      guard current.terminal == nil else {
+        return nil
+      }
       let decided = resolve(termination, current.isCancelRequested)
       current.terminal = decided
       let parked = current.joiners

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB+BootHealth.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB+BootHealth.swift
@@ -176,7 +176,9 @@ extension RunStoreGRDB {
       )
       var consecutiveFailures = 0
       for state in recentStates {
-        guard state == RunState.failed.rawValue else { break }
+        guard state == RunState.failed.rawValue else {
+          break
+        }
         consecutiveFailures += 1
       }
 

--- a/Sources/ClawGateway/Services/OutboxDispatcher.swift
+++ b/Sources/ClawGateway/Services/OutboxDispatcher.swift
@@ -186,7 +186,9 @@ private extension OutboxDispatcher {
   }
 
   static func floodControlRetryAfter(_ error: any Error) -> Int? {
-    guard case .some(.floodControl(let retryAfter)) = error as? TelegramError else { return nil }
+    guard case .some(.floodControl(let retryAfter)) = error as? TelegramError else {
+      return nil
+    }
     return retryAfter
   }
 }
@@ -201,7 +203,9 @@ private final class FloodControlHolds<Instant: InstantProtocol>: Sendable {
   /// stays the size of the currently-throttled chats.
   func isHeld(_ chatId: Int64, now: Instant) -> Bool {
     notBefore.withLock { held in
-      guard let deadline = held[chatId] else { return false }
+      guard let deadline = held[chatId] else {
+        return false
+      }
       if now < deadline { return true }
       held[chatId] = nil
       return false

--- a/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
+++ b/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
@@ -451,7 +451,9 @@ private extension OpenAICompatibleProvider {
   /// A transport failure already carries its own diagnostic; interpolating the struct would bury it
   /// in synthesized field syntax.
   static func describe(_ error: any Error) -> String {
-    guard let failure = error as? HTTPTransportFailure else { return "\(error)" }
+    guard let failure = error as? HTTPTransportFailure else {
+      return "\(error)"
+    }
     return failure.safeMessage
   }
 }

--- a/Tests/ClawAgentTests/Runtime/AgentRuntimeStreamingTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentRuntimeStreamingTests.swift
@@ -280,7 +280,9 @@ actor BlockingFinalDrafts: RichDraftStreaming {
   }
 
   func waitUntilFinalBlocked() async {
-    guard !finalBlocked else { return }
+    guard !finalBlocked else {
+      return
+    }
     await withCheckedContinuation { continuation in
       observeWaiters.append(continuation)
     }
@@ -343,7 +345,9 @@ actor BlockingDrafts: RichDraftStreaming {
   }
 
   func waitUntilFirstSendBlocked() async {
-    guard !firstSendBlocked else { return }
+    guard !firstSendBlocked else {
+      return
+    }
     await withCheckedContinuation { continuation in
       blockedWaiters.append(continuation)
     }
@@ -380,14 +384,18 @@ actor NonCooperativeStreamGate {
     }
     startedWaiters.removeAll()
 
-    guard !released else { return }
+    guard !released else {
+      return
+    }
     await withCheckedContinuation { continuation in
       releaseWaiters.append(continuation)
     }
   }
 
   func waitUntilStarted() async {
-    guard !started else { return }
+    guard !started else {
+      return
+    }
     await withCheckedContinuation { continuation in
       startedWaiters.append(continuation)
     }
@@ -412,7 +420,9 @@ actor TurnResultBox {
   private var waiters: [CheckedContinuation<TimedTurnResult, Never>] = []
 
   func resolve(_ result: TimedTurnResult) {
-    guard self.result == nil else { return }
+    guard self.result == nil else {
+      return
+    }
     self.result = result
     for waiter in waiters {
       waiter.resume(returning: result)

--- a/Tests/ClawAgentTests/Runtime/ProviderDeadlineCoordinatorTests.swift
+++ b/Tests/ClawAgentTests/Runtime/ProviderDeadlineCoordinatorTests.swift
@@ -88,7 +88,9 @@ private actor OutcomeBox {
   private var waiters: [CheckedContinuation<ProviderDeadlineOutcome, Never>] = []
 
   func resolve(_ resolved: ProviderDeadlineOutcome) {
-    guard outcome == nil else { return }
+    guard outcome == nil else {
+      return
+    }
     outcome = resolved
     for waiter in waiters {
       waiter.resume(returning: resolved)

--- a/Tests/ClawAuthTests/Credentials/ChatGPTCredentialSourceTests.swift
+++ b/Tests/ClawAuthTests/Credentials/ChatGPTCredentialSourceTests.swift
@@ -261,12 +261,16 @@ func authorizing(_ source: ChatGPTCredentialSource<ScriptedClock>) -> Caller {
 
 extension ChatGPTCredentialError {
   var throttleDelay: Duration? {
-    guard case .throttled(let retryAfter) = self else { return nil }
+    guard case .throttled(let retryAfter) = self else {
+      return nil
+    }
     return retryAfter
   }
 
   var unavailableDelay: Duration? {
-    guard case .temporarilyUnavailable(let retryAfter, _) = self else { return nil }
+    guard case .temporarilyUnavailable(let retryAfter, _) = self else {
+      return nil
+    }
     return retryAfter
   }
 }

--- a/Tests/ClawAuthTests/OAuth/ChatGPTOAuthClientTests.swift
+++ b/Tests/ClawAuthTests/OAuth/ChatGPTOAuthClientTests.swift
@@ -75,17 +75,23 @@ enum OAuthFixture {
 /// written into an equality expectation.
 extension ChatGPTOAuthFailure {
   var isMalformed: Bool {
-    guard case .malformedResponse = self else { return false }
+    guard case .malformedResponse = self else {
+      return false
+    }
     return true
   }
 
   var isGrantRejected: Bool {
-    guard case .grantRejected = self else { return false }
+    guard case .grantRejected = self else {
+      return false
+    }
     return true
   }
 
   var isTransport: Bool {
-    guard case .transport = self else { return false }
+    guard case .transport = self else {
+      return false
+    }
     return true
   }
 

--- a/Tests/ClawDataTests/Database/PersistenceSchemaMigrationTests.swift
+++ b/Tests/ClawDataTests/Database/PersistenceSchemaMigrationTests.swift
@@ -44,7 +44,9 @@ import Testing
         )
       }
     } throws: { error in
-      guard let dbErr = error as? DatabaseError else { return false }
+      guard let dbErr = error as? DatabaseError else {
+        return false
+      }
       return dbErr.resultCode.primaryResultCode == .SQLITE_CONSTRAINT
         && (dbErr.message?.contains("FOREIGN KEY") ?? false)
     }

--- a/Tests/ClawExecTests/ClawExecTestSupport.swift
+++ b/Tests/ClawExecTests/ClawExecTestSupport.swift
@@ -126,7 +126,9 @@ func writeCidfile(from arguments: [String]) {
 
 func scratchChildren(_ stateRoot: URL) throws -> [URL] {
   let root = stateRoot.appending(path: "exec-scratch")
-  guard FileManager.default.fileExists(atPath: root.path) else { return [] }
+  guard FileManager.default.fileExists(atPath: root.path) else {
+    return []
+  }
   return try FileManager.default.contentsOfDirectory(
     at: root,
     includingPropertiesForKeys: nil

--- a/Tests/ClawExecTests/ContainerBackendMaintenanceTests.swift
+++ b/Tests/ClawExecTests/ContainerBackendMaintenanceTests.swift
@@ -298,7 +298,9 @@ private final class MaintenanceFixture: @unchecked Sendable {
       let workloadImage = PinnedImageReference.parse(
         "cgr.dev/swift-claw/python@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       )
-    else { throw MaintenanceFixtureError.missingIdentity }
+    else {
+      throw MaintenanceFixtureError.missingIdentity
+    }
     settings = ExecSandboxSettings(
       workloadImage: workloadImage,
       memoryMiB: 1024,

--- a/Tests/ClawExecTests/ContainerInvocationTests.swift
+++ b/Tests/ClawExecTests/ContainerInvocationTests.swift
@@ -262,7 +262,9 @@ import Testing
 
 extension Array where Element: Equatable {
   fileprivate func containsSubsequence(_ subsequence: [Element]) -> Bool {
-    guard !subsequence.isEmpty, subsequence.count <= count else { return false }
+    guard !subsequence.isEmpty, subsequence.count <= count else {
+      return false
+    }
     return indices.dropLast(subsequence.count - 1).contains { index in
       Array(self[index..<(index + subsequence.count)]) == subsequence
     }

--- a/Tests/ClawGatewayTests/Acceptance/ExecuteCodeApprovalFlowTests.swift
+++ b/Tests/ClawGatewayTests/Acceptance/ExecuteCodeApprovalFlowTests.swift
@@ -60,7 +60,9 @@ import Testing
       execEnabled: true,
       executionBackend: executionBackend,
       beforeCompletion: { completion, request in
-        guard completion == 1 else { return }
+        guard completion == 1 else {
+          return
+        }
         #expect(request.messages.allSatisfy { $0.content.text.contains(privateText) == false })
         try privateText.write(
           to: privateFile,

--- a/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
+++ b/Tests/ClawGatewayTests/LLMTurnPersistenceAcceptanceTests.swift
@@ -141,7 +141,9 @@ actor StreamingAcceptanceProvider: LLMProvider {
   }
 
   func waitForStreamCalls(_ count: Int) async {
-    guard streamCalls < count else { return }
+    guard streamCalls < count else {
+      return
+    }
     await withCheckedContinuation { continuation in
       requestWaiters.append((threshold: count, continuation: continuation))
     }
@@ -184,7 +186,9 @@ actor StreamingAcceptanceProvider: LLMProvider {
   }
 
   private func waitForPostDeltaRelease() async {
-    guard !postDeltaReleased else { return }
+    guard !postDeltaReleased else {
+      return
+    }
     await withCheckedContinuation { continuation in
       postDeltaRelease = continuation
     }
@@ -216,7 +220,9 @@ actor StopNewProvider: LLMProvider {
   }
 
   func waitForRequestCount(_ count: Int) async {
-    guard requests.count < count else { return }
+    guard requests.count < count else {
+      return
+    }
     await withCheckedContinuation { continuation in
       requestContinuations.append((count: count, continuation: continuation))
     }

--- a/Tests/ClawGatewayTests/Routing/ApprovedActionExecutorTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ApprovedActionExecutorTests.swift
@@ -30,14 +30,18 @@ import Testing
         waiter.resume()
       }
       startedWaiters.removeAll()
-      guard released == false else { return }
+      guard released == false else {
+        return
+      }
       await withCheckedContinuation { continuation in
         releaseWaiters.append(continuation)
       }
     }
 
     func waitUntilStarted() async {
-      guard started == false else { return }
+      guard started == false else {
+        return
+      }
       await withCheckedContinuation { continuation in
         startedWaiters.append(continuation)
       }

--- a/Tests/ClawGatewayTests/Services/OutboxDispatcherTests.swift
+++ b/Tests/ClawGatewayTests/Services/OutboxDispatcherTests.swift
@@ -92,7 +92,9 @@ private actor DeliverySpy: MessageDelivery {
     case .some(.unreachable):
       throw TelegramError.transport("chat \(chatId) down")
     case .some(.floodControl(let retryAfter, let times)):
-      guard times > 0 else { return }
+      guard times > 0 else {
+        return
+      }
       outcomes[chatId] = .floodControl(retryAfter: retryAfter, times: times - 1)
       throw TelegramError.floodControl(retryAfter: retryAfter)
     }
@@ -119,7 +121,9 @@ private final class RetryWaitHold: Sendable {
       requested.withLock { delays in
         delays.append(delay)
       }
-      guard delay == retryAfter else { return }
+      guard delay == retryAfter else {
+        return
+      }
       waitStarted.open()
       await released.wait()
     }

--- a/Tests/ClawGatewayTests/Services/TelegramPollerServiceTests.swift
+++ b/Tests/ClawGatewayTests/Services/TelegramPollerServiceTests.swift
@@ -29,7 +29,9 @@ private actor BlockingTurnRunner: TurnDispatching {
   }
 
   func waitUntilStarted() async {
-    guard callCount == 0 else { return }
+    guard callCount == 0 else {
+      return
+    }
     await withCheckedContinuation { continuation in
       started = continuation
     }

--- a/Tests/ClawGatewayTests/Support/TestSupport.swift
+++ b/Tests/ClawGatewayTests/Support/TestSupport.swift
@@ -224,14 +224,18 @@ actor RecordingTransport: TelegramTransport {
   }
 
   private func wait(_ event: Event, current: Int, threshold: Int) async {
-    guard current < threshold else { return }
+    guard current < threshold else {
+      return
+    }
     await withCheckedContinuation { continuation in
       waiters[event, default: []].append((threshold, continuation))
     }
   }
 
   private func resumeWaiters(_ event: Event, reached current: Int) {
-    guard let pending = waiters[event] else { return }
+    guard let pending = waiters[event] else {
+      return
+    }
     waiters[event] = pending.filter { $0.threshold > current }
     for waiter in pending where waiter.threshold <= current {
       waiter.continuation.resume()

--- a/Tests/ClawLLMTests/ChatGPT/ChatGPTResponsesProviderTests.swift
+++ b/Tests/ClawLLMTests/ChatGPT/ChatGPTResponsesProviderTests.swift
@@ -421,7 +421,9 @@ import Testing
 
     // then — only the pre-done delta is published, and the final content never grows past it
     let deltas = drained.events.compactMap { event -> String? in
-      guard case .delta(let text) = event else { return nil }
+      guard case .delta(let text) = event else {
+        return nil
+      }
       return text
     }
     #expect(deltas == ["Hello"])

--- a/Tests/ClawLLMTests/Provider/OpenAICompatibleProviderTests.swift
+++ b/Tests/ClawLLMTests/Provider/OpenAICompatibleProviderTests.swift
@@ -249,7 +249,9 @@ import Testing
     } throws: { error in
       // The buffered path wraps its cause in a ProviderFailure that carries the accounting: a clean
       // 4xx head generated nothing, so the failure is notStarted.
-      guard case .terminal(let status, _)? = ProviderError.cause(of: error) else { return false }
+      guard case .terminal(let status, _)? = ProviderError.cause(of: error) else {
+        return false
+      }
       return status == 400 && ProviderFailureAccounting.classify(error) == .notStarted
     }
     let attempts = await exec.recorded.count
@@ -290,7 +292,9 @@ import Testing
     } throws: { error in
       // Each 500 was proven clean before the exhausting throw, so the wrapped failure charges no
       // phantom usage — it is notStarted, not the case-guessed mayHaveStarted.
-      guard case .retryable(let status, _)? = ProviderError.cause(of: error) else { return false }
+      guard case .retryable(let status, _)? = ProviderError.cause(of: error) else {
+        return false
+      }
       return status == 500 && ProviderFailureAccounting.classify(error) == .notStarted
     }
     let attempts = await exec.recorded.count
@@ -314,7 +318,9 @@ import Testing
     await #expect {
       _ = try await provider.complete(request: sampleRequest)
     } throws: { error in
-      guard case .retryable(let status, _)? = ProviderError.cause(of: error) else { return false }
+      guard case .retryable(let status, _)? = ProviderError.cause(of: error) else {
+        return false
+      }
       return status == 500
     }
 
@@ -345,7 +351,9 @@ import Testing
     await #expect {
       _ = try await provider.complete(request: sampleRequest)
     } throws: { error in
-      guard case .retryable(_, let message)? = ProviderError.cause(of: error) else { return false }
+      guard case .retryable(_, let message)? = ProviderError.cause(of: error) else {
+        return false
+      }
       thrownMessage = message
       return true
     }
@@ -397,7 +405,9 @@ import Testing
     } throws: { error in
       // The attempt reached the transport and cannot be proven clean, so the failure carries
       // conservative accounting rather than being replayed.
-      guard case .retryable(let status, _)? = ProviderError.cause(of: error) else { return false }
+      guard case .retryable(let status, _)? = ProviderError.cause(of: error) else {
+        return false
+      }
       return status == nil
         && ProviderFailureAccounting.classify(error) == .mayHaveStarted(observing: 0)
     }
@@ -663,7 +673,9 @@ import Testing
     await #expect {
       _ = try await provider.complete(request: sampleRequest)
     } throws: { error in
-      guard case .retryable(_, let message)? = ProviderError.cause(of: error) else { return false }
+      guard case .retryable(_, let message)? = ProviderError.cause(of: error) else {
+        return false
+      }
       thrownMessage = message
       return true
     }
@@ -691,7 +703,9 @@ import Testing
     await #expect {
       _ = try await provider.complete(request: sampleRequest)
     } throws: { error in
-      guard case ProviderError.terminal(let status, let message) = error else { return false }
+      guard case ProviderError.terminal(let status, let message) = error else {
+        return false
+      }
       return status == nil && message.contains("Host")
     }
 
@@ -712,7 +726,9 @@ import Testing
     await #expect {
       _ = try await provider.complete(request: sampleRequest)
     } throws: { error in
-      guard case ProviderError.terminal(_, let message) = error else { return false }
+      guard case ProviderError.terminal(_, let message) = error else {
+        return false
+      }
       return message.contains("content-type")
     }
     #expect(await exec.recorded.isEmpty)

--- a/Tests/ClawTelegramTests/Client/TelegramClientTests.swift
+++ b/Tests/ClawTelegramTests/Client/TelegramClientTests.swift
@@ -168,7 +168,9 @@ private func client(status: Int, json: String) -> TelegramClient {
     await #expect {
       _ = try await telegram.getMe()
     } throws: { error in
-      guard let telegramErr = error as? TelegramError else { return false }
+      guard let telegramErr = error as? TelegramError else {
+        return false
+      }
       if case .decoding = telegramErr { return true }
       return false
     }
@@ -187,7 +189,9 @@ private func client(status: Int, json: String) -> TelegramClient {
     await #expect {
       _ = try await telegram.getMe()
     } throws: { error in
-      guard case TelegramError.transport(let message) = error else { return false }
+      guard case TelegramError.transport(let message) = error else {
+        return false
+      }
       thrownMessage = message
       return true
     }

--- a/Tests/ClawTelegramTests/Wire/AsyncHTTPExecutorGeneralRequestTests.swift
+++ b/Tests/ClawTelegramTests/Wire/AsyncHTTPExecutorGeneralRequestTests.swift
@@ -120,7 +120,9 @@ private final class ScriptedHandler: ChannelInboundHandler, @unchecked Sendable 
         body.append(contentsOf: bytes)
       }
     case .end:
-      guard let requestHead = head else { return }
+      guard let requestHead = head else {
+        return
+      }
       var collected: [String: [String]] = [:]
       for header in requestHead.headers {
         collected[header.name.lowercased(), default: []].append(header.value)
@@ -189,7 +191,9 @@ private final class CloseAfterRequestHandler: ChannelInboundHandler, @unchecked 
   typealias InboundIn = HTTPServerRequestPart
 
   func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-    guard case .end = unwrapInboundIn(data) else { return }
+    guard case .end = unwrapInboundIn(data) else {
+      return
+    }
     context.close(promise: nil)
   }
 }

--- a/Tests/ClawTelegramTests/Wire/AsyncHTTPExecutorStreamingTests.swift
+++ b/Tests/ClawTelegramTests/Wire/AsyncHTTPExecutorStreamingTests.swift
@@ -29,7 +29,9 @@ private final class BurstingHandler: ChannelInboundHandler, @unchecked Sendable 
   }
 
   func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-    guard case .end = unwrapInboundIn(data) else { return }
+    guard case .end = unwrapInboundIn(data) else {
+      return
+    }
 
     let headers = HTTPHeaders([("content-type", "text/event-stream")])
     context.write(

--- a/Tests/ClawdCompositionTests/Support/CompositionAcceptanceHarness.swift
+++ b/Tests/ClawdCompositionTests/Support/CompositionAcceptanceHarness.swift
@@ -357,7 +357,9 @@ struct CompositionAcceptanceHarness {
     sandbox: DaemonBuilder.SandboxStack,
     capture: BootCapture
   ) async -> [String: String] {
-    guard let cooldown = try? capture.requireCooldown() else { return [:] }
+    guard let cooldown = try? capture.requireCooldown() else {
+      return [:]
+    }
     return await rowValues(
       builder.makeDoctorReporter(sandbox: sandbox, cooldown: cooldown, mcpOutcomes: [])
     )
@@ -399,21 +401,27 @@ final class BootCapture: @unchecked Sendable {
   func requireBuilder() throws -> DaemonBuilder {
     lock.lock()
     defer { lock.unlock() }
-    guard let builder else { throw BootNeverAssembled() }
+    guard let builder else {
+      throw BootNeverAssembled()
+    }
     return builder
   }
 
   func requireRosterStack() throws -> RosterStack {
     lock.lock()
     defer { lock.unlock() }
-    guard let rosterStack else { throw BootNeverAssembled() }
+    guard let rosterStack else {
+      throw BootNeverAssembled()
+    }
     return rosterStack
   }
 
   func requireCooldown() throws -> PrimaryRouteCooldown<ContinuousClock> {
     lock.lock()
     defer { lock.unlock() }
-    guard let cooldown else { throw BootNeverAssembled() }
+    guard let cooldown else {
+      throw BootNeverAssembled()
+    }
     return cooldown
   }
 }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,23 +1,40 @@
 #!/usr/bin/env bash
-# Lint gate: swift-format (layout) + SwiftLint (complexity/correctness/idiom).
-# Config: .swift-format and .swiftlint.yml.
+# Lint gate: swift-format + targeted SwiftFormat rules + SwiftLint.
+# Config: .swift-format, BuildTools/guard-bodies.swiftformat, and .swiftlint.yml.
 #   scripts/lint.sh        check only (CI / pre-commit)
-#   scripts/lint.sh --fix  auto-apply both tools' fixes
+#   scripts/lint.sh --fix  auto-apply all formatter and linter fixes
 #   STRICT=1 scripts/lint.sh   promote SwiftLint warnings to failures
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-paths=(Sources Tests Package.swift)
+paths=(Sources Tests Package.swift BuildTools/Package.swift BuildTools/Sources)
+repository_root=$PWD
+guard_format_paths=(
+  "$repository_root/Sources"
+  "$repository_root/Tests"
+  "$repository_root/Package.swift"
+  "$repository_root/BuildTools/Package.swift"
+  "$repository_root/BuildTools/Sources"
+)
+
+run_guard_formatter() {
+  swift run --package-path BuildTools swiftformat \
+    --config "$repository_root/BuildTools/guard-bodies.swiftformat" \
+    "$@" \
+    "${guard_format_paths[@]}"
+}
 
 if [[ "${1:-}" == "--fix" ]]; then
+  run_guard_formatter
   swift format -i -r "${paths[@]}"
   command -v swiftlint >/dev/null 2>&1 && swiftlint --fix --quiet
   echo "lint: applied fixes"
   exit 0
 fi
 
-# swift-format is the source of truth for layout; any drift fails the gate.
+# Apple swift-format owns general layout; the targeted pass fills its guard-body gap.
 swift format lint --strict -r "${paths[@]}"
+run_guard_formatter --lint
 
 if ! command -v swiftlint >/dev/null 2>&1; then
   echo "lint: swiftlint not found — install with 'brew install swiftlint'" >&2


### PR DESCRIPTION
The existing lint gate did not enforce the project's multiline `guard` body rule. This adds a pinned SwiftFormat pass for `wrapGuardStatementBodies`: check mode rejects one-line bodies and `--fix` expands them. Apple swift-format continues to own general layout; SwiftLint handles correctness and idiom.

- Add the standalone `BuildTools` package, exact SwiftFormat 0.62.1 pin/lockfile and single-rule configuration. Application package dependencies are unchanged.
- Invoke the targeted pass from `scripts/lint.sh` and align `CLAUDE.md`/the existing `AGENTS.md` symlink with the three-tool gate.
- Expand guard bodies in 26 existing Swift files. Compared with main, these source/test files are byte-identical after whitespace removal; no assertions, fixtures or application behavior were added.

Review and merge in stack order: #184 → #186 → #187 → #183. This PR targets `main`; HTTP PR #186 depends on it. Native execution and product integration follow in #187 and #183.

Validation on the exact tooling-only tree, in a separate snapshot/build directory: `scripts/lint.sh` PASS (`lint: ok`, 11 inherited warnings), `swift build` PASS, and full `swift test` PASS: **2,806 tests in 350 suites, 3.108s**. All tracked snapshot bytes were checked against the committed tree after the run. No Coder implementation or live native probe was included.
