### PR TITLE
Fix approval replay, resumed turn limits, and reset-boundary recall

### DIFF
--- a/Sources/ClawAgent/Runtime/AgentRuntime.swift
+++ b/Sources/ClawAgent/Runtime/AgentRuntime.swift
@@ -314,7 +314,10 @@ public struct AgentRuntime: Sendable {
     // The wall-clock deadline is left per-segment by construction — it is recomputed at each
     // `runTurn` entry above; only the round count needs to account for rounds already consumed.
     let priorRounds = carryOver?.rounds ?? 0
-    for roundTripIndex in 1...max(1, budget.maxTurns - priorRounds) {
+    guard priorRounds < budget.maxTurns else {
+      return outcome(.budgetStopped(cap: BudgetGate.perRunTurnCap))
+    }
+    for roundTripIndex in 1...(budget.maxTurns - priorRounds) {
       let callID = providerCallIDGenerator.next()
       // Scoped to this round-trip: when a re-issue on the next route also fails, the reported kind is
       // the one the round-trip started with, because "your plan quota is out" is the actionable fact
@@ -583,7 +586,7 @@ public struct AgentRuntime: Sendable {
       }
     }
 
-    return outcome(.budgetStopped(cap: "per-run turn"))
+    return outcome(.budgetStopped(cap: BudgetGate.perRunTurnCap))
   }
   // swiftlint:enable function_parameter_count function_body_length cyclomatic_complexity
 }

--- a/Sources/ClawCore/LLM/RunBudget.swift
+++ b/Sources/ClawCore/LLM/RunBudget.swift
@@ -85,6 +85,7 @@ public struct BudgetGate: Sendable {
   public static let perDayTokenCap = "per-day token"
   public static let perRunSpendCap = "per-run spend"
   public static let perRunInputTokenCap = "per-run input-token"
+  public static let perRunTurnCap = "per-run turn"
 
   public let budget: RunBudget
   /// How the route is billed. Injected — never inferred from a model name — so a subscription call

--- a/Sources/ClawCore/Persistence/RunStore.swift
+++ b/Sources/ClawCore/Persistence/RunStore.swift
@@ -199,7 +199,7 @@ public protocol RunStore: Sendable {
     now: Date
   ) throws(StoreError) -> SuspendedCommitReceipt
   /// Approve resume, pre-execution half (file_write / web_fetch): one txn, guarded on the
-  /// placeholder check (per-approval exactly-once) and the AWAITING_APPROVAL → RUNNING flip. The
+  /// durable unresolved flag (per-approval exactly-once) and the AWAITING_APPROVAL → RUNNING flip. The
   /// caller executes the recorded action ONLY on `.committed` — claiming BEFORE the external
   /// effect is what stops a write from landing after `/stop`//`new` drove the run terminal. On
   /// `.runNotResumable` the placeholder is resolved with `notResumableObservationContent` in the
@@ -211,7 +211,7 @@ public protocol RunStore: Sendable {
     now: Date
   ) throws(StoreError) -> ApprovedExecutionClaim
   /// Approve resume, post-execution half: UPDATE the claimed placeholder observation in place with
-  /// the tool's real result, apply the state-guarded taint/private-data provenance, and append the
+  /// the tool's real result and resolved flag, apply the taint/private-data provenance, and append the
   /// `.toolCall` audit — all in ONE transaction, so a fault rolls back content, flags, and audit
   /// together. Only ever called after `claimApprovedExecution` returned `.committed` for the same
   /// ids.
@@ -222,7 +222,7 @@ public protocol RunStore: Sendable {
   ) throws(StoreError)
   /// memory_write fused path (exactly-once): the memory item insert (via
   /// `MemoryStoreGRDB.insertItem`), the observation UPDATE, and the `.toolCall` audit share ONE
-  /// txn, gated by the SAME placeholder + AWAITING_APPROVAL → RUNNING guards as
+  /// txn, gated by the SAME unresolved flag + AWAITING_APPROVAL → RUNNING guards as
   /// `claimApprovedExecution` — the side effect is in-DB, so claim and effect fuse instead of
   /// splitting.
   func applyApprovedMemoryWrite(  // swiftlint:disable:this function_parameter_count
@@ -235,7 +235,7 @@ public protocol RunStore: Sendable {
     now: Date
   ) throws(StoreError) -> ApprovedExecutionClaim
   /// Boot settlement of the claimed crash window: an APPROVED approval whose observation
-  /// is still the placeholder but whose run left AWAITING_APPROVAL means the pre-execution claim
+  /// is still unresolved but whose run left AWAITING_APPROVAL means the pre-execution claim
   /// committed and the process died before the result record — whether the external effect landed
   /// is unknowable, so no replay. One txn: fail the run if it is not already terminal, resolve the
   /// placeholder with `observationContent`, and enqueue `noticeText` for the owner UNCONDITIONALLY

--- a/Sources/ClawData/Database/ClawDatabase.swift
+++ b/Sources/ClawData/Database/ClawDatabase.swift
@@ -274,6 +274,9 @@ public enum ClawDatabase {
         table.add(column: "actor_user_id", .integer)
       }
     }
+    migrator.registerMigration("v13") { db in
+      try addApprovalResolutionState(db)
+    }
     return migrator
   }
 
