### PR TITLE
docs: correct README allowlist revocation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ swift-claw assumes you are the only person it serves.
 
 - **Default-deny.** Only allowlisted Telegram IDs get a conversation. clawd refuses
   everyone else, and answers `/start` with the sender's own numeric ID so you can
-  allowlist them. `CLAW_ALLOWLIST` only ever adds, so revoking an ID means deleting its
-  row from the database ([details](docs/CUSTOMIZATION.md#everything-else)).
+  allowlist them. `CLAW_ALLOWLIST` only ever adds, so revoking an ID means stopping the
+  daemon, removing the ID from `CLAW_ALLOWLIST`, and deleting its row from the database
+  ([details](docs/CUSTOMIZATION.md#everything-else)).
 - **Secrets encrypted at rest.** `clawd secrets seal` wraps the bot token and API keys in
   an AES-GCM envelope. Plaintext env secrets remain available as a dev fallback that
   warns on every boot.


### PR DESCRIPTION
The README says deleting an allowlist database row revokes access, but the daemon restores any ID still in `CLAW_ALLOWLIST` at startup. Correct that sentence to include stopping the daemon and removing the configured ID before deleting its row, matching `docs/CUSTOMIZATION.md`.

Only `README.md` changes.

Validation:
- `git diff --check` passed.
- `scripts/lint.sh` passed (existing warnings).
- `swift test` passed: 2,909 tests in 371 suites.