@@ -299,5 +302,34 @@ public enum ClawDatabase {
     default:
       return StoreError.unexpected("\(databaseError)")
     }
+  }
+}
+
+// MARK: - Approval Resolution Migration
+
+private extension ClawDatabase {
+  static func addApprovalResolutionState(_ db: Database) throws {
+    try db.alter(table: "messages") { table in
+      table.add(column: "approval_resolved", .boolean).notNull().defaults(to: false)
+    }
+    // A later approval or completed run proves the earlier result was filled even when its
+    // text collided with the legacy placeholder. Other collisions retain conservative recovery.
+    try db.execute(
+      sql: """
+        UPDATE messages SET approval_resolved = 1
+        WHERE role = ? AND EXISTS (
+          SELECT 1 FROM approvals a JOIN runs r ON r.id = a.run_id
+          WHERE a.observation_message_id = messages.id AND a.run_id = messages.run_id
+            AND (messages.content != ? OR r.state = ? OR EXISTS (
+              SELECT 1 FROM approvals later WHERE later.run_id = a.run_id AND later.id > a.id
+            ))
+        )
+        """,
+      arguments: [
+        MessageRole.tool.rawValue,
+        RunStoreGRDB.placeholderObservationContent,
+        RunState.done.rawValue,
+      ]
+    )
   }
 }

--- a/Sources/ClawData/Stores/Approval/ApprovalStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Approval/ApprovalStoreGRDB.swift
@@ -160,7 +160,7 @@ public struct ApprovalStoreGRDB: ApprovalStore {
   public func unresolvedAtBoot() throws(StoreError) -> [Approval] {
     try database.readMapping { db in
       // The resolved-states arms are the crash-window belts, recognizable by the observation
-      // row STILL being the placeholder — without that condition, a run parked on its SECOND
+      // row STILL being unresolved — without that condition, a run parked on its SECOND
       // approval would return its first, already-executed row too, and boot would replay the
       // recorded action. REJECTED/EXPIRED rows additionally require the run to still be
       // AWAITING_APPROVAL (their deny finalization never moves the run first). APPROVED rows are
@@ -181,7 +181,7 @@ public struct ApprovalStoreGRDB: ApprovalStore {
               WHERE messages.id = approvals.observation_message_id
                 AND messages.run_id = approvals.run_id
                 AND messages.role = '\(MessageRole.tool.rawValue)'
-                AND messages.content = ?
+                AND messages.approval_resolved = 0
             ))
           """,
         arguments: [
@@ -190,7 +190,6 @@ public struct ApprovalStoreGRDB: ApprovalStore {
           ApprovalState.rejected.rawValue,
           ApprovalState.expired.rawValue,
           RunState.awaitingApproval.rawValue,
-          RunStoreGRDB.placeholderObservationContent,
         ]
       )
     }

--- a/Sources/ClawData/Stores/Memory/RetrieverGRDB.swift
+++ b/Sources/ClawData/Stores/Memory/RetrieverGRDB.swift
@@ -44,8 +44,8 @@ public struct RetrieverGRDB: Retriever {
       }
 
       if let windowStart = windowStartMessageId {
-        // Dedup against the current session's in-window range.
-        sql += "\n  AND NOT (m.session_id = ? AND m.id >= ?)"
+        // The reset boundary is the last archived row; the current window starts AFTER it.
+        sql += "\n  AND NOT (m.session_id = ? AND m.id > ?)"
         arguments += [currentSessionId, windowStart]
       }
 

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB+BootHealth.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB+BootHealth.swift
@@ -101,7 +101,7 @@ extension RunStoreGRDB {
   ) throws(StoreError) -> ClaimedApprovalBootOutcome {
     try database.writeMapping { db in
       guard
-        try Self.observationIsPlaceholder(db, runId: runId, messageId: observationMessageId)
+        try Self.observationIsUnresolved(db, runId: runId, messageId: observationMessageId)
       else {
         return .alreadyResolved
       }

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB+SuspendResume.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB+SuspendResume.swift
@@ -74,10 +74,10 @@ extension RunStoreGRDB {
 // MARK: - Approved Resume
 
 extension RunStoreGRDB {
-  /// The shared claim body: exactly-once needs BOTH guards. The placeholder check is
+  /// The shared claim body: exactly-once needs BOTH guards. The unresolved-observation check is
   /// per-approval — once the run suspends a second time it is AWAITING_APPROVAL again, so the
   /// state flip alone would let a replay of an already-executed approval commit and steal the new
-  /// approval's park. A failed state flip with the placeholder intact means `/stop`//`new` drove
+  /// approval's park. A failed state flip with the observation unresolved means `/stop`//`new` drove
   /// the run terminal after the approve CAS: resolve the placeholder in the SAME txn (history
   /// never dangles) and tell the caller nothing may execute.
   static func claimResume(
@@ -87,7 +87,7 @@ extension RunStoreGRDB {
     notResumableObservationContent: String,
     now: Date
   ) throws -> ApprovedExecutionClaim {
-    guard try observationIsPlaceholder(db, runId: runId, messageId: observationMessageId) else {
+    guard try observationIsUnresolved(db, runId: runId, messageId: observationMessageId) else {
       return .alreadyResumed
     }
     guard try transitionRun(db, runId: runId, event: .resumeApproved, now: now) != nil else {
@@ -264,10 +264,9 @@ extension RunStoreGRDB {
     }
   }
 
-  /// The per-approval half of the exactly-once guard: true while the approval's reserved
-  /// observation row still carries the placeholder content, i.e. no resume commit has landed for
-  /// THIS approval. Same row scoping as `fillApprovedObservation`.
-  static func observationIsPlaceholder(
+  /// Resolution is persisted separately from tool-authored content, which may equal any prompt.
+  /// The reserved observation must belong to this run and remain unresolved before it can resume.
+  static func observationIsUnresolved(
     _ db: Database,
     runId: Int64,
     messageId: Int64
@@ -277,10 +276,11 @@ extension RunStoreGRDB {
       sql: """
         SELECT EXISTS(
           SELECT 1 FROM messages
-          WHERE id = ? AND run_id = ? AND role = '\(MessageRole.tool.rawValue)' AND content = ?
+          WHERE id = ? AND run_id = ? AND role = '\(MessageRole.tool.rawValue)'
+            AND approval_resolved = 0
         )
         """,
-      arguments: [messageId, runId, placeholderObservationContent]
+      arguments: [messageId, runId]
     ) ?? false
   }
 
@@ -294,8 +294,10 @@ extension RunStoreGRDB {
     content: String
   ) throws {
     try db.execute(
-      sql:
-        "UPDATE messages SET content = ? WHERE id = ? AND run_id = ? AND role = '\(MessageRole.tool.rawValue)'",
+      sql: """
+        UPDATE messages SET content = ?, approval_resolved = 1
+        WHERE id = ? AND run_id = ? AND role = '\(MessageRole.tool.rawValue)'
+        """,
       arguments: [content, messageId, runId]
     )
   }

--- a/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Run/RunStoreGRDB.swift
@@ -108,11 +108,13 @@ extension RunStoreGRDB {
       // Fill the placeholder observation in place: both `ContextBuilder.historyGroups` and
       // `HistoryHygiene` require every anchor's tool rows to be answered, so a dangling
       // "awaiting owner approval" row would drop the whole exchange from the next assembly. The
-      // UPDATE is by message id — idempotent on a boot re-park, and correct for the /stop//new
+      // UPDATE is scoped to the run — idempotent on a boot re-park, and correct for the /stop//new
       // path where the command transaction moved the run but never touched this row.
-      try db.execute(
-        sql: "UPDATE messages SET content = ? WHERE id = ?",
-        arguments: [content, observationMessageId]
+      try Self.fillApprovedObservation(
+        db,
+        runId: runId,
+        messageId: observationMessageId,
+        content: content
       )
 
       let event: RunEvent =

--- a/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentLoopTests.swift
@@ -213,7 +213,7 @@ import Testing
     let outcome = try await run(runtime)
 
     // then — no bonus round-trip: exactly maxTurns provider calls (§6.4)
-    #expect(outcome.result == .budgetStopped(cap: "per-run turn"))
+    #expect(outcome.result == .budgetStopped(cap: BudgetGate.perRunTurnCap))
     #expect(await provider.requests.count == 2)
     #expect(outcome.ingestedUntrusted)  // executed observations still taint
   }

--- a/Tests/ClawAgentTests/Runtime/AgentRuntimeCarryOverTests.swift
+++ b/Tests/ClawAgentTests/Runtime/AgentRuntimeCarryOverTests.swift
@@ -5,6 +5,31 @@ import Testing
 @testable import ClawAgent
 
 @Suite struct AgentRuntimeCarryOverTests {
+  @Test func carriedOverRoundsStopBeforeAnyProviderCall() async throws {
+    // given
+    let provider = StubProvider(.respond(okResponse(content: "should never send")))
+    let budget = makeBudget(maxTurns: 1)
+    let runtime = makeRuntime(provider: provider, budget: budget)
+    let carryOver = ResumeUsage(rounds: budget.maxTurns, toolCalls: 1, tokens: 1, costUSD: 0)
+
+    // when
+    let outcome = try await runtime.runTurn(
+      runId: 1,
+      sessionId: 1,
+      chatId: 7,
+      buildResult: makeBuildResult(),
+      sessionTainted: false,
+      sessionHasPrivateData: false,
+      todayTokens: 1,
+      todayUSD: 0,
+      carryOver: carryOver
+    )
+
+    // then
+    #expect(outcome.result == .budgetStopped(cap: BudgetGate.perRunTurnCap))
+    #expect(await provider.calls == 0)
+  }
+
   @Test func carriedOverSpendStopsBeforeAnyProviderCall() async throws {
     // given — a run that already spent its entire per-run USD budget before it suspended; the
     // resume must inherit that spend so a suspend cycle can't reset the cap (§6.3 no cap evasion)

--- a/Tests/ClawDataTests/Database/V13MigrationTests.swift
+++ b/Tests/ClawDataTests/Database/V13MigrationTests.swift
@@ -1,0 +1,106 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct V13MigrationTests {
+  @Test func upgradePreservesCrashWindowsAndSettledLegacyObservations() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrator.migrate(queue, upTo: "v12")
+    let expectedUnresolved = try queue.write { db in
+      try db.execute(
+        sql: "INSERT INTO sessions(session_key, created_ts, updated_ts) VALUES (?, ?, ?)",
+        arguments: [SessionKey.telegramDM(chatId: 7), Self.now, Self.now]
+      )
+      let sessionId = db.lastInsertedRowID
+      let awaitingRun = try Self.insertRun(db, sessionId: sessionId, state: .awaitingApproval)
+      let unclaimed = try Self.insertApproval(db, runId: awaitingRun, sessionId: sessionId)
+      let runningRun = try Self.insertRun(db, sessionId: sessionId, state: .running)
+      let claimed = try Self.insertApproval(db, runId: runningRun, sessionId: sessionId)
+      let completedRun = try Self.insertRun(db, sessionId: sessionId, state: .done)
+      _ = try Self.insertApproval(db, runId: completedRun, sessionId: sessionId)
+      let failedRun = try Self.insertRun(db, sessionId: sessionId, state: .failed)
+      _ = try Self.insertApproval(
+        db,
+        runId: failedRun,
+        sessionId: sessionId,
+        content: "The action completed before a later provider failure."
+      )
+      let reparkedRun = try Self.insertRun(db, sessionId: sessionId, state: .awaitingApproval)
+      _ = try Self.insertApproval(db, runId: reparkedRun, sessionId: sessionId)
+      let pending = try Self.insertApproval(
+        db,
+        runId: reparkedRun,
+        sessionId: sessionId,
+        state: .pending
+      )
+      let deniedRun = try Self.insertRun(db, sessionId: sessionId, state: .awaitingApproval)
+      let denied = try Self.insertApproval(
+        db,
+        runId: deniedRun,
+        sessionId: sessionId,
+        state: .rejected
+      )
+      return Set([unclaimed, claimed, pending, denied])
+    }
+
+    // when
+    try ClawDatabase.migrate(queue)
+    let unresolved = try ApprovalStoreGRDB(writer: queue).unresolvedAtBoot()
+
+    // then
+    #expect(Set(unresolved.map(\.id)) == expectedUnresolved)
+  }
+}
+
+// MARK: - Legacy Rows
+
+private extension V13MigrationTests {
+  static let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+  static func insertRun(_ db: Database, sessionId: Int64, state: RunState) throws -> Int64 {
+    try db.execute(
+      sql: "INSERT INTO runs(session_id, state, created_ts, updated_ts) VALUES (?, ?, ?, ?)",
+      arguments: [sessionId, state.rawValue, now, now]
+    )
+    return db.lastInsertedRowID
+  }
+
+  static func insertApproval(
+    _ db: Database,
+    runId: Int64,
+    sessionId: Int64,
+    state: ApprovalState = .approved,
+    content: String = RunStoreGRDB.placeholderObservationContent
+  ) throws -> Int64 {
+    let toolCallId = "call-\(runId)-\(state.rawValue)"
+    try db.execute(
+      sql: """
+        INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_call_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+      arguments: [
+        sessionId, runId, MessageRole.tool.rawValue, content, Provenance.untrusted.rawValue,
+        now, toolCallId,
+      ]
+    )
+    let observationId = db.lastInsertedRowID
+    try db.execute(
+      sql: """
+        INSERT INTO approvals(run_id, session_id, state, tool, canonical_args, canonical_target,
+          args_hash, policy_version, owner_user_id, nonce, observation_message_id, tool_call_id,
+          reason, created_ts, expires_ts)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+      arguments: [
+        runId, sessionId, state.rawValue, "remote_write", "{}", "remote-target",
+        ApprovalArgsHash.sha256Hex("{}"), "policy", 7, toolCallId, observationId, toolCallId,
+        ApprovalReason.askTier.rawValue, 1_700_000_000, 1_700_003_600,
+      ]
+    )
+    return db.lastInsertedRowID
+  }
+}

--- a/Tests/ClawDataTests/Stores/Approval/ApprovalStoreGRDBTests.swift
+++ b/Tests/ClawDataTests/Stores/Approval/ApprovalStoreGRDBTests.swift
@@ -39,20 +39,21 @@ import Testing
     }
   }
 
-  /// Inserts an observation row for the run: placeholder content models a crash-window row
-  /// (waiter commit never landed); any other content models an already-executed approval.
+  /// Seeds the reserved observation with its independently persisted resolution state.
   private func seedObservation(
     _ queue: DatabaseQueue,
     runId: Int64,
-    content: String = "awaiting owner approval"
+    content: String = RunStoreGRDB.placeholderObservationContent,
+    resolved: Bool = false
   ) throws -> Int64 {
     try queue.write { db in
       try db.execute(
         sql: """
-          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_call_id)
-          VALUES (1, ?, 'tool', ?, 'untrusted', ?, 'c1')
+          INSERT INTO messages(session_id, run_id, role, content, provenance, ts, tool_call_id,
+            approval_resolved)
+          VALUES (1, ?, 'tool', ?, 'untrusted', ?, 'c1', ?)
           """,
-        arguments: [runId, content, Date()]
+        arguments: [runId, content, Date(), resolved]
       )
       return db.lastInsertedRowID
     }
@@ -60,8 +61,10 @@ import Testing
 
   private func makeNewApproval(
     runId: Int64,
+    tool: String = "file_write",
     nonce: String = "nonce-a",
     canonicalArgsJSON: String = #"{"path":"/w/plan.md"}"#,
+    canonicalTarget: String = "/w/plan.md",
     policyVersion: String = "pv16",
     observationMessageId: Int64 = 1,
     createdTs: Date,
@@ -70,9 +73,9 @@ import Testing
     NewApproval(
       runId: runId,
       sessionId: 1,
-      tool: "file_write",
+      tool: tool,
       canonicalArgsJSON: canonicalArgsJSON,
-      canonicalTarget: "/w/plan.md",
+      canonicalTarget: canonicalTarget,
       argsHash: ApprovalArgsHash.sha256Hex(canonicalArgsJSON),
       policyVersion: policyVersion,
       ownerUserId: 7,
@@ -477,7 +480,8 @@ extension ApprovalStoreGRDBTests {
         observationMessageId: try seedObservation(
           env.queue,
           runId: recordedRun,
-          content: "Wrote 12 B to /w/plan.md (created)."
+          content: "Wrote 12 B to /w/plan.md (created).",
+          resolved: true
         ),
         createdTs: now,
         expiresTs: now.addingTimeInterval(3600)
@@ -497,50 +501,102 @@ extension ApprovalStoreGRDBTests {
     #expect(unresolved.map(\.id) == [claimedId])
   }
 
-  @Test func unresolvedAtBootExcludesResolvedRowsWhoseObservationIsFilled() throws {
-    // given — the multi-suspend shape: ONE run, approval #1 APPROVED with its observation already
-    // filled (executed before the restart), approval #2 PENDING on a fresh placeholder. Re-parking
-    // #1 would re-execute its recorded action and steal #2's park (§6.5 is for crash windows only).
+  @Test func resolvedObservationTextCannotReplayAnApproval() throws {
+    // given
     let env = try makeFixture()
+    let runs = RunStoreGRDB(writer: env.queue)
     let run = try seedRun(env.queue, state: .awaitingApproval)
-    let now = Date()
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let tool = "mcp__service__write"
+    let observationId = try seedObservation(env.queue, runId: run)
     let executedId = try insert(
       env.queue,
       makeNewApproval(
         runId: run,
+        tool: tool,
         nonce: "n-executed",
-        observationMessageId: try seedObservation(
-          env.queue,
-          runId: run,
-          content: "Wrote 12 B to /w/plan.md (created)."
-        ),
+        canonicalTarget: "service (https://example.com/mcp)",
+        observationMessageId: observationId,
         createdTs: now,
         expiresTs: now.addingTimeInterval(3600)
       )
     )
-    // Resolve #1 BEFORE inserting #2 — the UNIQUE partial index allows one PENDING row per run.
-    try env.queue.write { db in
-      try db.execute(
-        sql: "UPDATE approvals SET state = 'APPROVED' WHERE id = ?",
-        arguments: [executedId]
+    _ = try env.store.approve(id: executedId, currentPolicyVersion: "pv16", now: now)
+    let firstClaim = try runs.claimApprovedExecution(
+      runId: run,
+      observationMessageId: observationId,
+      notResumableObservationContent: "stopped",
+      now: now
+    )
+    try #require(firstClaim == .committed)
+    try runs.fillClaimedObservation(
+      runId: run,
+      observationMessageId: observationId,
+      fill: ClaimedObservationFill(
+        content: RunStoreGRDB.placeholderObservationContent,
+        status: .ok,
+        setTainted: true,
+        setPrivateData: false,
+        audit: ApprovedExecutionAudit(tool: tool, argsRedacted: "{}"),
+        now: now
       )
-    }
-    let parkedId = try insert(
-      env.queue,
-      makeNewApproval(
-        runId: run,
+    )
+    let nextArgs = #"{"content":"next","path":"next.md"}"#
+    let nextAction = RecordedToolAction(
+      tool: "file_write",
+      canonicalArgsJSON: nextArgs,
+      argsHash: ApprovalArgsHash.sha256Hex(nextArgs),
+      canonicalTarget: "/w/next.md",
+      reason: .askTier,
+      presentation: ToolApprovalPresentation(
+        blastRadius: "create",
+        contentPreview: nil,
+        warnings: []
+      )
+    )
+    let toolCallsJSON = try #require(
+      ToolCallCoding.encode([
+        ToolCall(id: "c2", name: nextAction.tool, argumentsJSON: nextAction.canonicalArgsJSON)
+      ])
+    )
+    let parked = try runs.commitSuspendedTurn(
+      runId: run,
+      sessionId: 1,
+      commit: SuspendedTurnCommit(
+        assistantContent: "",
+        toolCallsJSON: toolCallsJSON,
+        completedObservations: [],
+        pending: PendingToolAction(toolCallId: "c2", recorded: nextAction),
+        ownerUserId: 7,
         nonce: "n-parked",
-        observationMessageId: try seedObservation(env.queue, runId: run),
-        createdTs: now,
+        promptChunks: [],
+        setTainted: false,
+        setPrivateData: false,
         expiresTs: now.addingTimeInterval(3600)
-      )
+      ),
+      now: now
     )
 
     // when
     let unresolved = try env.store.unresolvedAtBoot()
+    let replay = try runs.claimApprovedExecution(
+      runId: run,
+      observationMessageId: observationId,
+      notResumableObservationContent: "stopped",
+      now: now
+    )
 
-    // then — only the still-parked placeholder approval comes back
-    #expect(unresolved.map(\.id) == [parkedId])
+    // then
+    #expect(unresolved.map(\.id) == [parked.approvalId])
+    #expect(replay == .alreadyResumed)
+    let content = try env.queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT content FROM messages WHERE id = ?",
+        arguments: [observationId]
+      )
+    }
+    #expect(content == RunStoreGRDB.placeholderObservationContent)
   }
 
   @Test func unresolvedAtBootReturnsDeniedRowsOnlyOnAwaitingRuns() throws {

--- a/Tests/ClawDataTests/Stores/Memory/RetrieverTests.swift
+++ b/Tests/ClawDataTests/Stores/Memory/RetrieverTests.swift
@@ -151,20 +151,36 @@ import Testing
     #expect(hits[0].role == .user)
   }
 
-  @Test func excludesInWindowMessagesOfTheCurrentSession() throws {
-    // given - one in-window message (current session, id >= windowStart) and one older out-of-window.
+  @Test func recallsThroughResetBoundaryAndExcludesCurrentWindow() throws {
+    // given
     let corpus = try makeCorpus()
+    let sessions = SessionMessageStoreGRDB(writer: corpus.queue)
     let oldId = try insertMessage(
       corpus,
       sessionId: corpus.sessionTwo,
       content: "swift earlier note",
       at: 10
     )
-    let inWindowId = try insertMessage(
+    try sessions.resetWindowAndDetaint(
+      sessionId: corpus.sessionTwo,
+      now: Date(timeIntervalSince1970: 15)
+    )
+    try insertMessage(
       corpus,
       sessionId: corpus.sessionTwo,
       content: "swift current note",
       at: 20
+    )
+    let latestId = try insertMessage(
+      corpus,
+      sessionId: corpus.sessionTwo,
+      content: "swift latest note",
+      at: 30
+    )
+    let snapshot = try sessions.loadContextSnapshot(
+      sessionId: corpus.sessionTwo,
+      throughMessageId: latestId,
+      limit: 1
     )
 
     // when
@@ -172,23 +188,22 @@ import Testing
       query: "swift",
       currentSessionId: corpus.sessionTwo,
       restrictToSessionId: nil,
-      windowStartMessageId: inWindowId,
-      excludedMessageIds: [],
+      windowStartMessageId: snapshot.windowStartMessageId,
+      excludedMessageIds: snapshot.historyMessageIds,
       limit: 10
     )
 
-    // then - the in-window message is excluded; the older one remains recallable.
+    // then
     #expect(hits.map(\.id) == [oldId])
   }
 
-  @Test func includesOtherSessionMessagesAtOrAboveWindowStart() throws {
-    // given - one in-window current-session message sets the windowStart; a second
-    // message belongs to a DIFFERENT session and has id >= windowStart.
+  @Test func includesOtherSessionMessagesAfterWindowResetBoundary() throws {
+    // given
     let corpus = try makeCorpus()
     let windowAnchorId = try insertMessage(
       corpus,
       sessionId: corpus.sessionTwo,
-      content: "swift in-window current session",
+      content: "current session reset boundary",
       at: 10
     )
     let otherSessionMsgId = try insertMessage(
@@ -198,7 +213,7 @@ import Testing
       at: 20
     )
 
-    // when - the exclusion clause is `session_id = sessionTwo AND id >= windowAnchorId`.
+    // when
     let hits = try corpus.retriever.searchRelevantMessages(
       query: "swift",
       currentSessionId: corpus.sessionTwo,
@@ -208,8 +223,7 @@ import Testing
       limit: 10
     )
 
-    // then - the other-session message survives: its id >= windowStart but its
-    // session_id != currentSessionId, so the session-scoped guard does not exclude it.
+    // then
     #expect(hits.map(\.id) == [otherSessionMsgId])
   }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -517,6 +517,12 @@ Connection invariants (every connection): `PRAGMA foreign_keys = ON`; `busy_time
 
 The `approvals` row (Inc 5a) additionally carries `session_id`, `observation_message_id`, `tool_call_id`, `reason` (`ask_tier | exfil_trifecta`), `prompt_message_id`, and `resolved_ts`, and enforces a **UNIQUE partial index `WHERE state = 'PENDING'`** — at most one live approval per run. `outbound_deliveries` gains nullable `approval_id` + `reply_markup` (additive, so pre-upgrade PENDING rows stay valid; the envelope is not smuggled into `payload`): the button prompt travels through the transactional outbox, and when `approval_id` is set `markSent` writes the resulting `telegram_message_id` onto the linked approval's `prompt_message_id` **in the same transaction**.
 
+Migration `v13` adds `messages.approval_resolved` (non-null boolean, default false). A reserved
+approval observation starts unresolved. Every resolution writes its content and sets this flag true
+in the same transaction, including approved results, denials, cancellation and boot settlement.
+The flag records observation completion separately from `approvals.state`, which records the owner's
+decision. Tool-authored content remains verbatim and never determines whether an action may replay.
+
 Synthetic session keys (Inc 4): `sched:job:<id>` (one dedicated session per scheduled job, created lazily at first fire) and `sched:heartbeat`. `sessions` carries no chat id — a job run's delivery/notice target is `scheduled_jobs.owner_chat_id`; the heartbeat's is the config-resolved owner DM. `SessionKey.chatId(from:)` returns nil for both by design, so boot reconciliation resolves crashed-run owner notices for job runs via `scheduled_jobs.owner_chat_id` and for heartbeat runs via the config-derived target passed in at boot (§6.3, spec §5.2/§12).
 
 ### 7.2 Audit (Inc 1) — ordinary append-only, NOT tamper-evident
@@ -859,6 +865,15 @@ A **state machine** persisted in `approvals` so it survives restart. See §7.1 c
 
 - **Bound to the exact action** (tool + fully-resolved target + canonical args); executes the **recorded** args (never a fresh model turn); a past approval is **never** cached into a future auto-run.
 - **Durable checkpoint = persist-the-partial-exchange**, not a serialized wire checkpoint: the assistant proposal + every completed observation + a **placeholder observation row updated in place** (the v5 `messages` columns) pin rowid adjacency at suspend; the approved action runs the recorded args; the run then continues as an ordinary assembly round-trip whose context bound is the filled observation's message id, with **carried-over turn/tool-call/token/USD counters** and a **fresh per-segment wall-clock** (suspension time never counts against any budget).
+- **Execution recovery uses durable observation state.** Both the per-approval execution claim and
+  the resolved-decision boot scan require `messages.approval_resolved = false`, scoped to the
+  reserved tool observation and its run. A tool returning the placeholder's exact text cannot make
+  an already-filled observation eligible again. Migration `v13` marks legacy observations resolved
+  when their text differs from the former placeholder, their run is `DONE`, or a later approval
+  exists for the same run: reaching another approval proves the earlier result was recorded.
+  Legacy placeholder-text collisions on claimed runs without that progress evidence cannot be
+  distinguished from missing results; boot conservatively reports their outcome as unknown and
+  never re-executes them.
 - **Callback auth** (§6.5): a DM requires its allowlisted owner; a group Coder submission requires
   the exact original prompt/chat/run binding plus a fresh current-participant check. Both use the
   ≥128-bit single-use random nonce and re-validate args-hash + `policy_version`. Args-hash +


### PR DESCRIPTION
## Summary

Fix exactly three verified bugs in approval continuation, conversation recall, and approval crash recovery. The changes preserve the existing per-run budget and exactly-once approval contracts, and add regression coverage at their public runtime/store seams.

## 1. Approval resumes could exceed the per-run model-call limit

**Root cause:** `AgentRuntime.runTurn` used `1...max(1, budget.maxTurns - priorRounds)`. The lower bound forced at least one provider round even when the persisted continuation had already consumed the entire run's round allowance.

**Trigger and impact:** A model proposes an approval-gated tool on the last permitted round. After approval, `TurnRunner` passes the persisted `ResumeUsage` into the continuation, but the runtime sends another model request. Further approval cycles can repeat this allowance until a different cap stops the run, creating unexpected model usage and bypassing the configured turn limit.

**Fix:** Return the existing per-run turn-budget result before entering the loop when carried-over rounds reach the limit. The loop now uses only the remaining allowance. A shared cap label keeps the fresh-run and resumed-run outcomes consistent.

**Reproduction:** With `maxTurns = 1` and `carryOver.rounds = 1`, the new regression previously received a completed model response and observed one provider request; it now observes a budget stop and zero provider requests.

## 2. Recall silently lost the final message before a conversation reset

**Root cause:** Resetting a session stores its current maximum message ID as the exclusive history boundary. History reads IDs strictly greater than that boundary, while `RetrieverGRDB` excluded IDs greater than or equal to it. The boundary message was therefore absent from both history and recall.

**Trigger and impact:** After `/new`, a query matching the final pre-reset message could not recall it, even though older trusted messages remained eligible. This lost potentially relevant context at every reset boundary.

**Fix:** Exclude only current-session IDs strictly greater than the reset boundary. Keep explicit history-message exclusion and session scoping intact.

**Reproduction:** The strengthened regression uses the real session reset and snapshot-loading APIs. Before the fix its recall results were empty; afterward it retrieves the archived boundary message while excluding current-window messages, including a current-window row outside the limited snapshot.

## 3. Tool output could make a completed approval look unresolved

**Root cause:** Both boot recovery and the per-approval execution claim inferred unresolved state from an observation's text equaling `awaiting owner approval`. Tool-result content is data, and an approved tool can legitimately return that exact text.

**Trigger and impact:** Approve a tool that returns the placeholder text, record its result, then suspend the same run for a second approval. On restart, the first approval was rediscovered as unresolved. Its old execution claim could succeed again, replaying an already-executed action and taking the second approval's parked run. A completed run could also be incorrectly reported as having an unknown execution outcome.

**Fix:** Persist `messages.approval_resolved`, update it atomically with every approval-result fill (including denial and boot settlement), and consult it for both boot recovery and execution claims. The observation body is preserved verbatim. Additive migration `v13` initializes existing observations without resetting live approval checkpoints; architecture documentation records the durable state contract.

**Reproduction:** Starting with a persisted approval checkpoint, the regression approves, claims, fills with the exact placeholder text, and suspends again through real stores. Before the fix boot returned both approvals and the old claim committed again. The regression now checks that only the new approval is returned at boot, that the old claim remains already resumed, and that the tool's original result text is preserved.

## Regression intent and review

| Risk | Primary test | Nearest existing coverage and distinct mutant |
| --- | --- | --- |
| Extra provider request after an exhausted continuation | `AgentRuntimeCarryOverTests.carriedOverRoundsStopBeforeAnyProviderCall` | The uninterrupted-loop cap test has no carried-over rounds; the carried-over spend test stops at the USD gate. Neither catches the forced one-round minimum. |
| Archived boundary message omitted from recall | `RetrieverTests.recallsThroughResetBoundaryAndExcludesCurrentWindow` | Replaces the previous synthetic in-window fixture, which incorrectly treated the reset boundary as inclusive. The real reset/snapshot arrangement catches `>=` and preserves current-window exclusion. |
| Completed approval replayed because result text equals the placeholder | `ApprovalStoreGRDBTests.resolvedObservationTextCannotReplayAnApproval` | Strengthens the prior multi-suspend recovery scenario, whose ordinary output could not expose content/state aliasing. It exercises both boot discovery and the independent claim guard, and rejects a workaround that rewrites the tool's result text. |
| Upgrade misclassifies historical or live approval observations | `V13MigrationTests.upgradePreservesCrashWindowsAndSettledLegacyObservations` | Existing migration tests do not cover the new resolution metadata or legacy text collisions. The fixture distinguishes completed text, later approval progress, completed runs, and live crash windows. |

An independent review checked test value, reachable mutants, and redundancy. Tests use real SQLite stores and existing provider doubles; no live model or Telegram requests are required.

## Validation

- Before fixes: the two round-limit/recall regressions failed with the expected extra provider call and missing boundary message; the approval collision and legacy migration regressions failed with the expected old approval rediscovery/reclaim.
- Focused round-limit and recall suites: **27 tests in 3 suites passed**.
- All persistence tests and affected gateway approval flows: **358 tests in 61 suites passed**.
- Final required sequence: `scripts/lint.sh --fix`, diff review, `scripts/lint.sh` (**`lint: ok`**), `swift build` (**passed**), `swift test` (**2,936 tests in 379 suites passed**).
- The full run retained the repository's environment-guarded skips for real-container acceptance and Apple speech fixtures; it did not exercise live providers or Telegram. The lint gate passes with existing repository warnings.
- `git diff --check`: **passed**. Independent code and test-value review: **no blockers**.
- Local environment: macOS arm64, Apple Swift **6.3.3**, Xcode **26.6**, SwiftLint **0.65.1**. Linux and hosted CI results are separate from this local validation.

## Scope and migration

Migration `v13` marks a legacy observation resolved when its result differs from the old placeholder, its run is `DONE`, or a later approval exists for the same run. The latter two conditions also repair historical placeholder-text collisions where persisted progress proves completion. A legacy collision on a claimed run with no such evidence remains indistinguishable from a missing result: recovery conservatively reports the outcome as unknown and does not execute it again. Live unclaimed approvals remain resumable.

Only these three fixes, their regression fixtures, and the approval persistence documentation are included. The checkout started clean at `765d02c7a11ccb70571285bfc7b72c8fbb46e4db`; the target default branch was confirmed through GitHub as `main`.
