### PR TITLE
[4/5] Add owner controls, bounded trials and terminal decisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Re-run the concurrency-sensitive suites on one cooperative thread
         env:
           LIBDISPATCH_COOPERATIVE_POOL_STRICT: "1"
-        run: swift test --filter 'CommandApprovalCancelSignalRaceTests|ApprovalExpiryServiceTests|ApprovalWaiterTests|ApprovalBootReconcilerTests'
+        run: swift test --filter 'CommandApprovalCancelSignalRaceTests|ApprovalExpiryServiceTests|ApprovalWaiterTests|ApprovalBootReconcilerTests|TrialSerializationTests'
 
   test-macos:
     runs-on: macos-26

--- a/Sources/ClawCore/Domain/Bot/Command.swift
+++ b/Sources/ClawCore/Domain/Bot/Command.swift
@@ -9,6 +9,7 @@ public enum Command: Sendable, Equatable {
   case remember(RememberCommand)
   case memory(MemoryCommand)
   case schedule(ScheduleCommand)
+  case learning(LearningCommand)
   case pause(jobId: Int64?)
   case resume(jobId: Int64?)
   case runNow(jobId: Int64?)
@@ -72,6 +73,9 @@ private extension Command {
     if let jobCommand = jobCommand(named: name, arguments: arguments) {
       return jobCommand
     }
+    if let familyCommand = familyCommand(named: name, arguments: arguments) {
+      return familyCommand
+    }
 
     switch name {
     case "start":
@@ -80,12 +84,6 @@ private extension Command {
       return .stop
     case "new":
       return .new
-    case "remember":
-      return .remember(RememberCommand.parse(arguments: arguments))
-    case "memory":
-      return .memory(MemoryCommand.parse(arguments: arguments))
-    case "schedule":
-      return .schedule(ScheduleCommand.parse(arguments: arguments))
     case "help":
       return .help
     case "status", "doctor":
@@ -96,6 +94,21 @@ private extension Command {
       return .skills
     default:
       return .plain(originalText)
+    }
+  }
+
+  static func familyCommand(named name: String, arguments: Substring) -> Command? {
+    switch name {
+    case "remember":
+      .remember(RememberCommand.parse(arguments: arguments))
+    case "memory":
+      .memory(MemoryCommand.parse(arguments: arguments))
+    case "schedule":
+      .schedule(ScheduleCommand.parse(arguments: arguments))
+    case "learning":
+      .learning(LearningCommand.parse(arguments: arguments))
+    default:
+      nil
     }
   }
 
@@ -135,19 +148,42 @@ public enum ScheduleCommand: Sendable, Equatable {
   }
 }
 
+/// Parsed `/learning` arguments. Unknown non-reset arguments list; reset never guesses an id.
+public enum LearningCommand: Sendable, Equatable {
+  case list
+  case detail(jobId: Int64)
+  case reset(jobId: Int64?)
+
+  public static func parse(arguments: Substring) -> LearningCommand {
+    let trimmed = arguments.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty || trimmed.caseInsensitiveCompare("list") == .orderedSame {
+      return .list
+    }
+    let pieces = trimmed.split(whereSeparator: \.isWhitespace)
+    if pieces.first?.caseInsensitiveCompare("reset") == .orderedSame {
+      guard pieces.count == 2 else {
+        return .reset(jobId: nil)
+      }
+      return .reset(jobId: PositiveInt64.parse(String(pieces[1])))
+    }
+    if let jobId = PositiveInt64.parse(trimmed) {
+      return .detail(jobId: jobId)
+    }
+    return .list
+  }
+}
+
 // MARK: - Availability
 
 public extension Command {
   /// True for the commands that only make sense in the owner's own conversation.
   ///
-  /// Durable memory and the schedule table are the owner's, single-owner scoped, and delivered to
-  /// a chat id the arming message chose. Both families also park a confirmation that the *next
-  /// plain message* resolves — in a shared room that message belongs to whoever typed fastest, so
-  /// one attendee could commit a draft another one wrote. Everything else a room may use: `/new`
-  /// and `/stop` act on the topic's own session, and the read-only reports name nothing private.
+  /// Durable memory, schedules, and scheduled-learning state are owner-private. Memory and
+  /// schedules also park a confirmation that the *next plain message* resolves — in a shared room
+  /// that message belongs to whoever typed fastest, so one attendee could commit another's draft.
   var isDirectOnly: Bool {
     switch self {
-    case .remember, .memory, .schedule, .pause, .resume, .runNow, .cancelJob:
+    case .remember, .memory, .schedule, .learning, .pause, .resume, .runNow, .cancelJob:
       true
     case .start, .stop, .new, .help, .doctor, .mcp, .skills, .plain:
       false

--- a/Sources/ClawCore/Domain/Learning/LearningCarriers.swift
+++ b/Sources/ClawCore/Domain/Learning/LearningCarriers.swift
@@ -178,6 +178,9 @@ public struct EvaluatorOutput: Sendable, Equatable, Codable {
     guard issueCodes.allSatisfy(Self.isWithinBounds) else {
       throw Self.corrupt(container, "an issue code is empty or exceeds the length bound")
     }
+    guard Set(issueCodes).count == issueCodes.count else {
+      throw Self.corrupt(container, "issue codes contain a duplicate")
+    }
 
     self.init(schemaVersion: schemaVersion, outcome: outcome, issueCodes: issueCodes)
   }

--- a/Sources/ClawCore/Domain/Learning/LearningDecision.swift
+++ b/Sources/ClawCore/Domain/Learning/LearningDecision.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// The reviewed predicates of one terminal trial request, never rebound to newer state.
+public struct TrialDecisionInputs: Sendable, Equatable, Codable {
+  public let identity: LearningTrialIdentity
+  public let candidateDigest: CandidateDigest
+  public let replacementDigest: LessonSetDigest
+  public let baseDigest: LessonSetDigest
+  public let baseRevision: StableRevision
+  public let feedbackRevision: FeedbackRevision
+  public let algorithm: LearningAlgorithm
+
+  public init(trial: LearningTrial, feedbackRevision: FeedbackRevision) {
+    identity = trial.identity
+    candidateDigest = trial.candidateDigest
+    replacementDigest = trial.replacementDigest
+    baseDigest = trial.baseDigest
+    baseRevision = trial.baseRevision
+    self.feedbackRevision = feedbackRevision
+    algorithm = trial.algorithm
+  }
+}
+
+public enum LearningDecisionResult: String, Sendable, Equatable, Codable {
+  case promoted
+  case fallback
+  case rolledBack = "rolled_back"
+  case stale
+}
+
+/// Exact authoritative resolution retained with the complete promotion cohort.
+public struct DecisionSupport: Sendable, Equatable, Codable {
+  public let runId: Int64
+  public let outcome: TrialOutcomeKind?
+  public let evaluationDigest: EvaluationDigest?
+  public let evaluationRequired: Bool
+  public let feedbackRevision: FeedbackRevision?
+  public let correctionEventDigest: FeedbackEventDigest?
+  public let ownerConfirmed: Bool
+
+  public init(assignment: TrialAssignment) {
+    runId = assignment.identity.runId
+    let evidence = assignment.resolvedEvidence
+    outcome = evidence?.outcome
+    evaluationDigest = evidence?.evaluationDigest
+    evaluationRequired = evidence?.evaluationRequired ?? false
+    feedbackRevision = evidence?.effectiveFeedbackRevision
+    correctionEventDigest = evidence?.correctionEventDigest
+    ownerConfirmed = evidence?.ownerConfirmed ?? false
+  }
+}
+
+public enum LearningDecisionKind: String, Sendable, Equatable, Codable {
+  case trial = "trial_decision"
+  case rollback
+}
+
+/// Stored result bytes exclude the database identity assigned by the insert.
+public struct LearningDecisionRecord: Sendable, Equatable, Codable {
+  public let result: LearningDecisionResult
+  public let reason: String
+  public let cohort: [DecisionSupport]
+  public let stableRevision: StableRevision
+  public let rollbackTrigger: RollbackTrigger?
+
+  public init(
+    result: LearningDecisionResult,
+    reason: String,
+    cohort: [DecisionSupport],
+    stableRevision: StableRevision,
+    rollbackTrigger: RollbackTrigger? = nil
+  ) {
+    self.result = result
+    self.reason = reason
+    self.cohort = cohort
+    self.stableRevision = stableRevision
+    self.rollbackTrigger = rollbackTrigger
+  }
+}
+
+public struct DecisionReceipt: Sendable, Equatable {
+  public let decisionId: Int64
+  public let inputs: TrialDecisionInputs
+  public let record: LearningDecisionRecord
+  public var result: LearningDecisionResult { record.result }
+  public var cohort: [DecisionSupport] { record.cohort }
+  public var promotionSubject: String { String(decisionId) }
+
+  public init(decisionId: Int64, inputs: TrialDecisionInputs, record: LearningDecisionRecord) {
+    self.decisionId = decisionId
+    self.inputs = inputs
+    self.record = record
+  }
+}
+
+public enum LearningSafetyFailure: String, Sendable, Equatable, Codable, CaseIterable {
+  case security
+  case secretLeakage = "secret_leakage"
+  case corruption
+  case invariantViolation = "invariant_violation"
+}
+
+public enum AdapterRollbackOutcome: String, Sendable, Equatable, Codable {
+  case critical
+  case regression
+}
+
+/// Owner triggers name durable authenticated events. Safety receipts come from trusted code;
+/// the adapter branch remains inert while production freezes no adapter.
+public enum RollbackTrigger: Sendable, Equatable, Codable {
+  case ownerFeedback(promotionId: Int64, eventId: Int64)
+  case supportWithdrawal(promotionId: Int64, eventId: Int64)
+  case adapter(promotionId: Int64, adapterId: String, outcome: AdapterRollbackOutcome)
+  case safety(promotionId: Int64, receiptDigest: String, failure: LearningSafetyFailure)
+
+  public var promotionId: Int64 {
+    switch self {
+    case .ownerFeedback(let id, _), .supportWithdrawal(let id, _),
+      .adapter(let id, _, _), .safety(let id, _, _):
+      id
+    }
+  }
+}
+
+public enum PromotionReplyOutcome: Sendable, Equatable {
+  case committed
+  case duplicate
+  case stale
+}

--- a/Sources/ClawCore/Domain/Learning/LearningReset.swift
+++ b/Sources/ClawCore/Domain/Learning/LearningReset.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+/// The state identity captured immediately before an owner reset raises the learning epoch.
+public struct LearningResetDecisionInputs: Sendable, Equatable, Codable {
+  public let oldEpoch: LearningEpoch
+  public let oldStableDigest: LessonSetDigest
+  public let oldStableRevision: StableRevision
+  public let feedbackRevisionAtCut: FeedbackRevision
+  public let priorOpenTrialId: Int64?
+
+  public init(
+    oldEpoch: LearningEpoch,
+    oldStableDigest: LessonSetDigest,
+    oldStableRevision: StableRevision,
+    feedbackRevisionAtCut: FeedbackRevision,
+    priorOpenTrialId: Int64?
+  ) {
+    self.oldEpoch = oldEpoch
+    self.oldStableDigest = oldStableDigest
+    self.oldStableRevision = oldStableRevision
+    self.feedbackRevisionAtCut = feedbackRevisionAtCut
+    self.priorOpenTrialId = priorOpenTrialId
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case oldEpoch = "old_epoch"
+    case oldStableDigest = "old_stable_digest"
+    case oldStableRevision = "old_stable_revision"
+    case feedbackRevisionAtCut = "feedback_revision_at_cut"
+    case priorOpenTrialId = "prior_open_trial_id"
+  }
+}
+
+/// The immutable identity of one live trial closed by a reset barrier.
+public struct ResetTrialIdentity: Sendable, Equatable, Codable {
+  public let trialId: Int64
+  public let jobId: Int64
+  public let epoch: LearningEpoch
+  public let generation: Int
+  public let baseDigest: LessonSetDigest
+  public let candidateDigest: CandidateDigest
+  public let algorithm: LearningAlgorithm
+
+  public init(
+    trialId: Int64,
+    jobId: Int64,
+    epoch: LearningEpoch,
+    generation: Int,
+    baseDigest: LessonSetDigest,
+    candidateDigest: CandidateDigest,
+    algorithm: LearningAlgorithm
+  ) {
+    self.trialId = trialId
+    self.jobId = jobId
+    self.epoch = epoch
+    self.generation = generation
+    self.baseDigest = baseDigest
+    self.candidateDigest = candidateDigest
+    self.algorithm = algorithm
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case trialId = "trial_id"
+    case jobId = "job_id"
+    case epoch = "learning_epoch"
+    case generation
+    case baseDigest = "base_digest"
+    case candidateDigest = "candidate_digest"
+    case algorithm
+  }
+}
+
+/// The complete identity-only result of one effective reset barrier.
+public struct LearningResetDecisionResult: Sendable, Equatable, Codable {
+  public let newEpoch: LearningEpoch
+  public let emptyStableDigest: LessonSetDigest
+  public let newStableRevision: StableRevision
+  public let closedTrials: [ResetTrialIdentity]
+  public let invalidatedTargetCount: Int
+  public let invalidatedChallengeCount: Int
+  public let staleNoCallOperationIds: [LearningOperationID]
+  public let inFlightOperationIds: [LearningOperationID]
+
+  public init(  // swiftlint:disable:this function_parameter_count
+    newEpoch: LearningEpoch,
+    emptyStableDigest: LessonSetDigest,
+    newStableRevision: StableRevision,
+    closedTrials: [ResetTrialIdentity],
+    invalidatedTargetCount: Int,
+    invalidatedChallengeCount: Int,
+    staleNoCallOperationIds: [LearningOperationID],
+    inFlightOperationIds: [LearningOperationID]
+  ) {
+    self.newEpoch = newEpoch
+    self.emptyStableDigest = emptyStableDigest
+    self.newStableRevision = newStableRevision
+    self.closedTrials = closedTrials
+    self.invalidatedTargetCount = invalidatedTargetCount
+    self.invalidatedChallengeCount = invalidatedChallengeCount
+    self.staleNoCallOperationIds = staleNoCallOperationIds
+    self.inFlightOperationIds = inFlightOperationIds
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case newEpoch = "new_epoch"
+    case emptyStableDigest = "empty_stable_digest"
+    case newStableRevision = "new_stable_revision"
+    case closedTrials = "closed_trials"
+    case invalidatedTargetCount = "invalidated_target_count"
+    case invalidatedChallengeCount = "invalidated_challenge_count"
+    case staleNoCallOperationIds = "stale_no_call_operation_ids"
+    case inFlightOperationIds = "in_flight_operation_ids"
+  }
+}
+
+/// The reset decision row plus its canonical typed input and result payloads.
+public struct ResetReceipt: Sendable, Equatable {
+  public static let kind = "learning_reset"
+
+  public let decisionId: Int64
+  public let jobId: Int64
+  public let algorithm: LearningAlgorithm
+  public let decidedAt: Date
+  public let inputs: LearningResetDecisionInputs
+  public let result: LearningResetDecisionResult
+
+  public init(
+    decisionId: Int64,
+    jobId: Int64,
+    algorithm: LearningAlgorithm,
+    decidedAt: Date,
+    inputs: LearningResetDecisionInputs,
+    result: LearningResetDecisionResult
+  ) {
+    self.decisionId = decisionId
+    self.jobId = jobId
+    self.algorithm = algorithm
+    self.decidedAt = decidedAt
+    self.inputs = inputs
+    self.result = result
+  }
+}
+
+/// The semantic result of a newly claimed owner confirmation.
+public enum LearningResetOutcome: Sendable, Equatable {
+  case applied(ResetReceipt)
+  case alreadyReset(ResetReceipt)
+  case unarmed
+  case notFound
+}
+
+/// A fused transport-claim/reset result. Duplicates carry no semantic outcome by construction.
+public struct ConfirmedLearningResetResult: Sendable, Equatable {
+  public let newlyClaimed: Bool
+  public let outcome: LearningResetOutcome?
+
+  public static let duplicate = ConfirmedLearningResetResult(newlyClaimed: false, outcome: nil)
+
+  public static func claimed(_ outcome: LearningResetOutcome) -> ConfirmedLearningResetResult {
+    ConfirmedLearningResetResult(newlyClaimed: true, outcome: outcome)
+  }
+
+  private init(newlyClaimed: Bool, outcome: LearningResetOutcome?) {
+    self.newlyClaimed = newlyClaimed
+    self.outcome = outcome
+  }
+}
+
+/// The narrow seam used by confirmation resolution to claim and apply a reset atomically.
+public protocol LearningResetApplying: Sendable {
+  func applyReset(
+    updateId: Int64,
+    jobId: Int64,
+    now: Date
+  ) throws(StoreError) -> ConfirmedLearningResetResult
+}

--- a/Sources/ClawCore/Domain/Learning/LearningTrial.swift
+++ b/Sources/ClawCore/Domain/Learning/LearningTrial.swift
@@ -10,41 +10,64 @@ public enum TrialAdmissionPolicy {
 /// out, and until when it may grant more. A trial stops granting assignments well before it is
 /// decided, so `state` and `consumedAssignments` answer different questions.
 public struct LearningTrial: Sendable, Equatable {
-  public let trialId: Int64
-  public let jobId: Int64
-  public let epoch: LearningEpoch
-  public let generation: Int
+  public let identity: LearningTrialIdentity
+  public let baseDigest: LessonSetDigest
+  public let baseRevision: StableRevision
   public let candidateDigest: CandidateDigest
+  public let replacementDigest: LessonSetDigest
+  public let algorithm: LearningAlgorithm
+  public let admittedAt: Date
+  public let cohortCutoff: Date
   public let maxAssignments: Int
   public let consumedAssignments: Int
   public let assignmentDeadline: Date
+  public let decisionDeadline: Date
   public let state: LearningTrialState
+  public let hardVetoes: Set<HardVeto>
+
+  public var trialId: Int64 { identity.trialId }
+  public var jobId: Int64 { identity.jobId }
+  public var epoch: LearningEpoch { identity.epoch }
+  public var generation: Int { identity.generation }
 
   /// The two bounds that stop new exposure. Reaching either drains the trial: runs already
   /// assigned still finish, but no further fire binds to the candidate.
-  public func acceptsAssignment(at moment: Date) -> Bool {
-    state == .open && consumedAssignments < maxAssignments && moment < assignmentDeadline
+  public func acceptsAssignment(occurrenceAt: Date, now: Date) -> Bool {
+    state == .open
+      && consumedAssignments < maxAssignments
+      && occurrenceAt >= cohortCutoff
+      && now < assignmentDeadline
   }
 
-  public init(
-    trialId: Int64,
-    jobId: Int64,
-    epoch: LearningEpoch,
-    generation: Int,
+  public init(  // swiftlint:disable:this function_parameter_count
+    identity: LearningTrialIdentity,
+    baseDigest: LessonSetDigest,
+    baseRevision: StableRevision,
     candidateDigest: CandidateDigest,
+    replacementDigest: LessonSetDigest,
+    algorithm: LearningAlgorithm,
+    admittedAt: Date,
+    cohortCutoff: Date,
     maxAssignments: Int,
     consumedAssignments: Int,
     assignmentDeadline: Date,
-    state: LearningTrialState
+    decisionDeadline: Date,
+    state: LearningTrialState,
+    hardVetoes: Set<HardVeto>
   ) {
-    self.trialId = trialId
-    self.jobId = jobId
-    self.epoch = epoch
-    self.generation = generation
+    self.identity = identity
+    self.baseDigest = baseDigest
+    self.baseRevision = baseRevision
     self.candidateDigest = candidateDigest
+    self.replacementDigest = replacementDigest
+    self.algorithm = algorithm
+    self.admittedAt = admittedAt
+    self.cohortCutoff = cohortCutoff
     self.maxAssignments = maxAssignments
     self.consumedAssignments = consumedAssignments
     self.assignmentDeadline = assignmentDeadline
+    self.decisionDeadline = decisionDeadline
     self.state = state
+    self.hardVetoes = hardVetoes
   }
 }

--- a/Sources/ClawCore/Domain/Learning/LearningTrialResolution.swift
+++ b/Sources/ClawCore/Domain/Learning/LearningTrialResolution.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct LearningTrialIdentity: Sendable, Equatable, Hashable {
+public struct LearningTrialIdentity: Sendable, Equatable, Hashable, Codable {
   public let trialId: Int64
   public let jobId: Int64
   public let epoch: LearningEpoch
@@ -24,7 +24,7 @@ public struct TrialAssignmentIdentity: Sendable, Equatable, Hashable {
   }
 }
 
-public enum TrialOutcomeKind: String, Sendable, Equatable, CaseIterable {
+public enum TrialOutcomeKind: String, Sendable, Equatable, CaseIterable, Codable {
   case positive
   case negative
   case neutral

--- a/Sources/ClawCore/Domain/Learning/LearningTrialResolution.swift
+++ b/Sources/ClawCore/Domain/Learning/LearningTrialResolution.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+public struct LearningTrialIdentity: Sendable, Equatable, Hashable {
+  public let trialId: Int64
+  public let jobId: Int64
+  public let epoch: LearningEpoch
+  public let generation: Int
+
+  public init(trialId: Int64, jobId: Int64, epoch: LearningEpoch, generation: Int) {
+    self.trialId = trialId
+    self.jobId = jobId
+    self.epoch = epoch
+    self.generation = generation
+  }
+}
+
+public struct TrialAssignmentIdentity: Sendable, Equatable, Hashable {
+  public let trial: LearningTrialIdentity
+  public let runId: Int64
+
+  public init(trial: LearningTrialIdentity, runId: Int64) {
+    self.trial = trial
+    self.runId = runId
+  }
+}
+
+public enum TrialOutcomeKind: String, Sendable, Equatable, CaseIterable {
+  case positive
+  case negative
+  case neutral
+}
+
+public enum TrialAssignmentCloseReason: String, Sendable, Equatable, CaseIterable {
+  case assignmentLimit = "assignment_limit"
+  case assignmentDeadline = "assignment_deadline"
+  case positiveCohortComplete = "positive_cohort_complete"
+}
+
+public enum TrialFallbackReason: String, Sendable, Equatable, CaseIterable {
+  case hardVeto = "hard_veto"
+  case negativeOutcome = "negative_outcome"
+  case decisionDeadlineIncomplete = "decision_deadline_incomplete"
+  case insufficientSupport = "insufficient_support"
+}
+
+public enum TrialDecision: Sendable, Equatable {
+  case wait
+  case closeAssignment(reason: TrialAssignmentCloseReason)
+  case promote
+  case fallback(reason: TrialFallbackReason)
+}
+
+public struct ResolvedRunEvidence: Sendable, Equatable {
+  public let effective: ResolvedOutcome
+  public let evaluationDigest: EvaluationDigest?
+  public let correctionEventDigest: FeedbackEventDigest?
+  public let effectiveFeedbackRevision: FeedbackRevision
+
+  public init(
+    effective: ResolvedOutcome,
+    evaluationDigest: EvaluationDigest?,
+    correctionEventDigest: FeedbackEventDigest?,
+    effectiveFeedbackRevision: FeedbackRevision
+  ) {
+    self.effective = effective
+    self.evaluationDigest = evaluationDigest
+    self.correctionEventDigest = correctionEventDigest
+    self.effectiveFeedbackRevision = effectiveFeedbackRevision
+  }
+
+  public var outcome: TrialOutcomeKind {
+    switch effective.outcome {
+    case .positive:
+      return .positive
+    case .negative:
+      return .negative
+    case .neutral:
+      return .neutral
+    }
+  }
+
+  public var issueCodes: [String] {
+    guard case .negative(let issueCodes) = effective.outcome else {
+      return []
+    }
+    return issueCodes
+  }
+
+  public var evaluationRequired: Bool { effective.evaluationRequired }
+  public var ownerConfirmed: Bool { effective.ownerConfirmed }
+  public var hardVetoes: Set<HardVeto> { effective.hardVetoes }
+}
+
+public struct TrialAssignment: Sendable, Equatable {
+  public let identity: TrialAssignmentIdentity
+  public let assignedAt: Date
+  public let state: TrialAssignmentState
+  public let resolvedEvidence: ResolvedRunEvidence?
+  public let resolvedAt: Date?
+
+  public init(
+    identity: TrialAssignmentIdentity,
+    assignedAt: Date,
+    state: TrialAssignmentState,
+    resolvedEvidence: ResolvedRunEvidence?,
+    resolvedAt: Date?
+  ) {
+    self.identity = identity
+    self.assignedAt = assignedAt
+    self.state = state
+    self.resolvedEvidence = resolvedEvidence
+    self.resolvedAt = resolvedAt
+  }
+}
+
+public enum AssignmentRecomputation: Sendable, Equatable {
+  case notAssigned
+  case stale
+  case unchanged(TrialAssignment)
+  case updated(TrialAssignment)
+}
+
+public struct TrialReconciliation: Sendable, Equatable {
+  public let identity: LearningTrialIdentity
+  public let didDrain: Bool
+  public let assignments: [TrialAssignment]
+  public let decision: TrialDecision
+
+  public init(
+    identity: LearningTrialIdentity,
+    didDrain: Bool,
+    assignments: [TrialAssignment],
+    decision: TrialDecision
+  ) {
+    self.identity = identity
+    self.didDrain = didDrain
+    self.assignments = assignments
+    self.decision = decision
+  }
+}
+
+public enum TrialReconciliationResult: Sendable, Equatable {
+  case stale
+  case reconciled(TrialReconciliation)
+}
+
+public enum TrialPolicy {
+  public static func decide(
+    trial: LearningTrial,
+    assignments: [TrialAssignment],
+    now: Date
+  ) -> TrialDecision {
+    let resolved = assignments.compactMap(\.resolvedEvidence)
+    let hasHardVeto =
+      trial.hardVetoes.isEmpty == false
+      || resolved.contains { evidence in
+        evidence.hardVetoes.isEmpty == false
+      }
+    if hasHardVeto {
+      return .fallback(reason: .hardVeto)
+    }
+    if resolved.contains(where: { evidence in evidence.outcome == .negative }) {
+      return .fallback(reason: .negativeOutcome)
+    }
+
+    let hasUnresolved = resolved.count != assignments.count
+    if now >= trial.decisionDeadline, hasUnresolved {
+      return .fallback(reason: .decisionDeadlineIncomplete)
+    }
+
+    let positiveCount = resolved.count { evidence in evidence.outcome == .positive }
+    let limitReached = trial.consumedAssignments >= trial.maxAssignments
+    let deadlineReached = now >= trial.assignmentDeadline
+    let positiveCohortComplete = positiveCount >= 2 && hasUnresolved == false
+    let exposureClosed =
+      trial.state == .draining
+      || limitReached
+      || deadlineReached
+      || positiveCohortComplete
+    guard exposureClosed else {
+      return .wait
+    }
+    if trial.state == .draining, hasUnresolved {
+      return .wait
+    }
+    if trial.state == .open, hasUnresolved {
+      if limitReached {
+        return .closeAssignment(reason: .assignmentLimit)
+      }
+      if deadlineReached {
+        return .closeAssignment(reason: .assignmentDeadline)
+      }
+    }
+    if positiveCount >= 2 {
+      return .promote
+    }
+    return .fallback(reason: .insufficientSupport)
+  }
+}

--- a/Sources/ClawCore/Domain/Learning/LearningView.swift
+++ b/Sources/ClawCore/Domain/Learning/LearningView.swift
@@ -135,12 +135,16 @@ public struct ReflectionNoCandidateReceipt: Sendable, Equatable, Codable {
   }
 }
 
-/// The only two immutable decision receipt shapes production can currently write.
+/// The immutable decision receipt shapes production can currently write.
 public enum LearningDecisionDetail: Sendable, Equatable {
   case candidateAdmission(inputs: AdmissionDecisionInputs, result: AdmissionReceipt)
   case reflectionNoCandidate(
     inputs: ReflectionNoCandidateInputs,
     result: ReflectionNoCandidateReceipt
+  )
+  case learningReset(
+    inputs: LearningResetDecisionInputs,
+    result: LearningResetDecisionResult
   )
 }
 

--- a/Sources/ClawCore/Domain/Learning/LearningView.swift
+++ b/Sources/ClawCore/Domain/Learning/LearningView.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+/// The scheduled-job fields the owner view may render. Prompt and recurrence bytes stay private
+/// to the scheduler; the learning surface needs only identity and display context.
+public struct LearningJobIdentity: Sendable, Equatable {
+  public let jobId: Int64
+  public let label: String
+  public let status: ScheduledJobStatus
+  public let timezone: String
+
+  public init(jobId: Int64, label: String, status: ScheduledJobStatus, timezone: String) {
+    self.jobId = jobId
+    self.label = label
+    self.status = status
+    self.timezone = timezone
+  }
+}
+
+/// The bounded identity retained when a damaged job cannot be decoded safely.
+public struct UnreadableLearningJob: Sendable, Equatable {
+  public let jobId: Int64
+  public let validatedLabel: String?
+
+  public init(jobId: Int64, validatedLabel: String?) {
+    self.jobId = jobId
+    self.validatedLabel = validatedLabel
+  }
+}
+
+/// A non-authoritative mismatch that can be reported without hiding authoritative state.
+public enum LearningViewWarning: String, Sendable, Equatable {
+  case trialPointerMismatch = "stored trial pointer does not match the live trial"
+}
+
+/// Current assignment facts. Until durable resolution exists, every reachable assignment is
+/// unresolved; the projection never treats a cached outcome as final.
+public struct LearningTrialCounts: Sendable, Equatable {
+  public let consumed: Int
+  public let maximum: Int
+  public let unresolved: Int
+
+  public init(consumed: Int, maximum: Int, unresolved: Int) {
+    self.consumed = consumed
+    self.maximum = maximum
+    self.unresolved = unresolved
+  }
+}
+
+/// One authoritative open-or-draining trial and the immutable candidate identities it exposes.
+public struct LearningTrialView: Sendable, Equatable {
+  public let trialId: Int64
+  public let epoch: LearningEpoch
+  public let generation: Int
+  public let state: LearningTrialState
+  public let candidateDigest: CandidateDigest
+  public let baseDigest: LessonSetDigest
+  public let baseRevision: StableRevision
+  public let replacementDigest: LessonSetDigest
+  public let counts: LearningTrialCounts
+  public let assignmentDeadline: Date
+  public let decisionDeadline: Date
+
+  public init(  // swiftlint:disable:this function_parameter_count
+    trialId: Int64,
+    epoch: LearningEpoch,
+    generation: Int,
+    state: LearningTrialState,
+    candidateDigest: CandidateDigest,
+    baseDigest: LessonSetDigest,
+    baseRevision: StableRevision,
+    replacementDigest: LessonSetDigest,
+    counts: LearningTrialCounts,
+    assignmentDeadline: Date,
+    decisionDeadline: Date
+  ) {
+    self.trialId = trialId
+    self.epoch = epoch
+    self.generation = generation
+    self.state = state
+    self.candidateDigest = candidateDigest
+    self.baseDigest = baseDigest
+    self.baseRevision = baseRevision
+    self.replacementDigest = replacementDigest
+    self.counts = counts
+    self.assignmentDeadline = assignmentDeadline
+    self.decisionDeadline = decisionDeadline
+  }
+}
+
+public struct AdmissionDecisionInputs: Sendable, Equatable, Codable {
+  public let candidateDigest: CandidateDigest
+
+  public init(candidateDigest: CandidateDigest) {
+    self.candidateDigest = candidateDigest
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case candidateDigest = "candidate_digest"
+  }
+}
+
+public struct ReflectionNoCandidateInputs: Sendable, Equatable, Codable {
+  public let triggerDigest: TriggerDigest
+  public let operationId: LearningOperationID
+  public let carrierDigest: CarrierDigest
+
+  public init(
+    triggerDigest: TriggerDigest,
+    operationId: LearningOperationID,
+    carrierDigest: CarrierDigest
+  ) {
+    self.triggerDigest = triggerDigest
+    self.operationId = operationId
+    self.carrierDigest = carrierDigest
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case triggerDigest = "trigger_digest"
+    case operationId = "operation_id"
+    case carrierDigest = "carrier_digest"
+  }
+}
+
+public struct ReflectionNoCandidateReceipt: Sendable, Equatable, Codable {
+  public static let kind = "reflection_no_candidate"
+
+  public let resultDigest: ReflectionResultDigest
+
+  public init(resultDigest: ReflectionResultDigest) {
+    self.resultDigest = resultDigest
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case resultDigest = "result_digest"
+  }
+}
+
+/// The only two immutable decision receipt shapes production can currently write.
+public enum LearningDecisionDetail: Sendable, Equatable {
+  case candidateAdmission(inputs: AdmissionDecisionInputs, result: AdmissionReceipt)
+  case reflectionNoCandidate(
+    inputs: ReflectionNoCandidateInputs,
+    result: ReflectionNoCandidateReceipt
+  )
+}
+
+public struct LearningDecisionView: Sendable, Equatable {
+  public let decisionId: Int64
+  public let jobId: Int64
+  public let epoch: LearningEpoch
+  public let algorithm: LearningAlgorithm
+  public let decidedAt: Date
+  public let detail: LearningDecisionDetail
+
+  public init(
+    decisionId: Int64,
+    jobId: Int64,
+    epoch: LearningEpoch,
+    algorithm: LearningAlgorithm,
+    decidedAt: Date,
+    detail: LearningDecisionDetail
+  ) {
+    self.decisionId = decisionId
+    self.jobId = jobId
+    self.epoch = epoch
+    self.algorithm = algorithm
+    self.decidedAt = decidedAt
+    self.detail = detail
+  }
+}
+
+public struct ReadableJobLearningView: Sendable, Equatable {
+  public let job: LearningJobIdentity
+  public let epoch: LearningEpoch
+  public let stableRevision: StableRevision
+  public let stableLessons: LessonSet
+  public let liveTrial: LearningTrialView?
+  public let lastDecision: LearningDecisionView?
+  public let warnings: [LearningViewWarning]
+
+  public init(
+    job: LearningJobIdentity,
+    epoch: LearningEpoch,
+    stableRevision: StableRevision,
+    stableLessons: LessonSet,
+    liveTrial: LearningTrialView?,
+    lastDecision: LearningDecisionView?,
+    warnings: [LearningViewWarning]
+  ) {
+    self.job = job
+    self.epoch = epoch
+    self.stableRevision = stableRevision
+    self.stableLessons = stableLessons
+    self.liveTrial = liveTrial
+    self.lastDecision = lastDecision
+    self.warnings = warnings
+  }
+}
+
+/// One list/detail query result. A detail request always returns exactly one case; a list returns
+/// readable or unreadable armed jobs only and uses an empty array for no learning state.
+public enum JobLearningView: Sendable, Equatable {
+  case readable(ReadableJobLearningView)
+  case unarmed(LearningJobIdentity)
+  case notFound(jobId: Int64)
+  case unreadable(UnreadableLearningJob)
+}

--- a/Sources/ClawCore/Domain/Learning/LearningView.swift
+++ b/Sources/ClawCore/Domain/Learning/LearningView.swift
@@ -149,6 +149,7 @@ public struct ReflectionNoCandidateReceipt: Sendable, Equatable, Codable {
 
 /// The immutable decision receipt shapes production can currently write.
 public enum LearningDecisionDetail: Sendable, Equatable {
+  case terminal(DecisionReceipt)
   case candidateAdmission(inputs: AdmissionDecisionInputs, result: AdmissionReceipt)
   case reflectionNoCandidate(
     inputs: ReflectionNoCandidateInputs,

--- a/Sources/ClawCore/Domain/Learning/LearningView.swift
+++ b/Sources/ClawCore/Domain/Learning/LearningView.swift
@@ -32,16 +32,28 @@ public enum LearningViewWarning: Sendable, Equatable {
   case trialPointerMismatch
 }
 
-/// Current assignment facts. Until durable resolution exists, every reachable assignment is
-/// unresolved; the projection never treats a cached outcome as final.
+/// Current assignment facts projected from authoritative source rows in one read snapshot.
 public struct LearningTrialCounts: Sendable, Equatable {
   public let consumed: Int
   public let maximum: Int
+  public let positive: Int
+  public let negative: Int
+  public let neutral: Int
   public let unresolved: Int
 
-  public init(consumed: Int, maximum: Int, unresolved: Int) {
+  public init(
+    consumed: Int,
+    maximum: Int,
+    positive: Int,
+    negative: Int,
+    neutral: Int,
+    unresolved: Int
+  ) {
     self.consumed = consumed
     self.maximum = maximum
+    self.positive = positive
+    self.negative = negative
+    self.neutral = neutral
     self.unresolved = unresolved
   }
 }

--- a/Sources/ClawCore/Domain/Learning/LearningView.swift
+++ b/Sources/ClawCore/Domain/Learning/LearningView.swift
@@ -28,8 +28,8 @@ public struct UnreadableLearningJob: Sendable, Equatable {
 }
 
 /// A non-authoritative mismatch that can be reported without hiding authoritative state.
-public enum LearningViewWarning: String, Sendable, Equatable {
-  case trialPointerMismatch = "stored trial pointer does not match the live trial"
+public enum LearningViewWarning: Sendable, Equatable {
+  case trialPointerMismatch
 }
 
 /// Current assignment facts. Until durable resolution exists, every reachable assignment is

--- a/Sources/ClawCore/Domain/Learning/LearningVocabulary.swift
+++ b/Sources/ClawCore/Domain/Learning/LearningVocabulary.swift
@@ -141,18 +141,9 @@ public enum TrialAssignmentState: String, Sendable, Equatable {
   case learningOutcomeResolved = "learning_outcome_resolved"
 }
 
-/// What the trial policy decides once an assignment's exposure and settlement state are known.
-public enum TrialDecision: Sendable, Equatable {
-  case wait
-  case closeAssignment(reason: String)
-  case promote
-  case fallback(reason: String)
-}
-
-/// The lifecycle of one admitted trial. `open` is the only state that grants new assignments,
-/// which is what the partial unique index on `learning_trials` keys on to hold at most one
-/// assigning trial per job. A `draining` trial has hit an exposure bound: it grants nothing more,
-/// but the runs it already assigned still settle and still decide it.
+/// The lifecycle of one admitted trial. `open` is the only state that grants new assignments.
+/// The partial unique index covers `open` and `draining`, so at most one live trial owns a job.
+/// A draining trial grants nothing more, but its assigned runs still settle and still decide it.
 public enum LearningTrialState: String, Sendable, Equatable, CaseIterable {
   case open
   case draining

--- a/Sources/ClawCore/Domain/Learning/LearningVocabulary.swift
+++ b/Sources/ClawCore/Domain/Learning/LearningVocabulary.swift
@@ -64,6 +64,7 @@ public enum LearningOperationFailure: String, Sendable, Equatable {
   case carrierPolicyDenied = "carrier_policy_denied"
   case schemaInvalid = "schema_invalid"
   case providerTerminal = "provider_terminal"
+  case staleEpoch = "stale_epoch"
 }
 
 /// The evaluator's raw structured verdict on one run, before owner precedence resolves it into an
@@ -158,6 +159,11 @@ public enum LearningTrialState: String, Sendable, Equatable, CaseIterable {
   case promoted
   case fellBack = "fell_back"
   case closed
+}
+
+/// Why a trial reached the generic closed state without promotion or fallback.
+public enum LearningTrialCloseReason: String, Sendable, Equatable {
+  case learningReset = "learning_reset"
 }
 
 /// Where a stored lesson set came from. Arming inserts the canonical empty set under its own

--- a/Sources/ClawCore/Domain/Support/TelegramMessageLimits.swift
+++ b/Sources/ClawCore/Domain/Support/TelegramMessageLimits.swift
@@ -1,3 +1,4 @@
 public enum TelegramMessageLimits {
+  public static let maxPlainMessageCharacters = 4_096
   public static let maxRichMessageCharacters = 32_768
 }

--- a/Sources/ClawCore/Persistence/Persistence.swift
+++ b/Sources/ClawCore/Persistence/Persistence.swift
@@ -605,6 +605,7 @@ public enum AuditAction: String, Sendable, Equatable {
   case learningBound = "learning_bound"
   case learningFeedback = "learning_feedback"
   case learningCandidateAdmitted = "learning_candidate_admitted"
+  case learningReset = "learning_reset"
 }
 
 public struct AuditEvent: Sendable, Equatable {

--- a/Sources/ClawCore/Persistence/ScheduledLearningStore.swift
+++ b/Sources/ClawCore/Persistence/ScheduledLearningStore.swift
@@ -213,7 +213,7 @@ public struct JobLearningState: Sendable, Equatable {
   }
 }
 
-public protocol ScheduledLearningStore: Sendable {
+public protocol ScheduledLearningStore: LearningResetApplying, Sendable {
   /// One read snapshot for the complete owner-facing learning projection. nil lists armed jobs;
   /// a positive id returns exactly one readable, unarmed, missing, or unreadable result.
   func learningView(jobId: Int64?) throws(StoreError) -> [JobLearningView]

--- a/Sources/ClawCore/Persistence/ScheduledLearningStore.swift
+++ b/Sources/ClawCore/Persistence/ScheduledLearningStore.swift
@@ -300,6 +300,21 @@ public protocol ScheduledLearningStore: LearningResetApplying, Sendable {
   /// `JobLearningState.openTrialId`.
   func openTrial(jobId: Int64) throws(StoreError) -> LearningTrial?
 
+  /// Rebuilds one assignment cache from its exact durable sources and current feedback.
+  func recomputeAssignment(
+    runId: Int64,
+    now: Date
+  ) throws(StoreError) -> AssignmentRecomputation
+
+  /// Every open-or-draining trial identity, sorted by job and trial id.
+  func liveTrialIdentities() throws(StoreError) -> [LearningTrialIdentity]
+
+  /// Reprojects one exact live cohort and applies only its open-to-draining edge.
+  func reconcileTrial(
+    _ identity: LearningTrialIdentity,
+    now: Date
+  ) throws(StoreError) -> TrialReconciliationResult
+
   /// The terminal receipt the transaction that won the run's state wrote. Nil for a run that never
   /// bound, or one that is still live.
   func settlement(runId: Int64) throws(StoreError) -> RunSettlement?

--- a/Sources/ClawCore/Persistence/ScheduledLearningStore.swift
+++ b/Sources/ClawCore/Persistence/ScheduledLearningStore.swift
@@ -315,6 +315,27 @@ public protocol ScheduledLearningStore: LearningResetApplying, Sendable {
     now: Date
   ) throws(StoreError) -> TrialReconciliationResult
 
+  /// Revalidates the complete cohort and commits an exact terminal recommendation atomically.
+  func applyTrialDecision(
+    _ decision: TrialDecision,
+    trial: LearningTrial,
+    feedbackRevision: FeedbackRevision,
+    now: Date
+  ) throws(StoreError) -> DecisionReceipt?
+
+  /// Restores only the direct base of the named current promotion.
+  func rollback(_ trigger: RollbackTrigger, now: Date) throws(StoreError) -> DecisionReceipt?
+
+  /// Claims the command update and commits an exact current promotion target with all chunks.
+  func commitPromotionReply(
+    updateId: Int64,
+    target: NewFeedbackTarget,
+    chunks: [LearningNoticeChunk],
+    now: Date
+  ) throws(StoreError) -> PromotionReplyOutcome
+
+  func currentPromotion(jobId: Int64) throws(StoreError) -> DecisionReceipt?
+
   /// The terminal receipt the transaction that won the run's state wrote. Nil for a run that never
   /// bound, or one that is still live.
   func settlement(runId: Int64) throws(StoreError) -> RunSettlement?

--- a/Sources/ClawCore/Persistence/ScheduledLearningStore.swift
+++ b/Sources/ClawCore/Persistence/ScheduledLearningStore.swift
@@ -214,6 +214,10 @@ public struct JobLearningState: Sendable, Equatable {
 }
 
 public protocol ScheduledLearningStore: Sendable {
+  /// One read snapshot for the complete owner-facing learning projection. nil lists armed jobs;
+  /// a positive id returns exactly one readable, unarmed, missing, or unreadable result.
+  func learningView(jobId: Int64?) throws(StoreError) -> [JobLearningView]
+
   /// Revalidates and admits one already-persisted immutable candidate.
   func admitCandidate(
     digest: CandidateDigest,

--- a/Sources/ClawData/Database/ClawDatabase+SchemaV13.swift
+++ b/Sources/ClawData/Database/ClawDatabase+SchemaV13.swift
@@ -1,0 +1,18 @@
+import ClawCore
+import GRDB
+
+// MARK: - Schema V13
+
+extension ClawDatabase {
+  static func replaceOpenTrialIndexWithLiveTrialIndex(_ db: Database) throws {
+    try db.drop(index: "idx_learning_trials_open_job")
+    let open = LearningTrialState.open.rawValue
+    let draining = LearningTrialState.draining.rawValue
+    try db.execute(
+      sql: """
+        CREATE UNIQUE INDEX idx_learning_trials_live_job ON learning_trials(job_id)
+        WHERE state IN ('\(open)', '\(draining)')
+        """
+    )
+  }
+}

--- a/Sources/ClawData/Database/ClawDatabase.swift
+++ b/Sources/ClawData/Database/ClawDatabase.swift
@@ -276,6 +276,9 @@ public enum ClawDatabase {
     migrator.registerMigration("v12") { db in
       try addLearningOperationClaimKey(db)
     }
+    migrator.registerMigration("v13") { db in
+      try replaceOpenTrialIndexWithLiveTrialIndex(db)
+    }
     return migrator
   }
 

--- a/Sources/ClawData/Database/SQLiteStoredValue.swift
+++ b/Sources/ClawData/Database/SQLiteStoredValue.swift
@@ -122,6 +122,20 @@ enum SQLiteStoredValue {
     }
   }
 
+  static func nullableData(in row: Row, column: String) -> Nullable<Data>? {
+    guard let storage = databaseValue(in: row, column: column)?.storage else {
+      return nil
+    }
+    switch storage {
+    case .null:
+      return Nullable(value: nil)
+    case .blob(let value):
+      return Nullable(value: value)
+    case .int64, .double, .string:
+      return nil
+    }
+  }
+
   private static func databaseValue(in row: Row, column: String) -> DatabaseValue? {
     row[column] as DatabaseValue?
   }

--- a/Sources/ClawData/Database/SQLiteStoredValue.swift
+++ b/Sources/ClawData/Database/SQLiteStoredValue.swift
@@ -1,0 +1,128 @@
+import Foundation
+import GRDB
+
+/// Exact SQLite storage-class decoding for persisted values that must fail closed on bad rows.
+enum SQLiteStoredValue {
+  enum BooleanValue {
+    case falseValue
+    case trueValue
+  }
+
+  struct Nullable<Value> {
+    let value: Value?
+  }
+
+  static func int64(in row: Row, column: String) -> Int64? {
+    guard case .int64(let value) = databaseValue(in: row, column: column)?.storage else {
+      return nil
+    }
+    return value
+  }
+
+  static func int(in row: Row, column: String) -> Int? {
+    guard let value = int64(in: row, column: column) else {
+      return nil
+    }
+    return Int(exactly: value)
+  }
+
+  static func boolean(in row: Row, column: String) -> BooleanValue? {
+    switch int64(in: row, column: column) {
+    case 0:
+      return .falseValue
+    case 1:
+      return .trueValue
+    default:
+      return nil
+    }
+  }
+
+  static func double(in row: Row, column: String) -> Double? {
+    guard let storage = databaseValue(in: row, column: column)?.storage else {
+      return nil
+    }
+    switch storage {
+    case .double(let value):
+      return value
+    case .int64(let value):
+      return Double(value)
+    case .null, .string, .blob:
+      return nil
+    }
+  }
+
+  static func string(in row: Row, column: String) -> String? {
+    guard case .string(let value) = databaseValue(in: row, column: column)?.storage else {
+      return nil
+    }
+    return value
+  }
+
+  static func data(in row: Row, column: String) -> Data? {
+    guard case .blob(let value) = databaseValue(in: row, column: column)?.storage else {
+      return nil
+    }
+    return value
+  }
+
+  static func nullableInt64(in row: Row, column: String) -> Nullable<Int64>? {
+    guard let storage = databaseValue(in: row, column: column)?.storage else {
+      return nil
+    }
+    switch storage {
+    case .null:
+      return Nullable(value: nil)
+    case .int64(let value):
+      return Nullable(value: value)
+    case .double, .string, .blob:
+      return nil
+    }
+  }
+
+  static func nullableInt(in row: Row, column: String) -> Nullable<Int>? {
+    guard let decoded = nullableInt64(in: row, column: column) else {
+      return nil
+    }
+    guard let value = decoded.value else {
+      return Nullable(value: nil)
+    }
+    guard let exact = Int(exactly: value) else {
+      return nil
+    }
+    return Nullable(value: exact)
+  }
+
+  static func nullableDouble(in row: Row, column: String) -> Nullable<Double>? {
+    guard let storage = databaseValue(in: row, column: column)?.storage else {
+      return nil
+    }
+    switch storage {
+    case .null:
+      return Nullable(value: nil)
+    case .double(let value):
+      return Nullable(value: value)
+    case .int64(let value):
+      return Nullable(value: Double(value))
+    case .string, .blob:
+      return nil
+    }
+  }
+
+  static func nullableString(in row: Row, column: String) -> Nullable<String>? {
+    guard let storage = databaseValue(in: row, column: column)?.storage else {
+      return nil
+    }
+    switch storage {
+    case .null:
+      return Nullable(value: nil)
+    case .string(let value):
+      return Nullable(value: value)
+    case .int64, .double, .blob:
+      return nil
+    }
+  }
+
+  private static func databaseValue(in row: Row, column: String) -> DatabaseValue? {
+    row[column] as DatabaseValue?
+  }
+}

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+AdmissionPersistence.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+AdmissionPersistence.swift
@@ -59,19 +59,28 @@ extension ScheduledLearningStoreGRDB {
     guard let row = rows.first else {
       return nil
     }
-    guard let state = LearningTrialState(rawValue: row["state"]) else {
+    guard
+      let trialId = SQLiteStoredValue.int64(in: row, column: "trial_id"),
+      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
+      let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      let baseDigest = SQLiteStoredValue.string(in: row, column: "base_digest"),
+      let candidateDigest = SQLiteStoredValue.string(in: row, column: "candidate_digest"),
+      let generation = SQLiteStoredValue.int(in: row, column: "generation"),
+      let stateRaw = SQLiteStoredValue.string(in: row, column: "state"),
+      let state = LearningTrialState(rawValue: stateRaw),
+      let algorithm = SQLiteStoredValue.string(in: row, column: "algorithm")
+    else {
       throw StoreError.unexpected("candidate admission trial is unreadable")
     }
-    let algorithm = LearningAlgorithm(rawValue: row["algorithm"])
     return TrialRow(
-      id: row["trial_id"],
-      jobId: row["job_id"],
-      epoch: LearningEpoch(row["learning_epoch"]),
-      baseDigest: LessonSetDigest(rawValue: row["base_digest"]),
-      candidateDigest: CandidateDigest(rawValue: row["candidate_digest"]),
-      generation: row["generation"],
+      id: trialId,
+      jobId: jobId,
+      epoch: LearningEpoch(epoch),
+      baseDigest: LessonSetDigest(rawValue: baseDigest),
+      candidateDigest: CandidateDigest(rawValue: candidateDigest),
+      generation: generation,
       state: state,
-      algorithm: algorithm
+      algorithm: LearningAlgorithm(rawValue: algorithm)
     )
   }
 
@@ -132,10 +141,17 @@ private extension ScheduledLearningStoreGRDB {
     )
     var matches: [AdmissionReceipt] = []
     for row in rows {
-      let inputsBytes = Data((row["inputs"] as String).utf8)
-      let resultBytes = Data((row["result"] as String).utf8)
       guard
-        (row["algorithm"] as String) == artifact.manifest.algorithm.rawValue,
+        let inputsJSON = SQLiteStoredValue.string(in: row, column: "inputs"),
+        let resultJSON = SQLiteStoredValue.string(in: row, column: "result"),
+        let algorithm = SQLiteStoredValue.string(in: row, column: "algorithm"),
+        algorithm == artifact.manifest.algorithm.rawValue
+      else {
+        throw StoreError.unexpected("candidate admission decision is unreadable")
+      }
+      let inputsBytes = Data(inputsJSON.utf8)
+      let resultBytes = Data(resultJSON.utf8)
+      guard
         let inputs = try? JSONDecoder().decode(AdmissionDecisionInputs.self, from: inputsBytes),
         let receipt = try? JSONDecoder().decode(AdmissionReceipt.self, from: resultBytes),
         let canonicalInputs = try? CanonicalJSON.data(encoding: inputs),

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+AdmissionPersistence.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+AdmissionPersistence.swift
@@ -149,15 +149,9 @@ private extension ScheduledLearningStoreGRDB {
       else {
         throw StoreError.unexpected("candidate admission decision is unreadable")
       }
-      let inputsBytes = Data(inputsJSON.utf8)
-      let resultBytes = Data(resultJSON.utf8)
       guard
-        let inputs = try? JSONDecoder().decode(AdmissionDecisionInputs.self, from: inputsBytes),
-        let receipt = try? JSONDecoder().decode(AdmissionReceipt.self, from: resultBytes),
-        let canonicalInputs = try? CanonicalJSON.data(encoding: inputs),
-        let canonicalResult = try? CanonicalJSON.data(encoding: receipt),
-        canonicalInputs == inputsBytes,
-        canonicalResult == resultBytes
+        let inputs: AdmissionDecisionInputs = try? decodeCanonicalDecision(inputsJSON),
+        let receipt: AdmissionReceipt = try? decodeCanonicalDecision(resultJSON)
       else {
         throw StoreError.unexpected("candidate admission decision is unreadable")
       }

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+AdmissionPersistence.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+AdmissionPersistence.swift
@@ -112,16 +112,6 @@ extension ScheduledLearningStoreGRDB {
   }
 }
 
-// MARK: - Decision Decoding
-
-private struct AdmissionInputs: Codable {
-  let candidateDigest: CandidateDigest
-
-  enum CodingKeys: String, CodingKey {
-    case candidateDigest = "candidate_digest"
-  }
-}
-
 private extension ScheduledLearningStoreGRDB {
   static func admissionReceipts(
     _ db: Database,
@@ -146,7 +136,7 @@ private extension ScheduledLearningStoreGRDB {
       let resultBytes = Data((row["result"] as String).utf8)
       guard
         (row["algorithm"] as String) == artifact.manifest.algorithm.rawValue,
-        let inputs = try? JSONDecoder().decode(AdmissionInputs.self, from: inputsBytes),
+        let inputs = try? JSONDecoder().decode(AdmissionDecisionInputs.self, from: inputsBytes),
         let receipt = try? JSONDecoder().decode(AdmissionReceipt.self, from: resultBytes),
         let canonicalInputs = try? CanonicalJSON.data(encoding: inputs),
         let canonicalResult = try? CanonicalJSON.data(encoding: receipt),

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+CandidateSources.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+CandidateSources.swift
@@ -471,34 +471,15 @@ extension ScheduledLearningStoreGRDB {
 
   static func closeCandidateTrial(
     _ db: Database,
-    candidate: CandidateArtifact
+    candidate: CandidateArtifact,
+    now: Date
   ) throws -> Int64? {
-    let trialId = try Int64.fetchOne(
-      db,
-      sql: """
-        UPDATE learning_trials SET state = ?, close_reason = ?
-        WHERE candidate_digest = ? AND job_id = ? AND learning_epoch = ? AND state IN (?, ?)
-        RETURNING trial_id
-        """,
-      arguments: [
-        LearningTrialState.fellBack.rawValue,
-        hardVetoReason,
-        candidate.digest.rawValue,
-        candidate.manifest.jobId,
-        candidate.manifest.epoch.value,
-        LearningTrialState.open.rawValue,
-        LearningTrialState.draining.rawValue,
-      ]
-    )
-    if let trialId {
-      try db.execute(
-        sql: """
-          UPDATE job_learning_state SET open_trial_id = NULL
-          WHERE job_id = ? AND learning_epoch = ? AND open_trial_id = ?
-          """,
-        arguments: [candidate.manifest.jobId, candidate.manifest.epoch.value, trialId]
-      )
+    guard let trial = try trialRow(db, candidate: candidate.digest),
+      trial.state == .open || trial.state == .draining
+    else {
+      return nil
     }
-    return trialId
+    try terminalFallback(db, trialId: trial.id, now: now)
+    return trial.id
   }
 }

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+DecisionPersistence.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+DecisionPersistence.swift
@@ -1,0 +1,55 @@
+import ClawCore
+import Foundation
+import GRDB
+
+// MARK: - Canonical Decision Persistence
+
+extension ScheduledLearningStoreGRDB {
+  static func canonicalDecisionJSON<Value: Encodable>(_ value: Value) throws -> String {
+    let bytes = try CanonicalJSON.data(encoding: value)
+    // swiftlint:disable:next optional_data_string_conversion
+    return String(decoding: bytes, as: UTF8.self)
+  }
+
+  static func decodeCanonicalDecision<Value: Codable>(_ json: String) throws -> Value {
+    let bytes = Data(json.utf8)
+    guard
+      let value = try? JSONDecoder().decode(Value.self, from: bytes),
+      let canonical = try? CanonicalJSON.data(encoding: value),
+      canonical == bytes
+    else {
+      throw StoreError.unexpected("learning decision payload is unreadable")
+    }
+    return value
+  }
+
+  @discardableResult
+  // swiftlint:disable:next function_parameter_count
+  static func insertDecision<Inputs: Encodable, Result: Encodable>(
+    _ db: Database,
+    kind: String,
+    jobId: Int64,
+    epoch: LearningEpoch,
+    inputs: Inputs,
+    result: Result,
+    algorithm: LearningAlgorithm,
+    now: Date
+  ) throws -> Int64 {
+    try db.execute(
+      sql: """
+        INSERT INTO learning_decisions(kind, job_id, learning_epoch, inputs, result, algorithm,
+          decided_at) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+      arguments: [
+        kind,
+        jobId,
+        epoch.value,
+        try canonicalDecisionJSON(inputs),
+        try canonicalDecisionJSON(result),
+        algorithm.rawValue,
+        EpochSecondCodec.epoch(now),
+      ]
+    )
+    return db.lastInsertedRowID
+  }
+}

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Decisions.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Decisions.swift
@@ -505,28 +505,15 @@ private extension ScheduledLearningStoreGRDB {
     receipt: AdmissionReceipt,
     now: Date
   ) throws {
-    let inputs = try CanonicalJSON.data(
-      encoding: AdmissionDecisionInputs(candidateDigest: artifact.digest)
-    )
-    let result = try CanonicalJSON.data(encoding: receipt)
-    // swiftlint:disable:next optional_data_string_conversion
-    let inputsJSON = String(decoding: inputs, as: UTF8.self)
-    // swiftlint:disable:next optional_data_string_conversion
-    let resultJSON = String(decoding: result, as: UTF8.self)
-    try db.execute(
-      sql: """
-        INSERT INTO learning_decisions(kind, job_id, learning_epoch, inputs, result, algorithm,
-          decided_at) VALUES (?, ?, ?, ?, ?, ?, ?)
-        """,
-      arguments: [
-        AdmissionReceipt.kind,
-        artifact.manifest.jobId,
-        artifact.manifest.epoch.value,
-        inputsJSON,
-        resultJSON,
-        artifact.manifest.algorithm.rawValue,
-        EpochSecondCodec.epoch(now),
-      ]
+    try insertDecision(
+      db,
+      kind: AdmissionReceipt.kind,
+      jobId: artifact.manifest.jobId,
+      epoch: artifact.manifest.epoch,
+      inputs: AdmissionDecisionInputs(candidateDigest: artifact.digest),
+      result: receipt,
+      algorithm: artifact.manifest.algorithm,
+      now: now
     )
   }
 }

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Decisions.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Decisions.swift
@@ -505,14 +505,9 @@ private extension ScheduledLearningStoreGRDB {
     receipt: AdmissionReceipt,
     now: Date
   ) throws {
-    struct Inputs: Encodable {
-      let candidateDigest: CandidateDigest
-
-      enum CodingKeys: String, CodingKey {
-        case candidateDigest = "candidate_digest"
-      }
-    }
-    let inputs = try CanonicalJSON.data(encoding: Inputs(candidateDigest: artifact.digest))
+    let inputs = try CanonicalJSON.data(
+      encoding: AdmissionDecisionInputs(candidateDigest: artifact.digest)
+    )
     let result = try CanonicalJSON.data(encoding: receipt)
     // swiftlint:disable:next optional_data_string_conversion
     let inputsJSON = String(decoding: inputs, as: UTF8.self)

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Decisions.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Decisions.swift
@@ -205,7 +205,7 @@ extension ScheduledLearningStoreGRDB {
       guard case .awaitingApproval = plan else {
         return Self.outcome(for: plan, artifact: successor)
       }
-      _ = try Self.closeCandidateTrial(db, candidate: context.predecessor)
+      _ = try Self.closeCandidateTrial(db, candidate: context.predecessor, now: now)
       try Self.recordCandidateArtifact(
         db,
         artifact: successor,
@@ -484,7 +484,7 @@ private extension ScheduledLearningStoreGRDB {
           JOIN learning_candidates AS candidate
             ON candidate.candidate_digest = trial.candidate_digest
           WHERE trial.job_id = ? AND trial.learning_epoch = ? AND trial.base_digest = ?
-            AND candidate.replacement_digest = ?
+            AND candidate.replacement_digest = ? AND trial.algorithm = ?
             AND trial.state NOT IN (?, ?)
         )
         """,
@@ -493,6 +493,7 @@ private extension ScheduledLearningStoreGRDB {
         artifact.manifest.epoch.value,
         artifact.manifest.baseDigest.rawValue,
         artifact.replacement.digest.rawValue,
+        artifact.manifest.algorithm.rawValue,
         LearningTrialState.open.rawValue,
         LearningTrialState.draining.rawValue,
       ]

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Evaluations.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Evaluations.swift
@@ -187,6 +187,7 @@ extension ScheduledLearningStoreGRDB {
       codes.allSatisfy({ code in
         code.isEmpty == false && code.count <= EvaluatorOutput.maxIssueCodeCharacters
       }),
+      Set(codes).count == codes.count,
       codes == codes.sorted(),
       try issueCodesJSON(codes) == json
     else {

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Evaluations.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Evaluations.swift
@@ -5,6 +5,18 @@ import GRDB
 // MARK: - Verdicts
 
 extension ScheduledLearningStoreGRDB {
+  struct StoredEvaluationProjection {
+    let digest: EvaluationDigest
+    let jobId: Int64
+    let epoch: LearningEpoch
+    let runId: Int64
+    let evidenceDigest: EvidenceDigest
+    let evaluation: LearningEvaluation
+    let issueCodesJSON: String
+    let compatibilityDigest: CompatibilityDigest
+    let createdAt: Date
+  }
+
   public func evaluation(runId: Int64) throws(StoreError) -> LearningEvaluation? {
     try database.readMapping { db in
       try Self.readEvaluation(db, runId: runId)
@@ -76,7 +88,7 @@ extension ScheduledLearningStoreGRDB {
 
 // MARK: - Verdict Rows
 
-private extension ScheduledLearningStoreGRDB {
+extension ScheduledLearningStoreGRDB {
   /// The evaluator's source digest names a sealed receipt, and a receipt is keyed by its run — so
   /// the run is resolved from the operation's own identity rather than taken from the caller, which
   /// could otherwise file one run's verdict against another.
@@ -133,35 +145,94 @@ private extension ScheduledLearningStoreGRDB {
   }
 
   static func readEvaluation(_ db: Database, runId: Int64) throws -> LearningEvaluation? {
-    let row = try Row.fetchOne(
+    let rows = try storedEvaluations(db, runId: runId)
+    guard rows.count <= 1 else {
+      throw StoreError.unexpected("run \(runId) holds multiple evaluations")
+    }
+    return rows.first?.evaluation
+  }
+
+  static func storedEvaluations(
+    _ db: Database,
+    runId: Int64
+  ) throws -> [StoredEvaluationProjection] {
+    let rows = try Row.fetchAll(
       db,
       sql: """
-        SELECT learning_evaluations.outcome, learning_evaluations.issue_codes,
+        SELECT learning_evaluations.evaluation_digest, learning_evaluations.job_id,
+          learning_evaluations.learning_epoch, learning_evaluations.run_id,
+          learning_evaluations.evidence_digest, learning_evaluations.outcome,
+          learning_evaluations.issue_codes,
           learning_evaluations.rubric_version, learning_evaluations.evaluator_prompt_version,
-          learning_evaluations.evaluator_schema_version, run_compatibility.evaluator_route
+          learning_evaluations.evaluator_schema_version,
+          learning_evaluations.compatibility_digest, learning_evaluations.created_at,
+          run_compatibility.evaluator_route
         FROM learning_evaluations
         LEFT JOIN run_compatibility ON run_compatibility.run_id = learning_evaluations.run_id
         WHERE learning_evaluations.run_id = ?
+        ORDER BY learning_evaluations.evaluation_digest
         """,
       arguments: [runId]
     )
-    guard let row else {
-      return nil
+    return try rows.map { row in
+      try decodeStoredEvaluation(row, expectedRunId: runId)
     }
+  }
+
+  static func decodeCanonicalIssueCodes(_ json: String) throws -> [String] {
     guard
-      let outcome = EvaluatorOutcome(rawValue: row["outcome"]),
-      let route: String = row["evaluator_route"],
-      let promptVersion = Int(row["evaluator_prompt_version"] as String),
-      let schemaVersion = Int(row["evaluator_schema_version"] as String),
-      let rubricVersion = Int(row["rubric_version"] as String),
-      let issueCodes = try? JSONDecoder().decode(
-        [String].self,
-        from: Data((row["issue_codes"] as String).utf8)
-      )
+      let data = json.data(using: .utf8),
+      let codes = try? JSONDecoder().decode([String].self, from: data),
+      codes.count <= EvaluatorOutput.maxIssueCodes,
+      codes.allSatisfy({ code in
+        code.isEmpty == false && code.count <= EvaluatorOutput.maxIssueCodeCharacters
+      }),
+      codes == codes.sorted(),
+      try issueCodesJSON(codes) == json
     else {
-      throw StoreError.unexpected("run \(runId) holds an unreadable evaluation")
+      throw StoreError.unexpected("assignment source has noncanonical issue codes")
     }
-    return LearningEvaluation(
+    return codes
+  }
+
+  private static func decodeStoredEvaluation(
+    _ row: Row,
+    expectedRunId: Int64
+  ) throws -> StoredEvaluationProjection {
+    guard
+      let digestRaw = SQLiteStoredValue.string(in: row, column: "evaluation_digest"),
+      isCanonicalDigest(digestRaw),
+      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
+      jobId > 0,
+      let epochRaw = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      epochRaw > 0,
+      let runId = SQLiteStoredValue.int64(in: row, column: "run_id"),
+      runId == expectedRunId,
+      let evidenceRaw = SQLiteStoredValue.string(in: row, column: "evidence_digest"),
+      isCanonicalDigest(evidenceRaw),
+      let outcomeRaw = SQLiteStoredValue.string(in: row, column: "outcome"),
+      let outcome = EvaluatorOutcome(rawValue: outcomeRaw),
+      let issueJSON = SQLiteStoredValue.string(in: row, column: "issue_codes"),
+      let issueCodes = try? decodeCanonicalIssueCodes(issueJSON),
+      let rubricRaw = SQLiteStoredValue.string(in: row, column: "rubric_version"),
+      let rubricVersion = Int(rubricRaw),
+      let promptRaw = SQLiteStoredValue.string(in: row, column: "evaluator_prompt_version"),
+      let promptVersion = Int(promptRaw),
+      let schemaRaw = SQLiteStoredValue.string(in: row, column: "evaluator_schema_version"),
+      let schemaVersion = Int(schemaRaw),
+      let compatibilityRaw = SQLiteStoredValue.string(
+        in: row,
+        column: "compatibility_digest"
+      ),
+      isCanonicalDigest(compatibilityRaw),
+      let createdRaw = SQLiteStoredValue.int64(in: row, column: "created_at"),
+      let createdAt = EpochSecondCodec.date(fromEpoch: createdRaw),
+      let route = SQLiteStoredValue.string(in: row, column: "evaluator_route"),
+      route.isEmpty == false
+    else {
+      throw StoreError.unexpected("run \(expectedRunId) holds an unreadable evaluation")
+    }
+    let evaluation = LearningEvaluation(
       outcome: outcome,
       issueCodes: issueCodes,
       evaluator: EvaluatorSurface(
@@ -170,6 +241,20 @@ private extension ScheduledLearningStoreGRDB {
         schemaVersion: schemaVersion,
         rubricVersion: rubricVersion
       )
+    )
+    guard evaluation.issueCodes == issueCodes else {
+      throw StoreError.unexpected("run \(expectedRunId) holds noncanonical evaluation codes")
+    }
+    return StoredEvaluationProjection(
+      digest: EvaluationDigest(rawValue: digestRaw),
+      jobId: jobId,
+      epoch: LearningEpoch(epochRaw),
+      runId: runId,
+      evidenceDigest: EvidenceDigest(rawValue: evidenceRaw),
+      evaluation: evaluation,
+      issueCodesJSON: issueJSON,
+      compatibilityDigest: CompatibilityDigest(rawValue: compatibilityRaw),
+      createdAt: createdAt
     )
   }
 }

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Evidence.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Evidence.swift
@@ -53,6 +53,7 @@ private extension ScheduledLearningStoreGRDB {
   /// content-free tombstone so the run is closed exactly once.
   static func seal(_ db: Database, runId: Int64, now: Date) throws -> SealOutcome {
     guard try readEvidence(db, runId: runId) == nil else {
+      _ = try recomputeAndReconcile(db, runId: runId, now: now)
       return .alreadySealed
     }
     guard let binding = try readBinding(db, runId: runId) else {
@@ -104,6 +105,7 @@ private extension ScheduledLearningStoreGRDB {
       now: now
     )
     try stampSealingVersions(db, runId: runId)
+    _ = try recomputeAndReconcile(db, runId: runId, now: now)
     return .sealed(eligibility: eligibility)
   }
 
@@ -125,6 +127,7 @@ private extension ScheduledLearningStoreGRDB {
       now: now
     )
     try stampSealingVersions(db, runId: binding.runId)
+    _ = try recomputeAndReconcile(db, runId: binding.runId, now: now)
     return .excluded(reason)
   }
 

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Evidence.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Evidence.swift
@@ -232,8 +232,8 @@ extension ScheduledLearningStoreGRDB {
     let row = try Row.fetchOne(
       db,
       sql: """
-        SELECT job_id, learning_epoch, evidence_digest, payload, exclusion_reason, eligibility,
-          classifier_version, sealed_at
+        SELECT run_id, job_id, learning_epoch, evidence_digest, payload, exclusion_reason,
+          eligibility, classifier_version, sealed_at
         FROM learning_evidence WHERE run_id = ?
         """,
       arguments: [runId]
@@ -241,25 +241,93 @@ extension ScheduledLearningStoreGRDB {
     guard let row else {
       return nil
     }
+    return try decodeEvidence(row, expectedRunId: runId)
+  }
+}
+
+// MARK: - Receipt Decoding
+
+private extension ScheduledLearningStoreGRDB {
+  static func decodeEvidence(_ row: Row, expectedRunId: Int64) throws -> SealedEvidence {
     guard
-      let eligibility = LearningEligibility(rawValue: row["eligibility"]),
-      let sealedAt = EpochSecondCodec.date(fromEpoch: row["sealed_at"])
+      let storedRunId = SQLiteStoredValue.int64(in: row, column: "run_id"),
+      storedRunId == expectedRunId,
+      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
+      jobId > 0,
+      let epochRaw = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      epochRaw > 0,
+      let digestRaw = SQLiteStoredValue.string(in: row, column: "evidence_digest"),
+      isCanonicalDigest(digestRaw),
+      let payloadStored = SQLiteStoredValue.nullableData(in: row, column: "payload"),
+      let exclusionStored = SQLiteStoredValue.nullableString(in: row, column: "exclusion_reason"),
+      let eligibilityRaw = SQLiteStoredValue.string(in: row, column: "eligibility"),
+      let eligibility = LearningEligibility(rawValue: eligibilityRaw),
+      let classifier = SQLiteStoredValue.string(in: row, column: "classifier_version"),
+      classifier == EligibilityClassifier.version,
+      let sealedRaw = SQLiteStoredValue.int64(in: row, column: "sealed_at"),
+      let sealedAt = EpochSecondCodec.date(fromEpoch: sealedRaw)
     else {
-      throw StoreError.unexpected("run \(runId) has an unreadable evidence receipt")
+      throw StoreError.unexpected("run \(expectedRunId) has an unreadable evidence receipt")
     }
-    let payloadBytes: Data? = row["payload"]
-    return SealedEvidence(
-      runId: runId,
-      jobId: row["job_id"],
-      epoch: LearningEpoch(row["learning_epoch"]),
-      digest: EvidenceDigest(rawValue: row["evidence_digest"]),
+    let exclusion = exclusionStored.value.flatMap(EvidenceExclusion.init(rawValue:))
+    guard exclusionStored.value == nil || exclusion != nil else {
+      throw StoreError.unexpected("run \(expectedRunId) has an unknown evidence exclusion")
+    }
+    let payload = try decodeEvidencePayload(
+      payloadStored.value,
+      runId: expectedRunId,
+      digestRaw: digestRaw,
       eligibility: eligibility,
-      classifierVersion: row["classifier_version"],
-      exclusion: (row["exclusion_reason"] as String?).flatMap(EvidenceExclusion.init(rawValue:)),
-      payload: payloadBytes.flatMap { bytes in
-        try? JSONDecoder().decode(EvidencePayload.self, from: bytes)
-      },
+      exclusion: exclusion
+    )
+    return SealedEvidence(
+      runId: expectedRunId,
+      jobId: jobId,
+      epoch: LearningEpoch(epochRaw),
+      digest: EvidenceDigest(rawValue: digestRaw),
+      eligibility: eligibility,
+      classifierVersion: classifier,
+      exclusion: exclusion,
+      payload: payload,
       sealedAt: sealedAt
     )
+  }
+
+  static func decodeEvidencePayload(
+    _ payloadBytes: Data?,
+    runId: Int64,
+    digestRaw: String,
+    eligibility: LearningEligibility,
+    exclusion: EvidenceExclusion?
+  ) throws -> EvidencePayload? {
+    if let payloadBytes {
+      guard
+        eligibility.reachesEvaluator,
+        exclusion == nil,
+        let decoded = try? JSONDecoder().decode(EvidencePayload.self, from: payloadBytes),
+        decoded.schemaVersion == EvidenceLimits.schemaVersion,
+        let canonical = try? CanonicalJSON.data(encoding: decoded),
+        canonical == payloadBytes,
+        digest(runId: runId, eligibility: eligibility, payloadBytes: payloadBytes).rawValue
+          == digestRaw
+      else {
+        throw StoreError.unexpected("run \(runId) has an invalid evidence payload")
+      }
+      return decoded
+    }
+    guard
+      eligibility.reachesEvaluator
+        || digest(
+          runId: runId,
+          eligibility: eligibility,
+          payloadBytes: nil
+        ).rawValue == digestRaw,
+      exclusion == nil
+        || (eligibility == .insufficientEvidence && exclusion != .legacyUnbound),
+      eligibility.reachesEvaluator == false || exclusion == nil
+    else {
+      throw StoreError.unexpected("run \(runId) has an invalid evidence receipt shape")
+    }
+    return nil
   }
 }

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Feedback.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Feedback.swift
@@ -55,7 +55,7 @@ extension ScheduledLearningStoreGRDB {
         subjectDigest: target.subjectDigest,
         now: now
       )
-      try Self.applyImmediateVeto(db, target: target, signal: tap.signal)
+      try Self.applyImmediateVeto(db, target: target, signal: tap.signal, now: now)
       let outcome = FeedbackOutcome.recorded(event)
       try Self.auditFeedback(db, tap: tap, target: target, outcome: outcome, now: now)
       return outcome
@@ -415,7 +415,8 @@ private extension ScheduledLearningStoreGRDB {
   static func applyImmediateVeto(
     _ db: Database,
     target: FeedbackTarget,
-    signal: OwnerSignal
+    signal: OwnerSignal,
+    now: Date
   ) throws {
     let trialId: Int64?
     switch signal {
@@ -428,13 +429,7 @@ private extension ScheduledLearningStoreGRDB {
       trialId = nil
     }
     if let trialId {
-      try db.execute(
-        sql: """
-          UPDATE job_learning_state SET open_trial_id = NULL
-          WHERE job_id = ? AND learning_epoch = ? AND open_trial_id = ?
-          """,
-        arguments: [target.jobId, target.epoch.value, trialId]
-      )
+      try terminalFallback(db, trialId: trialId, now: now)
     }
   }
 
@@ -442,8 +437,7 @@ private extension ScheduledLearningStoreGRDB {
     try Int64.fetchOne(
       db,
       sql: """
-        UPDATE learning_trials SET state = ?, close_reason = ?
-        WHERE trial_id = (
+        SELECT trial_id FROM learning_trials WHERE trial_id = (
           SELECT trial.trial_id
           FROM learning_trials AS trial
           JOIN learning_candidates AS candidate
@@ -464,11 +458,8 @@ private extension ScheduledLearningStoreGRDB {
             AND candidate.algorithm = trial.algorithm
           ORDER BY trial.trial_id DESC LIMIT 1
         )
-        RETURNING trial_id
         """,
       arguments: [
-        LearningTrialState.fellBack.rawValue,
-        Self.hardVetoReason,
         target.jobId,
         target.epoch.value,
         LearningTrialState.open.rawValue,
@@ -516,21 +507,7 @@ private extension ScheduledLearningStoreGRDB {
       else {
         continue
       }
-      let trialId: Int64 = row["trial_id"]
-      try db.execute(
-        sql: """
-          UPDATE learning_trials SET state = ?, close_reason = ?
-          WHERE trial_id = ? AND state IN (?, ?)
-          """,
-        arguments: [
-          LearningTrialState.fellBack.rawValue,
-          Self.hardVetoReason,
-          trialId,
-          LearningTrialState.open.rawValue,
-          LearningTrialState.draining.rawValue,
-        ]
-      )
-      return db.changesCount == 1 ? trialId : nil
+      return row["trial_id"] as Int64
     }
     return nil
   }

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Feedback.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Feedback.swift
@@ -47,6 +47,14 @@ extension ScheduledLearningStoreGRDB {
         throw StoreError.unexpected("feedback revision CAS lost after target consumption")
       }
       let event = try Self.insertEvent(db, tap: tap, target: target, revision: revision, now: now)
+      try Self.recomputeFeedbackSubject(
+        db,
+        jobId: target.jobId,
+        epoch: target.epoch,
+        subjectKind: target.subjectKind,
+        subjectDigest: target.subjectDigest,
+        now: now
+      )
       try Self.applyImmediateVeto(db, target: target, signal: tap.signal)
       let outcome = FeedbackOutcome.recorded(event)
       try Self.auditFeedback(db, tap: tap, target: target, outcome: outcome, now: now)
@@ -129,6 +137,14 @@ extension ScheduledLearningStoreGRDB {
         challenge: challenge,
         payload: payload,
         revision: revision,
+        now: now
+      )
+      try Self.recomputeFeedbackSubject(
+        db,
+        jobId: challenge.jobId,
+        epoch: challenge.epoch,
+        subjectKind: challenge.subjectKind,
+        subjectDigest: challenge.subjectDigest,
         now: now
       )
       let outcome = FeedbackOutcome.recorded(event)

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+FeedbackProjection.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+FeedbackProjection.swift
@@ -1,0 +1,158 @@
+import ClawCore
+import Foundation
+import GRDB
+
+// MARK: - Strict Feedback Projection
+
+extension ScheduledLearningStoreGRDB {
+  struct StoredFeedbackProjection {
+    let event: FeedbackEvent
+    let source: CandidateFeedbackSource
+  }
+
+  static func storedFeedback(
+    _ db: Database,
+    jobId: Int64,
+    epoch: LearningEpoch,
+    runIds: Set<Int64>,
+    evaluationRuns: [String: Int64],
+    cutoff: FeedbackRevision? = nil
+  ) throws -> [StoredFeedbackProjection] {
+    let runSubjects = runIds.map(String.init).sorted()
+    let evaluationSubjects = evaluationRuns.keys.sorted()
+    guard runSubjects.isEmpty == false || evaluationSubjects.isEmpty == false else {
+      return []
+    }
+
+    var subjectPredicates: [String] = []
+    var arguments: [any DatabaseValueConvertible] = [jobId, epoch.value]
+    if runSubjects.isEmpty == false {
+      let placeholders = Array(repeating: "?", count: runSubjects.count).joined(separator: ", ")
+      subjectPredicates.append("(subject_kind = ? AND subject_digest IN (\(placeholders)))")
+      arguments.append(FeedbackSubjectKind.run.rawValue)
+      arguments.append(contentsOf: runSubjects)
+    }
+    if evaluationSubjects.isEmpty == false {
+      let placeholders = Array(repeating: "?", count: evaluationSubjects.count)
+        .joined(separator: ", ")
+      subjectPredicates.append("(subject_kind = ? AND subject_digest IN (\(placeholders)))")
+      arguments.append(FeedbackSubjectKind.evaluation.rawValue)
+      arguments.append(contentsOf: evaluationSubjects)
+    }
+    let cutoffPredicate: String
+    if let cutoff {
+      cutoffPredicate = "AND feedback_revision <= ?"
+      arguments.append(cutoff.value)
+    } else {
+      cutoffPredicate = ""
+    }
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT event_id, subject_kind, subject_digest, signal, payload, feedback_revision,
+          supersedes, occurred_at, actor, transport_update_id
+        FROM feedback_events
+        WHERE job_id = ? AND learning_epoch = ?
+          AND (\(subjectPredicates.joined(separator: " OR ")))
+          \(cutoffPredicate)
+        ORDER BY feedback_revision, event_id
+        """,
+      arguments: StatementArguments(arguments)
+    )
+    return try rows.map { row in
+      try decodeStoredFeedback(
+        row,
+        jobId: jobId,
+        epoch: epoch,
+        runIds: runIds,
+        evaluationRuns: evaluationRuns
+      )
+    }
+  }
+
+  private static func decodeStoredFeedback(
+    _ row: Row,
+    jobId: Int64,
+    epoch: LearningEpoch,
+    runIds: Set<Int64>,
+    evaluationRuns: [String: Int64]
+  ) throws -> StoredFeedbackProjection {
+    guard
+      let eventId = SQLiteStoredValue.int64(in: row, column: "event_id"),
+      eventId > 0,
+      let kindRaw = SQLiteStoredValue.string(in: row, column: "subject_kind"),
+      let kind = FeedbackSubjectKind(rawValue: kindRaw),
+      let subject = SQLiteStoredValue.string(in: row, column: "subject_digest"),
+      let signalRaw = SQLiteStoredValue.string(in: row, column: "signal"),
+      let signal = OwnerSignal(rawValue: signalRaw),
+      signal.feedbackSubjectKind == kind,
+      let payload = SQLiteStoredValue.nullableString(in: row, column: "payload"),
+      let revisionRaw = SQLiteStoredValue.int64(in: row, column: "feedback_revision"),
+      revisionRaw > 0,
+      let supersedes = SQLiteStoredValue.nullableInt64(in: row, column: "supersedes"),
+      let occurredRaw = SQLiteStoredValue.int64(in: row, column: "occurred_at"),
+      let occurredAt = EpochSecondCodec.date(fromEpoch: occurredRaw),
+      let actorRaw = SQLiteStoredValue.string(in: row, column: "actor"),
+      let actor = AuditActor(rawValue: actorRaw),
+      let updateId = SQLiteStoredValue.nullableInt64(in: row, column: "transport_update_id")
+    else {
+      throw StoreError.unexpected("assignment source holds an unreadable feedback event")
+    }
+    let runId: Int64
+    switch kind {
+    case .run:
+      guard
+        let parsed = Int64(subject),
+        String(parsed) == subject,
+        runIds.contains(parsed)
+      else {
+        throw StoreError.unexpected("run feedback subject does not match its assignment")
+      }
+      runId = parsed
+    case .evaluation:
+      guard let parsed = evaluationRuns[subject] else {
+        throw StoreError.unexpected("evaluation feedback subject does not match its assignment")
+      }
+      runId = parsed
+    case .candidate, .promotion:
+      throw StoreError.unexpected("assignment feedback has an unsupported subject")
+    }
+    let revision = FeedbackRevision(revisionRaw)
+    let event = FeedbackEvent(
+      id: eventId,
+      runId: runId,
+      signal: signal,
+      payload: payload.value,
+      revision: revision,
+      supersedes: supersedes.value,
+      occurredAt: occurredAt,
+      actor: actor,
+      transportUpdateId: updateId.value
+    )
+    let digest = try FeedbackEventDigest.of(
+      eventId: eventId,
+      jobId: jobId,
+      epoch: epoch,
+      subjectKind: kind,
+      subjectDigest: subject,
+      signal: signal,
+      payload: payload.value,
+      actor: actor,
+      transportUpdateId: updateId.value,
+      revision: revision,
+      supersedes: supersedes.value,
+      occurredAtEpochSecond: occurredRaw
+    )
+    return StoredFeedbackProjection(
+      event: event,
+      source: CandidateFeedbackSource(
+        eventId: eventId,
+        digest: digest,
+        revision: revision,
+        subjectKind: kind,
+        subjectDigest: subject,
+        signal: signal
+      )
+    )
+  }
+}

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+FireBinding.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+FireBinding.swift
@@ -6,8 +6,7 @@ import GRDB
 /// supplied it.
 private struct EffectiveSelection {
   let digest: LessonSetDigest
-  let trialId: Int64?
-  let generation: Int?
+  let trial: LearningTrial?
 }
 
 // MARK: - Fire Binding
@@ -30,7 +29,12 @@ extension ScheduledLearningStoreGRDB {
     now: Date
   ) throws -> RunLearningBinding {
     let state = try armState(db, jobId: jobId, now: now)
-    let selection = try selectEffectiveSet(db, state: state, now: now)
+    let selection = try selectEffectiveSet(
+      db,
+      state: state,
+      occurrenceAt: occurrenceAt,
+      now: now
+    )
     let binding = RunLearningBinding(
       runId: runId,
       jobId: jobId,
@@ -40,12 +44,12 @@ extension ScheduledLearningStoreGRDB {
       epoch: state.epoch,
       stableDigest: state.stableDigest,
       effectiveDigest: selection.digest,
-      trialId: selection.trialId,
-      trialGeneration: selection.generation
+      trialId: selection.trial?.trialId,
+      trialGeneration: selection.trial?.generation
     )
     try insertBinding(db, binding)
-    if let trialId = selection.trialId {
-      try consumeAssignment(db, binding: binding, trialId: trialId, now: now)
+    if let trial = selection.trial {
+      try consumeAssignment(db, binding: binding, trial: trial, now: now)
     }
     try AuditLogGRDB.insertAudit(
       db,
@@ -96,39 +100,42 @@ extension ScheduledLearningStoreGRDB {
   /// The job's trial while it still owns the job's learning position — open or draining. A decided
   /// trial is gone from this read, which is what makes the job admissible for a new candidate.
   static func liveTrial(_ db: Database, jobId: Int64) throws -> LearningTrial? {
-    let row = try Row.fetchOne(
+    let rows = try Row.fetchAll(
       db,
       sql: """
-        SELECT trial_id, learning_epoch, candidate_digest, generation, max_assignments,
-          consumed_assignments, assignment_deadline, state
+        SELECT trial_id, job_id, learning_epoch, base_digest, candidate_digest, generation,
+          admitted_at, assignment_deadline, decision_deadline, max_assignments,
+          consumed_assignments, cohort_cutoff, state, close_reason, algorithm
         FROM learning_trials
         WHERE job_id = ? AND state IN (?, ?)
-        ORDER BY trial_id DESC LIMIT 1
+        ORDER BY trial_id
         """,
       arguments: [
         jobId, LearningTrialState.open.rawValue, LearningTrialState.draining.rawValue,
       ]
     )
-    guard let row else {
+    guard rows.count <= 1 else {
+      throw StoreError.unexpected("job \(jobId) has multiple live trials")
+    }
+    guard let row = rows.first else {
       return nil
     }
-    guard
-      let state = LearningTrialState(rawValue: row["state"]),
-      let deadline = EpochSecondCodec.date(fromEpoch: row["assignment_deadline"])
-    else {
-      throw StoreError.unexpected("job \(jobId) has an unreadable trial row")
+    guard let state = try readState(db, jobId: jobId) else {
+      throw StoreError.unexpected("job \(jobId) has a live trial without learning state")
     }
-    return LearningTrial(
-      trialId: row["trial_id"],
-      jobId: jobId,
-      epoch: LearningEpoch(row["learning_epoch"]),
-      generation: row["generation"],
-      candidateDigest: CandidateDigest(rawValue: row["candidate_digest"]),
-      maxAssignments: row["max_assignments"],
-      consumedAssignments: row["consumed_assignments"],
-      assignmentDeadline: deadline,
-      state: state
-    )
+    return try decodeLiveTrial(db, row: row, currentState: state)
+  }
+
+  static func decodeLiveTrial(
+    _ db: Database,
+    row: Row,
+    currentState: JobLearningState
+  ) throws -> LearningTrial {
+    let trial = try strictTrial(db, row: row, currentState: currentState)
+    guard trial.state == .open || trial.state == .draining else {
+      throw StoreError.unexpected("job \(currentState.jobId) has a non-live trial in its live set")
+    }
+    return trial
   }
 }
 
@@ -141,48 +148,55 @@ private extension ScheduledLearningStoreGRDB {
   static func selectEffectiveSet(
     _ db: Database,
     state: JobLearningState,
+    occurrenceAt: Date,
     now: Date
   ) throws -> EffectiveSelection {
-    let stable = EffectiveSelection(digest: state.stableDigest, trialId: nil, generation: nil)
+    let stable = EffectiveSelection(digest: state.stableDigest, trial: nil)
     guard let trial = try liveTrial(db, jobId: state.jobId) else {
       return stable
     }
-    guard trial.acceptsAssignment(at: now) else {
-      if trial.state == .open {
-        try drain(db, trialId: trial.trialId)
-      }
+    if trial.state == .open,
+      trial.consumedAssignments >= trial.maxAssignments || now >= trial.assignmentDeadline
+    {
+      try drain(db, trial: trial)
       return stable
     }
-    guard let replacement = try replacementDigest(db, trial: trial) else {
-      throw StoreError.unexpected(
-        "trial \(trial.trialId) names candidate \(trial.candidateDigest.rawValue) with no set"
-      )
+    guard trial.state == .open else {
+      return stable
     }
-    return EffectiveSelection(
-      digest: replacement,
-      trialId: trial.trialId,
-      generation: trial.generation
-    )
-  }
-
-  static func replacementDigest(_ db: Database, trial: LearningTrial) throws -> LessonSetDigest? {
-    let digest = try String.fetchOne(
-      db,
-      sql: "SELECT replacement_digest FROM learning_candidates WHERE candidate_digest = ?",
-      arguments: [trial.candidateDigest.rawValue]
-    )
-    return digest.map { raw in
-      LessonSetDigest(rawValue: raw)
+    guard occurrenceAt >= trial.cohortCutoff else {
+      return stable
     }
+    guard trial.acceptsAssignment(occurrenceAt: occurrenceAt, now: now) else {
+      throw StoreError.unexpected("trial \(trial.trialId) changed during fire selection")
+    }
+    return EffectiveSelection(digest: trial.replacementDigest, trial: trial)
   }
+}
 
-  static func drain(_ db: Database, trialId: Int64) throws {
+extension ScheduledLearningStoreGRDB {
+  static func drain(_ db: Database, trial: LearningTrial) throws {
     try db.execute(
-      sql: "UPDATE learning_trials SET state = ? WHERE trial_id = ? AND state = ?",
+      sql: """
+        UPDATE learning_trials SET state = ?
+        WHERE trial_id = ? AND job_id = ? AND learning_epoch = ? AND generation = ?
+          AND base_digest = ? AND candidate_digest = ? AND algorithm = ? AND state = ?
+        """,
       arguments: [
-        LearningTrialState.draining.rawValue, trialId, LearningTrialState.open.rawValue,
+        LearningTrialState.draining.rawValue,
+        trial.trialId,
+        trial.jobId,
+        trial.epoch.value,
+        trial.generation,
+        trial.baseDigest.rawValue,
+        trial.candidateDigest.rawValue,
+        trial.algorithm.rawValue,
+        LearningTrialState.open.rawValue,
       ]
     )
+    guard db.changesCount == 1 else {
+      throw StoreError.unexpected("trial \(trial.trialId) could not drain exactly once")
+    }
   }
 }
 
@@ -217,16 +231,52 @@ private extension ScheduledLearningStoreGRDB {
   static func consumeAssignment(
     _ db: Database,
     binding: RunLearningBinding,
-    trialId: Int64,
+    trial: LearningTrial,
     now: Date
   ) throws {
-    try db.execute(
+    let consumed = try Int.fetchOne(
+      db,
       sql: """
-        UPDATE learning_trials SET consumed_assignments = consumed_assignments + 1
-        WHERE trial_id = ?
+        UPDATE learning_trials
+        SET consumed_assignments = consumed_assignments + 1,
+          state = CASE
+            WHEN consumed_assignments + 1 = max_assignments THEN ?
+            ELSE state
+          END
+        WHERE trial_id = ? AND job_id = ? AND learning_epoch = ? AND generation = ?
+          AND base_digest = ? AND candidate_digest = ? AND algorithm = ? AND state = ?
+          AND consumed_assignments < max_assignments
+          AND cohort_cutoff <= ? AND assignment_deadline > ?
+          AND EXISTS(
+            SELECT 1 FROM learning_candidates AS candidate
+            WHERE candidate.candidate_digest = learning_trials.candidate_digest
+              AND candidate.job_id = learning_trials.job_id
+              AND candidate.learning_epoch = learning_trials.learning_epoch
+              AND candidate.base_digest = learning_trials.base_digest
+              AND candidate.base_revision = ? AND candidate.replacement_digest = ?
+              AND candidate.algorithm = learning_trials.algorithm
+          )
+        RETURNING consumed_assignments
         """,
-      arguments: [trialId]
+      arguments: [
+        LearningTrialState.draining.rawValue,
+        trial.trialId,
+        trial.jobId,
+        trial.epoch.value,
+        trial.generation,
+        trial.baseDigest.rawValue,
+        trial.candidateDigest.rawValue,
+        trial.algorithm.rawValue,
+        LearningTrialState.open.rawValue,
+        EpochSecondCodec.epoch(binding.occurrenceAt),
+        EpochSecondCodec.epoch(now),
+        trial.baseRevision.value,
+        trial.replacementDigest.rawValue,
+      ]
     )
+    guard consumed != nil else {
+      throw StoreError.unexpected("trial \(trial.trialId) could not consume exact assignment")
+    }
     try db.execute(
       sql: """
         INSERT INTO trial_assignments(run_id, trial_id, job_id, learning_epoch, trial_generation,
@@ -235,7 +285,7 @@ private extension ScheduledLearningStoreGRDB {
         """,
       arguments: [
         binding.runId,
-        trialId,
+        trial.trialId,
         binding.jobId,
         binding.epoch.value,
         binding.trialGeneration,

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+OperationSpend.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+OperationSpend.swift
@@ -93,6 +93,9 @@ extension ScheduledLearningStoreGRDB {
       isEstimated: result.usage.isEstimated,
       now: now
     )
+    guard try readState(db, jobId: operation.jobId)?.epoch == operation.epoch else {
+      return true
+    }
     switch result.product {
     case .failure:
       break

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+OperationSpend.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+OperationSpend.swift
@@ -62,13 +62,9 @@ extension ScheduledLearningStoreGRDB {
       return false
     }
     // Deliberately throwing, not another `false`: `started` is written by the same statement that
-    // stamps the call id, so a row missing one is corrupt, and returning "duplicate" would let the
-    // caller discard a real result as one already committed.
-    guard let callID = operation.providerCallID else {
-      throw StoreError.unexpected(
-        "started operation \(operation.id.rawValue) has no provider call id to charge"
-      )
-    }
+    // stamps the call reservation, so a row missing any required part is corrupt. Returning
+    // "duplicate" would let the caller discard a real result as one already committed.
+    let reservation = try startedOperationReservation(operation)
     guard product(result.product, belongsTo: operation.phase) else {
       throw StoreError.unexpected(
         "operation \(operation.id.rawValue) received a product for another phase"
@@ -84,7 +80,7 @@ extension ScheduledLearningStoreGRDB {
     try chargeLearningUsage(
       db,
       operation: operation,
-      callID: callID,
+      callID: reservation.providerCallID,
       model: result.usage.model,
       promptTokens: result.usage.promptTokens,
       completionTokens: result.usage.completionTokens,
@@ -412,21 +408,17 @@ private extension ScheduledLearningStoreGRDB {
     guard let operation = try readOperation(db, id: id) else {
       return
     }
-    guard let callID = operation.providerCallID, let route = operation.route else {
-      throw StoreError.unexpected(
-        "started operation \(id.rawValue) has no provider call id or route to charge"
-      )
-    }
+    let reservation = try startedOperationReservation(operation)
     // Before the state change, so a failure to charge aborts the whole reconciliation rather than
     // leaving a closed reservation whose spend was never recorded.
     try chargeLearningUsage(
       db,
       operation: operation,
-      callID: callID,
-      model: route,
-      promptTokens: operation.reservedTokens,
+      callID: reservation.providerCallID,
+      model: reservation.route,
+      promptTokens: reservation.reservedTokens,
       completionTokens: 0,
-      costUSD: operation.reservedCostUSD,
+      costUSD: reservation.reservedCostUSD,
       costSource: .heuristic,
       isEstimated: true,
       now: now

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+OperationSpend.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+OperationSpend.swift
@@ -40,12 +40,18 @@ extension ScheduledLearningStoreGRDB {
       return .superseded
     }
     guard authorization.carrier.isPermitted else {
-      return try closeWithoutCall(db, operation, failure: .carrierPolicyDenied)
+      let outcome = try closeWithoutCall(db, operation, failure: .carrierPolicyDenied)
+      try recomputeEvaluatorOperation(db, operation: operation, outcome: outcome, now: now)
+      return outcome
     }
     guard try budgetPermits(db, authorization, now: now) else {
-      return try closeWithoutCall(db, operation, failure: .budgetDenied)
+      let outcome = try closeWithoutCall(db, operation, failure: .budgetDenied)
+      try recomputeEvaluatorOperation(db, operation: operation, outcome: outcome, now: now)
+      return outcome
     }
-    return try start(db, operation, authorization)
+    let outcome = try start(db, operation, authorization)
+    try recomputeEvaluatorOperation(db, operation: operation, outcome: outcome, now: now)
+    return outcome
   }
 }
 
@@ -111,6 +117,15 @@ extension ScheduledLearningStoreGRDB {
           now: now
         )
       }
+    }
+    if operation.phase == .evaluator {
+      try recomputeEvaluatorSource(
+        db,
+        jobId: operation.jobId,
+        epoch: operation.epoch,
+        evidenceDigest: operation.sourceDigest,
+        now: now
+      )
     }
     return true
   }
@@ -253,6 +268,7 @@ extension ScheduledLearningStoreGRDB {
   /// The daemon owns its database alone, so every row still `started` or `claimed` at boot belongs
   /// to a process that is gone.
   static func reconcile(_ db: Database, now: Date) throws -> OperationReconciliation {
+    let affectedEvaluatorRuns = try bootAffectedEvaluatorRuns(db)
     let interrupted = try operationIDs(db, state: .started)
     for id in interrupted {
       try chargeInterrupted(db, id: id, now: now)
@@ -264,9 +280,59 @@ extension ScheduledLearningStoreGRDB {
         LearningOperationState.claimed.rawValue,
       ]
     )
+    let returnedToClaimable = db.changesCount
+    for runId in affectedEvaluatorRuns {
+      _ = try recomputeAndReconcile(db, runId: runId, now: now)
+    }
     return OperationReconciliation(
       interrupted: interrupted.count,
-      returnedToClaimable: db.changesCount
+      returnedToClaimable: returnedToClaimable
+    )
+  }
+}
+
+// MARK: - Trial Projection Hooks
+
+private extension ScheduledLearningStoreGRDB {
+  static func recomputeEvaluatorOperation(
+    _ db: Database,
+    operation: OperationRow,
+    outcome: AuthorizeOutcome,
+    now: Date
+  ) throws {
+    guard operation.phase == .evaluator, outcome != .superseded else {
+      return
+    }
+    try recomputeEvaluatorSource(
+      db,
+      jobId: operation.jobId,
+      epoch: operation.epoch,
+      evidenceDigest: operation.sourceDigest,
+      now: now
+    )
+  }
+
+  static func bootAffectedEvaluatorRuns(_ db: Database) throws -> [Int64] {
+    try Int64.fetchAll(
+      db,
+      sql: """
+        SELECT DISTINCT evidence.run_id
+        FROM learning_operations AS operation
+        JOIN learning_evidence AS evidence
+          ON evidence.job_id = operation.job_id
+          AND evidence.learning_epoch = operation.learning_epoch
+          AND evidence.evidence_digest = operation.source_digest
+        JOIN trial_assignments AS assignment ON assignment.run_id = evidence.run_id
+        JOIN job_learning_state AS learning ON learning.job_id = assignment.job_id
+          AND learning.learning_epoch = assignment.learning_epoch
+        WHERE operation.phase = ? AND operation.state IN (?, ?)
+        ORDER BY evidence.run_id
+        """,
+      arguments: [
+        LearningPhase.evaluator.rawValue,
+        LearningOperationState.started.rawValue,
+        LearningOperationState.claimed.rawValue,
+      ]
     )
   }
 }

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Operations.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Operations.swift
@@ -248,7 +248,8 @@ extension ScheduledLearningStoreGRDB {
       db,
       sql: """
         SELECT job_id, learning_epoch, phase, source_digest, key_digest, carrier_digest, state,
-          route, provider_call_id, reserved_tokens, reserved_cost_usd, reservation_state
+          failure_code, route, provider_call_id, reserved_tokens, reserved_cost_usd,
+          reservation_state
         FROM learning_operations WHERE operation_id = ?
         """,
       arguments: [id.rawValue]
@@ -264,6 +265,7 @@ extension ScheduledLearningStoreGRDB {
       let keyDigest = SQLiteStoredValue.string(in: row, column: "key_digest"),
       let carrier = SQLiteStoredValue.nullableString(in: row, column: "carrier_digest"),
       let stateRaw = SQLiteStoredValue.string(in: row, column: "state"),
+      let failureRaw = SQLiteStoredValue.nullableString(in: row, column: "failure_code"),
       let route = SQLiteStoredValue.nullableString(in: row, column: "route"),
       let providerCall = SQLiteStoredValue.nullableString(in: row, column: "provider_call_id"),
       let reservedTokens = SQLiteStoredValue.nullableInt(in: row, column: "reserved_tokens"),
@@ -271,6 +273,10 @@ extension ScheduledLearningStoreGRDB {
       let reservationState = SQLiteStoredValue.nullableString(in: row, column: "reservation_state")
     else {
       throw StoreError.unexpected("operation \(id.rawValue) holds unreadable stored values")
+    }
+    let failure = failureRaw.value.flatMap(LearningOperationFailure.init(rawValue:))
+    guard failureRaw.value == nil || failure != nil else {
+      throw StoreError.unexpected("operation \(id.rawValue) holds an unreadable failure")
     }
     return OperationRow(
       id: id,
@@ -281,6 +287,7 @@ extension ScheduledLearningStoreGRDB {
       keyDigest: LearningOperationKeyDigest(rawValue: keyDigest),
       carrierDigest: carrier.value.map(CarrierDigest.init(rawValue:)),
       state: try operationState(stateRaw, of: id),
+      failure: failure,
       route: route.value,
       providerCallID: providerCall.value.map(ProviderCallID.init(rawValue:)),
       reservedTokens: reservedTokens.value,
@@ -349,6 +356,7 @@ extension ScheduledLearningStoreGRDB {
     let keyDigest: LearningOperationKeyDigest
     let carrierDigest: CarrierDigest?
     let state: LearningOperationState
+    let failure: LearningOperationFailure?
     let route: String?
     let providerCallID: ProviderCallID?
     let reservedTokens: Int?

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Operations.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Operations.swift
@@ -237,7 +237,7 @@ extension ScheduledLearningStoreGRDB {
       db,
       sql: """
         SELECT job_id, learning_epoch, phase, source_digest, key_digest, carrier_digest, state,
-          route, provider_call_id, reserved_tokens, reserved_cost_usd
+          route, provider_call_id, reserved_tokens, reserved_cost_usd, reservation_state
         FROM learning_operations WHERE operation_id = ?
         """,
       arguments: [id.rawValue]
@@ -256,7 +256,8 @@ extension ScheduledLearningStoreGRDB {
       let route = SQLiteStoredValue.nullableString(in: row, column: "route"),
       let providerCall = SQLiteStoredValue.nullableString(in: row, column: "provider_call_id"),
       let reservedTokens = SQLiteStoredValue.nullableInt(in: row, column: "reserved_tokens"),
-      let reservedCost = SQLiteStoredValue.nullableDouble(in: row, column: "reserved_cost_usd")
+      let reservedCost = SQLiteStoredValue.nullableDouble(in: row, column: "reserved_cost_usd"),
+      let reservationState = SQLiteStoredValue.nullableString(in: row, column: "reservation_state")
     else {
       throw StoreError.unexpected("operation \(id.rawValue) holds unreadable stored values")
     }
@@ -271,8 +272,36 @@ extension ScheduledLearningStoreGRDB {
       state: try operationState(stateRaw, of: id),
       route: route.value,
       providerCallID: providerCall.value.map(ProviderCallID.init(rawValue:)),
-      reservedTokens: reservedTokens.value ?? 0,
-      reservedCostUSD: reservedCost.value ?? 0
+      reservedTokens: reservedTokens.value,
+      reservedCostUSD: reservedCost.value,
+      reservationState: reservationState.value
+    )
+  }
+
+  static func startedOperationReservation(
+    _ operation: OperationRow
+  ) throws -> StartedOperationReservation {
+    guard
+      let providerCallID = operation.providerCallID,
+      providerCallID.rawValue.isEmpty == false,
+      let route = operation.route,
+      route.isEmpty == false,
+      let reservedTokens = operation.reservedTokens,
+      reservedTokens >= 0,
+      let reservedCostUSD = operation.reservedCostUSD,
+      reservedCostUSD.isFinite,
+      reservedCostUSD >= 0,
+      operation.reservationState == LearningReservationState.open.rawValue
+    else {
+      throw StoreError.unexpected(
+        "started operation \(operation.id.rawValue) has an unreadable call reservation"
+      )
+    }
+    return StartedOperationReservation(
+      providerCallID: providerCallID,
+      route: route,
+      reservedTokens: reservedTokens,
+      reservedCostUSD: reservedCostUSD
     )
   }
 
@@ -311,6 +340,14 @@ extension ScheduledLearningStoreGRDB {
     let state: LearningOperationState
     let route: String?
     let providerCallID: ProviderCallID?
+    let reservedTokens: Int?
+    let reservedCostUSD: Double?
+    let reservationState: String?
+  }
+
+  struct StartedOperationReservation {
+    let providerCallID: ProviderCallID
+    let route: String
     let reservedTokens: Int
     let reservedCostUSD: Double
   }

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Operations.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Operations.swift
@@ -62,26 +62,37 @@ private extension ScheduledLearningStoreGRDB {
     guard try sourceIsClaimable(db, key: key) else {
       return nil
     }
-    guard let latest = try latestAttempt(db, key: key.digest) else {
-      return try insertClaim(db, key: key, generation: 1, supersedes: nil, now: now)
+    let claimed: ClaimedOperation?
+    if let latest = try latestAttempt(db, key: key.digest) {
+      switch latest.state {
+      case .pending:
+        // A claim the last process took but never authorized. No call was ever made under this row,
+        // so the attempt is resumed where it stopped rather than replaced by a new generation.
+        claimed = try reclaim(db, latest, key: key)
+      case .interruptedUnknown:
+        claimed = try insertClaim(
+          db,
+          key: key,
+          generation: latest.attemptGeneration + 1,
+          supersedes: latest.id,
+          now: now
+        )
+      case .claimed, .started, .succeeded, .failed, .failedNoCall:
+        claimed = nil
+      }
+    } else {
+      claimed = try insertClaim(db, key: key, generation: 1, supersedes: nil, now: now)
     }
-
-    switch latest.state {
-    case .pending:
-      // A claim the last process took but never authorized. No call was ever made under this row,
-      // so the attempt is resumed where it stopped rather than replaced by a new generation.
-      return try reclaim(db, latest, key: key)
-    case .interruptedUnknown:
-      return try insertClaim(
+    if claimed != nil, key.phase == .evaluator {
+      try recomputeEvaluatorSource(
         db,
-        key: key,
-        generation: latest.attemptGeneration + 1,
-        supersedes: latest.id,
+        jobId: key.jobId,
+        epoch: key.epoch,
+        evidenceDigest: key.sourceDigest,
         now: now
       )
-    case .claimed, .started, .succeeded, .failed, .failedNoCall:
-      return nil
     }
+    return claimed
   }
 
   /// What the key's source has to be for the question to still be worth asking.

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Operations.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Operations.swift
@@ -245,19 +245,34 @@ extension ScheduledLearningStoreGRDB {
     guard let row else {
       return nil
     }
+    guard
+      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
+      let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      let phaseRaw = SQLiteStoredValue.string(in: row, column: "phase"),
+      let sourceDigest = SQLiteStoredValue.string(in: row, column: "source_digest"),
+      let keyDigest = SQLiteStoredValue.string(in: row, column: "key_digest"),
+      let carrier = SQLiteStoredValue.nullableString(in: row, column: "carrier_digest"),
+      let stateRaw = SQLiteStoredValue.string(in: row, column: "state"),
+      let route = SQLiteStoredValue.nullableString(in: row, column: "route"),
+      let providerCall = SQLiteStoredValue.nullableString(in: row, column: "provider_call_id"),
+      let reservedTokens = SQLiteStoredValue.nullableInt(in: row, column: "reserved_tokens"),
+      let reservedCost = SQLiteStoredValue.nullableDouble(in: row, column: "reserved_cost_usd")
+    else {
+      throw StoreError.unexpected("operation \(id.rawValue) holds unreadable stored values")
+    }
     return OperationRow(
       id: id,
-      jobId: row["job_id"],
-      epoch: LearningEpoch(row["learning_epoch"]),
-      phase: try learningPhase(row["phase"], of: id),
-      sourceDigest: row["source_digest"],
-      keyDigest: LearningOperationKeyDigest(rawValue: row["key_digest"]),
-      carrierDigest: (row["carrier_digest"] as String?).map(CarrierDigest.init(rawValue:)),
-      state: try operationState(row["state"], of: id),
-      route: row["route"],
-      providerCallID: (row["provider_call_id"] as String?).map(ProviderCallID.init(rawValue:)),
-      reservedTokens: row["reserved_tokens"] ?? 0,
-      reservedCostUSD: row["reserved_cost_usd"] ?? 0
+      jobId: jobId,
+      epoch: LearningEpoch(epoch),
+      phase: try learningPhase(phaseRaw, of: id),
+      sourceDigest: sourceDigest,
+      keyDigest: LearningOperationKeyDigest(rawValue: keyDigest),
+      carrierDigest: carrier.value.map(CarrierDigest.init(rawValue:)),
+      state: try operationState(stateRaw, of: id),
+      route: route.value,
+      providerCallID: providerCall.value.map(ProviderCallID.init(rawValue:)),
+      reservedTokens: reservedTokens.value ?? 0,
+      reservedCostUSD: reservedCost.value ?? 0
     )
   }
 

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+PromotionReply.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+PromotionReply.swift
@@ -1,0 +1,59 @@
+import ClawCore
+import Foundation
+import GRDB
+
+extension ScheduledLearningStoreGRDB {
+  public func commitPromotionReply(
+    updateId: Int64,
+    target: NewFeedbackTarget,
+    chunks: [LearningNoticeChunk],
+    now: Date
+  ) throws(StoreError) -> PromotionReplyOutcome {
+    try database.writeMapping { db in
+      guard let state = try Self.readState(db, jobId: target.jobId),
+        state.epoch == target.epoch,
+        let promotion = try Self.currentPromotion(db, state: state),
+        target.subjectKind == .promotion, target.subjectDigest == promotion.promotionSubject,
+        target.allowedActions == [.promotionRollback], target.expiresAt > now,
+        let job = try Self.admissionJob(db, jobId: target.jobId),
+        target.chatId == job.ownerChatId
+      else {
+        return .stale
+      }
+      guard chunks.isEmpty == false else {
+        throw StoreError.unexpected("promotion reply contains no chunks")
+      }
+      for (index, chunk) in chunks.enumerated() {
+        guard chunk.ordinal == index, chunk.chatId == target.chatId,
+          chunk.subjectDigest == chunks[0].subjectDigest,
+          chunk.payloadHash == ContentHash.fnv1a(chunk.payload)
+        else {
+          throw StoreError.unexpected("promotion reply chunk binding is invalid")
+        }
+        if index == chunks.count - 1 {
+          guard let markup = chunk.replyMarkup,
+            let buttons = try? FeedbackKeyboard.parseMarkup(markup),
+            buttons.count == 1, buttons[0].count == 1,
+            buttons[0][0].nonce == target.nonce,
+            buttons[0][0].action == .promotionRollback
+          else {
+            throw StoreError.unexpected("promotion reply has no exact final rollback button")
+          }
+        } else if chunk.replyMarkup != nil {
+          throw StoreError.unexpected("promotion keyboard must be on the final reply chunk")
+        }
+      }
+      guard try ProcessedUpdateStoreGRDB.claimUpdate(db: db, updateId: updateId, claimedAt: now)
+      else {
+        return .duplicate
+      }
+      try Self.insertTarget(db, target)
+      for chunk in chunks {
+        guard try OutboxStoreGRDB.insertNotice(db, chunk: chunk, now: now) else {
+          throw StoreError.unexpected("promotion reply outbox identity already exists")
+        }
+      }
+      return .committed
+    }
+  }
+}

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Reflection.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Reflection.swift
@@ -499,27 +499,15 @@ extension ScheduledLearningStoreGRDB {
       carrierDigest: result.carrierDigest
     )
     let receipt = ReflectionNoCandidateReceipt(resultDigest: result.resultDigest)
-    let inputsBytes = try CanonicalJSON.data(encoding: inputs)
-    let receiptBytes = try CanonicalJSON.data(encoding: receipt)
-    // swiftlint:disable:next optional_data_string_conversion
-    let inputsJSON = String(decoding: inputsBytes, as: UTF8.self)
-    // swiftlint:disable:next optional_data_string_conversion
-    let receiptJSON = String(decoding: receiptBytes, as: UTF8.self)
-    try db.execute(
-      sql: """
-        INSERT INTO learning_decisions(kind, job_id, learning_epoch, inputs, result, algorithm,
-          decided_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
-        """,
-      arguments: [
-        ReflectionNoCandidateReceipt.kind,
-        jobId,
-        epoch.value,
-        inputsJSON,
-        receiptJSON,
-        result.algorithm.rawValue,
-        EpochSecondCodec.epoch(now),
-      ]
+    try insertDecision(
+      db,
+      kind: ReflectionNoCandidateReceipt.kind,
+      jobId: jobId,
+      epoch: epoch,
+      inputs: inputs,
+      result: receipt,
+      algorithm: result.algorithm,
+      now: now
     )
   }
 

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Reflection.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Reflection.swift
@@ -541,7 +541,9 @@ extension ScheduledLearningStoreGRDB {
     else {
       return nil
     }
-    let stored = StoredCandidateProjection(row: row)
+    guard let stored = StoredCandidateProjection(row: row) else {
+      throw StoreError.unexpected("candidate \(digest.rawValue) has an unreadable artifact")
+    }
     let manifestBytes = Data(stored.manifestJSON.utf8)
     guard
       let manifest = CandidateSourceManifest.decodedCanonical(from: manifestBytes),
@@ -574,18 +576,36 @@ private struct StoredCandidateProjection {
   let predecessorDigest: String?
   let algorithm: String
 
-  init(row: Row) {
-    candidateDigest = row["candidate_digest"]
-    jobId = row["job_id"]
-    epoch = row["learning_epoch"]
-    replacementDigest = row["replacement_digest"]
-    baseDigest = row["base_digest"]
-    baseRevision = row["base_revision"]
-    feedbackRevision = row["frozen_feedback_revision"]
-    origin = row["origin"]
-    manifestJSON = row["source_manifest"]
-    predecessorDigest = row["predecessor_digest"]
-    algorithm = row["algorithm"]
+  init?(row: Row) {
+    guard
+      let candidateDigest = SQLiteStoredValue.string(in: row, column: "candidate_digest"),
+      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
+      let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      let replacementDigest = SQLiteStoredValue.string(in: row, column: "replacement_digest"),
+      let baseDigest = SQLiteStoredValue.string(in: row, column: "base_digest"),
+      let baseRevision = SQLiteStoredValue.int64(in: row, column: "base_revision"),
+      let feedbackRevision = SQLiteStoredValue.int64(
+        in: row,
+        column: "frozen_feedback_revision"
+      ),
+      let origin = SQLiteStoredValue.string(in: row, column: "origin"),
+      let manifestJSON = SQLiteStoredValue.string(in: row, column: "source_manifest"),
+      let predecessor = SQLiteStoredValue.nullableString(in: row, column: "predecessor_digest"),
+      let algorithm = SQLiteStoredValue.string(in: row, column: "algorithm")
+    else {
+      return nil
+    }
+    self.candidateDigest = candidateDigest
+    self.jobId = jobId
+    self.epoch = epoch
+    self.replacementDigest = replacementDigest
+    self.baseDigest = baseDigest
+    self.baseRevision = baseRevision
+    self.feedbackRevision = feedbackRevision
+    self.origin = origin
+    self.manifestJSON = manifestJSON
+    predecessorDigest = predecessor.value
+    self.algorithm = algorithm
   }
 
   func matches(

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Reflection.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Reflection.swift
@@ -115,11 +115,6 @@ private extension ScheduledLearningStoreGRDB {
     let finalOutput: String
   }
 
-  struct StoredReflectionFeedback {
-    let event: FeedbackEvent
-    let source: CandidateFeedbackSource
-  }
-
   struct ReducedReflectionRows {
     let prepared: [PreparedReflectionEvaluation]
     let effective: [EffectiveEvaluation]
@@ -127,12 +122,6 @@ private extension ScheduledLearningStoreGRDB {
     let feedbackSources: [CandidateFeedbackSource]
     let payloads: [PreparedOwnerPayload]
     let vetoed: Bool
-  }
-
-  struct ReflectionSubjects {
-    let runIds: Set<String>
-    let evaluationDigests: Set<String>
-    let rows: [ReflectionRow]
   }
 
   static func reflectionRows(
@@ -196,108 +185,22 @@ private extension ScheduledLearningStoreGRDB {
     trigger: TriggerIdentity,
     rows: [ReflectionRow],
     cutoff: FeedbackRevision
-  ) throws -> [StoredReflectionFeedback] {
-    let subjects = ReflectionSubjects(
-      runIds: Set(
-        rows.map { row in
-          String(row.runId)
-        }
-      ),
-      evaluationDigests: Set(
-        rows.map { row in
-          row.evaluationDigest.rawValue
-        }
-      ),
-      rows: rows
-    )
-    let stored = try Row.fetchAll(
+  ) throws -> [StoredFeedbackProjection] {
+    var evaluationRuns: [String: Int64] = [:]
+    for row in rows {
+      guard evaluationRuns.updateValue(row.runId, forKey: row.evaluationDigest.rawValue) == nil
+      else {
+        throw StoreError.unexpected("reflection source has a duplicate evaluation digest")
+      }
+    }
+    return try storedFeedback(
       db,
-      sql: """
-          SELECT event_id, subject_kind, subject_digest, signal, payload, feedback_revision,
-            supersedes, occurred_at, actor, transport_update_id
-          FROM feedback_events
-          WHERE job_id = ? AND learning_epoch = ? AND feedback_revision <= ?
-          ORDER BY feedback_revision, event_id
-        """,
-      arguments: [trigger.jobId, trigger.epoch.value, cutoff.value]
+      jobId: trigger.jobId,
+      epoch: trigger.epoch,
+      runIds: Set(rows.map(\.runId)),
+      evaluationRuns: evaluationRuns,
+      cutoff: cutoff
     )
-    return try stored.compactMap { row in
-      try storedReflectionFeedback(row, trigger: trigger, subjects: subjects)
-    }
-  }
-
-  static func storedReflectionFeedback(
-    _ row: Row,
-    trigger: TriggerIdentity,
-    subjects: ReflectionSubjects
-  ) throws -> StoredReflectionFeedback? {
-    guard
-      let subjectKind = FeedbackSubjectKind(rawValue: row["subject_kind"]),
-      let signal = OwnerSignal(rawValue: row["signal"]),
-      let occurredAt = EpochSecondCodec.date(fromEpoch: row["occurred_at"]),
-      let actor = AuditActor(rawValue: row["actor"])
-    else {
-      throw StoreError.unexpected("reflection source holds an unreadable feedback event")
-    }
-    let subject: String = row["subject_digest"]
-    let belongs =
-      (subjectKind == .run && subjects.runIds.contains(subject))
-      || (subjectKind == .evaluation && subjects.evaluationDigests.contains(subject))
-    guard belongs else {
-      return nil
-    }
-    let event = FeedbackEvent(
-      id: row["event_id"],
-      runId: runId(rows: subjects.rows, subjectKind: subjectKind, subject: subject),
-      signal: signal,
-      payload: row["payload"],
-      revision: FeedbackRevision(row["feedback_revision"]),
-      supersedes: row["supersedes"],
-      occurredAt: occurredAt,
-      actor: actor,
-      transportUpdateId: row["transport_update_id"]
-    )
-    return StoredReflectionFeedback(
-      event: event,
-      source: CandidateFeedbackSource(
-        eventId: event.id,
-        digest: try FeedbackEventDigest.of(
-          eventId: event.id,
-          jobId: trigger.jobId,
-          epoch: trigger.epoch,
-          subjectKind: subjectKind,
-          subjectDigest: subject,
-          signal: signal,
-          payload: event.payload,
-          actor: actor,
-          transportUpdateId: event.transportUpdateId,
-          revision: event.revision,
-          supersedes: event.supersedes,
-          occurredAtEpochSecond: EpochSecondCodec.epoch(event.occurredAt)
-        ),
-        revision: event.revision,
-        subjectKind: subjectKind,
-        subjectDigest: subject,
-        signal: signal
-      )
-    )
-  }
-
-  static func runId(
-    rows: [ReflectionRow],
-    subjectKind: FeedbackSubjectKind,
-    subject: String
-  ) -> Int64? {
-    switch subjectKind {
-    case .run:
-      return Int64(subject)
-    case .evaluation:
-      return rows.first { row in
-        row.evaluationDigest.rawValue == subject
-      }?.runId
-    case .candidate, .promotion:
-      return nil
-    }
   }
 }
 
@@ -314,7 +217,7 @@ private extension ScheduledLearningStoreGRDB {
 
   static func reduceReflectionRows(
     _ rows: [ReflectionRow],
-    feedback: [StoredReflectionFeedback],
+    feedback: [StoredFeedbackProjection],
     trigger: TriggerIdentity
   ) throws -> ReducedReflectionRows {
     let reduced = rows.map { row in
@@ -345,7 +248,7 @@ private extension ScheduledLearningStoreGRDB {
 
   static func reduceReflectionRow(
     _ row: ReflectionRow,
-    feedback: [StoredReflectionFeedback],
+    feedback: [StoredFeedbackProjection],
     trigger: TriggerIdentity
   ) -> ReducedReflectionRow {
     let events = feedback.map(\.event)
@@ -404,7 +307,7 @@ private extension ScheduledLearningStoreGRDB {
 
   static func ownerPayload(
     for correction: FeedbackEvent?,
-    feedback: [StoredReflectionFeedback],
+    feedback: [StoredFeedbackProjection],
     effectiveEvents: [FeedbackEvent]
   ) -> PreparedOwnerPayload? {
     guard

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Reflection.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Reflection.swift
@@ -493,12 +493,12 @@ extension ScheduledLearningStoreGRDB {
     epoch: LearningEpoch,
     now: Date
   ) throws {
-    let inputs = NoCandidateInputs(
-      triggerDigest: result.triggerDigest.rawValue,
-      operationId: result.operationId.rawValue,
-      carrierDigest: result.carrierDigest.rawValue
+    let inputs = ReflectionNoCandidateInputs(
+      triggerDigest: result.triggerDigest,
+      operationId: result.operationId,
+      carrierDigest: result.carrierDigest
     )
-    let receipt = NoCandidateReceipt(resultDigest: result.resultDigest.rawValue)
+    let receipt = ReflectionNoCandidateReceipt(resultDigest: result.resultDigest)
     let inputsBytes = try CanonicalJSON.data(encoding: inputs)
     let receiptBytes = try CanonicalJSON.data(encoding: receipt)
     // swiftlint:disable:next optional_data_string_conversion
@@ -512,7 +512,7 @@ extension ScheduledLearningStoreGRDB {
         VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
       arguments: [
-        NoCandidateReceipt.kind,
+        ReflectionNoCandidateReceipt.kind,
         jobId,
         epoch.value,
         inputsJSON,
@@ -558,27 +558,6 @@ extension ScheduledLearningStoreGRDB {
       throw StoreError.unexpected("candidate \(digest.rawValue) does not match its source bytes")
     }
     return artifact
-  }
-
-  private struct NoCandidateInputs: Encodable {
-    let triggerDigest: String
-    let operationId: String
-    let carrierDigest: String
-
-    enum CodingKeys: String, CodingKey {
-      case triggerDigest = "trigger_digest"
-      case operationId = "operation_id"
-      case carrierDigest = "carrier_digest"
-    }
-  }
-
-  private struct NoCandidateReceipt: Encodable {
-    static let kind = "reflection_no_candidate"
-    let resultDigest: String
-
-    enum CodingKeys: String, CodingKey {
-      case resultDigest = "result_digest"
-    }
   }
 }
 

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Reset.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Reset.swift
@@ -1,0 +1,391 @@
+import ClawCore
+import Foundation
+import GRDB
+
+// MARK: - Confirmed Reset
+
+extension ScheduledLearningStoreGRDB {
+  public func applyReset(
+    updateId: Int64,
+    jobId: Int64,
+    now: Date
+  ) throws(StoreError) -> ConfirmedLearningResetResult {
+    try database.writeMapping { db in
+      guard
+        try ProcessedUpdateStoreGRDB.claimUpdate(
+          db: db,
+          updateId: updateId,
+          claimedAt: now
+        )
+      else {
+        return .duplicate
+      }
+      guard let job = try Self.resetJob(db, jobId: jobId) else {
+        return .claimed(.notFound)
+      }
+      guard let state = try Self.readState(db, jobId: jobId) else {
+        return .claimed(.unarmed)
+      }
+      if let receipt = try Self.cleanResetReceipt(db, state: state) {
+        return .claimed(.alreadyReset(receipt))
+      }
+      let receipt = try Self.applyReset(db, job: job, state: state, now: now)
+      return .claimed(.applied(receipt))
+    }
+  }
+}
+
+// MARK: - Reset Transaction
+
+private extension ScheduledLearningStoreGRDB {
+  struct ResetJob {
+    let jobId: Int64
+    let sessionId: Int64?
+  }
+
+  struct ResetOperationPlan {
+    let staleNoCall: [LearningOperationID]
+    let inFlight: [LearningOperationID]
+  }
+
+  struct ResetAuditProjection: Encodable {
+    let decisionId: Int64
+    let kind: String
+    let jobId: Int64
+    let algorithm: LearningAlgorithm
+    let decidedAt: Int64
+    let inputs: LearningResetDecisionInputs
+    let result: LearningResetDecisionResult
+
+    enum CodingKeys: String, CodingKey {
+      case decisionId = "decision_id"
+      case kind
+      case jobId = "job_id"
+      case algorithm
+      case decidedAt = "decided_at"
+      case inputs
+      case result
+    }
+  }
+
+  static func resetJob(_ db: Database, jobId: Int64) throws -> ResetJob? {
+    guard
+      let row = try Row.fetchOne(
+        db,
+        sql: "SELECT id, session_id FROM scheduled_jobs WHERE id = ?",
+        arguments: [jobId]
+      )
+    else {
+      return nil
+    }
+    guard
+      SQLiteStoredValue.int64(in: row, column: "id") == jobId,
+      let sessionId = SQLiteStoredValue.nullableInt64(in: row, column: "session_id")
+    else {
+      throw StoreError.unexpected("scheduled job is unreadable for learning reset")
+    }
+    return ResetJob(jobId: jobId, sessionId: sessionId.value)
+  }
+
+  static func applyReset(
+    _ db: Database,
+    job: ResetJob,
+    state: JobLearningState,
+    now: Date
+  ) throws -> ResetReceipt {
+    try validateResetState(state, job: job)
+    let empty = LessonSet.empty(jobId: job.jobId)
+    try ensureCanonicalEmptySet(db, empty, now: now)
+    guard let decidedAt = EpochSecondCodec.date(fromEpoch: EpochSecondCodec.epoch(now)) else {
+      throw StoreError.unexpected("learning reset time is out of range")
+    }
+
+    let inputs = LearningResetDecisionInputs(
+      oldEpoch: state.epoch,
+      oldStableDigest: state.stableDigest,
+      oldStableRevision: state.stableRevision,
+      feedbackRevisionAtCut: state.feedbackRevision,
+      priorOpenTrialId: state.openTrialId
+    )
+    let newEpoch = state.epoch.next()
+    let newRevision = state.stableRevision.next()
+    try advanceResetState(
+      db,
+      state: state,
+      newEpoch: newEpoch,
+      newRevision: newRevision,
+      emptyDigest: empty.digest
+    )
+    let trials = try resetLiveTrials(db, jobId: job.jobId)
+    let targetCount = try invalidateTargets(db, jobId: job.jobId, now: now)
+    let challengeCount = try invalidateChallenges(db, jobId: job.jobId, now: now)
+    let operations = try resetOperations(db, jobId: job.jobId, before: newEpoch)
+    let result = LearningResetDecisionResult(
+      newEpoch: newEpoch,
+      emptyStableDigest: empty.digest,
+      newStableRevision: newRevision,
+      closedTrials: trials,
+      invalidatedTargetCount: targetCount,
+      invalidatedChallengeCount: challengeCount,
+      staleNoCallOperationIds: operations.staleNoCall,
+      inFlightOperationIds: operations.inFlight
+    )
+    let decisionId = try insertDecision(
+      db,
+      kind: ResetReceipt.kind,
+      jobId: job.jobId,
+      epoch: newEpoch,
+      inputs: inputs,
+      result: result,
+      algorithm: .v1,
+      now: decidedAt
+    )
+    let receipt = ResetReceipt(
+      decisionId: decisionId,
+      jobId: job.jobId,
+      algorithm: .v1,
+      decidedAt: decidedAt,
+      inputs: inputs,
+      result: result
+    )
+    try insertResetAudit(db, receipt: receipt, sessionId: job.sessionId)
+    return receipt
+  }
+
+  static func validateResetState(_ state: JobLearningState, job: ResetJob) throws {
+    guard
+      state.jobId == job.jobId,
+      state.epoch.value > 0,
+      state.epoch.value < Int64.max,
+      resetDigestIsCanonical(state.stableDigest.rawValue),
+      state.stableRevision.value >= 0,
+      state.stableRevision.value < Int64.max,
+      state.feedbackRevision.value >= 0,
+      state.openTrialId.map({ $0 > 0 }) ?? true
+    else {
+      throw StoreError.unexpected("learning state cannot advance through reset")
+    }
+  }
+
+  static func advanceResetState(
+    _ db: Database,
+    state: JobLearningState,
+    newEpoch: LearningEpoch,
+    newRevision: StableRevision,
+    emptyDigest: LessonSetDigest
+  ) throws {
+    try db.execute(
+      sql: """
+        UPDATE job_learning_state
+        SET learning_epoch = ?, stable_lesson_set_digest = ?, stable_revision = ?,
+          open_trial_id = NULL
+        WHERE job_id = ? AND learning_epoch = ? AND stable_revision = ?
+        """,
+      arguments: [
+        newEpoch.value,
+        emptyDigest.rawValue,
+        newRevision.value,
+        state.jobId,
+        state.epoch.value,
+        state.stableRevision.value,
+      ]
+    )
+    guard db.changesCount == 1 else {
+      throw StoreError.unexpected("learning state changed during reset")
+    }
+  }
+
+  static func resetLiveTrials(_ db: Database, jobId: Int64) throws -> [ResetTrialIdentity] {
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT trial_id, job_id, learning_epoch, generation, base_digest, candidate_digest,
+          algorithm
+        FROM learning_trials
+        WHERE job_id = ? AND state IN (?, ?)
+        ORDER BY trial_id
+        """,
+      arguments: [
+        jobId,
+        LearningTrialState.open.rawValue,
+        LearningTrialState.draining.rawValue,
+      ]
+    )
+    let trials = try rows.map { row in
+      try resetTrialIdentity(row, expectedJobId: jobId)
+    }
+    try db.execute(
+      sql: """
+        UPDATE learning_trials SET state = ?, close_reason = ?
+        WHERE job_id = ? AND state IN (?, ?)
+        """,
+      arguments: [
+        LearningTrialState.closed.rawValue,
+        LearningTrialCloseReason.learningReset.rawValue,
+        jobId,
+        LearningTrialState.open.rawValue,
+        LearningTrialState.draining.rawValue,
+      ]
+    )
+    guard db.changesCount == trials.count else {
+      throw StoreError.unexpected("live trials changed during reset")
+    }
+    return trials
+  }
+
+  static func resetTrialIdentity(_ row: Row, expectedJobId: Int64) throws -> ResetTrialIdentity {
+    guard
+      let trialId = SQLiteStoredValue.int64(in: row, column: "trial_id"),
+      trialId > 0,
+      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
+      jobId == expectedJobId,
+      let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      epoch > 0,
+      let generation = SQLiteStoredValue.int(in: row, column: "generation"),
+      generation > 0,
+      let baseDigest = SQLiteStoredValue.string(in: row, column: "base_digest"),
+      resetDigestIsCanonical(baseDigest),
+      let candidateDigest = SQLiteStoredValue.string(in: row, column: "candidate_digest"),
+      resetDigestIsCanonical(candidateDigest),
+      let algorithmRaw = SQLiteStoredValue.string(in: row, column: "algorithm"),
+      LearningAlgorithm(rawValue: algorithmRaw) == .v1
+    else {
+      throw StoreError.unexpected("live trial is unreadable for learning reset")
+    }
+    return ResetTrialIdentity(
+      trialId: trialId,
+      jobId: jobId,
+      epoch: LearningEpoch(epoch),
+      generation: generation,
+      baseDigest: LessonSetDigest(rawValue: baseDigest),
+      candidateDigest: CandidateDigest(rawValue: candidateDigest),
+      algorithm: .v1
+    )
+  }
+
+  static func invalidateTargets(_ db: Database, jobId: Int64, now: Date) throws -> Int {
+    try db.execute(
+      sql: "UPDATE feedback_targets SET consumed_at = ? WHERE job_id = ? AND consumed_at IS NULL",
+      arguments: [EpochSecondCodec.epoch(now), jobId]
+    )
+    return db.changesCount
+  }
+
+  static func invalidateChallenges(_ db: Database, jobId: Int64, now: Date) throws -> Int {
+    try db.execute(
+      sql: """
+        UPDATE feedback_challenges SET consumed_at = ?
+        WHERE job_id = ? AND superseded_by IS NULL AND consumed_at IS NULL
+        """,
+      arguments: [EpochSecondCodec.epoch(now), jobId]
+    )
+    return db.changesCount
+  }
+
+  static func resetOperations(
+    _ db: Database,
+    jobId: Int64,
+    before newEpoch: LearningEpoch
+  ) throws -> ResetOperationPlan {
+    let stale = try resetOperationIDs(
+      db,
+      jobId: jobId,
+      before: newEpoch,
+      states: [.pending, .claimed]
+    )
+    let inFlight = try resetOperationIDs(
+      db,
+      jobId: jobId,
+      before: newEpoch,
+      states: [.started]
+    )
+    try db.execute(
+      sql: """
+        UPDATE learning_operations
+        SET state = ?, failure_code = ?, reserved_tokens = 0, reserved_cost_usd = 0,
+          reservation_state = ?
+        WHERE job_id = ? AND learning_epoch < ? AND state IN (?, ?)
+        """,
+      arguments: [
+        LearningOperationState.failedNoCall.rawValue,
+        LearningOperationFailure.staleEpoch.rawValue,
+        LearningReservationState.closed.rawValue,
+        jobId,
+        newEpoch.value,
+        LearningOperationState.pending.rawValue,
+        LearningOperationState.claimed.rawValue,
+      ]
+    )
+    guard db.changesCount == stale.count else {
+      throw StoreError.unexpected("not-started operations changed during reset")
+    }
+    return ResetOperationPlan(staleNoCall: stale, inFlight: inFlight)
+  }
+}
+
+extension ScheduledLearningStoreGRDB {
+  static func resetOperationIDs(
+    _ db: Database,
+    jobId: Int64,
+    before newEpoch: LearningEpoch,
+    states: [LearningOperationState]
+  ) throws -> [LearningOperationID] {
+    let stateValues = states.map(\.rawValue)
+    let placeholders = Array(repeating: "?", count: stateValues.count).joined(separator: ", ")
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT operation_id, job_id, learning_epoch, state
+        FROM learning_operations
+        WHERE job_id = ? AND learning_epoch < ? AND state IN (\(placeholders))
+        ORDER BY operation_id
+        """,
+      arguments: [jobId, newEpoch.value] + StatementArguments(stateValues)
+    )
+    return try rows.map { row in
+      guard
+        let operationId = SQLiteStoredValue.string(in: row, column: "operation_id"),
+        operationId.isEmpty == false,
+        SQLiteStoredValue.int64(in: row, column: "job_id") == jobId,
+        let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+        epoch < newEpoch.value,
+        let stateRaw = SQLiteStoredValue.string(in: row, column: "state"),
+        stateValues.contains(stateRaw)
+      else {
+        throw StoreError.unexpected("learning operation is unreadable for reset")
+      }
+      return LearningOperationID(rawValue: operationId)
+    }
+  }
+}
+
+private extension ScheduledLearningStoreGRDB {
+  static func insertResetAudit(
+    _ db: Database,
+    receipt: ResetReceipt,
+    sessionId: Int64?
+  ) throws {
+    let projection = ResetAuditProjection(
+      decisionId: receipt.decisionId,
+      kind: ResetReceipt.kind,
+      jobId: receipt.jobId,
+      algorithm: receipt.algorithm,
+      decidedAt: EpochSecondCodec.epoch(receipt.decidedAt),
+      inputs: receipt.inputs,
+      result: receipt.result
+    )
+    try AuditLogGRDB.insertAudit(
+      db,
+      AuditEvent(
+        actor: .owner,
+        action: .learningReset,
+        tool: "/learning reset",
+        argsRedacted: try canonicalDecisionJSON(projection),
+        resultSize: 0,
+        decision: "applied",
+        sessionId: sessionId,
+        ts: receipt.decidedAt
+      )
+    )
+  }
+}

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Reset.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Reset.swift
@@ -157,7 +157,7 @@ private extension ScheduledLearningStoreGRDB {
       state.jobId == job.jobId,
       state.epoch.value > 0,
       state.epoch.value < Int64.max,
-      resetDigestIsCanonical(state.stableDigest.rawValue),
+      isCanonicalDigest(state.stableDigest.rawValue),
       state.stableRevision.value >= 0,
       state.stableRevision.value < Int64.max,
       state.feedbackRevision.value >= 0,
@@ -244,9 +244,9 @@ private extension ScheduledLearningStoreGRDB {
       let generation = SQLiteStoredValue.int(in: row, column: "generation"),
       generation > 0,
       let baseDigest = SQLiteStoredValue.string(in: row, column: "base_digest"),
-      resetDigestIsCanonical(baseDigest),
+      isCanonicalDigest(baseDigest),
       let candidateDigest = SQLiteStoredValue.string(in: row, column: "candidate_digest"),
-      resetDigestIsCanonical(candidateDigest),
+      isCanonicalDigest(candidateDigest),
       let algorithmRaw = SQLiteStoredValue.string(in: row, column: "algorithm"),
       LearningAlgorithm(rawValue: algorithmRaw) == .v1
     else {
@@ -335,7 +335,7 @@ extension ScheduledLearningStoreGRDB {
     let rows = try Row.fetchAll(
       db,
       sql: """
-        SELECT operation_id, job_id, learning_epoch, state
+        SELECT operation_id
         FROM learning_operations
         WHERE job_id = ? AND learning_epoch < ? AND state IN (\(placeholders))
         ORDER BY operation_id
@@ -345,16 +345,23 @@ extension ScheduledLearningStoreGRDB {
     return try rows.map { row in
       guard
         let operationId = SQLiteStoredValue.string(in: row, column: "operation_id"),
-        operationId.isEmpty == false,
-        SQLiteStoredValue.int64(in: row, column: "job_id") == jobId,
-        let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
-        epoch < newEpoch.value,
-        let stateRaw = SQLiteStoredValue.string(in: row, column: "state"),
-        stateValues.contains(stateRaw)
+        operationId.isEmpty == false
       else {
         throw StoreError.unexpected("learning operation is unreadable for reset")
       }
-      return LearningOperationID(rawValue: operationId)
+      let id = LearningOperationID(rawValue: operationId)
+      guard
+        let operation = try readOperation(db, id: id),
+        operation.jobId == jobId,
+        operation.epoch.value < newEpoch.value,
+        stateValues.contains(operation.state.rawValue)
+      else {
+        throw StoreError.unexpected("learning operation is unreadable for reset")
+      }
+      if operation.state == .started {
+        _ = try startedOperationReservation(operation)
+      }
+      return id
     }
   }
 }

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+ResetReplay.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+ResetReplay.swift
@@ -373,6 +373,12 @@ private extension ScheduledLearningStoreGRDB {
       return false
     }
     guard case .staleNoCall = expectation else {
+      if state == .started {
+        guard let operation = try readOperation(db, id: id) else {
+          return false
+        }
+        _ = try startedOperationReservation(operation)
+      }
       return true
     }
     return SQLiteStoredValue.string(in: row, column: "failure_code")

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+ResetReplay.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+ResetReplay.swift
@@ -43,7 +43,7 @@ extension ScheduledLearningStoreGRDB {
       inputs.oldEpoch.value < Int64.max,
       inputs.oldEpoch.next() == result.newEpoch,
       result.newEpoch == record.epoch,
-      resetDigestIsCanonical(inputs.oldStableDigest.rawValue),
+      isCanonicalDigest(inputs.oldStableDigest.rawValue),
       inputs.oldStableRevision.value >= 0,
       inputs.oldStableRevision.value < Int64.max,
       inputs.oldStableRevision.next() == result.newStableRevision,
@@ -279,8 +279,8 @@ private extension ScheduledLearningStoreGRDB {
         trial.trialId > 0,
         trial.epoch.value > 0,
         trial.generation > 0,
-        resetDigestIsCanonical(trial.baseDigest.rawValue),
-        resetDigestIsCanonical(trial.candidateDigest.rawValue),
+        isCanonicalDigest(trial.baseDigest.rawValue),
+        isCanonicalDigest(trial.candidateDigest.rawValue),
         trial.algorithm == .v1,
         let row = try Row.fetchOne(
           db,
@@ -389,15 +389,6 @@ private extension ScheduledLearningStoreGRDB {
     arguments: StatementArguments
   ) throws -> Bool {
     try Bool.fetchOne(db, sql: sql, arguments: arguments) ?? true
-  }
-}
-
-extension ScheduledLearningStoreGRDB {
-  static func resetDigestIsCanonical(_ value: String) -> Bool {
-    value.utf8.count == 64
-      && value.utf8.allSatisfy { byte in
-        (48...57).contains(byte) || (97...102).contains(byte)
-      }
   }
 }
 

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+ResetReplay.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+ResetReplay.swift
@@ -1,0 +1,412 @@
+import ClawCore
+import Foundation
+import GRDB
+
+// MARK: - Logical Replay
+
+extension ScheduledLearningStoreGRDB {
+  struct ResetDecisionRecord {
+    let decisionId: Int64
+    let jobId: Int64
+    let epoch: LearningEpoch
+    let inputsJSON: String
+    let resultJSON: String
+    let algorithm: LearningAlgorithm
+    let decidedAt: Date
+  }
+
+  static func resetReceipt(
+    _ db: Database,
+    record: ResetDecisionRecord
+  ) throws -> ResetReceipt? {
+    guard
+      record.decisionId > 0,
+      record.jobId > 0,
+      record.epoch.value > 0,
+      record.algorithm == .v1
+    else {
+      return nil
+    }
+    let inputs: LearningResetDecisionInputs
+    let result: LearningResetDecisionResult
+    do {
+      inputs = try decodeCanonicalDecision(record.inputsJSON)
+      result = try decodeCanonicalDecision(record.resultJSON)
+    } catch let error as StoreError {
+      guard case .unexpected = error else {
+        throw error
+      }
+      return nil
+    }
+    guard
+      inputs.oldEpoch.value > 0,
+      inputs.oldEpoch.value < Int64.max,
+      inputs.oldEpoch.next() == result.newEpoch,
+      result.newEpoch == record.epoch,
+      resetDigestIsCanonical(inputs.oldStableDigest.rawValue),
+      inputs.oldStableRevision.value >= 0,
+      inputs.oldStableRevision.value < Int64.max,
+      inputs.oldStableRevision.next() == result.newStableRevision,
+      inputs.feedbackRevisionAtCut.value >= 0,
+      inputs.priorOpenTrialId.map({ $0 > 0 }) ?? true,
+      result.emptyStableDigest == LessonSet.empty(jobId: record.jobId).digest,
+      result.invalidatedTargetCount >= 0,
+      result.invalidatedChallengeCount >= 0,
+      resetTrialsAreSortedAndUnique(result.closedTrials),
+      resetOperationsAreSortedAndUnique(result.staleNoCallOperationIds),
+      resetOperationsAreSortedAndUnique(result.inFlightOperationIds),
+      Set(result.staleNoCallOperationIds).isDisjoint(with: result.inFlightOperationIds),
+      try resetTrialRowsMatch(db, result.closedTrials, jobId: record.jobId),
+      try resetOperationRowsMatch(
+        db,
+        staleNoCall: result.staleNoCallOperationIds,
+        inFlight: result.inFlightOperationIds,
+        jobId: record.jobId,
+        before: result.newEpoch
+      )
+    else {
+      return nil
+    }
+    return ResetReceipt(
+      decisionId: record.decisionId,
+      jobId: record.jobId,
+      algorithm: record.algorithm,
+      decidedAt: record.decidedAt,
+      inputs: inputs,
+      result: result
+    )
+  }
+}
+
+private extension ScheduledLearningStoreGRDB {
+  enum ResetOperationExpectation {
+    case staleNoCall
+    case inFlight
+
+    var allowedStates: [LearningOperationState] {
+      switch self {
+      case .staleNoCall:
+        [.failedNoCall]
+      case .inFlight:
+        [.started, .succeeded, .failed, .interruptedUnknown]
+      }
+    }
+  }
+
+  static let resetActivityTables = [
+    "run_learning_bindings",
+    "run_compatibility",
+    "learning_evidence",
+    "learning_operations",
+    "learning_evaluations",
+    "feedback_targets",
+    "feedback_challenges",
+    "feedback_events",
+    "learning_candidates",
+    "learning_trials",
+    "trial_assignments",
+  ]
+}
+
+extension ScheduledLearningStoreGRDB {
+  static func cleanResetReceipt(
+    _ db: Database,
+    state: JobLearningState
+  ) throws -> ResetReceipt? {
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT decision_id, kind, job_id, learning_epoch, inputs, result, algorithm, decided_at
+        FROM learning_decisions WHERE job_id = ? AND learning_epoch = ?
+        ORDER BY decision_id
+        """,
+      arguments: [state.jobId, state.epoch.value]
+    )
+    guard rows.count == 1, let row = rows.first else {
+      return nil
+    }
+    guard
+      SQLiteStoredValue.string(in: row, column: "kind") == ResetReceipt.kind,
+      let decisionId = SQLiteStoredValue.int64(in: row, column: "decision_id"),
+      SQLiteStoredValue.int64(in: row, column: "job_id") == state.jobId,
+      let epochValue = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      let inputsJSON = SQLiteStoredValue.string(in: row, column: "inputs"),
+      let resultJSON = SQLiteStoredValue.string(in: row, column: "result"),
+      let algorithmRaw = SQLiteStoredValue.string(in: row, column: "algorithm"),
+      let decidedEpoch = SQLiteStoredValue.int64(in: row, column: "decided_at"),
+      let decidedAt = EpochSecondCodec.date(fromEpoch: decidedEpoch),
+      let receipt = try resetReceipt(
+        db,
+        record: ResetDecisionRecord(
+          decisionId: decisionId,
+          jobId: state.jobId,
+          epoch: LearningEpoch(epochValue),
+          inputsJSON: inputsJSON,
+          resultJSON: resultJSON,
+          algorithm: LearningAlgorithm(rawValue: algorithmRaw),
+          decidedAt: decidedAt
+        )
+      ),
+      resetStateMatches(state, receipt: receipt),
+      try resetEffectsAreClean(db, state: state, receipt: receipt)
+    else {
+      return nil
+    }
+    return receipt
+  }
+}
+
+private extension ScheduledLearningStoreGRDB {
+  static func resetStateMatches(_ state: JobLearningState, receipt: ResetReceipt) -> Bool {
+    state.epoch == receipt.result.newEpoch
+      && state.stableDigest == receipt.result.emptyStableDigest
+      && state.stableRevision == receipt.result.newStableRevision
+      && state.feedbackRevision == receipt.inputs.feedbackRevisionAtCut
+      && state.openTrialId == nil
+  }
+
+  static func resetEffectsAreClean(
+    _ db: Database,
+    state: JobLearningState,
+    receipt: ResetReceipt
+  ) throws -> Bool {
+    let empty = LessonSet.empty(jobId: state.jobId)
+    guard
+      let emptyRow = try Row.fetchOne(
+        db,
+        sql: """
+          SELECT job_id, digest, schema_version, canonical_bytes, source
+          FROM lesson_sets WHERE job_id = ? AND digest = ?
+          """,
+        arguments: [state.jobId, empty.digest.rawValue]
+      ),
+      canonicalEmptySetMatches(emptyRow, set: empty),
+      try rowExists(
+        db,
+        sql: """
+          SELECT EXISTS(SELECT 1 FROM learning_trials
+            WHERE job_id = ? AND state IN (?, ?))
+          """,
+        arguments: [
+          state.jobId,
+          LearningTrialState.open.rawValue,
+          LearningTrialState.draining.rawValue,
+        ]
+      ) == false,
+      try rowExists(
+        db,
+        sql:
+          "SELECT EXISTS(SELECT 1 FROM feedback_targets WHERE job_id = ? AND consumed_at IS NULL)",
+        arguments: [state.jobId]
+      ) == false,
+      try rowExists(
+        db,
+        sql: """
+          SELECT EXISTS(SELECT 1 FROM feedback_challenges
+            WHERE job_id = ? AND superseded_by IS NULL AND consumed_at IS NULL)
+          """,
+        arguments: [state.jobId]
+      ) == false,
+      try rowExists(
+        db,
+        sql: """
+          SELECT EXISTS(SELECT 1 FROM learning_operations
+            WHERE job_id = ? AND learning_epoch < ? AND state IN (?, ?))
+          """,
+        arguments: [
+          state.jobId,
+          state.epoch.value,
+          LearningOperationState.pending.rawValue,
+          LearningOperationState.claimed.rawValue,
+        ]
+      ) == false,
+      try startedOperationsAreCovered(db, state: state, receipt: receipt),
+      try currentEpochHasNoPostResetActivity(db, state: state)
+    else {
+      return false
+    }
+    return true
+  }
+
+  static func startedOperationsAreCovered(
+    _ db: Database,
+    state: JobLearningState,
+    receipt: ResetReceipt
+  ) throws -> Bool {
+    let started = try resetOperationIDs(
+      db,
+      jobId: state.jobId,
+      before: state.epoch,
+      states: [.started]
+    )
+    return Set(started).isSubset(of: receipt.result.inFlightOperationIds)
+  }
+
+  static func currentEpochHasNoPostResetActivity(
+    _ db: Database,
+    state: JobLearningState
+  ) throws -> Bool {
+    for table in resetActivityTables {
+      let count = try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM \(table) WHERE job_id = ? AND learning_epoch = ?",
+        arguments: [state.jobId, state.epoch.value]
+      )
+      guard count == 0 else {
+        return false
+      }
+    }
+    return true
+  }
+
+  static func resetTrialsAreSortedAndUnique(_ trials: [ResetTrialIdentity]) -> Bool {
+    trials.elementsAreInStrictAscendingOrder(by: \.trialId)
+  }
+
+  static func resetOperationsAreSortedAndUnique(_ operations: [LearningOperationID]) -> Bool {
+    operations.allSatisfy { $0.rawValue.isEmpty == false }
+      && operations.elementsAreInStrictAscendingOrder(by: \.rawValue)
+  }
+
+  static func resetTrialRowsMatch(
+    _ db: Database,
+    _ trials: [ResetTrialIdentity],
+    jobId: Int64
+  ) throws -> Bool {
+    for trial in trials {
+      guard
+        trial.jobId == jobId,
+        trial.trialId > 0,
+        trial.epoch.value > 0,
+        trial.generation > 0,
+        resetDigestIsCanonical(trial.baseDigest.rawValue),
+        resetDigestIsCanonical(trial.candidateDigest.rawValue),
+        trial.algorithm == .v1,
+        let row = try Row.fetchOne(
+          db,
+          sql: """
+            SELECT job_id, learning_epoch, generation, base_digest, candidate_digest, state,
+              close_reason, algorithm
+            FROM learning_trials WHERE trial_id = ?
+            """,
+          arguments: [trial.trialId]
+        ),
+        SQLiteStoredValue.int64(in: row, column: "job_id") == trial.jobId,
+        SQLiteStoredValue.int64(in: row, column: "learning_epoch") == trial.epoch.value,
+        SQLiteStoredValue.int(in: row, column: "generation") == trial.generation,
+        SQLiteStoredValue.string(in: row, column: "base_digest")
+          == trial.baseDigest.rawValue,
+        SQLiteStoredValue.string(in: row, column: "candidate_digest")
+          == trial.candidateDigest.rawValue,
+        SQLiteStoredValue.string(in: row, column: "state")
+          == LearningTrialState.closed.rawValue,
+        SQLiteStoredValue.string(in: row, column: "close_reason")
+          == LearningTrialCloseReason.learningReset.rawValue,
+        SQLiteStoredValue.string(in: row, column: "algorithm") == trial.algorithm.rawValue
+      else {
+        return false
+      }
+    }
+    return true
+  }
+
+  static func resetOperationRowsMatch(
+    _ db: Database,
+    staleNoCall: [LearningOperationID],
+    inFlight: [LearningOperationID],
+    jobId: Int64,
+    before newEpoch: LearningEpoch
+  ) throws -> Bool {
+    for id in staleNoCall {
+      guard
+        try resetOperationMatches(
+          db,
+          id: id,
+          jobId: jobId,
+          before: newEpoch,
+          expectation: .staleNoCall
+        )
+      else {
+        return false
+      }
+    }
+    for id in inFlight {
+      guard
+        try resetOperationMatches(
+          db,
+          id: id,
+          jobId: jobId,
+          before: newEpoch,
+          expectation: .inFlight
+        )
+      else {
+        return false
+      }
+    }
+    return true
+  }
+
+  static func resetOperationMatches(
+    _ db: Database,
+    id: LearningOperationID,
+    jobId: Int64,
+    before newEpoch: LearningEpoch,
+    expectation: ResetOperationExpectation
+  ) throws -> Bool {
+    guard
+      let row = try Row.fetchOne(
+        db,
+        sql: """
+          SELECT job_id, learning_epoch, state, failure_code, reserved_tokens,
+            reserved_cost_usd, reservation_state
+          FROM learning_operations WHERE operation_id = ?
+          """,
+        arguments: [id.rawValue]
+      ),
+      SQLiteStoredValue.int64(in: row, column: "job_id") == jobId,
+      let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      epoch < newEpoch.value,
+      let stateRaw = SQLiteStoredValue.string(in: row, column: "state"),
+      let state = LearningOperationState(rawValue: stateRaw),
+      expectation.allowedStates.contains(state)
+    else {
+      return false
+    }
+    guard case .staleNoCall = expectation else {
+      return true
+    }
+    return SQLiteStoredValue.string(in: row, column: "failure_code")
+      == LearningOperationFailure.staleEpoch.rawValue
+      && SQLiteStoredValue.int(in: row, column: "reserved_tokens") == 0
+      && SQLiteStoredValue.double(in: row, column: "reserved_cost_usd") == 0
+      && SQLiteStoredValue.string(in: row, column: "reservation_state")
+        == LearningReservationState.closed.rawValue
+  }
+
+  static func rowExists(
+    _ db: Database,
+    sql: String,
+    arguments: StatementArguments
+  ) throws -> Bool {
+    try Bool.fetchOne(db, sql: sql, arguments: arguments) ?? true
+  }
+}
+
+extension ScheduledLearningStoreGRDB {
+  static func resetDigestIsCanonical(_ value: String) -> Bool {
+    value.utf8.count == 64
+      && value.utf8.allSatisfy { byte in
+        (48...57).contains(byte) || (97...102).contains(byte)
+      }
+  }
+}
+
+private extension Array {
+  func elementsAreInStrictAscendingOrder<Value: Comparable>(
+    by keyPath: KeyPath<Element, Value>
+  ) -> Bool {
+    zip(self, dropFirst()).allSatisfy { left, right in
+      left[keyPath: keyPath] < right[keyPath: keyPath]
+    }
+  }
+}

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Rollback.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+Rollback.swift
@@ -1,0 +1,224 @@
+import ClawCore
+import Foundation
+import GRDB
+
+// MARK: - Exact Promotion Rollback
+
+extension ScheduledLearningStoreGRDB {
+  public func currentPromotion(jobId: Int64) throws(StoreError) -> DecisionReceipt? {
+    try database.readMapping { db in
+      guard let state = try Self.readState(db, jobId: jobId) else {
+        return nil
+      }
+      return try Self.currentPromotion(db, state: state)
+    }
+  }
+
+  public func rollback(
+    _ trigger: RollbackTrigger,
+    now: Date
+  ) throws(StoreError) -> DecisionReceipt? {
+    try database.writeMapping { db in
+      guard
+        let row = try Row.fetchOne(
+          db,
+          sql:
+            "SELECT decision_id, inputs, result FROM learning_decisions WHERE decision_id = ? AND kind = ?",
+          arguments: [trigger.promotionId, LearningDecisionKind.trial.rawValue]
+        )
+      else {
+        return nil
+      }
+      let promotion = try Self.decodeTerminalReceipt(row)
+      guard promotion.result == .promoted else {
+        return nil
+      }
+      let inputs = promotion.inputs
+      let state = try Self.readState(db, jobId: inputs.identity.jobId)
+      let current =
+        state.map { value in
+          value.epoch == inputs.identity.epoch
+            && value.stableDigest == inputs.replacementDigest
+            && value.stableRevision == promotion.record.stableRevision
+        } ?? false
+      let valid =
+        try current && Self.rollbackTriggerIsValid(db, trigger: trigger, promotion: promotion)
+      let revision =
+        valid
+        ? StableRevision(promotion.record.stableRevision.value + 1)
+        : state?.stableRevision ?? promotion.record.stableRevision
+      let result: LearningDecisionResult = valid ? .rolledBack : .stale
+      if valid, let state {
+        try Self.closeDependentTrialForRollback(db, state: state, now: now)
+      }
+      let record = LearningDecisionRecord(
+        result: result,
+        reason: result.rawValue,
+        cohort: promotion.cohort,
+        stableRevision: revision,
+        rollbackTrigger: trigger
+      )
+      let receipt = try Self.persistTerminalDecision(db, inputs: inputs, record: record, now: now)
+      if valid {
+        try db.execute(
+          sql: """
+            UPDATE job_learning_state SET stable_lesson_set_digest = ?, stable_revision = ?
+            WHERE job_id = ? AND learning_epoch = ? AND stable_lesson_set_digest = ?
+              AND stable_revision = ?
+            """,
+          arguments: [
+            inputs.baseDigest.rawValue, revision.value, inputs.identity.jobId,
+            inputs.identity.epoch.value, inputs.replacementDigest.rawValue,
+            promotion.record.stableRevision.value,
+          ]
+        )
+        guard db.changesCount == 1 else {
+          throw StoreError.unexpected("rollback CAS changed inside its write transaction")
+        }
+      }
+      return receipt
+    }
+  }
+
+  static func currentPromotion(
+    _ db: Database,
+    state: JobLearningState
+  ) throws -> DecisionReceipt? {
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT decision_id, inputs, result FROM learning_decisions
+        WHERE job_id = ? AND learning_epoch = ? AND kind = ? ORDER BY decision_id DESC
+        """,
+      arguments: [state.jobId, state.epoch.value, LearningDecisionKind.trial.rawValue]
+    )
+    for row in rows {
+      let receipt = try decodeTerminalReceipt(row)
+      if receipt.result == .promoted,
+        receipt.inputs.replacementDigest == state.stableDigest,
+        receipt.record.stableRevision == state.stableRevision
+      {
+        return receipt
+      }
+    }
+    return nil
+  }
+}
+
+// MARK: - Trigger Authority
+
+private extension ScheduledLearningStoreGRDB {
+  static func closeDependentTrialForRollback(
+    _ db: Database,
+    state: JobLearningState,
+    now: Date
+  ) throws {
+    guard let trial = try liveTrial(db, jobId: state.jobId) else {
+      return
+    }
+    let assignments = try assignmentRunIds(db, trialId: trial.trialId).map { runId in
+      try authoritativeAssignment(db, runId: runId, trial: trial, currentState: state)
+    }
+    _ = try finishTrial(
+      db,
+      trial: trial,
+      inputs: TrialDecisionInputs(trial: trial, feedbackRevision: state.feedbackRevision),
+      result: .stale,
+      reason: LearningDecisionResult.rolledBack.rawValue,
+      cohort: assignments.map(DecisionSupport.init),
+      revision: state.stableRevision,
+      closesTrial: true,
+      now: now
+    )
+  }
+
+  static func rollbackTriggerIsValid(
+    _ db: Database,
+    trigger: RollbackTrigger,
+    promotion: DecisionReceipt
+  ) throws -> Bool {
+    switch trigger {
+    case .adapter:
+      return false
+    case .safety(_, let digest, _):
+      return isCanonicalDigest(digest)
+    case .ownerFeedback(_, let eventId):
+      guard let event = try effectiveOwnerEvent(db, id: eventId, promotion: promotion) else {
+        return false
+      }
+      let signal: String = event["signal"]
+      let kind: String = event["subject_kind"]
+      let digest: String = event["subject_digest"]
+      return
+        (signal == OwnerSignal.promotionRollback.rawValue
+        && kind == FeedbackSubjectKind.promotion.rawValue && digest == promotion.promotionSubject)
+        || (signal == OwnerSignal.candidateReject.rawValue
+          && kind == FeedbackSubjectKind.candidate.rawValue
+          && digest == promotion.inputs.candidateDigest.rawValue)
+    case .supportWithdrawal(_, let eventId):
+      guard let event = try effectiveOwnerEvent(db, id: eventId, promotion: promotion),
+        let signal = OwnerSignal(rawValue: event["signal"]),
+        [.resultNotUseful, .resultCorrection, .evaluationDispute].contains(signal),
+        let state = try readState(db, jobId: promotion.inputs.identity.jobId),
+        let row = try trialRow(db, trialId: promotion.inputs.identity.trialId)
+      else {
+        return false
+      }
+      let positives = promotion.cohort.filter { support in
+        support.outcome == .positive
+      }
+      let kind: String = event["subject_kind"]
+      let digest: String = event["subject_digest"]
+      let affected = positives.filter { support in
+        (kind == FeedbackSubjectKind.run.rawValue && digest == String(support.runId))
+          || (kind == FeedbackSubjectKind.evaluation.rawValue && support.evaluationRequired
+            && digest == support.evaluationDigest?.rawValue)
+      }
+      guard affected.isEmpty == false else {
+        return false
+      }
+      let trial = try strictTrial(db, row: row, currentState: nil)
+      var remaining = 0
+      var affectedWithdrawn = false
+      for support in positives {
+        let projected = try authoritativeAssignment(
+          db,
+          runId: support.runId,
+          trial: trial,
+          currentState: state
+        )
+        let valid =
+          projected.resolvedEvidence?.outcome == .positive
+          && projected.resolvedEvidence?.hardVetoes.isEmpty == true
+        if valid {
+          remaining += 1
+        } else if affected.contains(support) {
+          affectedWithdrawn = true
+        }
+      }
+      return affectedWithdrawn && remaining < 2
+    }
+  }
+
+  static func effectiveOwnerEvent(
+    _ db: Database,
+    id: Int64,
+    promotion: DecisionReceipt
+  ) throws -> Row? {
+    try Row.fetchOne(
+      db,
+      sql: """
+        SELECT event.signal, event.subject_kind, event.subject_digest
+        FROM feedback_events AS event
+        WHERE event.event_id = ? AND event.job_id = ? AND event.learning_epoch = ?
+          AND event.actor = ?
+          AND NOT EXISTS (SELECT 1 FROM feedback_events AS successor
+            WHERE successor.supersedes = event.event_id)
+        """,
+      arguments: [
+        id, promotion.inputs.identity.jobId, promotion.inputs.identity.epoch.value,
+        AuditActor.owner.rawValue,
+      ]
+    )
+  }
+}

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TerminalDecisions.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TerminalDecisions.swift
@@ -1,0 +1,254 @@
+import ClawCore
+import Foundation
+import GRDB
+
+// MARK: - Terminal Trial Decisions
+
+extension ScheduledLearningStoreGRDB {
+  public func applyTrialDecision(
+    _ decision: TrialDecision,
+    trial: LearningTrial,
+    feedbackRevision: FeedbackRevision,
+    now: Date
+  ) throws(StoreError) -> DecisionReceipt? {
+    switch decision {
+    case .wait, .closeAssignment:
+      return nil
+    case .promote, .fallback:
+      break
+    }
+    let inputs = TrialDecisionInputs(trial: trial, feedbackRevision: feedbackRevision)
+    return try database.writeMapping { db -> DecisionReceipt? in
+      if let replay = try Self.terminalReceipt(db, inputs: inputs) {
+        return replay
+      }
+      guard let row = try Self.trialRow(db, trialId: trial.trialId) else {
+        return nil
+      }
+      let current = try Self.readState(db, jobId: trial.jobId)
+      let stored = try Self.strictTrial(db, row: row, currentState: nil)
+      guard
+        let current,
+        let job = try Self.admissionJob(db, jobId: trial.jobId),
+        job.hasRecurrence, job.status != .cancelled,
+        current.epoch == inputs.identity.epoch,
+        stored.identity == inputs.identity,
+        stored.candidateDigest == inputs.candidateDigest,
+        stored.replacementDigest == inputs.replacementDigest,
+        stored.baseDigest == inputs.baseDigest, stored.baseRevision == inputs.baseRevision,
+        current.stableDigest == inputs.baseDigest,
+        current.stableRevision == inputs.baseRevision,
+        current.feedbackRevision == inputs.feedbackRevision,
+        stored.algorithm == inputs.algorithm, inputs.algorithm == .v1,
+        stored.state == .open || stored.state == .draining
+      else {
+        return try Self.finishTrial(
+          db,
+          trial: stored,
+          inputs: inputs,
+          result: .stale,
+          reason: LearningDecisionResult.stale.rawValue,
+          cohort: [],
+          revision: current?.stableRevision ?? inputs.baseRevision,
+          closesTrial: stored.identity == inputs.identity,
+          now: now
+        )
+      }
+      let runIds = try Self.assignmentRunIds(db, trialId: stored.trialId)
+      guard runIds.count == stored.consumedAssignments else {
+        throw StoreError.unexpected("terminal cohort does not match consumed assignments")
+      }
+      let assignments = try runIds.map { runId in
+        try Self.authoritativeAssignment(db, runId: runId, trial: stored, currentState: current)
+      }
+      let actual = TrialPolicy.decide(trial: stored, assignments: assignments, now: now)
+      let result: LearningDecisionResult
+      let reason: String
+      switch actual {
+      case .promote:
+        guard decision == .promote else {
+          return nil
+        }
+        guard let candidate = try Self.readCandidateArtifact(db, digest: stored.candidateDigest),
+          try Self.sourceBindingsAreCurrent(db, artifact: candidate, state: current)
+        else {
+          return try Self.finishTrial(
+            db,
+            trial: stored,
+            inputs: inputs,
+            result: .stale,
+            reason: LearningDecisionResult.stale.rawValue,
+            cohort: assignments.map(DecisionSupport.init),
+            revision: current.stableRevision,
+            closesTrial: true,
+            now: now
+          )
+        }
+        result = .promoted
+        reason = LearningDecisionResult.promoted.rawValue
+      case .fallback(let fallback):
+        result = .fallback
+        reason = fallback.rawValue
+      case .wait, .closeAssignment:
+        return nil
+      }
+      let revision =
+        result == .promoted
+        ? StableRevision(current.stableRevision.value + 1) : current.stableRevision
+      return try Self.finishTrial(
+        db,
+        trial: stored,
+        inputs: inputs,
+        result: result,
+        reason: reason,
+        cohort: assignments.map(DecisionSupport.init),
+        revision: revision,
+        closesTrial: true,
+        now: now
+      )
+    }
+  }
+}
+
+// MARK: - Shared Terminal Transaction
+
+extension ScheduledLearningStoreGRDB {
+  // swiftlint:disable:next function_parameter_count
+  static func finishTrial(
+    _ db: Database,
+    trial: LearningTrial,
+    inputs: TrialDecisionInputs,
+    result: LearningDecisionResult,
+    reason: String,
+    cohort: [DecisionSupport],
+    revision: StableRevision,
+    closesTrial: Bool,
+    now: Date
+  ) throws -> DecisionReceipt {
+    let record = LearningDecisionRecord(
+      result: result,
+      reason: reason,
+      cohort: cohort,
+      stableRevision: revision
+    )
+    let receipt = try persistTerminalDecision(db, inputs: inputs, record: record, now: now)
+    if result == .promoted {
+      try db.execute(
+        sql: """
+          UPDATE job_learning_state SET stable_lesson_set_digest = ?, stable_revision = ?
+          WHERE job_id = ? AND learning_epoch = ? AND stable_lesson_set_digest = ?
+            AND stable_revision = ? AND feedback_revision = ?
+          """,
+        arguments: [
+          inputs.replacementDigest.rawValue, revision.value, trial.jobId, trial.epoch.value,
+          inputs.baseDigest.rawValue, inputs.baseRevision.value, inputs.feedbackRevision.value,
+        ]
+      )
+      guard db.changesCount == 1 else {
+        throw StoreError.unexpected("promotion CAS changed inside its write transaction")
+      }
+    }
+    if closesTrial, trial.state == .open || trial.state == .draining {
+      let state: LearningTrialState = result == .promoted ? .promoted : .fellBack
+      try db.execute(
+        sql: """
+          UPDATE learning_trials SET state = ?, close_reason = ?
+          WHERE trial_id = ? AND job_id = ? AND learning_epoch = ? AND generation = ?
+            AND state IN (?, ?)
+          """,
+        arguments: [
+          state.rawValue, reason, trial.trialId, trial.jobId, trial.epoch.value, trial.generation,
+          LearningTrialState.open.rawValue, LearningTrialState.draining.rawValue,
+        ]
+      )
+      try db.execute(
+        sql: """
+          UPDATE job_learning_state SET open_trial_id = NULL
+          WHERE job_id = ? AND learning_epoch = ? AND open_trial_id = ?
+          """,
+        arguments: [trial.jobId, trial.epoch.value, trial.trialId]
+      )
+    }
+    return receipt
+  }
+
+  static func terminalFallback(
+    _ db: Database,
+    trialId: Int64,
+    now: Date
+  ) throws {
+    guard let row = try trialRow(db, trialId: trialId) else {
+      return
+    }
+    let trial = try strictTrial(db, row: row, currentState: nil)
+    guard trial.state == .open || trial.state == .draining,
+      let state = try readState(db, jobId: trial.jobId)
+    else {
+      return
+    }
+    let assignments = try assignmentRunIds(db, trialId: trialId).map { runId in
+      try authoritativeAssignment(db, runId: runId, trial: trial, currentState: state)
+    }
+    _ = try finishTrial(
+      db,
+      trial: trial,
+      inputs: TrialDecisionInputs(trial: trial, feedbackRevision: state.feedbackRevision),
+      result: .fallback,
+      reason: TrialFallbackReason.hardVeto.rawValue,
+      cohort: assignments.map(DecisionSupport.init),
+      revision: state.stableRevision,
+      closesTrial: true,
+      now: now
+    )
+  }
+
+  static func persistTerminalDecision(
+    _ db: Database,
+    inputs: TrialDecisionInputs,
+    record: LearningDecisionRecord,
+    now: Date
+  ) throws -> DecisionReceipt {
+    let kind: LearningDecisionKind = record.rollbackTrigger == nil ? .trial : .rollback
+    let id = try insertDecision(
+      db,
+      kind: kind.rawValue,
+      jobId: inputs.identity.jobId,
+      epoch: inputs.identity.epoch,
+      inputs: inputs,
+      result: record,
+      algorithm: inputs.algorithm,
+      now: now
+    )
+    return DecisionReceipt(decisionId: id, inputs: inputs, record: record)
+  }
+
+  static func terminalReceipt(_ db: Database, inputs: TrialDecisionInputs) throws
+    -> DecisionReceipt?
+  {
+    guard
+      let row = try Row.fetchOne(
+        db,
+        sql: """
+          SELECT decision_id, inputs, result FROM learning_decisions
+          WHERE kind = ? AND job_id = ? AND learning_epoch = ? AND inputs = ?
+          ORDER BY decision_id LIMIT 1
+          """,
+        arguments: [
+          LearningDecisionKind.trial.rawValue, inputs.identity.jobId, inputs.identity.epoch.value,
+          try canonicalDecisionJSON(inputs),
+        ]
+      )
+    else {
+      return nil
+    }
+    return try decodeTerminalReceipt(row)
+  }
+
+  static func decodeTerminalReceipt(_ row: Row) throws -> DecisionReceipt {
+    DecisionReceipt(
+      decisionId: row["decision_id"],
+      inputs: try decodeCanonicalDecision(row["inputs"]),
+      record: try decodeCanonicalDecision(row["result"])
+    )
+  }
+}

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TrialReconciliation.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TrialReconciliation.swift
@@ -58,16 +58,20 @@ extension ScheduledLearningStoreGRDB {
     guard let row = try trialRow(db, trialId: identity.trialId) else {
       return .stale
     }
-    let trial = try strictTrial(db, row: row, currentState: nil)
+    var trial = try strictTrial(db, row: row, currentState: nil)
     guard trial.state == .open || trial.state == .draining else {
       return .stale
     }
     guard trial.identity == identity else {
       throw StoreError.unexpected("live trial identity changed during reconciliation")
     }
-    guard try readState(db, jobId: trial.jobId)?.epoch == trial.epoch else {
+    guard
+      let currentState = try readState(db, jobId: trial.jobId),
+      currentState.epoch == trial.epoch
+    else {
       return .stale
     }
+    trial = try strictTrial(db, row: row, currentState: currentState)
 
     let runIds = try assignmentRunIds(db, trialId: trial.trialId)
     guard

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TrialReconciliation.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TrialReconciliation.swift
@@ -1,0 +1,208 @@
+import ClawCore
+import Foundation
+import GRDB
+
+// MARK: - Public Trial Resolution
+
+extension ScheduledLearningStoreGRDB {
+  public func recomputeAssignment(
+    runId: Int64,
+    now: Date
+  ) throws(StoreError) -> AssignmentRecomputation {
+    try database.writeMapping { db in
+      try Self.recomputeAssignment(db, runId: runId, now: now)
+    }
+  }
+
+  public func liveTrialIdentities() throws(StoreError) -> [LearningTrialIdentity] {
+    try database.readMapping { db in
+      try Self.readLiveTrialIdentities(db)
+    }
+  }
+
+  public func reconcileTrial(
+    _ identity: LearningTrialIdentity,
+    now: Date
+  ) throws(StoreError) -> TrialReconciliationResult {
+    try database.writeMapping { db in
+      try Self.reconcileTrial(db, identity: identity, now: now)
+    }
+  }
+}
+
+// MARK: - Reconciliation
+
+extension ScheduledLearningStoreGRDB {
+  @discardableResult
+  static func recomputeAndReconcile(
+    _ db: Database,
+    runId: Int64,
+    now: Date
+  ) throws -> TrialReconciliationResult? {
+    let recomputation = try recomputeAssignment(db, runId: runId, now: now)
+    let identity: LearningTrialIdentity
+    switch recomputation {
+    case .notAssigned, .stale:
+      return nil
+    case .unchanged(let assignment), .updated(let assignment):
+      identity = assignment.identity.trial
+    }
+    return try reconcileTrial(db, identity: identity, now: now)
+  }
+
+  static func reconcileTrial(
+    _ db: Database,
+    identity: LearningTrialIdentity,
+    now: Date
+  ) throws -> TrialReconciliationResult {
+    guard let row = try trialRow(db, trialId: identity.trialId) else {
+      return .stale
+    }
+    let trial = try strictTrial(db, row: row, currentState: nil)
+    guard trial.state == .open || trial.state == .draining else {
+      return .stale
+    }
+    guard trial.identity == identity else {
+      throw StoreError.unexpected("live trial identity changed during reconciliation")
+    }
+    guard try readState(db, jobId: trial.jobId)?.epoch == trial.epoch else {
+      return .stale
+    }
+
+    let runIds = try assignmentRunIds(db, trialId: trial.trialId)
+    guard
+      runIds.count == trial.consumedAssignments,
+      Set(runIds).count == runIds.count
+    else {
+      throw StoreError.unexpected("trial assignment count does not match its exposure counter")
+    }
+    var assignments: [TrialAssignment] = []
+    for runId in runIds {
+      switch try recomputeAssignment(db, runId: runId, now: now) {
+      case .unchanged(let assignment), .updated(let assignment):
+        guard assignment.identity.trial == identity else {
+          throw StoreError.unexpected("trial cohort contains a foreign assignment")
+        }
+        assignments.append(assignment)
+      case .notAssigned, .stale:
+        throw StoreError.unexpected("live trial cohort lost an assignment during reconciliation")
+      }
+    }
+    let decision = TrialPolicy.decide(trial: trial, assignments: assignments, now: now)
+    let shouldDrain = trial.state == .open && decision != .wait
+    if shouldDrain {
+      try drain(db, trial: trial)
+    }
+    return .reconciled(
+      TrialReconciliation(
+        identity: identity,
+        didDrain: shouldDrain,
+        assignments: assignments,
+        decision: decision
+      )
+    )
+  }
+
+  static func readLiveTrialIdentities(_ db: Database) throws -> [LearningTrialIdentity] {
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT trial_id, job_id, learning_epoch, base_digest, candidate_digest, generation,
+          admitted_at, assignment_deadline, decision_deadline, max_assignments,
+          consumed_assignments, cohort_cutoff, state, close_reason, algorithm
+        FROM learning_trials WHERE state IN (?, ?)
+        ORDER BY job_id, trial_id
+        """,
+      arguments: [LearningTrialState.open.rawValue, LearningTrialState.draining.rawValue]
+    )
+    var seenJobs: Set<Int64> = []
+    return try rows.map { row in
+      guard
+        let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
+        jobId > 0,
+        seenJobs.insert(jobId).inserted,
+        let currentState = try readState(db, jobId: jobId)
+      else {
+        throw StoreError.unexpected("live trial identity set is unreadable or duplicated")
+      }
+      return try strictTrial(db, row: row, currentState: currentState).identity
+    }
+  }
+
+  static func recomputeEvaluatorSource(
+    _ db: Database,
+    jobId: Int64,
+    epoch: LearningEpoch,
+    evidenceDigest: String,
+    now: Date
+  ) throws {
+    let runIds = try Int64.fetchAll(
+      db,
+      sql: """
+        SELECT run_id FROM learning_evidence
+        WHERE job_id = ? AND learning_epoch = ? AND evidence_digest = ?
+        ORDER BY run_id
+        """,
+      arguments: [jobId, epoch.value, evidenceDigest]
+    )
+    guard runIds.count <= 1 else {
+      throw StoreError.unexpected("evaluator source resolves to multiple evidence receipts")
+    }
+    if let runId = runIds.first {
+      _ = try recomputeAndReconcile(db, runId: runId, now: now)
+    }
+  }
+
+  static func recomputeFeedbackSubject(
+    _ db: Database,
+    jobId: Int64,
+    epoch: LearningEpoch,
+    subjectKind: FeedbackSubjectKind,
+    subjectDigest: String,
+    now: Date
+  ) throws {
+    let runId: Int64?
+    switch subjectKind {
+    case .run:
+      guard let parsed = Int64(subjectDigest), String(parsed) == subjectDigest else {
+        return
+      }
+      let isAssigned =
+        try Bool.fetchOne(
+          db,
+          sql: """
+            SELECT EXISTS(
+              SELECT 1 FROM trial_assignments
+              WHERE run_id = ? AND job_id = ? AND learning_epoch = ?
+            )
+            """,
+          arguments: [parsed, jobId, epoch.value]
+        ) ?? false
+      runId = isAssigned ? parsed : nil
+    case .evaluation:
+      let rows = try Int64.fetchAll(
+        db,
+        sql: """
+          SELECT evaluation.run_id
+          FROM learning_evaluations AS evaluation
+          JOIN trial_assignments AS assignment ON assignment.run_id = evaluation.run_id
+            AND assignment.job_id = evaluation.job_id
+            AND assignment.learning_epoch = evaluation.learning_epoch
+          WHERE evaluation.job_id = ? AND evaluation.learning_epoch = ?
+            AND evaluation.evaluation_digest = ?
+          ORDER BY evaluation.run_id
+          """,
+        arguments: [jobId, epoch.value, subjectDigest]
+      )
+      guard rows.count <= 1 else {
+        throw StoreError.unexpected("evaluation feedback resolves to multiple runs")
+      }
+      runId = rows.first
+    case .candidate, .promotion:
+      runId = nil
+    }
+    if let runId {
+      _ = try recomputeAndReconcile(db, runId: runId, now: now)
+    }
+  }
+}

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TrialResolution.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TrialResolution.swift
@@ -28,7 +28,7 @@ extension ScheduledLearningStoreGRDB {
     guard let trialRow = try trialRow(db, trialId: cached.identity.trial.trialId) else {
       throw StoreError.unexpected("assignment \(runId) names a missing trial")
     }
-    let trial = try strictTrial(db, row: trialRow, currentState: nil)
+    var trial = try strictTrial(db, row: trialRow, currentState: nil)
     try validateAssignmentIdentity(db, cached: cached, trial: trial)
     guard let current = try readState(db, jobId: trial.jobId) else {
       throw StoreError.unexpected("assignment \(runId) belongs to a job without learning state")
@@ -38,6 +38,9 @@ extension ScheduledLearningStoreGRDB {
     }
     guard trial.epoch == current.epoch else {
       throw StoreError.unexpected("assignment \(runId) is ahead of the job learning epoch")
+    }
+    if trial.state == .open || trial.state == .draining {
+      trial = try strictTrial(db, row: trialRow, currentState: current)
     }
 
     let projected = try projectAssignment(
@@ -313,22 +316,6 @@ extension ScheduledLearningStoreGRDB {
 // MARK: - Authoritative Projection
 
 extension ScheduledLearningStoreGRDB {
-  private struct StrictEvidence {
-    let digest: EvidenceDigest
-    let eligibility: LearningEligibility
-  }
-
-  private struct StrictAttempt {
-    let operation: OperationRow
-    let generation: Int
-    let supersedes: LearningOperationID?
-  }
-
-  private struct StrictEvaluation {
-    let digest: EvaluationDigest
-    let evaluation: LearningEvaluation
-  }
-
   private static func projectAssignment(
     _ db: Database,
     cached: CachedAssignment,
@@ -336,6 +323,11 @@ extension ScheduledLearningStoreGRDB {
     currentState: JobLearningState
   ) throws -> TrialAssignment {
     let runId = cached.identity.runId
+    if let cachedRevision = cached.feedbackRevision,
+      cachedRevision > currentState.feedbackRevision
+    {
+      throw StoreError.unexpected("assignment \(runId) names a future feedback revision")
+    }
     guard let settlement = try readSettlement(db, runId: runId), settlement.settledAt != nil else {
       return unresolvedAssignment(cached, state: .created)
     }
@@ -357,19 +349,26 @@ extension ScheduledLearningStoreGRDB {
       )
     }
 
-    guard let attempt = try latestEvaluatorAttempt(db, trial: trial, evidence: evidence) else {
+    let source = try strictEvaluatorSource(
+      db,
+      runId: runId,
+      trial: trial,
+      evidence: evidence
+    )
+    guard let attempt = source.attempt else {
       return unresolvedAssignment(cached, state: .primaryRunSettled)
     }
     switch attempt.operation.state {
     case .pending, .claimed, .started, .interruptedUnknown:
       return unresolvedAssignment(cached, state: .learningOutcomeUnresolved)
     case .failed, .failedNoCall:
-      let feedback = try storedFeedback(
+      let feedback = try assignmentFeedback(
         db,
         jobId: trial.jobId,
         epoch: trial.epoch,
         runIds: [runId],
-        evaluationRuns: [:]
+        evaluationRuns: [:],
+        currentRevision: currentState.feedbackRevision
       )
       let resolved = OwnerPrecedence.resolve(
         evaluator: nil,
@@ -389,19 +388,16 @@ extension ScheduledLearningStoreGRDB {
         currentState: currentState
       )
     case .succeeded:
-      let evaluation = try strictEvaluation(
-        db,
-        runId: runId,
-        trial: trial,
-        evidence: evidence,
-        operation: attempt.operation
-      )
-      let feedback = try storedFeedback(
+      guard let evaluation = source.evaluation else {
+        throw StoreError.unexpected("succeeded evaluator has no exact evaluation")
+      }
+      let feedback = try assignmentFeedback(
         db,
         jobId: trial.jobId,
         epoch: trial.epoch,
         runIds: [runId],
-        evaluationRuns: [evaluation.digest.rawValue: runId]
+        evaluationRuns: [evaluation.digest.rawValue: runId],
+        currentRevision: currentState.feedbackRevision
       )
       let resolved = OwnerPrecedence.resolve(
         evaluator: evaluation.evaluation.outcome,
@@ -468,155 +464,28 @@ extension ScheduledLearningStoreGRDB {
     )
   }
 
-  private static func strictEvidence(
+  private static func assignmentFeedback(
     _ db: Database,
-    runId: Int64,
-    trial: LearningTrial
-  ) throws -> StrictEvidence? {
-    guard
-      let row = try Row.fetchOne(
-        db,
-        sql: """
-          SELECT run_id, job_id, learning_epoch, evidence_digest, eligibility,
-            classifier_version, sealed_at
-          FROM learning_evidence WHERE run_id = ?
-          """,
-        arguments: [runId]
-      )
-    else {
-      return nil
-    }
-    guard
-      let storedRunId = SQLiteStoredValue.int64(in: row, column: "run_id"),
-      storedRunId == runId,
-      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
-      jobId == trial.jobId,
-      let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
-      LearningEpoch(epoch) == trial.epoch,
-      let digestRaw = SQLiteStoredValue.string(in: row, column: "evidence_digest"),
-      isCanonicalDigest(digestRaw),
-      let eligibilityRaw = SQLiteStoredValue.string(in: row, column: "eligibility"),
-      let eligibility = LearningEligibility(rawValue: eligibilityRaw),
-      let classifier = SQLiteStoredValue.string(in: row, column: "classifier_version"),
-      classifier == EligibilityClassifier.version,
-      let sealedRaw = SQLiteStoredValue.int64(in: row, column: "sealed_at"),
-      EpochSecondCodec.date(fromEpoch: sealedRaw) != nil
-    else {
-      throw StoreError.unexpected("assignment \(runId) has an unreadable evidence receipt")
-    }
-    return StrictEvidence(digest: EvidenceDigest(rawValue: digestRaw), eligibility: eligibility)
-  }
-
-  private static func latestEvaluatorAttempt(
-    _ db: Database,
-    trial: LearningTrial,
-    evidence: StrictEvidence
-  ) throws -> StrictAttempt? {
-    let key = LearningOperationKey(
-      jobId: trial.jobId,
-      epoch: trial.epoch,
-      phase: .evaluator,
-      sourceDigest: evidence.digest.rawValue,
-      promptVersion: EvaluatorPrompt.v1.version,
-      schemaVersion: EvaluatorOutput.currentSchemaVersion,
-      rubricVersion: EvaluatorRubric.v1.version
-    )
-    let rows = try Row.fetchAll(
+    jobId: Int64,
+    epoch: LearningEpoch,
+    runIds: Set<Int64>,
+    evaluationRuns: [String: Int64],
+    currentRevision: FeedbackRevision
+  ) throws -> [StoredFeedbackProjection] {
+    let feedback = try storedFeedback(
       db,
-      sql: """
-        SELECT operation_id, attempt_generation, supersedes
-        FROM learning_operations
-        WHERE job_id = ? AND learning_epoch = ? AND phase = ? AND source_digest = ?
-          AND key_digest = ?
-        ORDER BY attempt_generation
-        """,
-      arguments: [
-        trial.jobId,
-        trial.epoch.value,
-        LearningPhase.evaluator.rawValue,
-        evidence.digest.rawValue,
-        key.digest.rawValue,
-      ]
+      jobId: jobId,
+      epoch: epoch,
+      runIds: runIds,
+      evaluationRuns: evaluationRuns
     )
-    var attempts: [StrictAttempt] = []
-    for row in rows {
-      guard
-        let idRaw = SQLiteStoredValue.string(in: row, column: "operation_id"),
-        let generation = SQLiteStoredValue.int(in: row, column: "attempt_generation"),
-        generation > 0,
-        let supersedesRaw = SQLiteStoredValue.nullableString(in: row, column: "supersedes"),
-        idRaw == LearningOperationID(key: key.digest, attemptGeneration: generation).rawValue,
-        let operation = try readOperation(db, id: LearningOperationID(rawValue: idRaw)),
-        operation.jobId == trial.jobId,
-        operation.epoch == trial.epoch,
-        operation.phase == .evaluator,
-        operation.sourceDigest == evidence.digest.rawValue,
-        operation.keyDigest == key.digest
-      else {
-        throw StoreError.unexpected("evaluator operation lineage is unreadable")
-      }
-      attempts.append(
-        StrictAttempt(
-          operation: operation,
-          generation: generation,
-          supersedes: supersedesRaw.value.map(LearningOperationID.init(rawValue:))
-        )
-      )
-    }
-    for (offset, attempt) in attempts.enumerated() {
-      guard attempt.generation == offset + 1 else {
-        throw StoreError.unexpected("evaluator operation lineage has a generation gap")
-      }
-      let expectedPredecessor = offset == 0 ? nil : attempts[offset - 1].operation.id
-      guard attempt.supersedes == expectedPredecessor else {
-        throw StoreError.unexpected("evaluator operation lineage has a broken predecessor")
-      }
-    }
-    return attempts.last
-  }
-
-  private static func strictEvaluation(
-    _ db: Database,
-    runId: Int64,
-    trial: LearningTrial,
-    evidence: StrictEvidence,
-    operation: OperationRow
-  ) throws -> StrictEvaluation {
-    let rows = try storedEvaluations(db, runId: runId)
-    guard rows.count == 1, let stored = rows.first else {
-      throw StoreError.unexpected("succeeded evaluator requires exactly one evaluation")
-    }
     guard
-      stored.jobId == trial.jobId,
-      stored.epoch == trial.epoch,
-      stored.runId == runId,
-      stored.evidenceDigest == evidence.digest,
-      stored.evaluation.evaluator.rubricVersion == EvaluatorRubric.v1.version,
-      stored.evaluation.evaluator.promptVersion == EvaluatorPrompt.v1.version,
-      stored.evaluation.evaluator.schemaVersion == EvaluatorOutput.currentSchemaVersion,
-      let compatibility = try readCompatibility(db, runId: runId),
-      let binding = try readBinding(db, runId: runId)
+      feedback.allSatisfy({ stored in
+        stored.event.revision <= currentRevision
+      })
     else {
-      throw StoreError.unexpected("assignment \(runId) has an unreadable evaluation")
+      throw StoreError.unexpected("assignment source names a future feedback revision")
     }
-    let compatibilityDigest = compatibility.digest(
-      binding: binding,
-      terminalRoute: try readTerminalRoute(db, runId: runId),
-      evaluator: stored.evaluation.evaluator
-    )
-    guard compatibilityDigest == stored.compatibilityDigest else {
-      throw StoreError.unexpected("assignment \(runId) evaluation surface does not match")
-    }
-    let expectedDigest = digest(
-      operation: operation,
-      runId: runId,
-      evaluation: stored.evaluation,
-      issueCodes: stored.issueCodesJSON,
-      compatibility: compatibilityDigest
-    )
-    guard expectedDigest == stored.digest else {
-      throw StoreError.unexpected("assignment \(runId) evaluation digest does not match")
-    }
-    return StrictEvaluation(digest: expectedDigest, evaluation: stored.evaluation)
+    return feedback
   }
 }

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TrialResolution.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TrialResolution.swift
@@ -1,0 +1,622 @@
+import ClawCore
+import Foundation
+import GRDB
+
+// MARK: - Assignment Cache
+
+extension ScheduledLearningStoreGRDB {
+  struct CachedAssignment {
+    let identity: TrialAssignmentIdentity
+    let assignedAt: Date
+    let state: TrialAssignmentState
+    let outcome: TrialOutcomeKind?
+    let issueCodes: [String]?
+    let evaluationDigest: EvaluationDigest?
+    let evaluationRequired: Bool
+    let feedbackRevision: FeedbackRevision?
+    let resolvedAt: Date?
+  }
+
+  static func recomputeAssignment(
+    _ db: Database,
+    runId: Int64,
+    now: Date
+  ) throws -> AssignmentRecomputation {
+    guard let cached = try cachedAssignment(db, runId: runId) else {
+      return .notAssigned
+    }
+    guard let trialRow = try trialRow(db, trialId: cached.identity.trial.trialId) else {
+      throw StoreError.unexpected("assignment \(runId) names a missing trial")
+    }
+    let trial = try strictTrial(db, row: trialRow, currentState: nil)
+    try validateAssignmentIdentity(db, cached: cached, trial: trial)
+    guard let current = try readState(db, jobId: trial.jobId) else {
+      throw StoreError.unexpected("assignment \(runId) belongs to a job without learning state")
+    }
+    if trial.epoch < current.epoch {
+      return .stale
+    }
+    guard trial.epoch == current.epoch else {
+      throw StoreError.unexpected("assignment \(runId) is ahead of the job learning epoch")
+    }
+
+    let projected = try projectAssignment(
+      db,
+      cached: cached,
+      trial: trial,
+      currentState: current
+    )
+    if cached.state == .learningOutcomeResolved, projected.resolvedEvidence == nil {
+      throw StoreError.unexpected("resolved assignment cache has no authoritative resolution event")
+    }
+    if cacheMatches(cached, projected: projected) {
+      return .unchanged(withResolvedAt(projected, cached.resolvedAt))
+    }
+    let updated = withResolvedAt(
+      projected,
+      projected.resolvedEvidence == nil ? nil : now
+    )
+    try persistAssignment(db, cached: cached, assignment: updated)
+    return .updated(updated)
+  }
+
+  static func assignmentRunIds(_ db: Database, trialId: Int64) throws -> [Int64] {
+    try Int64.fetchAll(
+      db,
+      sql: "SELECT run_id FROM trial_assignments WHERE trial_id = ? ORDER BY run_id",
+      arguments: [trialId]
+    )
+  }
+
+  static func authoritativeAssignment(
+    _ db: Database,
+    runId: Int64,
+    trial: LearningTrial,
+    currentState: JobLearningState
+  ) throws -> TrialAssignment {
+    guard let cached = try cachedAssignment(db, runId: runId) else {
+      throw StoreError.unexpected("trial cohort names a missing assignment")
+    }
+    try validateAssignmentIdentity(db, cached: cached, trial: trial)
+    guard
+      trial.epoch == currentState.epoch,
+      trial.jobId == currentState.jobId
+    else {
+      throw StoreError.unexpected("live assignment projection crossed a learning epoch")
+    }
+    let projected = try projectAssignment(
+      db,
+      cached: cached,
+      trial: trial,
+      currentState: currentState
+    )
+    if cached.state == .learningOutcomeResolved, projected.resolvedEvidence == nil {
+      throw StoreError.unexpected("resolved assignment cache has no authoritative resolution event")
+    }
+    return projected
+  }
+
+  private static func cachedAssignment(_ db: Database, runId: Int64) throws -> CachedAssignment? {
+    guard
+      let row = try Row.fetchOne(
+        db,
+        sql: """
+          SELECT run_id, trial_id, job_id, learning_epoch, trial_generation, assigned_at, state,
+            outcome, issue_codes, evaluation_digest, evaluation_required,
+            effective_feedback_revision, resolved_at
+          FROM trial_assignments WHERE run_id = ?
+          """,
+        arguments: [runId]
+      )
+    else {
+      return nil
+    }
+    guard
+      let storedRunId = SQLiteStoredValue.int64(in: row, column: "run_id"),
+      storedRunId == runId,
+      let trialId = SQLiteStoredValue.int64(in: row, column: "trial_id"),
+      trialId > 0,
+      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
+      jobId > 0,
+      let epochRaw = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      epochRaw > 0,
+      let generation = SQLiteStoredValue.int(in: row, column: "trial_generation"),
+      generation > 0,
+      let assignedRaw = SQLiteStoredValue.int64(in: row, column: "assigned_at"),
+      let assignedAt = EpochSecondCodec.date(fromEpoch: assignedRaw),
+      let stateRaw = SQLiteStoredValue.string(in: row, column: "state"),
+      let state = TrialAssignmentState(rawValue: stateRaw),
+      let outcomeRaw = SQLiteStoredValue.nullableString(in: row, column: "outcome"),
+      let issueJSON = SQLiteStoredValue.nullableString(in: row, column: "issue_codes"),
+      let evaluationRaw = SQLiteStoredValue.nullableString(
+        in: row,
+        column: "evaluation_digest"
+      ),
+      let evaluationRequiredRaw = SQLiteStoredValue.boolean(
+        in: row,
+        column: "evaluation_required"
+      ),
+      let feedbackRaw = SQLiteStoredValue.nullableInt64(
+        in: row,
+        column: "effective_feedback_revision"
+      ),
+      let resolvedRaw = SQLiteStoredValue.nullableInt64(in: row, column: "resolved_at")
+    else {
+      throw StoreError.unexpected("assignment \(runId) has unreadable stored values")
+    }
+    let outcome = outcomeRaw.value.flatMap(TrialOutcomeKind.init(rawValue:))
+    guard outcomeRaw.value == nil || outcome != nil else {
+      throw StoreError.unexpected("assignment \(runId) has an unknown outcome")
+    }
+    let issueCodes = try issueJSON.value.map(decodeCanonicalIssueCodes)
+    let feedback = feedbackRaw.value.map(FeedbackRevision.init)
+    let resolvedAt = resolvedRaw.value.flatMap(EpochSecondCodec.date(fromEpoch:))
+    let evaluationRequired = evaluationRequiredRaw == .trueValue
+    let isResolved = state == .learningOutcomeResolved
+    if isResolved {
+      guard
+        let outcome,
+        let issueCodes,
+        let feedback,
+        feedback.value >= 0,
+        resolvedAt != nil,
+        issueCodesMatchOutcome(issueCodes, outcome: outcome)
+      else {
+        throw StoreError.unexpected("assignment \(runId) has an invalid resolved cache shape")
+      }
+    } else {
+      guard
+        outcome == nil,
+        issueCodes == nil,
+        evaluationRaw.value == nil,
+        evaluationRequired,
+        feedback == nil,
+        resolvedAt == nil
+      else {
+        throw StoreError.unexpected("assignment \(runId) has an invalid unresolved cache shape")
+      }
+    }
+    return CachedAssignment(
+      identity: TrialAssignmentIdentity(
+        trial: LearningTrialIdentity(
+          trialId: trialId,
+          jobId: jobId,
+          epoch: LearningEpoch(epochRaw),
+          generation: generation
+        ),
+        runId: runId
+      ),
+      assignedAt: assignedAt,
+      state: state,
+      outcome: outcome,
+      issueCodes: issueCodes,
+      evaluationDigest: evaluationRaw.value.map(EvaluationDigest.init(rawValue:)),
+      evaluationRequired: evaluationRequired,
+      feedbackRevision: feedback,
+      resolvedAt: resolvedAt
+    )
+  }
+
+  private static func validateAssignmentIdentity(
+    _ db: Database,
+    cached: CachedAssignment,
+    trial: LearningTrial
+  ) throws {
+    let identity = cached.identity
+    guard
+      identity.trial == trial.identity,
+      let binding = try readBinding(db, runId: identity.runId),
+      binding.runId == identity.runId,
+      binding.jobId == trial.jobId,
+      binding.epoch == trial.epoch,
+      binding.trialId == trial.trialId,
+      binding.trialGeneration == trial.generation,
+      binding.stableDigest == trial.baseDigest,
+      binding.effectiveDigest == trial.replacementDigest
+    else {
+      throw StoreError.unexpected(
+        "assignment \(identity.runId) has inconsistent five-part identity"
+      )
+    }
+  }
+
+  private static func cacheMatches(
+    _ cached: CachedAssignment,
+    projected: TrialAssignment
+  ) -> Bool {
+    guard
+      cached.identity == projected.identity,
+      cached.assignedAt == projected.assignedAt,
+      cached.state == projected.state
+    else {
+      return false
+    }
+    guard let evidence = projected.resolvedEvidence else {
+      return cached.outcome == nil
+        && cached.issueCodes == nil
+        && cached.evaluationDigest == nil
+        && cached.evaluationRequired
+        && cached.feedbackRevision == nil
+        && cached.resolvedAt == nil
+    }
+    return cached.outcome == evidence.outcome
+      && cached.issueCodes == evidence.issueCodes
+      && cached.evaluationDigest == evidence.evaluationDigest
+      && cached.evaluationRequired == evidence.evaluationRequired
+      && cached.feedbackRevision == evidence.effectiveFeedbackRevision
+      && cached.resolvedAt != nil
+  }
+
+  private static func persistAssignment(
+    _ db: Database,
+    cached: CachedAssignment,
+    assignment: TrialAssignment
+  ) throws {
+    let evidence = assignment.resolvedEvidence
+    let issueJSON = try evidence.map { value in
+      try issueCodesJSON(value.issueCodes)
+    }
+    try db.execute(
+      sql: """
+        UPDATE trial_assignments
+        SET state = ?, outcome = ?, issue_codes = ?, evaluation_digest = ?,
+          evaluation_required = ?, effective_feedback_revision = ?, resolved_at = ?
+        WHERE run_id = ? AND trial_id = ? AND job_id = ? AND learning_epoch = ?
+          AND trial_generation = ?
+        """,
+      arguments: [
+        assignment.state.rawValue,
+        evidence?.outcome.rawValue,
+        issueJSON,
+        evidence?.evaluationDigest?.rawValue,
+        evidence?.evaluationRequired ?? true,
+        evidence?.effectiveFeedbackRevision.value,
+        assignment.resolvedAt.map(EpochSecondCodec.epoch),
+        cached.identity.runId,
+        cached.identity.trial.trialId,
+        cached.identity.trial.jobId,
+        cached.identity.trial.epoch.value,
+        cached.identity.trial.generation,
+      ]
+    )
+    guard db.changesCount == 1 else {
+      throw StoreError.unexpected("assignment cache update lost its exact identity")
+    }
+  }
+
+  private static func withResolvedAt(
+    _ assignment: TrialAssignment,
+    _ resolvedAt: Date?
+  ) -> TrialAssignment {
+    TrialAssignment(
+      identity: assignment.identity,
+      assignedAt: assignment.assignedAt,
+      state: assignment.state,
+      resolvedEvidence: assignment.resolvedEvidence,
+      resolvedAt: resolvedAt
+    )
+  }
+
+  private static func issueCodesMatchOutcome(
+    _ issueCodes: [String],
+    outcome: TrialOutcomeKind
+  ) -> Bool {
+    switch outcome {
+    case .positive, .neutral:
+      return issueCodes.isEmpty
+    case .negative:
+      return true
+    }
+  }
+}
+
+// MARK: - Authoritative Projection
+
+extension ScheduledLearningStoreGRDB {
+  private struct StrictEvidence {
+    let digest: EvidenceDigest
+    let eligibility: LearningEligibility
+  }
+
+  private struct StrictAttempt {
+    let operation: OperationRow
+    let generation: Int
+    let supersedes: LearningOperationID?
+  }
+
+  private struct StrictEvaluation {
+    let digest: EvaluationDigest
+    let evaluation: LearningEvaluation
+  }
+
+  private static func projectAssignment(
+    _ db: Database,
+    cached: CachedAssignment,
+    trial: LearningTrial,
+    currentState: JobLearningState
+  ) throws -> TrialAssignment {
+    let runId = cached.identity.runId
+    guard let settlement = try readSettlement(db, runId: runId), settlement.settledAt != nil else {
+      return unresolvedAssignment(cached, state: .created)
+    }
+    guard let evidence = try strictEvidence(db, runId: runId, trial: trial) else {
+      return unresolvedAssignment(cached, state: .primaryRunSettled)
+    }
+    guard evidence.eligibility.reachesEvaluator else {
+      return resolvedAssignment(
+        cached,
+        effective: ResolvedOutcome(
+          outcome: .neutral,
+          ownerConfirmed: false,
+          evaluationRequired: false,
+          hardVetoes: []
+        ),
+        evaluationDigest: nil,
+        feedback: [],
+        currentState: currentState
+      )
+    }
+
+    guard let attempt = try latestEvaluatorAttempt(db, trial: trial, evidence: evidence) else {
+      return unresolvedAssignment(cached, state: .primaryRunSettled)
+    }
+    switch attempt.operation.state {
+    case .pending, .claimed, .started, .interruptedUnknown:
+      return unresolvedAssignment(cached, state: .learningOutcomeUnresolved)
+    case .failed, .failedNoCall:
+      let feedback = try storedFeedback(
+        db,
+        jobId: trial.jobId,
+        epoch: trial.epoch,
+        runIds: [runId],
+        evaluationRuns: [:]
+      )
+      let resolved = OwnerPrecedence.resolve(
+        evaluator: nil,
+        issueCodes: [],
+        signals: feedback.map(\.event)
+      )
+      return resolvedAssignment(
+        cached,
+        effective: ResolvedOutcome(
+          outcome: resolved.outcome,
+          ownerConfirmed: resolved.ownerConfirmed,
+          evaluationRequired: false,
+          hardVetoes: resolved.hardVetoes
+        ),
+        evaluationDigest: nil,
+        feedback: feedback,
+        currentState: currentState
+      )
+    case .succeeded:
+      let evaluation = try strictEvaluation(
+        db,
+        runId: runId,
+        trial: trial,
+        evidence: evidence,
+        operation: attempt.operation
+      )
+      let feedback = try storedFeedback(
+        db,
+        jobId: trial.jobId,
+        epoch: trial.epoch,
+        runIds: [runId],
+        evaluationRuns: [evaluation.digest.rawValue: runId]
+      )
+      let resolved = OwnerPrecedence.resolve(
+        evaluator: evaluation.evaluation.outcome,
+        issueCodes: evaluation.evaluation.issueCodes,
+        signals: feedback.map(\.event)
+      )
+      return resolvedAssignment(
+        cached,
+        effective: resolved,
+        evaluationDigest: evaluation.digest,
+        feedback: feedback,
+        currentState: currentState
+      )
+    }
+  }
+
+  private static func unresolvedAssignment(
+    _ cached: CachedAssignment,
+    state: TrialAssignmentState
+  ) -> TrialAssignment {
+    TrialAssignment(
+      identity: cached.identity,
+      assignedAt: cached.assignedAt,
+      state: state,
+      resolvedEvidence: nil,
+      resolvedAt: nil
+    )
+  }
+
+  private static func resolvedAssignment(
+    _ cached: CachedAssignment,
+    effective: ResolvedOutcome,
+    evaluationDigest: EvaluationDigest?,
+    feedback: [StoredFeedbackProjection],
+    currentState: JobLearningState
+  ) -> TrialAssignment {
+    let effectiveEvents = FeedbackEvent.unsuperseded(feedback.map(\.event))
+    let correction = FeedbackEvent.latestUnsupersededResult(in: effectiveEvents)
+    let correctionDigest: FeedbackEventDigest?
+    if correction?.signal == .resultCorrection {
+      correctionDigest =
+        feedback.first { stored in
+          stored.event.id == correction?.id
+        }?.source.digest
+    } else {
+      correctionDigest = nil
+    }
+    let latestRelevant = feedback.map(\.event.revision).max()
+    let revision =
+      cached.feedbackRevision.map { stored in
+        max(stored, latestRelevant ?? stored)
+      } ?? currentState.feedbackRevision
+    return TrialAssignment(
+      identity: cached.identity,
+      assignedAt: cached.assignedAt,
+      state: .learningOutcomeResolved,
+      resolvedEvidence: ResolvedRunEvidence(
+        effective: effective,
+        evaluationDigest: evaluationDigest,
+        correctionEventDigest: correctionDigest,
+        effectiveFeedbackRevision: revision
+      ),
+      resolvedAt: cached.resolvedAt
+    )
+  }
+
+  private static func strictEvidence(
+    _ db: Database,
+    runId: Int64,
+    trial: LearningTrial
+  ) throws -> StrictEvidence? {
+    guard
+      let row = try Row.fetchOne(
+        db,
+        sql: """
+          SELECT run_id, job_id, learning_epoch, evidence_digest, eligibility,
+            classifier_version, sealed_at
+          FROM learning_evidence WHERE run_id = ?
+          """,
+        arguments: [runId]
+      )
+    else {
+      return nil
+    }
+    guard
+      let storedRunId = SQLiteStoredValue.int64(in: row, column: "run_id"),
+      storedRunId == runId,
+      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
+      jobId == trial.jobId,
+      let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      LearningEpoch(epoch) == trial.epoch,
+      let digestRaw = SQLiteStoredValue.string(in: row, column: "evidence_digest"),
+      isCanonicalDigest(digestRaw),
+      let eligibilityRaw = SQLiteStoredValue.string(in: row, column: "eligibility"),
+      let eligibility = LearningEligibility(rawValue: eligibilityRaw),
+      let classifier = SQLiteStoredValue.string(in: row, column: "classifier_version"),
+      classifier == EligibilityClassifier.version,
+      let sealedRaw = SQLiteStoredValue.int64(in: row, column: "sealed_at"),
+      EpochSecondCodec.date(fromEpoch: sealedRaw) != nil
+    else {
+      throw StoreError.unexpected("assignment \(runId) has an unreadable evidence receipt")
+    }
+    return StrictEvidence(digest: EvidenceDigest(rawValue: digestRaw), eligibility: eligibility)
+  }
+
+  private static func latestEvaluatorAttempt(
+    _ db: Database,
+    trial: LearningTrial,
+    evidence: StrictEvidence
+  ) throws -> StrictAttempt? {
+    let key = LearningOperationKey(
+      jobId: trial.jobId,
+      epoch: trial.epoch,
+      phase: .evaluator,
+      sourceDigest: evidence.digest.rawValue,
+      promptVersion: EvaluatorPrompt.v1.version,
+      schemaVersion: EvaluatorOutput.currentSchemaVersion,
+      rubricVersion: EvaluatorRubric.v1.version
+    )
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT operation_id, attempt_generation, supersedes
+        FROM learning_operations
+        WHERE job_id = ? AND learning_epoch = ? AND phase = ? AND source_digest = ?
+          AND key_digest = ?
+        ORDER BY attempt_generation
+        """,
+      arguments: [
+        trial.jobId,
+        trial.epoch.value,
+        LearningPhase.evaluator.rawValue,
+        evidence.digest.rawValue,
+        key.digest.rawValue,
+      ]
+    )
+    var attempts: [StrictAttempt] = []
+    for row in rows {
+      guard
+        let idRaw = SQLiteStoredValue.string(in: row, column: "operation_id"),
+        let generation = SQLiteStoredValue.int(in: row, column: "attempt_generation"),
+        generation > 0,
+        let supersedesRaw = SQLiteStoredValue.nullableString(in: row, column: "supersedes"),
+        idRaw == LearningOperationID(key: key.digest, attemptGeneration: generation).rawValue,
+        let operation = try readOperation(db, id: LearningOperationID(rawValue: idRaw)),
+        operation.jobId == trial.jobId,
+        operation.epoch == trial.epoch,
+        operation.phase == .evaluator,
+        operation.sourceDigest == evidence.digest.rawValue,
+        operation.keyDigest == key.digest
+      else {
+        throw StoreError.unexpected("evaluator operation lineage is unreadable")
+      }
+      attempts.append(
+        StrictAttempt(
+          operation: operation,
+          generation: generation,
+          supersedes: supersedesRaw.value.map(LearningOperationID.init(rawValue:))
+        )
+      )
+    }
+    for (offset, attempt) in attempts.enumerated() {
+      guard attempt.generation == offset + 1 else {
+        throw StoreError.unexpected("evaluator operation lineage has a generation gap")
+      }
+      let expectedPredecessor = offset == 0 ? nil : attempts[offset - 1].operation.id
+      guard attempt.supersedes == expectedPredecessor else {
+        throw StoreError.unexpected("evaluator operation lineage has a broken predecessor")
+      }
+    }
+    return attempts.last
+  }
+
+  private static func strictEvaluation(
+    _ db: Database,
+    runId: Int64,
+    trial: LearningTrial,
+    evidence: StrictEvidence,
+    operation: OperationRow
+  ) throws -> StrictEvaluation {
+    let rows = try storedEvaluations(db, runId: runId)
+    guard rows.count == 1, let stored = rows.first else {
+      throw StoreError.unexpected("succeeded evaluator requires exactly one evaluation")
+    }
+    guard
+      stored.jobId == trial.jobId,
+      stored.epoch == trial.epoch,
+      stored.runId == runId,
+      stored.evidenceDigest == evidence.digest,
+      stored.evaluation.evaluator.rubricVersion == EvaluatorRubric.v1.version,
+      stored.evaluation.evaluator.promptVersion == EvaluatorPrompt.v1.version,
+      stored.evaluation.evaluator.schemaVersion == EvaluatorOutput.currentSchemaVersion,
+      let compatibility = try readCompatibility(db, runId: runId),
+      let binding = try readBinding(db, runId: runId)
+    else {
+      throw StoreError.unexpected("assignment \(runId) has an unreadable evaluation")
+    }
+    let compatibilityDigest = compatibility.digest(
+      binding: binding,
+      terminalRoute: try readTerminalRoute(db, runId: runId),
+      evaluator: stored.evaluation.evaluator
+    )
+    guard compatibilityDigest == stored.compatibilityDigest else {
+      throw StoreError.unexpected("assignment \(runId) evaluation surface does not match")
+    }
+    let expectedDigest = digest(
+      operation: operation,
+      runId: runId,
+      evaluation: stored.evaluation,
+      issueCodes: stored.issueCodesJSON,
+      compatibility: compatibilityDigest
+    )
+    guard expectedDigest == stored.digest else {
+      throw StoreError.unexpected("assignment \(runId) evaluation digest does not match")
+    }
+    return StrictEvaluation(digest: expectedDigest, evaluation: stored.evaluation)
+  }
+}

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TrialRows.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TrialRows.swift
@@ -1,0 +1,123 @@
+import ClawCore
+import Foundation
+import GRDB
+
+// MARK: - Strict Trial Rows
+
+extension ScheduledLearningStoreGRDB {
+  static func trialRow(_ db: Database, trialId: Int64) throws -> Row? {
+    try Row.fetchOne(
+      db,
+      sql: """
+        SELECT trial_id, job_id, learning_epoch, base_digest, candidate_digest, generation,
+          admitted_at, assignment_deadline, decision_deadline, max_assignments,
+          consumed_assignments, cohort_cutoff, state, close_reason, algorithm
+        FROM learning_trials WHERE trial_id = ?
+        """,
+      arguments: [trialId]
+    )
+  }
+
+  static func strictTrial(
+    _ db: Database,
+    row: Row,
+    currentState: JobLearningState?
+  ) throws -> LearningTrial {
+    guard
+      let trialId = SQLiteStoredValue.int64(in: row, column: "trial_id"),
+      trialId > 0,
+      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
+      jobId > 0,
+      let epochRaw = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      epochRaw > 0,
+      let baseRaw = SQLiteStoredValue.string(in: row, column: "base_digest"),
+      isCanonicalDigest(baseRaw),
+      let candidateRaw = SQLiteStoredValue.string(in: row, column: "candidate_digest"),
+      isCanonicalDigest(candidateRaw),
+      let generation = SQLiteStoredValue.int(in: row, column: "generation"),
+      generation > 0,
+      let admittedRaw = SQLiteStoredValue.int64(in: row, column: "admitted_at"),
+      let admittedAt = EpochSecondCodec.date(fromEpoch: admittedRaw),
+      let assignmentRaw = SQLiteStoredValue.int64(in: row, column: "assignment_deadline"),
+      let assignmentDeadline = EpochSecondCodec.date(fromEpoch: assignmentRaw),
+      let decisionRaw = SQLiteStoredValue.int64(in: row, column: "decision_deadline"),
+      let decisionDeadline = EpochSecondCodec.date(fromEpoch: decisionRaw),
+      let maximum = SQLiteStoredValue.int(in: row, column: "max_assignments"),
+      maximum == TrialAdmissionPolicy.maximumAssignments,
+      let consumed = SQLiteStoredValue.int(in: row, column: "consumed_assignments"),
+      consumed >= 0,
+      consumed <= maximum,
+      let cutoffRaw = SQLiteStoredValue.int64(in: row, column: "cohort_cutoff"),
+      let cohortCutoff = EpochSecondCodec.date(fromEpoch: cutoffRaw),
+      cohortCutoff == admittedAt,
+      assignmentDeadline
+        == admittedAt.addingTimeInterval(TrialAdmissionPolicy.assignmentWindow),
+      decisionDeadline == admittedAt.addingTimeInterval(TrialAdmissionPolicy.decisionWindow),
+      let stateRaw = SQLiteStoredValue.string(in: row, column: "state"),
+      let state = LearningTrialState(rawValue: stateRaw),
+      let closeReason = SQLiteStoredValue.nullableString(in: row, column: "close_reason"),
+      let algorithmRaw = SQLiteStoredValue.string(in: row, column: "algorithm"),
+      let algorithm = Optional(LearningAlgorithm(rawValue: algorithmRaw)),
+      algorithm == .v1
+    else {
+      throw StoreError.unexpected("learning trial row is unreadable")
+    }
+    let epoch = LearningEpoch(epochRaw)
+    let baseDigest = LessonSetDigest(rawValue: baseRaw)
+    let candidateDigest = CandidateDigest(rawValue: candidateRaw)
+    guard
+      state == .open || state == .draining || closeReason.value != nil,
+      (state == .open || state == .draining) == (closeReason.value == nil),
+      let artifact = try readCandidateArtifact(db, digest: candidateDigest),
+      artifact.manifest.jobId == jobId,
+      artifact.manifest.epoch == epoch,
+      artifact.manifest.baseDigest == baseDigest,
+      artifact.manifest.algorithm == algorithm,
+      artifact.replacement.jobId == jobId
+    else {
+      throw StoreError.unexpected("trial \(trialId) does not match its candidate artifact")
+    }
+    let admission = TrialRow(
+      id: trialId,
+      jobId: jobId,
+      epoch: epoch,
+      baseDigest: baseDigest,
+      candidateDigest: candidateDigest,
+      generation: generation,
+      state: state,
+      algorithm: algorithm
+    )
+    _ = try admissionReceipt(db, artifact: artifact, trial: admission)
+    if let currentState {
+      guard
+        currentState.jobId == jobId,
+        currentState.epoch == epoch,
+        currentState.stableDigest == baseDigest,
+        currentState.stableRevision == artifact.manifest.baseRevision
+      else {
+        throw StoreError.unexpected("live trial does not match current learning state")
+      }
+    }
+    return LearningTrial(
+      identity: LearningTrialIdentity(
+        trialId: trialId,
+        jobId: jobId,
+        epoch: epoch,
+        generation: generation
+      ),
+      baseDigest: baseDigest,
+      baseRevision: artifact.manifest.baseRevision,
+      candidateDigest: candidateDigest,
+      replacementDigest: artifact.replacement.digest,
+      algorithm: algorithm,
+      admittedAt: admittedAt,
+      cohortCutoff: cohortCutoff,
+      maxAssignments: maximum,
+      consumedAssignments: consumed,
+      assignmentDeadline: assignmentDeadline,
+      decisionDeadline: decisionDeadline,
+      state: state,
+      hardVetoes: try hardVetoes(db, artifact: artifact)
+    )
+  }
+}

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TrialSources.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+TrialSources.swift
@@ -1,0 +1,288 @@
+import ClawCore
+import Foundation
+import GRDB
+
+// MARK: - Strict Assignment Sources
+
+extension ScheduledLearningStoreGRDB {
+  struct StrictEvidence {
+    let digest: EvidenceDigest
+    let eligibility: LearningEligibility
+  }
+
+  struct StrictAttempt {
+    let operation: OperationRow
+    let generation: Int
+    let supersedes: LearningOperationID?
+  }
+
+  struct StrictEvaluation {
+    let digest: EvaluationDigest
+    let evaluation: LearningEvaluation
+  }
+
+  struct StrictEvaluatorSource {
+    let attempt: StrictAttempt?
+    let evaluation: StrictEvaluation?
+  }
+
+  static func strictEvidence(
+    _ db: Database,
+    runId: Int64,
+    trial: LearningTrial
+  ) throws -> StrictEvidence? {
+    guard let evidence = try readEvidence(db, runId: runId) else {
+      return nil
+    }
+    guard
+      evidence.jobId == trial.jobId,
+      evidence.epoch == trial.epoch
+    else {
+      throw StoreError.unexpected("assignment \(runId) has an unreadable evidence receipt")
+    }
+    return StrictEvidence(digest: evidence.digest, eligibility: evidence.eligibility)
+  }
+
+  static func strictEvaluatorSource(
+    _ db: Database,
+    runId: Int64,
+    trial: LearningTrial,
+    evidence: StrictEvidence
+  ) throws -> StrictEvaluatorSource {
+    let evaluations = try storedEvaluations(db, runId: runId)
+    guard let attempt = try latestEvaluatorAttempt(db, trial: trial, evidence: evidence) else {
+      guard evaluations.isEmpty else {
+        throw StoreError.unexpected("evaluation has no exact evaluator operation")
+      }
+      return StrictEvaluatorSource(attempt: nil, evaluation: nil)
+    }
+    guard attempt.operation.state == .succeeded else {
+      guard evaluations.isEmpty else {
+        throw StoreError.unexpected("non-succeeded evaluator operation has an evaluation")
+      }
+      return StrictEvaluatorSource(attempt: attempt, evaluation: nil)
+    }
+    guard evaluations.count == 1, let stored = evaluations.first else {
+      throw StoreError.unexpected("succeeded evaluator requires exactly one evaluation")
+    }
+    return StrictEvaluatorSource(
+      attempt: attempt,
+      evaluation: try strictEvaluation(
+        db,
+        runId: runId,
+        trial: trial,
+        evidence: evidence,
+        operation: attempt.operation,
+        stored: stored
+      )
+    )
+  }
+}
+
+// MARK: - Evaluator Operation Lineage
+
+private extension ScheduledLearningStoreGRDB {
+  static func latestEvaluatorAttempt(
+    _ db: Database,
+    trial: LearningTrial,
+    evidence: StrictEvidence
+  ) throws -> StrictAttempt? {
+    let key = exactEvaluatorKey(trial: trial, evidence: evidence)
+    let rows = try evaluatorAttemptRows(db, key: key, trial: trial, evidence: evidence)
+    var attempts: [StrictAttempt] = []
+    for row in rows {
+      guard
+        let idRaw = SQLiteStoredValue.string(in: row, column: "operation_id"),
+        let generation = SQLiteStoredValue.int(in: row, column: "attempt_generation"),
+        generation > 0,
+        let supersedesRaw = SQLiteStoredValue.nullableString(in: row, column: "supersedes"),
+        idRaw == LearningOperationID(key: key.digest, attemptGeneration: generation).rawValue,
+        let operation = try readOperation(db, id: LearningOperationID(rawValue: idRaw)),
+        operation.jobId == trial.jobId,
+        operation.epoch == trial.epoch,
+        operation.phase == .evaluator,
+        operation.sourceDigest == evidence.digest.rawValue,
+        operation.keyDigest == key.digest
+      else {
+        throw StoreError.unexpected("evaluator operation lineage is unreadable")
+      }
+      try validateEvaluatorOperation(operation)
+      attempts.append(
+        StrictAttempt(
+          operation: operation,
+          generation: generation,
+          supersedes: supersedesRaw.value.map(LearningOperationID.init(rawValue:))
+        )
+      )
+    }
+    for (offset, attempt) in attempts.enumerated() {
+      guard attempt.generation == offset + 1 else {
+        throw StoreError.unexpected("evaluator operation lineage has a generation gap")
+      }
+      let expectedPredecessor = offset == 0 ? nil : attempts[offset - 1].operation.id
+      guard attempt.supersedes == expectedPredecessor else {
+        throw StoreError.unexpected("evaluator operation lineage has a broken predecessor")
+      }
+      if offset < attempts.count - 1, attempt.operation.state != .interruptedUnknown {
+        throw StoreError.unexpected("superseded evaluator operation did not end interrupted")
+      }
+    }
+    return attempts.last
+  }
+
+  static func exactEvaluatorKey(
+    trial: LearningTrial,
+    evidence: StrictEvidence
+  ) -> LearningOperationKey {
+    LearningOperationKey(
+      jobId: trial.jobId,
+      epoch: trial.epoch,
+      phase: .evaluator,
+      sourceDigest: evidence.digest.rawValue,
+      promptVersion: EvaluatorPrompt.v1.version,
+      schemaVersion: EvaluatorOutput.currentSchemaVersion,
+      rubricVersion: EvaluatorRubric.v1.version
+    )
+  }
+
+  static func evaluatorAttemptRows(
+    _ db: Database,
+    key: LearningOperationKey,
+    trial: LearningTrial,
+    evidence: StrictEvidence
+  ) throws -> [Row] {
+    try Row.fetchAll(
+      db,
+      sql: """
+        SELECT operation_id, attempt_generation, supersedes
+        FROM learning_operations
+        WHERE key_digest = ? OR (
+          job_id = ? AND learning_epoch = ? AND phase = ? AND source_digest = ?
+        )
+        ORDER BY attempt_generation
+        """,
+      arguments: [
+        key.digest.rawValue,
+        trial.jobId,
+        trial.epoch.value,
+        LearningPhase.evaluator.rawValue,
+        evidence.digest.rawValue,
+      ]
+    )
+  }
+
+  static func validateEvaluatorOperation(_ operation: OperationRow) throws {
+    switch operation.state {
+    case .pending, .claimed:
+      guard
+        operation.failure == nil,
+        operation.carrierDigest == nil,
+        operation.route == nil,
+        operation.providerCallID == nil,
+        operation.reservedTokens == nil,
+        operation.reservedCostUSD == nil,
+        operation.reservationState == nil
+      else {
+        throw StoreError.unexpected("live evaluator operation has an invalid no-call shape")
+      }
+    case .started:
+      guard
+        operation.failure == nil,
+        let carrier = operation.carrierDigest,
+        carrier.rawValue.isEmpty == false
+      else {
+        throw StoreError.unexpected("started evaluator operation has an invalid source shape")
+      }
+      _ = try startedOperationReservation(operation)
+    case .succeeded, .interruptedUnknown:
+      guard operation.failure == nil, terminalCallShapeIsValid(operation) else {
+        throw StoreError.unexpected("terminal evaluator operation has an invalid call shape")
+      }
+    case .failed:
+      guard
+        operation.failure == .schemaInvalid || operation.failure == .providerTerminal,
+        terminalCallShapeIsValid(operation)
+      else {
+        throw StoreError.unexpected("failed evaluator operation has an invalid call shape")
+      }
+    case .failedNoCall:
+      let failureIsValid =
+        operation.failure == .budgetDenied
+        || operation.failure == .carrierPolicyDenied
+        || operation.failure == .staleEpoch
+      guard
+        failureIsValid,
+        operation.carrierDigest == nil,
+        operation.route == nil,
+        operation.providerCallID == nil,
+        operation.reservedTokens == 0,
+        operation.reservedCostUSD == 0,
+        operation.reservationState == LearningReservationState.closed.rawValue
+      else {
+        throw StoreError.unexpected("failed evaluator operation has an invalid no-call shape")
+      }
+    }
+  }
+
+  static func terminalCallShapeIsValid(_ operation: OperationRow) -> Bool {
+    guard
+      let carrier = operation.carrierDigest,
+      carrier.rawValue.isEmpty == false,
+      let route = operation.route,
+      route.isEmpty == false,
+      let providerCallID = operation.providerCallID,
+      providerCallID.rawValue.isEmpty == false
+    else {
+      return false
+    }
+    return operation.reservedTokens == 0
+      && operation.reservedCostUSD == 0
+      && operation.reservationState == LearningReservationState.closed.rawValue
+  }
+}
+
+// MARK: - Exact Evaluation
+
+private extension ScheduledLearningStoreGRDB {
+  static func strictEvaluation(
+    _ db: Database,
+    runId: Int64,
+    trial: LearningTrial,
+    evidence: StrictEvidence,
+    operation: OperationRow,
+    stored: StoredEvaluationProjection
+  ) throws -> StrictEvaluation {
+    guard
+      stored.jobId == trial.jobId,
+      stored.epoch == trial.epoch,
+      stored.runId == runId,
+      stored.evidenceDigest == evidence.digest,
+      stored.evaluation.evaluator.rubricVersion == EvaluatorRubric.v1.version,
+      stored.evaluation.evaluator.promptVersion == EvaluatorPrompt.v1.version,
+      stored.evaluation.evaluator.schemaVersion == EvaluatorOutput.currentSchemaVersion,
+      let compatibility = try readCompatibility(db, runId: runId),
+      let binding = try readBinding(db, runId: runId)
+    else {
+      throw StoreError.unexpected("assignment \(runId) has an unreadable evaluation")
+    }
+    let compatibilityDigest = compatibility.digest(
+      binding: binding,
+      terminalRoute: try readTerminalRoute(db, runId: runId),
+      evaluator: stored.evaluation.evaluator
+    )
+    guard compatibilityDigest == stored.compatibilityDigest else {
+      throw StoreError.unexpected("assignment \(runId) evaluation surface does not match")
+    }
+    let expectedDigest = digest(
+      operation: operation,
+      runId: runId,
+      evaluation: stored.evaluation,
+      issueCodes: stored.issueCodesJSON,
+      compatibility: compatibilityDigest
+    )
+    guard expectedDigest == stored.digest else {
+      throw StoreError.unexpected("assignment \(runId) evaluation digest does not match")
+    }
+    return StrictEvaluation(digest: expectedDigest, evaluation: stored.evaluation)
+  }
+}

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+View.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+View.swift
@@ -154,7 +154,7 @@ private extension ScheduledLearningStoreGRDB {
       state.epoch.value > 0,
       state.stableRevision.value >= 0,
       state.feedbackRevision.value >= 0,
-      isDigest(state.stableDigest.rawValue),
+      isCanonicalDigest(state.stableDigest.rawValue),
       let stable = try readLessonSet(db, jobId: job.jobId, digest: state.stableDigest),
       stable.jobId == job.jobId,
       stable.digest == state.stableDigest
@@ -368,7 +368,7 @@ private extension ScheduledLearningStoreGRDB {
       && row.generation > 0
       && row.algorithm == .v1
       && (row.state == .open || row.state == .draining)
-      && isDigest(row.candidateDigest.rawValue)
+      && isCanonicalDigest(row.candidateDigest.rawValue)
       && trial.maximumAssignments == TrialAdmissionPolicy.maximumAssignments
       && trial.consumedAssignments >= 0
       && trial.consumedAssignments <= trial.maximumAssignments
@@ -562,9 +562,9 @@ private extension ScheduledLearningStoreGRDB {
       let inputs: ReflectionNoCandidateInputs = try decodeCanonicalDecision(record.inputsJSON)
       let result: ReflectionNoCandidateReceipt = try decodeCanonicalDecision(record.resultJSON)
       guard
-        isDigest(inputs.triggerDigest.rawValue),
-        isDigest(inputs.carrierDigest.rawValue),
-        isDigest(result.resultDigest.rawValue),
+        isCanonicalDigest(inputs.triggerDigest.rawValue),
+        isCanonicalDigest(inputs.carrierDigest.rawValue),
+        isCanonicalDigest(result.resultDigest.rawValue),
         let operation = try readOperation(db, id: inputs.operationId),
         operation.jobId == state.jobId,
         operation.epoch == state.epoch,
@@ -597,12 +597,5 @@ private extension ScheduledLearningStoreGRDB {
     default:
       throw ViewCorruption.invalid
     }
-  }
-
-  static func isDigest(_ value: String) -> Bool {
-    value.utf8.count == 64
-      && value.utf8.allSatisfy { byte in
-        (48...57).contains(byte) || (97...102).contains(byte)
-      }
   }
 }

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+View.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+View.swift
@@ -27,10 +27,11 @@ extension ScheduledLearningStoreGRDB {
 private extension ScheduledLearningStoreGRDB {
   struct ViewJobRow {
     let jobId: Int64
-    let label: String
-    let status: String
-    let timezone: String
+    let label: String?
+    let status: String?
+    let timezone: String?
     let hasRecurrence: Bool
+    let primitivesAreValid: Bool
   }
 
   enum ViewCorruption: Error {
@@ -41,13 +42,16 @@ private extension ScheduledLearningStoreGRDB {
     let rows = try Row.fetchAll(
       db,
       sql: """
-        SELECT job.id, job.label, job.status, job.timezone, job.recurrence
+        SELECT state.job_id AS selected_job_id, job.id, job.label, job.status, job.timezone,
+          job.recurrence
         FROM job_learning_state AS state
         JOIN scheduled_jobs AS job ON job.id = state.job_id
         ORDER BY job.id
         """
     )
-    return rows.map(viewJob(row:))
+    return rows.map { row in
+      viewJob(row: row, requestedJobId: nil)
+    }
   }
 
   static func viewJob(_ db: Database, jobId: Int64) throws -> ViewJobRow? {
@@ -58,23 +62,37 @@ private extension ScheduledLearningStoreGRDB {
         FROM scheduled_jobs WHERE id = ?
         """,
       arguments: [jobId]
-    ).map(viewJob(row:))
+    ).map { row in
+      viewJob(row: row, requestedJobId: jobId)
+    }
   }
 
-  static func viewJob(row: Row) -> ViewJobRow {
-    ViewJobRow(
-      jobId: row["id"],
-      label: row["label"],
-      status: row["status"],
-      timezone: row["timezone"],
-      hasRecurrence: (row["recurrence"] as String?) != nil
+  static func viewJob(row: Row, requestedJobId: Int64?) -> ViewJobRow {
+    let storedJobId = SQLiteStoredValue.int64(in: row, column: "id")
+    let selectedJobId = SQLiteStoredValue.int64(in: row, column: "selected_job_id")
+    let jobId = requestedJobId ?? selectedJobId ?? storedJobId ?? 0
+    let label = SQLiteStoredValue.string(in: row, column: "label")
+    let status = SQLiteStoredValue.string(in: row, column: "status")
+    let timezone = SQLiteStoredValue.string(in: row, column: "timezone")
+    let recurrence = SQLiteStoredValue.nullableString(in: row, column: "recurrence")
+    return ViewJobRow(
+      jobId: jobId,
+      label: label,
+      status: status,
+      timezone: timezone,
+      hasRecurrence: recurrence?.value != nil,
+      primitivesAreValid: storedJobId == jobId
+        && label != nil
+        && status != nil
+        && timezone != nil
+        && recurrence != nil
     )
   }
 
   static func view(_ db: Database, job: ViewJobRow) throws -> JobLearningView {
     let fallback = UnreadableLearningJob(
       jobId: job.jobId,
-      validatedLabel: validatedLabel(job.label)
+      validatedLabel: job.label.flatMap(validatedLabel)
     )
     do {
       let identity = try jobIdentity(job)
@@ -94,10 +112,14 @@ private extension ScheduledLearningStoreGRDB {
 
   static func jobIdentity(_ row: ViewJobRow) throws -> LearningJobIdentity {
     guard
+      row.primitivesAreValid,
       row.jobId > 0,
-      let label = validatedLabel(row.label),
-      let status = ScheduledJobStatus(rawValue: row.status),
-      TimeZone(identifier: row.timezone) != nil
+      let rawLabel = row.label,
+      let label = validatedLabel(rawLabel),
+      let rawStatus = row.status,
+      let status = ScheduledJobStatus(rawValue: rawStatus),
+      let timezone = row.timezone,
+      TimeZone(identifier: timezone) != nil
     else {
       throw ViewCorruption.invalid
     }
@@ -105,7 +127,7 @@ private extension ScheduledLearningStoreGRDB {
       jobId: row.jobId,
       label: label,
       status: status,
-      timezone: row.timezone
+      timezone: timezone
     )
   }
 
@@ -202,7 +224,12 @@ private extension ScheduledLearningStoreGRDB {
     guard let row = rows.first else {
       return nil
     }
-    guard job.hasRecurrence else {
+    guard
+      job.hasRecurrence,
+      let rawStatus = job.status,
+      let status = ScheduledJobStatus(rawValue: rawStatus),
+      status == .active || status == .paused
+    else {
       throw ViewCorruption.invalid
     }
     let trial = try liveTrialProjection(row)
@@ -229,34 +256,48 @@ private extension ScheduledLearningStoreGRDB {
 
   static func liveTrialProjection(_ row: Row) throws -> LiveTrialProjection {
     guard
-      let state = LearningTrialState(rawValue: row["state"]),
-      let admittedAt = EpochSecondCodec.date(fromEpoch: row["admitted_at"]),
-      let assignmentDeadline = EpochSecondCodec.date(fromEpoch: row["assignment_deadline"]),
-      let decisionDeadline = EpochSecondCodec.date(fromEpoch: row["decision_deadline"]),
-      let cohortCutoff = EpochSecondCodec.date(fromEpoch: row["cohort_cutoff"])
+      let trialId = SQLiteStoredValue.int64(in: row, column: "trial_id"),
+      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
+      let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      let baseDigest = SQLiteStoredValue.string(in: row, column: "base_digest"),
+      let candidateDigest = SQLiteStoredValue.string(in: row, column: "candidate_digest"),
+      let generation = SQLiteStoredValue.int(in: row, column: "generation"),
+      let stateRaw = SQLiteStoredValue.string(in: row, column: "state"),
+      let state = LearningTrialState(rawValue: stateRaw),
+      let admittedEpoch = SQLiteStoredValue.int64(in: row, column: "admitted_at"),
+      let admittedAt = EpochSecondCodec.date(fromEpoch: admittedEpoch),
+      let assignmentEpoch = SQLiteStoredValue.int64(in: row, column: "assignment_deadline"),
+      let assignmentDeadline = EpochSecondCodec.date(fromEpoch: assignmentEpoch),
+      let decisionEpoch = SQLiteStoredValue.int64(in: row, column: "decision_deadline"),
+      let decisionDeadline = EpochSecondCodec.date(fromEpoch: decisionEpoch),
+      let maximumAssignments = SQLiteStoredValue.int(in: row, column: "max_assignments"),
+      let consumedAssignments = SQLiteStoredValue.int(in: row, column: "consumed_assignments"),
+      let cutoffEpoch = SQLiteStoredValue.int64(in: row, column: "cohort_cutoff"),
+      let cohortCutoff = EpochSecondCodec.date(fromEpoch: cutoffEpoch),
+      let closeReason = SQLiteStoredValue.nullableString(in: row, column: "close_reason"),
+      let algorithmRaw = SQLiteStoredValue.string(in: row, column: "algorithm")
     else {
       throw ViewCorruption.invalid
     }
-    let algorithm = LearningAlgorithm(rawValue: row["algorithm"])
     let trialRow = TrialRow(
-      id: row["trial_id"],
-      jobId: row["job_id"],
-      epoch: LearningEpoch(row["learning_epoch"]),
-      baseDigest: LessonSetDigest(rawValue: row["base_digest"]),
-      candidateDigest: CandidateDigest(rawValue: row["candidate_digest"]),
-      generation: row["generation"],
+      id: trialId,
+      jobId: jobId,
+      epoch: LearningEpoch(epoch),
+      baseDigest: LessonSetDigest(rawValue: baseDigest),
+      candidateDigest: CandidateDigest(rawValue: candidateDigest),
+      generation: generation,
       state: state,
-      algorithm: algorithm
+      algorithm: LearningAlgorithm(rawValue: algorithmRaw)
     )
     return LiveTrialProjection(
       row: trialRow,
       admittedAt: admittedAt,
       assignmentDeadline: assignmentDeadline,
       decisionDeadline: decisionDeadline,
-      maximumAssignments: row["max_assignments"],
-      consumedAssignments: row["consumed_assignments"],
+      maximumAssignments: maximumAssignments,
+      consumedAssignments: consumedAssignments,
       cohortCutoff: cohortCutoff,
-      closeReason: row["close_reason"]
+      closeReason: closeReason.value
     )
   }
 
@@ -267,23 +308,7 @@ private extension ScheduledLearningStoreGRDB {
   ) throws -> LearningTrialView {
     let row = trial.row
     guard
-      row.id > 0,
-      row.jobId == state.jobId,
-      row.epoch == state.epoch,
-      row.baseDigest == state.stableDigest,
-      row.generation > 0,
-      row.algorithm == .v1,
-      row.state == .open || row.state == .draining,
-      isDigest(row.candidateDigest.rawValue),
-      trial.maximumAssignments == TrialAdmissionPolicy.maximumAssignments,
-      trial.consumedAssignments >= 0,
-      trial.consumedAssignments <= trial.maximumAssignments,
-      trial.cohortCutoff == trial.admittedAt,
-      trial.assignmentDeadline
-        == trial.admittedAt.addingTimeInterval(TrialAdmissionPolicy.assignmentWindow),
-      trial.decisionDeadline
-        == trial.admittedAt.addingTimeInterval(TrialAdmissionPolicy.decisionWindow),
-      trial.closeReason == nil,
+      trialMetadataMatches(trial, state: state),
       let artifact = try readCandidateArtifact(db, digest: row.candidateDigest),
       artifact.manifest.jobId == state.jobId,
       artifact.manifest.epoch == state.epoch,
@@ -331,6 +356,30 @@ private extension ScheduledLearningStoreGRDB {
     )
   }
 
+  static func trialMetadataMatches(
+    _ trial: LiveTrialProjection,
+    state: JobLearningState
+  ) -> Bool {
+    let row = trial.row
+    return row.id > 0
+      && row.jobId == state.jobId
+      && row.epoch == state.epoch
+      && row.baseDigest == state.stableDigest
+      && row.generation > 0
+      && row.algorithm == .v1
+      && (row.state == .open || row.state == .draining)
+      && isDigest(row.candidateDigest.rawValue)
+      && trial.maximumAssignments == TrialAdmissionPolicy.maximumAssignments
+      && trial.consumedAssignments >= 0
+      && trial.consumedAssignments <= trial.maximumAssignments
+      && trial.cohortCutoff == trial.admittedAt
+      && trial.assignmentDeadline
+        == trial.admittedAt.addingTimeInterval(TrialAdmissionPolicy.assignmentWindow)
+      && trial.decisionDeadline
+        == trial.admittedAt.addingTimeInterval(TrialAdmissionPolicy.decisionWindow)
+      && trial.closeReason == nil
+  }
+
   static func validateCreatedAssignments(
     _ db: Database,
     trial: TrialRow,
@@ -355,29 +404,66 @@ private extension ScheduledLearningStoreGRDB {
       arguments: [trial.id]
     )
     for row in rows {
-      guard
-        (row["job_id"] as Int64) == trial.jobId,
-        LearningEpoch(row["learning_epoch"] as Int64) == trial.epoch,
-        (row["trial_generation"] as Int) == trial.generation,
-        (row["state"] as String) == TrialAssignmentState.created.rawValue,
-        (row["outcome"] as String?) == nil,
-        (row["issue_codes"] as String?) == nil,
-        (row["evaluation_digest"] as String?) == nil,
-        row["evaluation_required"] as Bool,
-        (row["effective_feedback_revision"] as Int64?) == nil,
-        (row["resolved_at"] as Int64?) == nil,
-        (row["binding_run_id"] as Int64?) == row["run_id"] as Int64,
-        (row["binding_job_id"] as Int64?) == trial.jobId,
-        (row["binding_epoch"] as Int64?) == trial.epoch.value,
-        (row["stable_digest"] as String?) == trial.baseDigest.rawValue,
-        (row["effective_digest"] as String?) == replacement.rawValue,
-        (row["trial_id"] as Int64?) == trial.id,
-        (row["binding_generation"] as Int?) == trial.generation
-      else {
+      guard createdAssignmentMatches(row, trial: trial, replacement: replacement) else {
         throw ViewCorruption.invalid
       }
     }
     return rows.count
+  }
+
+  static func createdAssignmentMatches(
+    _ row: Row,
+    trial: TrialRow,
+    replacement: LessonSetDigest
+  ) -> Bool {
+    guard
+      let runId = SQLiteStoredValue.int64(in: row, column: "run_id"),
+      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
+      jobId == trial.jobId,
+      let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      LearningEpoch(epoch) == trial.epoch,
+      let generation = SQLiteStoredValue.int(in: row, column: "trial_generation"),
+      generation == trial.generation,
+      let state = SQLiteStoredValue.string(in: row, column: "state"),
+      state == TrialAssignmentState.created.rawValue,
+      let outcome = SQLiteStoredValue.nullableString(in: row, column: "outcome"),
+      outcome.value == nil,
+      let issueCodes = SQLiteStoredValue.nullableString(in: row, column: "issue_codes"),
+      issueCodes.value == nil,
+      let evaluation = SQLiteStoredValue.nullableString(in: row, column: "evaluation_digest"),
+      evaluation.value == nil,
+      SQLiteStoredValue.boolean(in: row, column: "evaluation_required") == .trueValue,
+      let feedback = SQLiteStoredValue.nullableInt64(
+        in: row,
+        column: "effective_feedback_revision"
+      ),
+      feedback.value == nil,
+      let resolvedAt = SQLiteStoredValue.nullableInt64(in: row, column: "resolved_at"),
+      resolvedAt.value == nil,
+      let bindingRun = SQLiteStoredValue.nullableInt64(in: row, column: "binding_run_id"),
+      bindingRun.value == runId,
+      let bindingJob = SQLiteStoredValue.nullableInt64(in: row, column: "binding_job_id"),
+      bindingJob.value == trial.jobId,
+      let bindingEpoch = SQLiteStoredValue.nullableInt64(in: row, column: "binding_epoch"),
+      bindingEpoch.value == trial.epoch.value,
+      let stableDigest = SQLiteStoredValue.nullableString(in: row, column: "stable_digest"),
+      stableDigest.value == trial.baseDigest.rawValue,
+      let effectiveDigest = SQLiteStoredValue.nullableString(
+        in: row,
+        column: "effective_digest"
+      ),
+      effectiveDigest.value == replacement.rawValue,
+      let bindingTrial = SQLiteStoredValue.nullableInt64(in: row, column: "trial_id"),
+      bindingTrial.value == trial.id,
+      let bindingGeneration = SQLiteStoredValue.nullableInt(
+        in: row,
+        column: "binding_generation"
+      ),
+      bindingGeneration.value == trial.generation
+    else {
+      return false
+    }
+    return true
   }
 }
 
@@ -404,28 +490,34 @@ private extension ScheduledLearningStoreGRDB {
       return nil
     }
     guard
-      let decidedAt = EpochSecondCodec.date(fromEpoch: row["decided_at"]),
-      (row["decision_id"] as Int64) > 0,
-      (row["job_id"] as Int64) == state.jobId,
-      LearningEpoch(row["learning_epoch"] as Int64) == state.epoch
+      let decisionId = SQLiteStoredValue.int64(in: row, column: "decision_id"),
+      decisionId > 0,
+      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
+      jobId == state.jobId,
+      let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      LearningEpoch(epoch) == state.epoch,
+      let algorithmRaw = SQLiteStoredValue.string(in: row, column: "algorithm"),
+      let kind = SQLiteStoredValue.string(in: row, column: "kind"),
+      let inputsJSON = SQLiteStoredValue.string(in: row, column: "inputs"),
+      let resultJSON = SQLiteStoredValue.string(in: row, column: "result"),
+      let decidedEpoch = SQLiteStoredValue.int64(in: row, column: "decided_at"),
+      let decidedAt = EpochSecondCodec.date(fromEpoch: decidedEpoch)
     else {
       throw ViewCorruption.invalid
     }
-    let algorithm = LearningAlgorithm(rawValue: row["algorithm"])
+    let algorithm = LearningAlgorithm(rawValue: algorithmRaw)
     guard algorithm == .v1 else {
       throw ViewCorruption.invalid
     }
-    let inputsJSON: String = row["inputs"]
-    let resultJSON: String = row["result"]
     let detail = try decisionDetail(
       db,
-      kind: row["kind"],
+      kind: kind,
       inputsJSON: inputsJSON,
       resultJSON: resultJSON,
       state: state
     )
     return LearningDecisionView(
-      decisionId: row["decision_id"],
+      decisionId: decisionId,
       jobId: state.jobId,
       epoch: state.epoch,
       algorithm: algorithm,

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+View.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+View.swift
@@ -383,6 +383,17 @@ private extension ScheduledLearningStoreGRDB {
     state: JobLearningState
   ) throws -> LearningDecisionDetail {
     switch record.kind {
+    case LearningDecisionKind.trial.rawValue, LearningDecisionKind.rollback.rawValue:
+      let inputs: TrialDecisionInputs = try decodeCanonicalDecision(record.inputsJSON)
+      let result: LearningDecisionRecord = try decodeCanonicalDecision(record.resultJSON)
+      guard inputs.identity.jobId == state.jobId, inputs.identity.epoch == state.epoch,
+        inputs.algorithm == record.algorithm
+      else {
+        throw ViewCorruption.invalid
+      }
+      return .terminal(
+        DecisionReceipt(decisionId: record.decisionId, inputs: inputs, record: result)
+      )
     case AdmissionReceipt.kind:
       let inputs: AdmissionDecisionInputs = try decodeCanonicalDecision(record.inputsJSON)
       let result: AdmissionReceipt = try decodeCanonicalDecision(record.resultJSON)

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+View.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+View.swift
@@ -183,17 +183,6 @@ private extension ScheduledLearningStoreGRDB {
 // MARK: - Trial Projection
 
 private extension ScheduledLearningStoreGRDB {
-  struct LiveTrialProjection {
-    let row: TrialRow
-    let admittedAt: Date
-    let assignmentDeadline: Date
-    let decisionDeadline: Date
-    let maximumAssignments: Int
-    let consumedAssignments: Int
-    let cohortCutoff: Date
-    let closeReason: String?
-  }
-
   static func liveTrialView(
     _ db: Database,
     job: ViewJobRow,
@@ -232,8 +221,11 @@ private extension ScheduledLearningStoreGRDB {
     else {
       throw ViewCorruption.invalid
     }
-    let trial = try liveTrialProjection(row)
-    return try validateTrial(db, trial: trial, state: state)
+    let trial = try strictTrial(db, row: row, currentState: state)
+    guard trial.state == .open || trial.state == .draining else {
+      throw ViewCorruption.invalid
+    }
+    return try projectedTrialView(db, trial: trial, state: state)
   }
 
   static func currentEpochHasOnlyKnownTrialStates(
@@ -254,216 +246,64 @@ private extension ScheduledLearningStoreGRDB {
     ) ?? false
   }
 
-  static func liveTrialProjection(_ row: Row) throws -> LiveTrialProjection {
-    guard
-      let trialId = SQLiteStoredValue.int64(in: row, column: "trial_id"),
-      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
-      let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
-      let baseDigest = SQLiteStoredValue.string(in: row, column: "base_digest"),
-      let candidateDigest = SQLiteStoredValue.string(in: row, column: "candidate_digest"),
-      let generation = SQLiteStoredValue.int(in: row, column: "generation"),
-      let stateRaw = SQLiteStoredValue.string(in: row, column: "state"),
-      let state = LearningTrialState(rawValue: stateRaw),
-      let admittedEpoch = SQLiteStoredValue.int64(in: row, column: "admitted_at"),
-      let admittedAt = EpochSecondCodec.date(fromEpoch: admittedEpoch),
-      let assignmentEpoch = SQLiteStoredValue.int64(in: row, column: "assignment_deadline"),
-      let assignmentDeadline = EpochSecondCodec.date(fromEpoch: assignmentEpoch),
-      let decisionEpoch = SQLiteStoredValue.int64(in: row, column: "decision_deadline"),
-      let decisionDeadline = EpochSecondCodec.date(fromEpoch: decisionEpoch),
-      let maximumAssignments = SQLiteStoredValue.int(in: row, column: "max_assignments"),
-      let consumedAssignments = SQLiteStoredValue.int(in: row, column: "consumed_assignments"),
-      let cutoffEpoch = SQLiteStoredValue.int64(in: row, column: "cohort_cutoff"),
-      let cohortCutoff = EpochSecondCodec.date(fromEpoch: cutoffEpoch),
-      let closeReason = SQLiteStoredValue.nullableString(in: row, column: "close_reason"),
-      let algorithmRaw = SQLiteStoredValue.string(in: row, column: "algorithm")
-    else {
-      throw ViewCorruption.invalid
-    }
-    let trialRow = TrialRow(
-      id: trialId,
-      jobId: jobId,
-      epoch: LearningEpoch(epoch),
-      baseDigest: LessonSetDigest(rawValue: baseDigest),
-      candidateDigest: CandidateDigest(rawValue: candidateDigest),
-      generation: generation,
-      state: state,
-      algorithm: LearningAlgorithm(rawValue: algorithmRaw)
-    )
-    return LiveTrialProjection(
-      row: trialRow,
-      admittedAt: admittedAt,
-      assignmentDeadline: assignmentDeadline,
-      decisionDeadline: decisionDeadline,
-      maximumAssignments: maximumAssignments,
-      consumedAssignments: consumedAssignments,
-      cohortCutoff: cohortCutoff,
-      closeReason: closeReason.value
-    )
-  }
-
-  static func validateTrial(
+  static func projectedTrialView(
     _ db: Database,
-    trial: LiveTrialProjection,
+    trial: LearningTrial,
     state: JobLearningState
   ) throws -> LearningTrialView {
-    let row = trial.row
+    let runIds = try assignmentRunIds(db, trialId: trial.trialId)
     guard
-      trialMetadataMatches(trial, state: state),
-      let artifact = try readCandidateArtifact(db, digest: row.candidateDigest),
-      artifact.manifest.jobId == state.jobId,
-      artifact.manifest.epoch == state.epoch,
-      artifact.manifest.baseDigest == state.stableDigest,
-      artifact.manifest.baseRevision == state.stableRevision,
-      artifact.manifest.algorithm == .v1,
-      artifact.replacement.jobId == state.jobId
+      runIds.count == trial.consumedAssignments,
+      Set(runIds).count == runIds.count
     else {
       throw ViewCorruption.invalid
     }
-    let receipt = try admissionReceipt(db, artifact: artifact, trial: row)
-    guard
-      receipt.candidateDigest == row.candidateDigest,
-      receipt.replacementDigest == artifact.replacement.digest,
-      receipt.trialId == row.id,
-      receipt.generation == row.generation
-    else {
-      throw ViewCorruption.invalid
+    var positive = 0
+    var negative = 0
+    var neutral = 0
+    var unresolved = 0
+    for runId in runIds {
+      let assignment = try authoritativeAssignment(
+        db,
+        runId: runId,
+        trial: trial,
+        currentState: state
+      )
+      switch assignment.resolvedEvidence?.outcome {
+      case .positive:
+        positive += 1
+      case .negative:
+        negative += 1
+      case .neutral:
+        neutral += 1
+      case nil:
+        unresolved += 1
+      }
     }
-    let unresolved = try validateCreatedAssignments(
-      db,
-      trial: row,
-      replacement: artifact.replacement.digest
-    )
-    guard unresolved == trial.consumedAssignments else {
+    guard positive + negative + neutral + unresolved == trial.consumedAssignments else {
       throw ViewCorruption.invalid
     }
     let counts = LearningTrialCounts(
       consumed: trial.consumedAssignments,
-      maximum: trial.maximumAssignments,
+      maximum: trial.maxAssignments,
+      positive: positive,
+      negative: negative,
+      neutral: neutral,
       unresolved: unresolved
     )
     return LearningTrialView(
-      trialId: row.id,
-      epoch: row.epoch,
-      generation: row.generation,
-      state: row.state,
-      candidateDigest: row.candidateDigest,
-      baseDigest: row.baseDigest,
-      baseRevision: artifact.manifest.baseRevision,
-      replacementDigest: artifact.replacement.digest,
+      trialId: trial.trialId,
+      epoch: trial.epoch,
+      generation: trial.generation,
+      state: trial.state,
+      candidateDigest: trial.candidateDigest,
+      baseDigest: trial.baseDigest,
+      baseRevision: trial.baseRevision,
+      replacementDigest: trial.replacementDigest,
       counts: counts,
       assignmentDeadline: trial.assignmentDeadline,
       decisionDeadline: trial.decisionDeadline
     )
-  }
-
-  static func trialMetadataMatches(
-    _ trial: LiveTrialProjection,
-    state: JobLearningState
-  ) -> Bool {
-    let row = trial.row
-    return row.id > 0
-      && row.jobId == state.jobId
-      && row.epoch == state.epoch
-      && row.baseDigest == state.stableDigest
-      && row.generation > 0
-      && row.algorithm == .v1
-      && (row.state == .open || row.state == .draining)
-      && isCanonicalDigest(row.candidateDigest.rawValue)
-      && trial.maximumAssignments == TrialAdmissionPolicy.maximumAssignments
-      && trial.consumedAssignments >= 0
-      && trial.consumedAssignments <= trial.maximumAssignments
-      && trial.cohortCutoff == trial.admittedAt
-      && trial.assignmentDeadline
-        == trial.admittedAt.addingTimeInterval(TrialAdmissionPolicy.assignmentWindow)
-      && trial.decisionDeadline
-        == trial.admittedAt.addingTimeInterval(TrialAdmissionPolicy.decisionWindow)
-      && trial.closeReason == nil
-  }
-
-  static func validateCreatedAssignments(
-    _ db: Database,
-    trial: TrialRow,
-    replacement: LessonSetDigest
-  ) throws -> Int {
-    let rows = try Row.fetchAll(
-      db,
-      sql: """
-        SELECT assignment.run_id, assignment.job_id, assignment.learning_epoch,
-          assignment.trial_generation, assignment.state, assignment.outcome,
-          assignment.issue_codes, assignment.evaluation_digest,
-          assignment.evaluation_required, assignment.effective_feedback_revision,
-          assignment.resolved_at, binding.run_id AS binding_run_id,
-          binding.job_id AS binding_job_id, binding.learning_epoch AS binding_epoch,
-          binding.stable_digest, binding.effective_digest, binding.trial_id,
-          binding.trial_generation AS binding_generation
-        FROM trial_assignments AS assignment
-        LEFT JOIN run_learning_bindings AS binding ON binding.run_id = assignment.run_id
-        WHERE assignment.trial_id = ?
-        ORDER BY assignment.run_id
-        """,
-      arguments: [trial.id]
-    )
-    for row in rows {
-      guard createdAssignmentMatches(row, trial: trial, replacement: replacement) else {
-        throw ViewCorruption.invalid
-      }
-    }
-    return rows.count
-  }
-
-  static func createdAssignmentMatches(
-    _ row: Row,
-    trial: TrialRow,
-    replacement: LessonSetDigest
-  ) -> Bool {
-    guard
-      let runId = SQLiteStoredValue.int64(in: row, column: "run_id"),
-      let jobId = SQLiteStoredValue.int64(in: row, column: "job_id"),
-      jobId == trial.jobId,
-      let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
-      LearningEpoch(epoch) == trial.epoch,
-      let generation = SQLiteStoredValue.int(in: row, column: "trial_generation"),
-      generation == trial.generation,
-      let state = SQLiteStoredValue.string(in: row, column: "state"),
-      state == TrialAssignmentState.created.rawValue,
-      let outcome = SQLiteStoredValue.nullableString(in: row, column: "outcome"),
-      outcome.value == nil,
-      let issueCodes = SQLiteStoredValue.nullableString(in: row, column: "issue_codes"),
-      issueCodes.value == nil,
-      let evaluation = SQLiteStoredValue.nullableString(in: row, column: "evaluation_digest"),
-      evaluation.value == nil,
-      SQLiteStoredValue.boolean(in: row, column: "evaluation_required") == .trueValue,
-      let feedback = SQLiteStoredValue.nullableInt64(
-        in: row,
-        column: "effective_feedback_revision"
-      ),
-      feedback.value == nil,
-      let resolvedAt = SQLiteStoredValue.nullableInt64(in: row, column: "resolved_at"),
-      resolvedAt.value == nil,
-      let bindingRun = SQLiteStoredValue.nullableInt64(in: row, column: "binding_run_id"),
-      bindingRun.value == runId,
-      let bindingJob = SQLiteStoredValue.nullableInt64(in: row, column: "binding_job_id"),
-      bindingJob.value == trial.jobId,
-      let bindingEpoch = SQLiteStoredValue.nullableInt64(in: row, column: "binding_epoch"),
-      bindingEpoch.value == trial.epoch.value,
-      let stableDigest = SQLiteStoredValue.nullableString(in: row, column: "stable_digest"),
-      stableDigest.value == trial.baseDigest.rawValue,
-      let effectiveDigest = SQLiteStoredValue.nullableString(
-        in: row,
-        column: "effective_digest"
-      ),
-      effectiveDigest.value == replacement.rawValue,
-      let bindingTrial = SQLiteStoredValue.nullableInt64(in: row, column: "trial_id"),
-      bindingTrial.value == trial.id,
-      let bindingGeneration = SQLiteStoredValue.nullableInt(
-        in: row,
-        column: "binding_generation"
-      ),
-      bindingGeneration.value == trial.generation
-    else {
-      return false
-    }
-    return true
   }
 }
 

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+View.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+View.swift
@@ -470,6 +470,15 @@ private extension ScheduledLearningStoreGRDB {
 // MARK: - Decision Projection
 
 private extension ScheduledLearningStoreGRDB {
+  struct ViewDecisionRecord {
+    let decisionId: Int64
+    let kind: String
+    let inputsJSON: String
+    let resultJSON: String
+    let algorithm: LearningAlgorithm
+    let decidedAt: Date
+  }
+
   static func lastDecisionView(
     _ db: Database,
     state: JobLearningState
@@ -509,34 +518,34 @@ private extension ScheduledLearningStoreGRDB {
     guard algorithm == .v1 else {
       throw ViewCorruption.invalid
     }
-    let detail = try decisionDetail(
-      db,
+    let record = ViewDecisionRecord(
+      decisionId: decisionId,
       kind: kind,
       inputsJSON: inputsJSON,
       resultJSON: resultJSON,
-      state: state
+      algorithm: algorithm,
+      decidedAt: decidedAt
     )
+    let detail = try decisionDetail(db, record: record, state: state)
     return LearningDecisionView(
-      decisionId: decisionId,
+      decisionId: record.decisionId,
       jobId: state.jobId,
       epoch: state.epoch,
-      algorithm: algorithm,
-      decidedAt: decidedAt,
+      algorithm: record.algorithm,
+      decidedAt: record.decidedAt,
       detail: detail
     )
   }
 
   static func decisionDetail(
     _ db: Database,
-    kind: String,
-    inputsJSON: String,
-    resultJSON: String,
+    record: ViewDecisionRecord,
     state: JobLearningState
   ) throws -> LearningDecisionDetail {
-    switch kind {
+    switch record.kind {
     case AdmissionReceipt.kind:
-      let inputs: AdmissionDecisionInputs = try decodeCanonical(inputsJSON)
-      let result: AdmissionReceipt = try decodeCanonical(resultJSON)
+      let inputs: AdmissionDecisionInputs = try decodeCanonicalDecision(record.inputsJSON)
+      let result: AdmissionReceipt = try decodeCanonicalDecision(record.resultJSON)
       guard
         inputs.candidateDigest == result.candidateDigest,
         let artifact = try readCandidateArtifact(db, digest: inputs.candidateDigest),
@@ -550,8 +559,8 @@ private extension ScheduledLearningStoreGRDB {
       }
       return .candidateAdmission(inputs: inputs, result: result)
     case ReflectionNoCandidateReceipt.kind:
-      let inputs: ReflectionNoCandidateInputs = try decodeCanonical(inputsJSON)
-      let result: ReflectionNoCandidateReceipt = try decodeCanonical(resultJSON)
+      let inputs: ReflectionNoCandidateInputs = try decodeCanonicalDecision(record.inputsJSON)
+      let result: ReflectionNoCandidateReceipt = try decodeCanonicalDecision(record.resultJSON)
       guard
         isDigest(inputs.triggerDigest.rawValue),
         isDigest(inputs.carrierDigest.rawValue),
@@ -567,21 +576,27 @@ private extension ScheduledLearningStoreGRDB {
         throw ViewCorruption.invalid
       }
       return .reflectionNoCandidate(inputs: inputs, result: result)
+    case ResetReceipt.kind:
+      guard
+        let receipt = try resetReceipt(
+          db,
+          record: ResetDecisionRecord(
+            decisionId: record.decisionId,
+            jobId: state.jobId,
+            epoch: state.epoch,
+            inputsJSON: record.inputsJSON,
+            resultJSON: record.resultJSON,
+            algorithm: record.algorithm,
+            decidedAt: record.decidedAt
+          )
+        )
+      else {
+        throw ViewCorruption.invalid
+      }
+      return .learningReset(inputs: receipt.inputs, result: receipt.result)
     default:
       throw ViewCorruption.invalid
     }
-  }
-
-  static func decodeCanonical<Value: Codable>(_ json: String) throws -> Value {
-    let bytes = Data(json.utf8)
-    guard
-      let value = try? JSONDecoder().decode(Value.self, from: bytes),
-      let canonical = try? CanonicalJSON.data(encoding: value),
-      canonical == bytes
-    else {
-      throw ViewCorruption.invalid
-    }
-    return value
   }
 
   static func isDigest(_ value: String) -> Bool {

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+View.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB+View.swift
@@ -1,0 +1,501 @@
+import ClawCore
+import Foundation
+import GRDB
+
+// MARK: - Owner Learning View
+
+extension ScheduledLearningStoreGRDB {
+  public func learningView(jobId: Int64?) throws(StoreError) -> [JobLearningView] {
+    try database.readMapping { db in
+      if let jobId {
+        guard let job = try Self.viewJob(db, jobId: jobId) else {
+          return [.notFound(jobId: jobId)]
+        }
+        return [try Self.view(db, job: job)]
+      }
+
+      let jobs = try Self.armedViewJobs(db)
+      return try jobs.map { job in
+        try Self.view(db, job: job)
+      }
+    }
+  }
+}
+
+// MARK: - Snapshot Assembly
+
+private extension ScheduledLearningStoreGRDB {
+  struct ViewJobRow {
+    let jobId: Int64
+    let label: String
+    let status: String
+    let timezone: String
+    let hasRecurrence: Bool
+  }
+
+  enum ViewCorruption: Error {
+    case invalid
+  }
+
+  static func armedViewJobs(_ db: Database) throws -> [ViewJobRow] {
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT job.id, job.label, job.status, job.timezone, job.recurrence
+        FROM job_learning_state AS state
+        JOIN scheduled_jobs AS job ON job.id = state.job_id
+        ORDER BY job.id
+        """
+    )
+    return rows.map(viewJob(row:))
+  }
+
+  static func viewJob(_ db: Database, jobId: Int64) throws -> ViewJobRow? {
+    try Row.fetchOne(
+      db,
+      sql: """
+        SELECT id, label, status, timezone, recurrence
+        FROM scheduled_jobs WHERE id = ?
+        """,
+      arguments: [jobId]
+    ).map(viewJob(row:))
+  }
+
+  static func viewJob(row: Row) -> ViewJobRow {
+    ViewJobRow(
+      jobId: row["id"],
+      label: row["label"],
+      status: row["status"],
+      timezone: row["timezone"],
+      hasRecurrence: (row["recurrence"] as String?) != nil
+    )
+  }
+
+  static func view(_ db: Database, job: ViewJobRow) throws -> JobLearningView {
+    let fallback = UnreadableLearningJob(
+      jobId: job.jobId,
+      validatedLabel: validatedLabel(job.label)
+    )
+    do {
+      let identity = try jobIdentity(job)
+      guard let state = try readState(db, jobId: job.jobId) else {
+        return .unarmed(identity)
+      }
+      return .readable(try readableView(db, job: job, identity: identity, state: state))
+    } catch ViewCorruption.invalid {
+      return .unreadable(fallback)
+    } catch let error as StoreError {
+      guard case .unexpected = error else {
+        throw error
+      }
+      return .unreadable(fallback)
+    }
+  }
+
+  static func jobIdentity(_ row: ViewJobRow) throws -> LearningJobIdentity {
+    guard
+      row.jobId > 0,
+      let label = validatedLabel(row.label),
+      let status = ScheduledJobStatus(rawValue: row.status),
+      TimeZone(identifier: row.timezone) != nil
+    else {
+      throw ViewCorruption.invalid
+    }
+    return LearningJobIdentity(
+      jobId: row.jobId,
+      label: label,
+      status: status,
+      timezone: row.timezone
+    )
+  }
+
+  static func validatedLabel(_ raw: String) -> String? {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard
+      trimmed == raw,
+      trimmed.isEmpty == false,
+      trimmed.count <= ScheduleDraftValidator.maxLabelGraphemes
+    else {
+      return nil
+    }
+    return trimmed
+  }
+
+  static func readableView(
+    _ db: Database,
+    job: ViewJobRow,
+    identity: LearningJobIdentity,
+    state: JobLearningState
+  ) throws -> ReadableJobLearningView {
+    guard
+      state.jobId == job.jobId,
+      state.epoch.value > 0,
+      state.stableRevision.value >= 0,
+      state.feedbackRevision.value >= 0,
+      isDigest(state.stableDigest.rawValue),
+      let stable = try readLessonSet(db, jobId: job.jobId, digest: state.stableDigest),
+      stable.jobId == job.jobId,
+      stable.digest == state.stableDigest
+    else {
+      throw ViewCorruption.invalid
+    }
+
+    let liveTrial = try liveTrialView(db, job: job, state: state)
+    var warnings: [LearningViewWarning] = []
+    if state.openTrialId != liveTrial?.trialId {
+      warnings.append(.trialPointerMismatch)
+    }
+    let decision = try lastDecisionView(db, state: state)
+    return ReadableJobLearningView(
+      job: identity,
+      epoch: state.epoch,
+      stableRevision: state.stableRevision,
+      stableLessons: stable,
+      liveTrial: liveTrial,
+      lastDecision: decision,
+      warnings: warnings
+    )
+  }
+}
+
+// MARK: - Trial Projection
+
+private extension ScheduledLearningStoreGRDB {
+  struct LiveTrialProjection {
+    let row: TrialRow
+    let admittedAt: Date
+    let assignmentDeadline: Date
+    let decisionDeadline: Date
+    let maximumAssignments: Int
+    let consumedAssignments: Int
+    let cohortCutoff: Date
+    let closeReason: String?
+  }
+
+  static func liveTrialView(
+    _ db: Database,
+    job: ViewJobRow,
+    state: JobLearningState
+  ) throws -> LearningTrialView? {
+    guard try currentEpochHasOnlyKnownTrialStates(db, state: state) else {
+      throw ViewCorruption.invalid
+    }
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT trial_id, job_id, learning_epoch, base_digest, candidate_digest, generation,
+          admitted_at, assignment_deadline, decision_deadline, max_assignments,
+          consumed_assignments, cohort_cutoff, state, close_reason, algorithm
+        FROM learning_trials
+        WHERE job_id = ? AND state IN (?, ?)
+        ORDER BY trial_id
+        """,
+      arguments: [
+        job.jobId,
+        LearningTrialState.open.rawValue,
+        LearningTrialState.draining.rawValue,
+      ]
+    )
+    guard rows.count <= 1 else {
+      throw ViewCorruption.invalid
+    }
+    guard let row = rows.first else {
+      return nil
+    }
+    guard job.hasRecurrence else {
+      throw ViewCorruption.invalid
+    }
+    let trial = try liveTrialProjection(row)
+    return try validateTrial(db, trial: trial, state: state)
+  }
+
+  static func currentEpochHasOnlyKnownTrialStates(
+    _ db: Database,
+    state: JobLearningState
+  ) throws -> Bool {
+    let known = LearningTrialState.allCases.map(\.rawValue)
+    return try Bool.fetchOne(
+      db,
+      sql: """
+        SELECT NOT EXISTS(
+          SELECT 1 FROM learning_trials
+          WHERE job_id = ? AND learning_epoch = ?
+            AND state NOT IN (?, ?, ?, ?, ?)
+        )
+        """,
+      arguments: [state.jobId, state.epoch.value] + StatementArguments(known)
+    ) ?? false
+  }
+
+  static func liveTrialProjection(_ row: Row) throws -> LiveTrialProjection {
+    guard
+      let state = LearningTrialState(rawValue: row["state"]),
+      let admittedAt = EpochSecondCodec.date(fromEpoch: row["admitted_at"]),
+      let assignmentDeadline = EpochSecondCodec.date(fromEpoch: row["assignment_deadline"]),
+      let decisionDeadline = EpochSecondCodec.date(fromEpoch: row["decision_deadline"]),
+      let cohortCutoff = EpochSecondCodec.date(fromEpoch: row["cohort_cutoff"])
+    else {
+      throw ViewCorruption.invalid
+    }
+    let algorithm = LearningAlgorithm(rawValue: row["algorithm"])
+    let trialRow = TrialRow(
+      id: row["trial_id"],
+      jobId: row["job_id"],
+      epoch: LearningEpoch(row["learning_epoch"]),
+      baseDigest: LessonSetDigest(rawValue: row["base_digest"]),
+      candidateDigest: CandidateDigest(rawValue: row["candidate_digest"]),
+      generation: row["generation"],
+      state: state,
+      algorithm: algorithm
+    )
+    return LiveTrialProjection(
+      row: trialRow,
+      admittedAt: admittedAt,
+      assignmentDeadline: assignmentDeadline,
+      decisionDeadline: decisionDeadline,
+      maximumAssignments: row["max_assignments"],
+      consumedAssignments: row["consumed_assignments"],
+      cohortCutoff: cohortCutoff,
+      closeReason: row["close_reason"]
+    )
+  }
+
+  static func validateTrial(
+    _ db: Database,
+    trial: LiveTrialProjection,
+    state: JobLearningState
+  ) throws -> LearningTrialView {
+    let row = trial.row
+    guard
+      row.id > 0,
+      row.jobId == state.jobId,
+      row.epoch == state.epoch,
+      row.baseDigest == state.stableDigest,
+      row.generation > 0,
+      row.algorithm == .v1,
+      row.state == .open || row.state == .draining,
+      isDigest(row.candidateDigest.rawValue),
+      trial.maximumAssignments == TrialAdmissionPolicy.maximumAssignments,
+      trial.consumedAssignments >= 0,
+      trial.consumedAssignments <= trial.maximumAssignments,
+      trial.cohortCutoff == trial.admittedAt,
+      trial.assignmentDeadline
+        == trial.admittedAt.addingTimeInterval(TrialAdmissionPolicy.assignmentWindow),
+      trial.decisionDeadline
+        == trial.admittedAt.addingTimeInterval(TrialAdmissionPolicy.decisionWindow),
+      trial.closeReason == nil,
+      let artifact = try readCandidateArtifact(db, digest: row.candidateDigest),
+      artifact.manifest.jobId == state.jobId,
+      artifact.manifest.epoch == state.epoch,
+      artifact.manifest.baseDigest == state.stableDigest,
+      artifact.manifest.baseRevision == state.stableRevision,
+      artifact.manifest.algorithm == .v1,
+      artifact.replacement.jobId == state.jobId
+    else {
+      throw ViewCorruption.invalid
+    }
+    let receipt = try admissionReceipt(db, artifact: artifact, trial: row)
+    guard
+      receipt.candidateDigest == row.candidateDigest,
+      receipt.replacementDigest == artifact.replacement.digest,
+      receipt.trialId == row.id,
+      receipt.generation == row.generation
+    else {
+      throw ViewCorruption.invalid
+    }
+    let unresolved = try validateCreatedAssignments(
+      db,
+      trial: row,
+      replacement: artifact.replacement.digest
+    )
+    guard unresolved == trial.consumedAssignments else {
+      throw ViewCorruption.invalid
+    }
+    let counts = LearningTrialCounts(
+      consumed: trial.consumedAssignments,
+      maximum: trial.maximumAssignments,
+      unresolved: unresolved
+    )
+    return LearningTrialView(
+      trialId: row.id,
+      epoch: row.epoch,
+      generation: row.generation,
+      state: row.state,
+      candidateDigest: row.candidateDigest,
+      baseDigest: row.baseDigest,
+      baseRevision: artifact.manifest.baseRevision,
+      replacementDigest: artifact.replacement.digest,
+      counts: counts,
+      assignmentDeadline: trial.assignmentDeadline,
+      decisionDeadline: trial.decisionDeadline
+    )
+  }
+
+  static func validateCreatedAssignments(
+    _ db: Database,
+    trial: TrialRow,
+    replacement: LessonSetDigest
+  ) throws -> Int {
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT assignment.run_id, assignment.job_id, assignment.learning_epoch,
+          assignment.trial_generation, assignment.state, assignment.outcome,
+          assignment.issue_codes, assignment.evaluation_digest,
+          assignment.evaluation_required, assignment.effective_feedback_revision,
+          assignment.resolved_at, binding.run_id AS binding_run_id,
+          binding.job_id AS binding_job_id, binding.learning_epoch AS binding_epoch,
+          binding.stable_digest, binding.effective_digest, binding.trial_id,
+          binding.trial_generation AS binding_generation
+        FROM trial_assignments AS assignment
+        LEFT JOIN run_learning_bindings AS binding ON binding.run_id = assignment.run_id
+        WHERE assignment.trial_id = ?
+        ORDER BY assignment.run_id
+        """,
+      arguments: [trial.id]
+    )
+    for row in rows {
+      guard
+        (row["job_id"] as Int64) == trial.jobId,
+        LearningEpoch(row["learning_epoch"] as Int64) == trial.epoch,
+        (row["trial_generation"] as Int) == trial.generation,
+        (row["state"] as String) == TrialAssignmentState.created.rawValue,
+        (row["outcome"] as String?) == nil,
+        (row["issue_codes"] as String?) == nil,
+        (row["evaluation_digest"] as String?) == nil,
+        row["evaluation_required"] as Bool,
+        (row["effective_feedback_revision"] as Int64?) == nil,
+        (row["resolved_at"] as Int64?) == nil,
+        (row["binding_run_id"] as Int64?) == row["run_id"] as Int64,
+        (row["binding_job_id"] as Int64?) == trial.jobId,
+        (row["binding_epoch"] as Int64?) == trial.epoch.value,
+        (row["stable_digest"] as String?) == trial.baseDigest.rawValue,
+        (row["effective_digest"] as String?) == replacement.rawValue,
+        (row["trial_id"] as Int64?) == trial.id,
+        (row["binding_generation"] as Int?) == trial.generation
+      else {
+        throw ViewCorruption.invalid
+      }
+    }
+    return rows.count
+  }
+}
+
+// MARK: - Decision Projection
+
+private extension ScheduledLearningStoreGRDB {
+  static func lastDecisionView(
+    _ db: Database,
+    state: JobLearningState
+  ) throws -> LearningDecisionView? {
+    guard
+      let row = try Row.fetchOne(
+        db,
+        sql: """
+          SELECT decision_id, kind, job_id, learning_epoch, inputs, result, algorithm, decided_at
+          FROM learning_decisions
+          WHERE job_id = ? AND learning_epoch = ?
+          ORDER BY decided_at DESC, decision_id DESC
+          LIMIT 1
+          """,
+        arguments: [state.jobId, state.epoch.value]
+      )
+    else {
+      return nil
+    }
+    guard
+      let decidedAt = EpochSecondCodec.date(fromEpoch: row["decided_at"]),
+      (row["decision_id"] as Int64) > 0,
+      (row["job_id"] as Int64) == state.jobId,
+      LearningEpoch(row["learning_epoch"] as Int64) == state.epoch
+    else {
+      throw ViewCorruption.invalid
+    }
+    let algorithm = LearningAlgorithm(rawValue: row["algorithm"])
+    guard algorithm == .v1 else {
+      throw ViewCorruption.invalid
+    }
+    let inputsJSON: String = row["inputs"]
+    let resultJSON: String = row["result"]
+    let detail = try decisionDetail(
+      db,
+      kind: row["kind"],
+      inputsJSON: inputsJSON,
+      resultJSON: resultJSON,
+      state: state
+    )
+    return LearningDecisionView(
+      decisionId: row["decision_id"],
+      jobId: state.jobId,
+      epoch: state.epoch,
+      algorithm: algorithm,
+      decidedAt: decidedAt,
+      detail: detail
+    )
+  }
+
+  static func decisionDetail(
+    _ db: Database,
+    kind: String,
+    inputsJSON: String,
+    resultJSON: String,
+    state: JobLearningState
+  ) throws -> LearningDecisionDetail {
+    switch kind {
+    case AdmissionReceipt.kind:
+      let inputs: AdmissionDecisionInputs = try decodeCanonical(inputsJSON)
+      let result: AdmissionReceipt = try decodeCanonical(resultJSON)
+      guard
+        inputs.candidateDigest == result.candidateDigest,
+        let artifact = try readCandidateArtifact(db, digest: inputs.candidateDigest),
+        artifact.manifest.jobId == state.jobId,
+        artifact.manifest.epoch == state.epoch,
+        artifact.manifest.algorithm == .v1,
+        let trial = try trialRow(db, candidate: inputs.candidateDigest),
+        try admissionReceipt(db, artifact: artifact, trial: trial) == result
+      else {
+        throw ViewCorruption.invalid
+      }
+      return .candidateAdmission(inputs: inputs, result: result)
+    case ReflectionNoCandidateReceipt.kind:
+      let inputs: ReflectionNoCandidateInputs = try decodeCanonical(inputsJSON)
+      let result: ReflectionNoCandidateReceipt = try decodeCanonical(resultJSON)
+      guard
+        isDigest(inputs.triggerDigest.rawValue),
+        isDigest(inputs.carrierDigest.rawValue),
+        isDigest(result.resultDigest.rawValue),
+        let operation = try readOperation(db, id: inputs.operationId),
+        operation.jobId == state.jobId,
+        operation.epoch == state.epoch,
+        operation.phase == .reflector,
+        operation.sourceDigest == inputs.triggerDigest.rawValue,
+        operation.carrierDigest == inputs.carrierDigest,
+        operation.state == .succeeded
+      else {
+        throw ViewCorruption.invalid
+      }
+      return .reflectionNoCandidate(inputs: inputs, result: result)
+    default:
+      throw ViewCorruption.invalid
+    }
+  }
+
+  static func decodeCanonical<Value: Codable>(_ json: String) throws -> Value {
+    let bytes = Data(json.utf8)
+    guard
+      let value = try? JSONDecoder().decode(Value.self, from: bytes),
+      let canonical = try? CanonicalJSON.data(encoding: value),
+      canonical == bytes
+    else {
+      throw ViewCorruption.invalid
+    }
+    return value
+  }
+
+  static func isDigest(_ value: String) -> Bool {
+    value.utf8.count == 64
+      && value.utf8.allSatisfy { byte in
+        (48...57).contains(byte) || (97...102).contains(byte)
+      }
+  }
+}

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB.swift
@@ -50,8 +50,8 @@ extension ScheduledLearningStoreGRDB {
     guard let row else {
       return nil
     }
-    let bytes: Data = row["canonical_bytes"]
     guard
+      let bytes = SQLiteStoredValue.data(in: row, column: "canonical_bytes"),
       let set = LessonSet.decoded(jobId: jobId, canonicalBytes: bytes),
       set.digest == digest
     else {
@@ -94,13 +94,25 @@ extension ScheduledLearningStoreGRDB {
     guard let row else {
       return nil
     }
+    guard
+      let epoch = SQLiteStoredValue.int64(in: row, column: "learning_epoch"),
+      let stableDigest = SQLiteStoredValue.string(
+        in: row,
+        column: "stable_lesson_set_digest"
+      ),
+      let stableRevision = SQLiteStoredValue.int64(in: row, column: "stable_revision"),
+      let openTrial = SQLiteStoredValue.nullableInt64(in: row, column: "open_trial_id"),
+      let feedbackRevision = SQLiteStoredValue.int64(in: row, column: "feedback_revision")
+    else {
+      throw StoreError.unexpected("job \(jobId) has an unreadable learning state")
+    }
     return JobLearningState(
       jobId: jobId,
-      epoch: LearningEpoch(row["learning_epoch"]),
-      stableDigest: LessonSetDigest(rawValue: row["stable_lesson_set_digest"]),
-      stableRevision: StableRevision(row["stable_revision"]),
-      openTrialId: row["open_trial_id"],
-      feedbackRevision: FeedbackRevision(row["feedback_revision"])
+      epoch: LearningEpoch(epoch),
+      stableDigest: LessonSetDigest(rawValue: stableDigest),
+      stableRevision: StableRevision(stableRevision),
+      openTrialId: openTrial.value,
+      feedbackRevision: FeedbackRevision(feedbackRevision)
     )
   }
 }

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB.swift
@@ -66,7 +66,7 @@ extension ScheduledLearningStoreGRDB {
     // The empty set goes in first: the state row names a digest, and a state that pointed at a
     // lesson set no row holds would let a job fire against a binding it cannot resolve.
     let empty = LessonSet.empty(jobId: jobId)
-    try insertCanonicalEmptySet(db, empty, now: now)
+    try ensureCanonicalEmptySet(db, empty, now: now)
     try db.execute(
       sql: """
         INSERT OR IGNORE INTO job_learning_state(job_id, learning_epoch,
@@ -117,14 +117,27 @@ extension ScheduledLearningStoreGRDB {
   }
 }
 
-// MARK: - Rows
+// MARK: - Canonical Empty Row
 
-private extension ScheduledLearningStoreGRDB {
-  static func insertCanonicalEmptySet(_ db: Database, _ set: LessonSet, now: Date) throws {
+extension ScheduledLearningStoreGRDB {
+  static func ensureCanonicalEmptySet(_ db: Database, _ set: LessonSet, now: Date) throws {
+    let row = try Row.fetchOne(
+      db,
+      sql: """
+        SELECT job_id, digest, schema_version, canonical_bytes, source
+        FROM lesson_sets WHERE job_id = ? AND digest = ?
+        """,
+      arguments: [set.jobId, set.digest.rawValue]
+    )
+    if let row {
+      guard canonicalEmptySetMatches(row, set: set) else {
+        throw StoreError.unexpected("canonical empty lesson set is unreadable")
+      }
+      return
+    }
     try db.execute(
       sql: """
-        INSERT OR IGNORE INTO lesson_sets(job_id, digest, schema_version, canonical_bytes,
-          source, created_at)
+        INSERT INTO lesson_sets(job_id, digest, schema_version, canonical_bytes, source, created_at)
         VALUES (?, ?, ?, ?, ?, ?)
         """,
       arguments: [
@@ -136,5 +149,14 @@ private extension ScheduledLearningStoreGRDB {
         EpochSecondCodec.epoch(now),
       ]
     )
+  }
+
+  static func canonicalEmptySetMatches(_ row: Row, set: LessonSet) -> Bool {
+    SQLiteStoredValue.int64(in: row, column: "job_id") == set.jobId
+      && SQLiteStoredValue.string(in: row, column: "digest") == set.digest.rawValue
+      && SQLiteStoredValue.int(in: row, column: "schema_version") == set.schemaVersion
+      && SQLiteStoredValue.data(in: row, column: "canonical_bytes") == set.canonicalBytes
+      && SQLiteStoredValue.string(in: row, column: "source")
+        == LessonSetSource.canonicalEmpty.rawValue
   }
 }

--- a/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB.swift
+++ b/Sources/ClawData/Stores/Learning/ScheduledLearningStoreGRDB.swift
@@ -159,4 +159,11 @@ extension ScheduledLearningStoreGRDB {
       && SQLiteStoredValue.string(in: row, column: "source")
         == LessonSetSource.canonicalEmpty.rawValue
   }
+
+  static func isCanonicalDigest(_ value: String) -> Bool {
+    value.utf8.count == 64
+      && value.utf8.allSatisfy { byte in
+        (48...57).contains(byte) || (97...102).contains(byte)
+      }
+  }
 }

--- a/Sources/ClawGateway/Approval/ConfirmationResolver.swift
+++ b/Sources/ClawGateway/Approval/ConfirmationResolver.swift
@@ -9,6 +9,7 @@ struct ConfirmationResolver: Sendable {
   let sessionMessages: any SessionMessageStore
   let pendingConfirmations: PendingConfirmationRegistry
   let memoryCommands: any MemoryCommandStore
+  let learningReset: (any LearningResetApplying)?
 
   let schedule: ScheduleSurface
   let replies: ReplySender
@@ -166,6 +167,18 @@ private extension ConfirmationResolver {
         now: now()
       )
       return (result.newlyClaimed, ScheduleReplies.armed(job: result.job))
+    case .learningReset(let jobId):
+      guard let learningReset else {
+        throw StoreError.unexpected("learning reset is unavailable")
+      }
+      let result = try learningReset.applyReset(updateId: updateId, jobId: jobId, now: now())
+      guard result.newlyClaimed else {
+        return (false, "")
+      }
+      guard let outcome = result.outcome else {
+        throw StoreError.unexpected("claimed learning reset has no outcome")
+      }
+      return (true, LearningReplies.resetOutcome(outcome, jobId: jobId))
     }
   }
 
@@ -207,6 +220,8 @@ private extension ConfirmationResolver {
         MemoryReplies.deleteFailed
       case .scheduleArm:
         ScheduleReplies.armFailed
+      case .learningReset:
+        LearningReplies.resetFailed
       }
 
     return await replies.sendCommandAck(

--- a/Sources/ClawGateway/Approval/PendingConfirmationRegistry.swift
+++ b/Sources/ClawGateway/Approval/PendingConfirmationRegistry.swift
@@ -6,6 +6,7 @@ public enum CommandConfirmation: Sendable, Equatable {
   case rememberWrite(MemoryWriteRequest)
   case deleteItem(id: Int64)
   case scheduleArm(ValidatedSchedule)
+  case learningReset(jobId: Int64)
 }
 
 public actor PendingConfirmationRegistry {

--- a/Sources/ClawGateway/Learning/LearningHandlers+PromotionReply.swift
+++ b/Sources/ClawGateway/Learning/LearningHandlers+PromotionReply.swift
@@ -1,0 +1,86 @@
+import ClawCore
+import Foundation
+
+extension LearningHandlers {
+  func promotionReply(
+    jobId: Int64,
+    view: [JobLearningView],
+    rawUpdate: RawUpdate,
+    message: IncomingMessage,
+    signal: OutboxSignal
+  ) async throws(RoutingHalt) -> HandleOutcome? {
+    let target = DeliveryTarget.chat(message.chatId)
+    let promotion = try await replies.perform(
+      "current promotion",
+      updateId: rawUpdate.updateId,
+      target: target
+    ) {
+      try learning.currentPromotion(jobId: jobId)
+    }
+    guard let promotion,
+      case .readable(let readable)? = view.first,
+      readable.stableRevision == promotion.record.stableRevision,
+      readable.stableLessons.digest == promotion.inputs.replacementDigest
+    else {
+      return nil
+    }
+    let nonce = OpaqueNonce.generate()
+    let feedback = NewFeedbackTarget(
+      nonce: nonce,
+      jobId: jobId,
+      epoch: promotion.inputs.identity.epoch,
+      subjectKind: .promotion,
+      subjectDigest: promotion.promotionSubject,
+      allowedActions: [.promotionRollback],
+      ownerUserId: message.userId,
+      chatId: message.chatId,
+      expiresAt: now().addingTimeInterval(EvidenceWindow.maximumAge)
+    )
+    let markup = FeedbackKeyboard.markup(rows: [
+      [
+        FeedbackKeyboard.Button(
+          text: "Roll back promotion",
+          nonce: nonce,
+          action: .promotionRollback
+        )
+      ]
+    ])
+    let safe = redactor.redact(LearningSurface.render(view, style: .detail))
+    let parts = ReplySplitter.split(
+      text: safe,
+      limit: TelegramMessageLimits.maxPlainMessageCharacters
+    )
+    let subject = SHA256Digest.hex("learning-command/\(rawUpdate.updateId)")
+    let chunks = parts.enumerated().map { index, text in
+      LearningNoticeChunk(
+        subjectDigest: subject,
+        ordinal: index,
+        chatId: message.chatId,
+        payload: text,
+        payloadHash: ContentHash.fnv1a(text),
+        replyMarkup: index == parts.count - 1 ? markup : nil
+      )
+    }
+    let outcome = try await replies.perform(
+      "promotion reply",
+      updateId: rawUpdate.updateId,
+      target: target
+    ) {
+      try learning.commitPromotionReply(
+        updateId: rawUpdate.updateId,
+        target: feedback,
+        chunks: chunks,
+        now: now()
+      )
+    }
+    switch outcome {
+    case .committed:
+      signal.poke()
+      return .processed
+    case .duplicate:
+      return replies.skipDuplicate(updateId: rawUpdate.updateId)
+    case .stale:
+      return nil
+    }
+  }
+}

--- a/Sources/ClawGateway/Learning/LearningHandlers.swift
+++ b/Sources/ClawGateway/Learning/LearningHandlers.swift
@@ -1,0 +1,65 @@
+import ClawCore
+
+/// Provider-free `/learning` reads plus the current unavailable reset reply.
+struct LearningHandlers: Sendable {
+  let learning: any ScheduledLearningStore
+  let redactor: SecretRedactor
+  let replies: ReplySender
+
+  func handle(
+    _ command: LearningCommand,
+    rawUpdate: RawUpdate,
+    message: IncomingMessage
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    switch command {
+    case .list:
+      return try await read(
+        jobId: nil,
+        style: .list,
+        rawUpdate: rawUpdate,
+        message: message
+      )
+    case .detail(let jobId):
+      return try await read(
+        jobId: jobId,
+        style: .detail,
+        rawUpdate: rawUpdate,
+        message: message
+      )
+    case .reset(let jobId):
+      let text =
+        jobId == nil ? CommandReplies.learningUsage : CommandReplies.learningResetUnavailable
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
+        target: .chat(message.chatId),
+        text: text
+      )
+    }
+  }
+
+  private func read(
+    jobId: Int64?,
+    style: LearningSurface.Style,
+    rawUpdate: RawUpdate,
+    message: IncomingMessage
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    let view = try await replies.perform(
+      "learning view",
+      updateId: rawUpdate.updateId,
+      target: .chat(message.chatId)
+    ) {
+      try learning.learningView(jobId: jobId)
+    }
+    let rendered = LearningSurface.render(view, style: style)
+    let safe = redactor.redact(rendered)
+    let chunks = ReplySplitter.split(
+      text: safe,
+      limit: TelegramMessageLimits.maxPlainMessageCharacters
+    )
+    return await replies.sendCannedChunks(
+      updateId: rawUpdate.updateId,
+      target: .chat(message.chatId),
+      texts: chunks
+    )
+  }
+}

--- a/Sources/ClawGateway/Learning/LearningHandlers.swift
+++ b/Sources/ClawGateway/Learning/LearningHandlers.swift
@@ -9,6 +9,7 @@ struct LearningHandlers: Sendable {
   let pendingConfirmations: PendingConfirmationRegistry
   let replies: ReplySender
   let now: @Sendable () -> Date
+  let outboxSignal: OutboxSignal?
 
   func handle(
     _ command: LearningCommand,
@@ -122,6 +123,17 @@ struct LearningHandlers: Sendable {
       target: .chat(message.chatId)
     ) {
       try learning.learningView(jobId: jobId)
+    }
+    if let jobId, let outboxSignal,
+      let outcome = try await promotionReply(
+        jobId: jobId,
+        view: view,
+        rawUpdate: rawUpdate,
+        message: message,
+        signal: outboxSignal
+      )
+    {
+      return outcome
     }
     return await send(view: view, style: style, rawUpdate: rawUpdate, message: message)
   }

--- a/Sources/ClawGateway/Learning/LearningHandlers.swift
+++ b/Sources/ClawGateway/Learning/LearningHandlers.swift
@@ -1,10 +1,14 @@
 import ClawCore
+import Foundation
 
-/// Provider-free `/learning` reads plus the current unavailable reset reply.
+/// Provider-free `/learning` reads plus the owner-confirmed reset barrier.
 struct LearningHandlers: Sendable {
   let learning: any ScheduledLearningStore
   let redactor: SecretRedactor
+  let sessionMessages: any SessionMessageStore
+  let pendingConfirmations: PendingConfirmationRegistry
   let replies: ReplySender
+  let now: @Sendable () -> Date
 
   func handle(
     _ command: LearningCommand,
@@ -27,14 +31,83 @@ struct LearningHandlers: Sendable {
         message: message
       )
     case .reset(let jobId):
-      let text =
-        jobId == nil ? CommandReplies.learningUsage : CommandReplies.learningResetUnavailable
+      guard let jobId else {
+        return await replies.sendCanned(
+          updateId: rawUpdate.updateId,
+          target: .chat(message.chatId),
+          text: CommandReplies.learningUsage
+        )
+      }
+      return try await requestReset(jobId: jobId, rawUpdate: rawUpdate, message: message)
+    }
+  }
+
+  private func requestReset(
+    jobId: Int64,
+    rawUpdate: RawUpdate,
+    message: IncomingMessage
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    let view = try await replies.perform(
+      "learning reset view",
+      updateId: rawUpdate.updateId,
+      target: .chat(message.chatId)
+    ) {
+      try learning.learningView(jobId: jobId)
+    }
+    guard view.count == 1 else {
       return await replies.sendCanned(
         updateId: rawUpdate.updateId,
         target: .chat(message.chatId),
-        text: text
+        text: CommandReplies.learningUnavailable
       )
     }
+    switch view[0] {
+    case .notFound, .unarmed:
+      return await send(view: view, style: .detail, rawUpdate: rawUpdate, message: message)
+    case .readable(let readable):
+      return try await parkReset(
+        jobId: jobId,
+        label: readable.job.label,
+        rawUpdate: rawUpdate,
+        message: message
+      )
+    case .unreadable(let unreadable):
+      return try await parkReset(
+        jobId: jobId,
+        label: unreadable.validatedLabel,
+        rawUpdate: rawUpdate,
+        message: message
+      )
+    }
+  }
+
+  private func parkReset(
+    jobId: Int64,
+    label: String?,
+    rawUpdate: RawUpdate,
+    message: IncomingMessage
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    let claim = try await replies.perform(
+      "learning reset claim",
+      updateId: rawUpdate.updateId,
+      target: .chat(message.chatId)
+    ) {
+      try sessionMessages.claimCommandUpdate(
+        updateId: rawUpdate.updateId,
+        sessionKey: SessionKey.telegramDM(chatId: message.chatId),
+        now: now()
+      )
+    }
+    guard case .claimed(let sessionId) = claim else {
+      return replies.skipDuplicate(updateId: rawUpdate.updateId)
+    }
+    await pendingConfirmations.park(.learningReset(jobId: jobId), sessionId: sessionId)
+    let prompt = LearningReplies.resetConfirmation(jobId: jobId, label: label)
+    return await replies.sendCommandAck(
+      updateId: rawUpdate.updateId,
+      target: .chat(message.chatId),
+      text: redactor.redact(prompt)
+    )
   }
 
   private func read(
@@ -50,6 +123,15 @@ struct LearningHandlers: Sendable {
     ) {
       try learning.learningView(jobId: jobId)
     }
+    return await send(view: view, style: style, rawUpdate: rawUpdate, message: message)
+  }
+
+  private func send(
+    view: [JobLearningView],
+    style: LearningSurface.Style,
+    rawUpdate: RawUpdate,
+    message: IncomingMessage
+  ) async -> HandleOutcome {
     let rendered = LearningSurface.render(view, style: style)
     let safe = redactor.redact(rendered)
     let chunks = ReplySplitter.split(

--- a/Sources/ClawGateway/Learning/LearningSurface.swift
+++ b/Sources/ClawGateway/Learning/LearningSurface.swift
@@ -162,6 +162,20 @@ private extension LearningSurface {
       lines.append("decision input operation: \(inputs.operationId.rawValue)")
       lines.append("decision input carrier: \(inputs.carrierDigest.rawValue)")
       lines.append("decision result digest: \(result.resultDigest.rawValue)")
+    case .learningReset(let inputs, let result):
+      lines.append("reset old epoch: \(inputs.oldEpoch.value)")
+      lines.append("reset new epoch: \(result.newEpoch.value)")
+      lines.append("reset old stable digest: \(inputs.oldStableDigest.rawValue)")
+      lines.append("reset empty stable digest: \(result.emptyStableDigest.rawValue)")
+      lines.append("reset old stable revision: \(inputs.oldStableRevision.value)")
+      lines.append("reset new stable revision: \(result.newStableRevision.value)")
+      lines.append("reset feedback revision: \(inputs.feedbackRevisionAtCut.value)")
+      lines.append("reset prior live trial: \(inputs.priorOpenTrialId.map(String.init) ?? "none")")
+      lines.append("reset closed trials: \(result.closedTrials.count)")
+      lines.append("reset invalidated targets: \(result.invalidatedTargetCount)")
+      lines.append("reset invalidated challenges: \(result.invalidatedChallengeCount)")
+      lines.append("reset abandoned calls: \(result.staleNoCallOperationIds.count)")
+      lines.append("reset in-flight calls: \(result.inFlightOperationIds.count)")
     }
     return lines
   }
@@ -172,6 +186,8 @@ private extension LearningSurface {
       AdmissionReceipt.kind
     case .reflectionNoCandidate:
       ReflectionNoCandidateReceipt.kind
+    case .learningReset:
+      ResetReceipt.kind
     }
   }
 

--- a/Sources/ClawGateway/Learning/LearningSurface.swift
+++ b/Sources/ClawGateway/Learning/LearningSurface.swift
@@ -151,6 +151,21 @@ private extension LearningSurface {
       "decided at: \(time(decision.decidedAt, timezone: timezone))",
     ]
     switch decision.detail {
+    case .terminal(let receipt):
+      lines.append("decision result: \(receipt.result.rawValue)")
+      lines.append("decision reason: \(receipt.record.reason)")
+      lines.append("decision candidate: \(receipt.inputs.candidateDigest.rawValue)")
+      lines.append("decision base: \(receipt.inputs.baseDigest.rawValue)")
+      lines.append("decision replacement: \(receipt.inputs.replacementDigest.rawValue)")
+      lines.append("decision reviewed feedback: \(receipt.inputs.feedbackRevision.value)")
+      let runIds = receipt.cohort.map { support in
+        String(support.runId)
+      }.joined(separator: ", ")
+      lines.append("decision cohort runs: \(runIds)")
+      let confirmed = receipt.cohort.count { support in
+        support.outcome == .positive && support.ownerConfirmed
+      }
+      lines.append("evidence: heuristic; owner-confirmed positive runs: \(confirmed)")
     case .candidateAdmission(let inputs, let result):
       lines.append("decision input candidate: \(inputs.candidateDigest.rawValue)")
       lines.append("decision result candidate: \(result.candidateDigest.rawValue)")
@@ -182,6 +197,9 @@ private extension LearningSurface {
 
   static func decisionKind(_ detail: LearningDecisionDetail) -> String {
     switch detail {
+    case .terminal(let receipt):
+      receipt.record.rollbackTrigger == nil
+        ? LearningDecisionKind.trial.rawValue : LearningDecisionKind.rollback.rawValue
     case .candidateAdmission:
       AdmissionReceipt.kind
     case .reflectionNoCandidate:

--- a/Sources/ClawGateway/Learning/LearningSurface.swift
+++ b/Sources/ClawGateway/Learning/LearningSurface.swift
@@ -1,0 +1,184 @@
+import ClawCore
+import Foundation
+
+/// Pure owner-facing rendering for the typed learning snapshot.
+public enum LearningSurface {
+  public static let emptyList = "No scheduled jobs have learning state yet."
+
+  public enum Style: Sendable {
+    case list
+    case detail
+  }
+
+  public static func render(_ views: [JobLearningView], style: Style = .detail) -> String {
+    switch style {
+    case .list:
+      return renderList(views)
+    case .detail:
+      return renderDetail(views)
+    }
+  }
+}
+
+// MARK: - List
+
+private extension LearningSurface {
+  static func renderList(_ views: [JobLearningView]) -> String {
+    guard views.isEmpty == false else {
+      return emptyList
+    }
+    return views.map(listLine).joined(separator: "\n")
+  }
+
+  static func listLine(_ view: JobLearningView) -> String {
+    switch view {
+    case .readable(let readable):
+      let trial =
+        readable.liveTrial.map { value in
+          "trial \(value.state.rawValue) \(value.counts.consumed)/\(value.counts.maximum)"
+            + " (\(value.counts.unresolved) unresolved)"
+        } ?? "no live trial"
+      let decision =
+        readable.lastDecision.map { value in
+          "last \(decisionKind(value.detail)) \(value.decidedAt.wallClockMinute(in: zone(readable)))"
+        } ?? "no decision"
+      return """
+        \(readable.job.jobId) · \(readable.job.label) · \(readable.job.status.rawValue) · \
+        epoch \(readable.epoch.value) · \(readable.stableLessons.lessons.count) lessons · \
+        \(trial) · \(decision)
+        """
+    case .unreadable(let job):
+      return "\(job.jobId) · \(job.validatedLabel ?? "unknown label") · learning state unreadable"
+    case .unarmed(let job):
+      return "\(job.jobId) · \(job.label) · no learning state"
+    case .notFound(let jobId):
+      return "No schedule with id \(jobId). See /schedule list."
+    }
+  }
+}
+
+// MARK: - Detail
+
+private extension LearningSurface {
+  static func renderDetail(_ views: [JobLearningView]) -> String {
+    guard views.isEmpty == false else {
+      return emptyList
+    }
+    return views.map(detail).joined(separator: "\n\n")
+  }
+
+  static func detail(_ view: JobLearningView) -> String {
+    switch view {
+    case .notFound(let jobId):
+      return "No schedule with id \(jobId). See /schedule list."
+    case .unarmed(let job):
+      return """
+        Schedule \(job.jobId) · \(job.label)
+        status: \(job.status.rawValue)
+        timezone: \(job.timezone)
+        learning state: not created
+        """
+    case .unreadable(let job):
+      return """
+        Schedule \(job.jobId) · \(job.validatedLabel ?? "unknown label")
+        learning state: unreadable
+        Run /doctor and inspect the daemon logs; this read did not change or repair stored state.
+        """
+    case .readable(let readable):
+      return readableDetail(readable)
+    }
+  }
+
+  static func readableDetail(_ view: ReadableJobLearningView) -> String {
+    var lines = [
+      "Schedule \(view.job.jobId) · \(view.job.label)",
+      "status: \(view.job.status.rawValue)",
+      "timezone: \(view.job.timezone)",
+      "learning epoch: \(view.epoch.value)",
+      "stable revision: \(view.stableRevision.value)",
+      "stable digest: \(view.stableLessons.digest.rawValue)",
+      "lessons (\(view.stableLessons.lessons.count)):",
+    ]
+    if view.stableLessons.lessons.isEmpty {
+      lines.append("  none")
+    } else {
+      for (index, lesson) in view.stableLessons.lessons.enumerated() {
+        lines.append("  \(index + 1). \(lesson)")
+      }
+    }
+    lines.append(contentsOf: trialLines(view.liveTrial, timezone: zone(view)))
+    lines.append(contentsOf: decisionLines(view.lastDecision, timezone: zone(view)))
+    for warning in view.warnings {
+      lines.append("warning: \(warning.rawValue)")
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  static func trialLines(_ trial: LearningTrialView?, timezone: TimeZone) -> [String] {
+    guard let trial else {
+      return ["live trial: none"]
+    }
+    return [
+      "live trial: \(trial.trialId)",
+      "trial epoch: \(trial.epoch.value)",
+      "trial generation: \(trial.generation)",
+      "trial state: \(trial.state.rawValue)",
+      "candidate digest: \(trial.candidateDigest.rawValue)",
+      "trial base digest: \(trial.baseDigest.rawValue)",
+      "trial base revision: \(trial.baseRevision.value)",
+      "replacement digest: \(trial.replacementDigest.rawValue)",
+      "assignments: \(trial.counts.consumed) of \(trial.counts.maximum)",
+      "assignment outcomes: \(trial.counts.unresolved) unresolved",
+      "assignment deadline: \(time(trial.assignmentDeadline, timezone: timezone))",
+      "decision deadline: \(time(trial.decisionDeadline, timezone: timezone))",
+    ]
+  }
+
+  static func decisionLines(
+    _ decision: LearningDecisionView?,
+    timezone: TimeZone
+  ) -> [String] {
+    guard let decision else {
+      return ["last decision: none"]
+    }
+    var lines = [
+      "last decision: \(decision.decisionId)",
+      "decision kind: \(decisionKind(decision.detail))",
+      "decision job: \(decision.jobId)",
+      "decision epoch: \(decision.epoch.value)",
+      "decision algorithm: \(decision.algorithm.rawValue)",
+      "decided at: \(time(decision.decidedAt, timezone: timezone))",
+    ]
+    switch decision.detail {
+    case .candidateAdmission(let inputs, let result):
+      lines.append("decision input candidate: \(inputs.candidateDigest.rawValue)")
+      lines.append("decision result candidate: \(result.candidateDigest.rawValue)")
+      lines.append("decision result replacement: \(result.replacementDigest.rawValue)")
+      lines.append("decision result trial: \(result.trialId)")
+      lines.append("decision result generation: \(result.generation)")
+    case .reflectionNoCandidate(let inputs, let result):
+      lines.append("decision input trigger: \(inputs.triggerDigest.rawValue)")
+      lines.append("decision input operation: \(inputs.operationId.rawValue)")
+      lines.append("decision input carrier: \(inputs.carrierDigest.rawValue)")
+      lines.append("decision result digest: \(result.resultDigest.rawValue)")
+    }
+    return lines
+  }
+
+  static func decisionKind(_ detail: LearningDecisionDetail) -> String {
+    switch detail {
+    case .candidateAdmission:
+      AdmissionReceipt.kind
+    case .reflectionNoCandidate:
+      ReflectionNoCandidateReceipt.kind
+    }
+  }
+
+  static func zone(_ view: ReadableJobLearningView) -> TimeZone {
+    TimeZone(identifier: view.job.timezone) ?? .gmt
+  }
+
+  static func time(_ date: Date, timezone: TimeZone) -> String {
+    "\(date.wallClockMinute(in: timezone)) (\(timezone.identifier))"
+  }
+}

--- a/Sources/ClawGateway/Learning/LearningSurface.swift
+++ b/Sources/ClawGateway/Learning/LearningSurface.swift
@@ -42,10 +42,11 @@ private extension LearningSurface {
         readable.lastDecision.map { value in
           "last \(decisionKind(value.detail)) \(value.decidedAt.wallClockMinute(in: zone(readable)))"
         } ?? "no decision"
+      let warning = readable.warnings.isEmpty ? "" : " · warning"
       return """
         \(readable.job.jobId) · \(readable.job.label) · \(readable.job.status.rawValue) · \
         epoch \(readable.epoch.value) · \(readable.stableLessons.lessons.count) lessons · \
-        \(trial) · \(decision)
+        \(trial) · \(decision)\(warning)
         """
     case .unreadable(let job):
       return "\(job.jobId) · \(job.validatedLabel ?? "unknown label") · learning state unreadable"
@@ -109,7 +110,7 @@ private extension LearningSurface {
     lines.append(contentsOf: trialLines(view.liveTrial, timezone: zone(view)))
     lines.append(contentsOf: decisionLines(view.lastDecision, timezone: zone(view)))
     for warning in view.warnings {
-      lines.append("warning: \(warning.rawValue)")
+      lines.append("warning: \(warningText(warning))")
     }
     return lines.joined(separator: "\n")
   }
@@ -171,6 +172,13 @@ private extension LearningSurface {
       AdmissionReceipt.kind
     case .reflectionNoCandidate:
       ReflectionNoCandidateReceipt.kind
+    }
+  }
+
+  static func warningText(_ warning: LearningViewWarning) -> String {
+    switch warning {
+    case .trialPointerMismatch:
+      "stored trial pointer does not match the live trial"
     }
   }
 

--- a/Sources/ClawGateway/Learning/LearningSurface.swift
+++ b/Sources/ClawGateway/Learning/LearningSurface.swift
@@ -36,7 +36,7 @@ private extension LearningSurface {
       let trial =
         readable.liveTrial.map { value in
           "trial \(value.state.rawValue) \(value.counts.consumed)/\(value.counts.maximum)"
-            + " (\(value.counts.unresolved) unresolved)"
+            + " · \(assignmentOutcomes(value.counts))"
         } ?? "no live trial"
       let decision =
         readable.lastDecision.map { value in
@@ -129,7 +129,7 @@ private extension LearningSurface {
       "trial base revision: \(trial.baseRevision.value)",
       "replacement digest: \(trial.replacementDigest.rawValue)",
       "assignments: \(trial.counts.consumed) of \(trial.counts.maximum)",
-      "assignment outcomes: \(trial.counts.unresolved) unresolved",
+      assignmentOutcomes(trial.counts),
       "assignment deadline: \(time(trial.assignmentDeadline, timezone: timezone))",
       "decision deadline: \(time(trial.decisionDeadline, timezone: timezone))",
     ]
@@ -189,6 +189,11 @@ private extension LearningSurface {
     case .learningReset:
       ResetReceipt.kind
     }
+  }
+
+  static func assignmentOutcomes(_ counts: LearningTrialCounts) -> String {
+    "assignment outcomes: \(counts.positive) positive, \(counts.negative) negative, "
+      + "\(counts.neutral) neutral, \(counts.unresolved) unresolved"
   }
 
   static func warningText(_ warning: LearningViewWarning) -> String {

--- a/Sources/ClawGateway/Response/CommandReplies.swift
+++ b/Sources/ClawGateway/Response/CommandReplies.swift
@@ -6,10 +6,15 @@ public enum CommandReplies {
   public static let freshConversation =
     "Started a fresh conversation — earlier context cleared."
 
-  /// Refusal for the owner-scoped command families in a shared room. It names the two families so
+  /// Refusal for the owner-scoped command families in a shared room. It names the private state so
   /// the attendee learns the rule, not just this one rejection.
   public static let directOnly =
-    "Not here — memory and schedules live in my owner's direct chat."
+    "Not here — memory, schedules, and learning state live in my owner's direct chat."
+
+  public static let learningUsage = "Usage: /learning reset <id>. See /learning"
+  public static let learningResetUnavailable =
+    "Learning reset is not available in this build."
+  public static let learningUnavailable = "Learning status is unavailable. Try again."
 
   /// The owner manual, including the parked-entry interaction rules (stated verbatim as
   /// owner-visible text): slash commands bypass confirmation resolution entirely; only the
@@ -20,6 +25,8 @@ public enum CommandReplies {
     /schedule <text>: create a schedule (I confirm before it arms)
     /schedule list: list schedules
     /pause <id> · /resume <id> · /runnow <id> · /cancel <id>: manage schedules
+    /learning · /learning <id>: inspect scheduled-job learning
+    /learning reset <id>: reset learning (not available in this build)
     /remember, /memory: durable memory
     /new: fresh conversation · /stop: stop the current run
     /status: daemon health (also /doctor) · /mcp: MCP server status
@@ -43,7 +50,7 @@ public enum CommandReplies {
     /skills: accepted and rejected workspace skills
 
     Mention me or reply to me to ask something; I read the topic either way.
-    Memory and schedules live in my owner's direct chat, not here.
+    Memory, schedules, and learning state live in my owner's direct chat, not here.
     """
 
   /// The manual this conversation can act on.

--- a/Sources/ClawGateway/Response/CommandReplies.swift
+++ b/Sources/ClawGateway/Response/CommandReplies.swift
@@ -12,13 +12,11 @@ public enum CommandReplies {
     "Not here — memory, schedules, and learning state live in my owner's direct chat."
 
   public static let learningUsage = "Usage: /learning reset <id>. See /learning"
-  public static let learningResetUnavailable =
-    "Learning reset is not available in this build."
   public static let learningUnavailable = "Learning status is unavailable. Try again."
 
   /// The owner manual, including the parked-entry interaction rules (stated verbatim as
   /// owner-visible text): slash commands bypass confirmation resolution entirely; only the
-  /// next plain text resolves a parked entry; /new clears it; a second /schedule displaces it;
+  /// next plain text resolves a parked entry; /new clears it; another gated command displaces it;
   /// /stop and /new act on the interactive session only.
   public static let help = """
     Commands:
@@ -26,7 +24,7 @@ public enum CommandReplies {
     /schedule list: list schedules
     /pause <id> · /resume <id> · /runnow <id> · /cancel <id>: manage schedules
     /learning · /learning <id>: inspect scheduled-job learning
-    /learning reset <id>: reset learning (not available in this build)
+    /learning reset <id>: reset a job's learning after confirmation
     /remember, /memory: durable memory
     /new: fresh conversation · /stop: stop the current run
     /status: daemon health (also /doctor) · /mcp: MCP server status
@@ -35,8 +33,8 @@ public enum CommandReplies {
     Confirmations:
     Slash commands never resolve a pending confirmation. Only your next plain-text \
     message does: "yes" confirms, "no" or "cancel" rejects, anything else drops it. \
-    /new also clears a pending confirmation, and a second /schedule replaces a parked \
-    draft. /stop and /new act on this chat only, never on scheduled job sessions. \
+    /new also clears a pending confirmation, and another confirmation-gated command \
+    replaces it. /stop and /new act on this chat only, never on scheduled job sessions. \
     Stop a job's future fires with /cancel <id>.
     """
 

--- a/Sources/ClawGateway/Response/LearningReplies.swift
+++ b/Sources/ClawGateway/Response/LearningReplies.swift
@@ -1,0 +1,42 @@
+import ClawCore
+
+enum LearningReplies {
+  static let resetFailed = "Learning reset failed. Nothing changed. Run the command again."
+
+  static func resetConfirmation(jobId: Int64, label: String?) -> String {
+    let identity = label.map { "Schedule \(jobId) · \($0)" } ?? "Schedule \(jobId)"
+    return """
+      \(identity)
+      Reset its learning?
+
+      This will start a new learning epoch with an empty stable lesson set, close every live \
+      trial, invalidate pending feedback targets and challenges, and abandon learning calls that \
+      have not started. Calls already in flight may finish, but only their usage is retained. \
+      Existing runs keep the lessons they were pinned to, and learning history is retained. \
+      The exact current effects are resolved when you confirm.
+
+      Reply yes to confirm or no to cancel.
+      """
+  }
+
+  static func resetOutcome(_ outcome: LearningResetOutcome, jobId: Int64) -> String {
+    switch outcome {
+    case .applied(let receipt):
+      return """
+        Learning reset applied for schedule \(jobId): epoch \(receipt.inputs.oldEpoch.value) → \
+        \(receipt.result.newEpoch.value), \(receipt.result.closedTrials.count) live trial(s) \
+        closed, \(receipt.result.invalidatedTargetCount) target(s) and \
+        \(receipt.result.invalidatedChallengeCount) challenge(s) invalidated, \
+        \(receipt.result.staleNoCallOperationIds.count) not-started call(s) abandoned, \
+        \(receipt.result.inFlightOperationIds.count) in-flight call(s) left usage-only.
+        """
+    case .alreadyReset(let receipt):
+      let epoch = receipt.result.newEpoch.value
+      return "Learning for schedule \(jobId) was already reset at epoch \(epoch)."
+    case .unarmed:
+      return "Schedule \(jobId) has no learning state to reset."
+    case .notFound:
+      return "No schedule with id \(jobId). Nothing was reset."
+    }
+  }
+}

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -27,6 +27,7 @@ public struct MessageRouter: Sendable {
 
   private let commandHandlers: CommandHandlers
   private let scheduleHandlers: ScheduleHandlers
+  private let learningHandlers: LearningHandlers?
   private let confirmations: ConfirmationResolver
   private let turnDispatch: TurnDispatch
   private let approvalCallbacks: ApprovalCallbackHandler?
@@ -56,6 +57,8 @@ public struct MessageRouter: Sendable {
     /// The lane tail's settle-and-seal port; nil leaves a bound run's deferred settlement to the
     /// boot backstop and seals nothing.
     learning: ScheduledLearningService? = nil,
+    learningStore: (any ScheduledLearningStore)? = nil,
+    learningRedactor: SecretRedactor? = nil,
     approvalCallbacks: ApprovalCallbackHandler? = nil,
     feedbackCallbacks: FeedbackCallbackHandler? = nil,
     feedbackChallenges: FeedbackChallengeHandler? = nil,
@@ -120,6 +123,11 @@ public struct MessageRouter: Sendable {
       now: now,
       logger: logger
     )
+    self.learningHandlers = Self.makeLearningHandlers(
+      store: learningStore,
+      redactor: learningRedactor,
+      replies: replies
+    )
     self.confirmations = ConfirmationResolver(
       sessionMessages: sessionMessages,
       pendingConfirmations: pendingConfirmations,
@@ -151,6 +159,17 @@ public struct MessageRouter: Sendable {
 // MARK: - Routing
 
 private extension MessageRouter {
+  static func makeLearningHandlers(
+    store: (any ScheduledLearningStore)?,
+    redactor: SecretRedactor?,
+    replies: ReplySender
+  ) -> LearningHandlers? {
+    guard let store, let redactor else {
+      return nil
+    }
+    return LearningHandlers(learning: store, redactor: redactor, replies: replies)
+  }
+
   func route(rawUpdate: RawUpdate) async throws(RoutingHalt) -> HandleOutcome {
     // A callback-only update normalizes to nil (no message/edited_message); without this branch it
     // would .skipped and the cursor would advance past it. The handler returns a real
@@ -546,6 +565,12 @@ private extension MessageRouter {
       )
     case .schedule(let scheduleCommand):
       return try await routeSchedule(scheduleCommand, rawUpdate: rawUpdate, message: message)
+    case .learning(let learningCommand):
+      return try await routeLearning(
+        learningCommand,
+        rawUpdate: rawUpdate,
+        message: message
+      )
     case .pause(let jobId):
       return try await scheduleHandlers.pause(rawUpdate: rawUpdate, message: message, jobId: jobId)
     case .resume(let jobId):
@@ -615,6 +640,21 @@ private extension MessageRouter {
     case .list:
       return try await scheduleHandlers.list(rawUpdate: rawUpdate, chatId: message.chatId)
     }
+  }
+
+  func routeLearning(
+    _ command: LearningCommand,
+    rawUpdate: RawUpdate,
+    message: IncomingMessage
+  ) async throws(RoutingHalt) -> HandleOutcome {
+    guard let learningHandlers else {
+      return await replies.sendCanned(
+        updateId: rawUpdate.updateId,
+        target: .chat(message.chatId),
+        text: CommandReplies.learningUnavailable
+      )
+    }
+    return try await learningHandlers.handle(command, rawUpdate: rawUpdate, message: message)
   }
 
   /// Plain text first offers itself to any parked confirmation for the session; only an

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -59,6 +59,7 @@ public struct MessageRouter: Sendable {
     learning: ScheduledLearningService? = nil,
     learningStore: (any ScheduledLearningStore)? = nil,
     learningRedactor: SecretRedactor? = nil,
+    learningOutboxSignal: OutboxSignal? = nil,
     approvalCallbacks: ApprovalCallbackHandler? = nil,
     feedbackCallbacks: FeedbackCallbackHandler? = nil,
     feedbackChallenges: FeedbackChallengeHandler? = nil,
@@ -125,6 +126,7 @@ public struct MessageRouter: Sendable {
     )
     self.learningHandlers = Self.makeLearningHandlers(
       store: learningStore,
+      outboxSignal: learningOutboxSignal,
       redactor: learningRedactor,
       sessionMessages: sessionMessages,
       pendingConfirmations: pendingConfirmations,
@@ -165,6 +167,7 @@ public struct MessageRouter: Sendable {
 private extension MessageRouter {
   static func makeLearningHandlers(
     store: (any ScheduledLearningStore)?,
+    outboxSignal: OutboxSignal?,
     redactor: SecretRedactor?,
     sessionMessages: any SessionMessageStore,
     pendingConfirmations: PendingConfirmationRegistry,
@@ -180,7 +183,8 @@ private extension MessageRouter {
       sessionMessages: sessionMessages,
       pendingConfirmations: pendingConfirmations,
       replies: replies,
-      now: now
+      now: now,
+      outboxSignal: outboxSignal
     )
   }
 

--- a/Sources/ClawGateway/Routing/MessageRouter.swift
+++ b/Sources/ClawGateway/Routing/MessageRouter.swift
@@ -126,12 +126,16 @@ public struct MessageRouter: Sendable {
     self.learningHandlers = Self.makeLearningHandlers(
       store: learningStore,
       redactor: learningRedactor,
-      replies: replies
+      sessionMessages: sessionMessages,
+      pendingConfirmations: pendingConfirmations,
+      replies: replies,
+      now: now
     )
     self.confirmations = ConfirmationResolver(
       sessionMessages: sessionMessages,
       pendingConfirmations: pendingConfirmations,
       memoryCommands: memoryCommands,
+      learningReset: learningStore,
       schedule: schedule,
       replies: replies,
       now: now,
@@ -162,12 +166,22 @@ private extension MessageRouter {
   static func makeLearningHandlers(
     store: (any ScheduledLearningStore)?,
     redactor: SecretRedactor?,
-    replies: ReplySender
+    sessionMessages: any SessionMessageStore,
+    pendingConfirmations: PendingConfirmationRegistry,
+    replies: ReplySender,
+    now: @escaping @Sendable () -> Date
   ) -> LearningHandlers? {
     guard let store, let redactor else {
       return nil
     }
-    return LearningHandlers(learning: store, redactor: redactor, replies: replies)
+    return LearningHandlers(
+      learning: store,
+      redactor: redactor,
+      sessionMessages: sessionMessages,
+      pendingConfirmations: pendingConfirmations,
+      replies: replies,
+      now: now
+    )
   }
 
   func route(rawUpdate: RawUpdate) async throws(RoutingHalt) -> HandleOutcome {
@@ -661,7 +675,7 @@ private extension MessageRouter {
   /// unclaimed message becomes a durable turn.
   ///
   /// A room skips the offer outright instead of being trusted to come up empty. Nothing can park
-  /// there — the two families that park are refused in `routeAllowed` — and skipping keeps it that
+  /// there — all families that park are refused in `routeAllowed` — and skipping keeps it that
   /// way even if a third one is ever added: a "yes" typed in a topic is just a word.
   func routePlain(
     _ text: String,

--- a/Sources/ClawGateway/Routing/ReplySender.swift
+++ b/Sources/ClawGateway/Routing/ReplySender.swift
@@ -91,6 +91,33 @@ struct ReplySender: Sendable {
     return .processed
   }
 
+  /// One claimed canned response delivered in stable chunk order.
+  func sendCannedChunks(
+    updateId: Int64,
+    target: DeliveryTarget,
+    texts: [String]
+  ) async -> HandleOutcome {
+    guard Task.isCancelled == false, texts.isEmpty == false else {
+      return .transientFailure
+    }
+
+    do {
+      try await claimUpdate(updateId: updateId, target: target)
+    } catch {
+      return error.outcome
+    }
+
+    do {
+      for text in texts {
+        _ = try await delivery.sendMessage(to: target, text: text)
+      }
+    } catch {
+      logger.error("chunked send failed for update \(updateId): \(error)")
+      return .transientFailure
+    }
+    return .processed
+  }
+
   /// Ack for a command whose effect already claimed the update; the send is best-effort — a lost
   /// ack must not re-run the effect.
   func sendCommandAck(

--- a/Sources/ClawGateway/Services/Learning/ScheduledLearningService.swift
+++ b/Sources/ClawGateway/Services/Learning/ScheduledLearningService.swift
@@ -62,15 +62,16 @@ public actor ScheduledLearningService {
     _ = kickDrain(now: now())
   }
 
-  /// Three duties: seal what settled, reconcile open trials against their deadlines, and age data
-  /// out. Trial reconciliation and retention join later; sealing is the one that ships here.
+  /// Seals settled runs, then reconciles live trials against their deadlines. Retention joins
+  /// later; errors remain isolated so one bad row cannot starve later work.
   public func sweep(now: Date) async {
     await sealSettled(now: now)
+    _ = await reconcileTrials(now: now)
   }
 
   /// Runs after boot reconciliation has settled what the last process left open, so this pass sees
-  /// those runs already frozen. It reads the durable queue and seals; it never settles a run
-  /// itself, so it cannot disturb the ordering the boot sweep and its approval backstop rely on.
+  /// those runs already frozen. It reconciles operations, seals, then reconciles trials; it never
+  /// settles a run itself, so it cannot disturb the boot sweep and approval-backstop ordering.
   ///
   /// The operation pass goes first, and no learning call may be dispatched before it returns: a
   /// prior process's `started` operation has to be charged and closed as unknown before anything
@@ -79,6 +80,34 @@ public actor ScheduledLearningService {
   public func reconcileAtBoot(now: Date) async {
     reconcileOperations(now: now)
     await sealSettled(now: now)
+    _ = await reconcileTrials(now: now)
+  }
+
+  @discardableResult
+  public func reconcileTrials(now: Date) async -> [TrialReconciliation] {
+    let identities: [LearningTrialIdentity]
+    do {
+      identities = try store.liveTrialIdentities()
+    } catch {
+      logger.error("learning sweep could not read live trials: \(error)")
+      return []
+    }
+
+    var reconciliations: [TrialReconciliation] = []
+    for identity in identities {
+      do {
+        switch try store.reconcileTrial(identity, now: now) {
+        case .stale:
+          break
+        case .reconciled(let reconciliation):
+          reconciliations.append(reconciliation)
+        }
+      } catch {
+        logger.error("trial \(identity.trialId) reconciliation failed: \(error)")
+      }
+      await Task.yield()
+    }
+    return reconciliations
   }
 }
 

--- a/Sources/clawd/Composition/DaemonBuilder+Boot.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Boot.swift
@@ -12,6 +12,7 @@ extension DaemonBuilder {
     BotMenuCommand(command: "remember", description: "Save a memory."),
     BotMenuCommand(command: "memory", description: "Review saved memories."),
     BotMenuCommand(command: "schedule", description: "Create or list schedules."),
+    BotMenuCommand(command: "learning", description: "Inspect scheduled-job learning."),
     BotMenuCommand(command: "pause", description: "Pause a schedule."),
     BotMenuCommand(command: "resume", description: "Resume a paused schedule."),
     BotMenuCommand(command: "runnow", description: "Run a schedule now."),

--- a/Sources/clawd/Composition/DaemonBuilder+Intake.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Intake.swift
@@ -75,6 +75,8 @@ extension DaemonBuilder {
       lanes: coordination.lanes,
       schedule: scheduleSurface,
       learning: learning,
+      learningStore: stores.learning,
+      learningRedactor: SecretRedactor(secretValues: redactionValues),
       approvalCallbacks: approvalCallbacks,
       feedbackCallbacks: makeFeedbackCallbackHandler(challenges: feedbackChallenges),
       feedbackChallenges: feedbackChallenges,

--- a/Sources/clawd/Composition/DaemonBuilder+Intake.swift
+++ b/Sources/clawd/Composition/DaemonBuilder+Intake.swift
@@ -77,6 +77,7 @@ extension DaemonBuilder {
       learning: learning,
       learningStore: stores.learning,
       learningRedactor: SecretRedactor(secretValues: redactionValues),
+      learningOutboxSignal: coordination.outboxSignal,
       approvalCallbacks: approvalCallbacks,
       feedbackCallbacks: makeFeedbackCallbackHandler(challenges: feedbackChallenges),
       feedbackChallenges: feedbackChallenges,

--- a/Tests/ClawCoreTests/Domain/Bot/CommandTests.swift
+++ b/Tests/ClawCoreTests/Domain/Bot/CommandTests.swift
@@ -173,6 +173,7 @@ import Testing
     (Command.remember(.invalid), true),
     (.memory(.review), true),
     (.schedule(.list), true),
+    (.learning(.list), true),
     (.pause(jobId: 1), true),
     (.resume(jobId: 1), true),
     (.runNow(jobId: 1), true),

--- a/Tests/ClawCoreTests/Domain/Bot/LearningCommandParseTests.swift
+++ b/Tests/ClawCoreTests/Domain/Bot/LearningCommandParseTests.swift
@@ -1,0 +1,48 @@
+import Testing
+
+@testable import ClawCore
+
+@Suite struct LearningCommandParseTests {
+  @Test(arguments: [
+    ("/learning", Command.learning(.list)),
+    ("/learning list", .learning(.list)),
+    ("/learning LIST", .learning(.list)),
+    ("/LEARNING@CLAW_BOT list", .learning(.list)),
+    ("/learning 3", .learning(.detail(jobId: 3))),
+    ("/learning reset 3", .learning(.reset(jobId: 3))),
+    ("/learning RESET 3", .learning(.reset(jobId: 3))),
+    ("/learning reset", .learning(.reset(jobId: nil))),
+    ("/learning reset 0", .learning(.reset(jobId: nil))),
+    ("/learning reset junk", .learning(.reset(jobId: nil))),
+    ("/learning reset 3 extra", .learning(.reset(jobId: nil))),
+    ("/learning bogus", .learning(.list)),
+    ("/learning 0", .learning(.list)),
+    ("/learning -1", .learning(.list)),
+  ])
+  func grammar(text: String, expected: Command) {
+    // given
+    let botUsername = "claw_bot"
+
+    // when
+    let command = Command.parse(text, botUsername: botUsername)
+
+    // then — ignoring the argument tail collapses detail/reset into the list branch.
+    #expect(command == expected)
+  }
+
+  @Test(arguments: [
+    "please /learning",
+    " /learning",
+    "/learning@some_other_bot",
+  ])
+  func nonLeadingOrMismatchedCommandsStayPlain(text: String) {
+    // given
+    let botUsername = "claw_bot"
+
+    // when
+    let command = Command.parse(text, botUsername: botUsername)
+
+    // then — parsing a non-authoritative slash token turns ordinary text into a control request.
+    #expect(command == .plain(text))
+  }
+}

--- a/Tests/ClawCoreTests/Learning/EvaluatorCarrierTests.swift
+++ b/Tests/ClawCoreTests/Learning/EvaluatorCarrierTests.swift
@@ -17,6 +17,7 @@ private let repliesOutsideTheFrozenSchema: [String] = [
   #"{"schema_version":2,"outcome":"no_issue","issue_codes":[]}"#,
   #"{"schema_version":1,"outcome":"maybe","issue_codes":[]}"#,
   #"{"schema_version":1,"outcome":"reusable_issue","issue_codes":[""]}"#,
+  reply(issueCodes: ["duplicate", "duplicate"]),
   reply(issueCodes: (0...EvaluatorOutput.maxIssueCodes).map { "code_\($0)" }),
   reply(issueCodes: [String(repeating: "x", count: EvaluatorOutput.maxIssueCodeCharacters + 1)]),
 ]

--- a/Tests/ClawCoreTests/Learning/TrialResolutionTests.swift
+++ b/Tests/ClawCoreTests/Learning/TrialResolutionTests.swift
@@ -27,6 +27,19 @@ import Testing
         now: trial.assignmentDeadline
       ) == false
     )
+    // Removing either the open-state or capacity gate admits its matching invalid trial.
+    #expect(
+      fixtureTrial(state: .draining).acceptsAssignment(
+        occurrenceAt: admittedAt,
+        now: admittedAt.addingTimeInterval(1)
+      ) == false
+    )
+    #expect(
+      fixtureTrial(consumed: TrialAdmissionPolicy.maximumAssignments).acceptsAssignment(
+        occurrenceAt: admittedAt,
+        now: admittedAt.addingTimeInterval(1)
+      ) == false
+    )
   }
 
   @Test func twoPositivesWaitForTheLastUnresolvedAssignment() {

--- a/Tests/ClawCoreTests/Learning/TrialResolutionTests.swift
+++ b/Tests/ClawCoreTests/Learning/TrialResolutionTests.swift
@@ -1,0 +1,320 @@
+import ClawCore
+import Foundation
+import Testing
+
+@Suite struct TrialResolutionTests {
+  @Test func assignmentAcceptanceUsesOccurrenceAndProcessingClocks() {
+    // given
+    let admittedAt = Date(timeIntervalSince1970: 1_000)
+    let trial = fixtureTrial(admittedAt: admittedAt)
+
+    // when / then
+    #expect(
+      trial.acceptsAssignment(
+        occurrenceAt: admittedAt,
+        now: admittedAt.addingTimeInterval(1)
+      )
+    )
+    #expect(
+      trial.acceptsAssignment(
+        occurrenceAt: admittedAt.addingTimeInterval(-1),
+        now: admittedAt.addingTimeInterval(1)
+      ) == false
+    )
+    #expect(
+      trial.acceptsAssignment(
+        occurrenceAt: admittedAt,
+        now: trial.assignmentDeadline
+      ) == false
+    )
+  }
+
+  @Test func twoPositivesWaitForTheLastUnresolvedAssignment() {
+    // given
+    let trial = fixtureTrial(consumed: 3)
+    let assignments = [
+      fixtureAssignment(runId: 1, outcome: .positive),
+      fixtureAssignment(runId: 2, outcome: .positive),
+      fixtureAssignment(runId: 3),
+    ]
+
+    // when
+    let decision = TrialPolicy.decide(trial: trial, assignments: assignments, now: trial.admittedAt)
+
+    // then
+    #expect(decision == .closeAssignment(reason: .assignmentLimit))
+  }
+
+  @Test func negativeAndHardVetoPrecedeUnresolvedAndPositiveInputs() {
+    // given
+    let trial = fixtureTrial(consumed: 3, hardVetoes: [.staleControlState])
+    let assignments = [
+      fixtureAssignment(runId: 1, outcome: .positive),
+      fixtureAssignment(runId: 2, outcome: .negative(issueCodes: ["bad"])),
+      fixtureAssignment(runId: 3),
+    ]
+
+    // when
+    let withVeto = TrialPolicy.decide(
+      trial: trial,
+      assignments: assignments,
+      now: trial.decisionDeadline
+    )
+    let withoutVeto = TrialPolicy.decide(
+      trial: fixtureTrial(consumed: 3),
+      assignments: assignments,
+      now: trial.decisionDeadline
+    )
+
+    // then
+    #expect(withVeto == .fallback(reason: .hardVeto))
+    #expect(withoutVeto == .fallback(reason: .negativeOutcome))
+  }
+
+  @Test func assignmentHardVetoPrecedesAnOtherwisePromotableCohort() {
+    // given
+    let trial = fixtureTrial(consumed: 2)
+    let assignments = [
+      fixtureAssignment(runId: 1, outcome: .positive),
+      fixtureAssignment(
+        runId: 2,
+        outcome: .positive,
+        hardVetoes: [.ownerDependencyRejected]
+      ),
+    ]
+
+    // when
+    let decision = TrialPolicy.decide(trial: trial, assignments: assignments, now: trial.admittedAt)
+
+    // then — checking only candidate-level vetoes would promote this exact assignment cohort.
+    #expect(decision == .fallback(reason: .hardVeto))
+  }
+
+  @Test func decisionDeadlinePreservesIncompleteWithoutPersistingNeutral() {
+    // given
+    let trial = fixtureTrial(consumed: 1)
+    let assignments = [fixtureAssignment(runId: 1)]
+
+    // when
+    let before = TrialPolicy.decide(
+      trial: trial,
+      assignments: assignments,
+      now: trial.admittedAt
+    )
+    let atDeadline = TrialPolicy.decide(
+      trial: trial,
+      assignments: assignments,
+      now: trial.decisionDeadline
+    )
+
+    // then
+    #expect(before == .wait)
+    #expect(atDeadline == .fallback(reason: .decisionDeadlineIncomplete))
+    #expect(assignments[0].resolvedEvidence == nil)
+  }
+
+  @Test func alreadyDrainingUnresolvedTrialWaitsWithoutInventingACloseReason() {
+    // given
+    let trial = fixtureTrial(consumed: 3, state: .draining)
+    let assignments = [
+      fixtureAssignment(runId: 1, outcome: .positive),
+      fixtureAssignment(runId: 2, outcome: .positive),
+      fixtureAssignment(runId: 3),
+    ]
+
+    // when
+    let decision = TrialPolicy.decide(trial: trial, assignments: assignments, now: trial.admittedAt)
+
+    // then
+    #expect(decision == .wait)
+  }
+
+  @Test func emptyAndAllNeutralCohortsFallbackWhenAssignmentCloses() {
+    // given
+    let empty = fixtureTrial(consumed: 0)
+    let neutral = fixtureTrial(consumed: 3)
+
+    // when
+    let emptyDecision = TrialPolicy.decide(
+      trial: empty,
+      assignments: [],
+      now: empty.assignmentDeadline
+    )
+    let neutralDecision = TrialPolicy.decide(
+      trial: neutral,
+      assignments: [
+        fixtureAssignment(runId: 1, outcome: .neutral),
+        fixtureAssignment(runId: 2, outcome: .neutral),
+        fixtureAssignment(runId: 3, outcome: .neutral),
+      ],
+      now: neutral.admittedAt
+    )
+
+    // then
+    #expect(emptyDecision == .fallback(reason: .insufficientSupport))
+    #expect(neutralDecision == .fallback(reason: .insufficientSupport))
+  }
+
+  @Test func oneOrTwoNeutralOutcomesConsumeExposureWithoutClosingIt() {
+    // given
+    let one = fixtureTrial(consumed: 1)
+    let two = fixtureTrial(consumed: 2)
+
+    // when
+    let oneDecision = TrialPolicy.decide(
+      trial: one,
+      assignments: [fixtureAssignment(runId: 1, outcome: .neutral)],
+      now: one.admittedAt
+    )
+    let twoDecision = TrialPolicy.decide(
+      trial: two,
+      assignments: [
+        fixtureAssignment(runId: 1, outcome: .neutral),
+        fixtureAssignment(runId: 2, outcome: .neutral),
+      ],
+      now: two.admittedAt
+    )
+
+    // then — excluding neutral rows from exposure would close or over-assign this cohort.
+    #expect(oneDecision == .wait)
+    #expect(twoDecision == .wait)
+  }
+
+  @Test func assignmentBoundsUseEqualityAndLimitWinsWhenBothAreReached() {
+    // given
+    let atDeadline = fixtureTrial(consumed: 1)
+    let atBoth = fixtureTrial(consumed: 3)
+    let unresolved = [fixtureAssignment(runId: 1)]
+
+    // when
+    let deadlineDecision = TrialPolicy.decide(
+      trial: atDeadline,
+      assignments: unresolved,
+      now: atDeadline.assignmentDeadline
+    )
+    let bothDecision = TrialPolicy.decide(
+      trial: atBoth,
+      assignments: [
+        fixtureAssignment(runId: 1),
+        fixtureAssignment(runId: 2),
+        fixtureAssignment(runId: 3),
+      ],
+      now: atBoth.assignmentDeadline
+    )
+
+    // then — `>` misses equality, and deadline-first changes the stable typed reason at capacity.
+    #expect(deadlineDecision == .closeAssignment(reason: .assignmentDeadline))
+    #expect(bothDecision == .closeAssignment(reason: .assignmentLimit))
+  }
+
+  @Test func twoResolvedPositivesPromoteOnlyAfterTheWholeCohortResolves() {
+    // given
+    let trial = fixtureTrial(consumed: 2)
+    let assignments = [
+      fixtureAssignment(runId: 1, outcome: .positive),
+      fixtureAssignment(runId: 2, outcome: .positive),
+    ]
+
+    // when
+    let decision = TrialPolicy.decide(trial: trial, assignments: assignments, now: trial.admittedAt)
+
+    // then
+    #expect(decision == .promote)
+  }
+
+  @Test func onePositiveDoesNotMeetTheTwoRunPromotionThreshold() {
+    // given
+    let trial = fixtureTrial(consumed: 3)
+    let assignments = [
+      fixtureAssignment(runId: 1, outcome: .positive),
+      fixtureAssignment(runId: 2, outcome: .neutral),
+      fixtureAssignment(runId: 3, outcome: .neutral),
+    ]
+
+    // when
+    let decision = TrialPolicy.decide(trial: trial, assignments: assignments, now: trial.admittedAt)
+
+    // then — counting any positive as sufficient support would promote this closed cohort.
+    #expect(decision == .fallback(reason: .insufficientSupport))
+  }
+
+  @Test func resolvedEvidenceDerivesOneCanonicalOutcomeShape() {
+    // given
+    let resolved = ResolvedRunEvidence(
+      effective: ResolvedOutcome(
+        outcome: .negative(issueCodes: ["b", "a"]),
+        ownerConfirmed: true,
+        evaluationRequired: true,
+        hardVetoes: [.criticalOrRegressionReceipt]
+      ),
+      evaluationDigest: EvaluationDigest(rawValue: String(repeating: "a", count: 64)),
+      correctionEventDigest: nil,
+      effectiveFeedbackRevision: FeedbackRevision(4)
+    )
+
+    // when / then
+    #expect(resolved.outcome == .negative)
+    #expect(resolved.issueCodes == ["b", "a"])
+    #expect(resolved.evaluationRequired)
+    #expect(resolved.ownerConfirmed)
+    #expect(resolved.hardVetoes == [.criticalOrRegressionReceipt])
+  }
+}
+
+// MARK: - Fixtures
+
+private func fixtureTrial(
+  admittedAt: Date = Date(timeIntervalSince1970: 1_000),
+  consumed: Int = 0,
+  state: LearningTrialState = .open,
+  hardVetoes: Set<HardVeto> = []
+) -> LearningTrial {
+  LearningTrial(
+    identity: LearningTrialIdentity(
+      trialId: 11,
+      jobId: 7,
+      epoch: LearningEpoch(2),
+      generation: 3
+    ),
+    baseDigest: LessonSetDigest(rawValue: String(repeating: "a", count: 64)),
+    baseRevision: StableRevision(4),
+    candidateDigest: CandidateDigest(rawValue: String(repeating: "b", count: 64)),
+    replacementDigest: LessonSetDigest(rawValue: String(repeating: "c", count: 64)),
+    algorithm: .v1,
+    admittedAt: admittedAt,
+    cohortCutoff: admittedAt,
+    maxAssignments: TrialAdmissionPolicy.maximumAssignments,
+    consumedAssignments: consumed,
+    assignmentDeadline: admittedAt.addingTimeInterval(TrialAdmissionPolicy.assignmentWindow),
+    decisionDeadline: admittedAt.addingTimeInterval(TrialAdmissionPolicy.decisionWindow),
+    state: state,
+    hardVetoes: hardVetoes
+  )
+}
+
+private func fixtureAssignment(
+  runId: Int64,
+  outcome: EffectiveOutcome? = nil,
+  hardVetoes: Set<HardVeto> = []
+) -> TrialAssignment {
+  let evidence = outcome.map { outcome in
+    ResolvedRunEvidence(
+      effective: ResolvedOutcome(
+        outcome: outcome,
+        ownerConfirmed: false,
+        evaluationRequired: true,
+        hardVetoes: hardVetoes
+      ),
+      evaluationDigest: EvaluationDigest(rawValue: String(repeating: "d", count: 64)),
+      correctionEventDigest: nil,
+      effectiveFeedbackRevision: FeedbackRevision(0)
+    )
+  }
+  return TrialAssignment(
+    identity: TrialAssignmentIdentity(trial: fixtureTrial().identity, runId: runId),
+    assignedAt: Date(timeIntervalSince1970: 1_001),
+    state: evidence == nil ? .learningOutcomeUnresolved : .learningOutcomeResolved,
+    resolvedEvidence: evidence,
+    resolvedAt: evidence == nil ? nil : Date(timeIntervalSince1970: 1_002)
+  )
+}

--- a/Tests/ClawCoreTests/Persistence/AuditActionTests.swift
+++ b/Tests/ClawCoreTests/Persistence/AuditActionTests.swift
@@ -56,4 +56,13 @@ import Testing
     // given / when / then — rawValues are the durable audit vocabulary (spec §3.1, preamble)
     #expect(fixture.action.rawValue == fixture.rawValue)
   }
+
+  @Test func learningResetVocabularyHasStableTypedRawValues() {
+    // given / when / then — duplicated string literals at write sites would let one durable value
+    // drift while the other values continue to pass their integration paths.
+    #expect(AuditAction.learningReset.rawValue == "learning_reset")
+    #expect(LearningTrialCloseReason.learningReset.rawValue == "learning_reset")
+    #expect(LearningOperationFailure.staleEpoch.rawValue == "stale_epoch")
+    #expect(ResetReceipt.kind == "learning_reset")
+  }
 }

--- a/Tests/ClawDataTests/Database/SQLiteStoredValueTests.swift
+++ b/Tests/ClawDataTests/Database/SQLiteStoredValueTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct SQLiteStoredValueTests {
+  @Test func exactStorageClassMatrix() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let row = try queue.read { db in
+      try #require(
+        try Row.fetchOne(
+          db,
+          sql: """
+            SELECT NULL AS null_value, 0 AS zero_value, 1 AS one_value, 2 AS two_value,
+              9223372036854775807 AS maximum_integer, 1.5 AS real_value,
+              '1' AS text_value, X'01' AS blob_value
+            """
+        )
+      )
+    }
+
+    // when
+    let nullableInt64 = try #require(
+      SQLiteStoredValue.nullableInt64(in: row, column: "null_value")
+    )
+    let nullableInt = try #require(
+      SQLiteStoredValue.nullableInt(in: row, column: "null_value")
+    )
+    let nullableDouble = try #require(
+      SQLiteStoredValue.nullableDouble(in: row, column: "null_value")
+    )
+    let nullableString = try #require(
+      SQLiteStoredValue.nullableString(in: row, column: "null_value")
+    )
+
+    // then — collapsing missing/wrong-class values into SQL NULL, widening Boolean truth, or
+    // coercing storage classes violates the decoder; the nearest accepted view matrix reaches
+    // only non-optional fields.
+    #expect(nullableInt64.value == nil)
+    #expect(nullableInt.value == nil)
+    #expect(nullableDouble.value == nil)
+    #expect(nullableString.value == nil)
+    #expect(nonnullableDecodersRejectNull(in: row))
+    #expect(nullableDecodersRejectMissingColumn(in: row))
+    #expect(nullableDecodersRejectWrongStorageClass(in: row))
+    #expect(booleanDomainIsExact(in: row))
+    #expect(SQLiteStoredValue.data(in: row, column: "blob_value") == Data([0x01]))
+    #expect(SQLiteStoredValue.data(in: row, column: "text_value") == nil)
+    #expect(SQLiteStoredValue.int64(in: row, column: "one_value") == 1)
+    #expect(SQLiteStoredValue.int(in: row, column: "one_value") == 1)
+    #expect(nativeIntsRespectPlatformRange(in: row))
+    #expect(SQLiteStoredValue.string(in: row, column: "text_value") == "1")
+    #expect(doublesUseNumericStorageClasses(in: row))
+  }
+}
+
+private extension SQLiteStoredValueTests {
+  func nonnullableDecodersRejectNull(in row: Row) -> Bool {
+    SQLiteStoredValue.int64(in: row, column: "null_value") == nil
+      && SQLiteStoredValue.int(in: row, column: "null_value") == nil
+      && isAbsent(SQLiteStoredValue.boolean(in: row, column: "null_value"))
+      && SQLiteStoredValue.double(in: row, column: "null_value") == nil
+      && SQLiteStoredValue.string(in: row, column: "null_value") == nil
+      && SQLiteStoredValue.data(in: row, column: "null_value") == nil
+  }
+
+  func nullableDecodersRejectMissingColumn(in row: Row) -> Bool {
+    isAbsent(SQLiteStoredValue.nullableInt64(in: row, column: "missing_value"))
+      && isAbsent(SQLiteStoredValue.nullableInt(in: row, column: "missing_value"))
+      && isAbsent(SQLiteStoredValue.nullableDouble(in: row, column: "missing_value"))
+      && isAbsent(SQLiteStoredValue.nullableString(in: row, column: "missing_value"))
+  }
+
+  func nullableDecodersRejectWrongStorageClass(in row: Row) -> Bool {
+    isAbsent(SQLiteStoredValue.nullableInt64(in: row, column: "text_value"))
+      && isAbsent(SQLiteStoredValue.nullableInt(in: row, column: "text_value"))
+      && isAbsent(SQLiteStoredValue.nullableDouble(in: row, column: "text_value"))
+      && isAbsent(SQLiteStoredValue.nullableString(in: row, column: "blob_value"))
+  }
+
+  func booleanDomainIsExact(in row: Row) -> Bool {
+    guard
+      case .falseValue? = SQLiteStoredValue.boolean(in: row, column: "zero_value"),
+      case .trueValue? = SQLiteStoredValue.boolean(in: row, column: "one_value")
+    else {
+      return false
+    }
+    return isAbsent(SQLiteStoredValue.boolean(in: row, column: "two_value"))
+      && isAbsent(SQLiteStoredValue.boolean(in: row, column: "text_value"))
+  }
+
+  func nativeIntsRespectPlatformRange(in row: Row) -> Bool {
+    let expected = Int(exactly: Int64.max)
+    let decoded = SQLiteStoredValue.int(in: row, column: "maximum_integer")
+    let nullable = SQLiteStoredValue.nullableInt(in: row, column: "maximum_integer")
+    switch (expected, nullable) {
+    case (.some(let expected), .some(let nullable)):
+      return decoded == expected && nullable.value == expected
+    case (nil, nil):
+      return decoded == nil
+    default:
+      return false
+    }
+  }
+
+  func doublesUseNumericStorageClasses(in row: Row) -> Bool {
+    guard
+      let nullableInteger = SQLiteStoredValue.nullableDouble(in: row, column: "one_value"),
+      let nullableReal = SQLiteStoredValue.nullableDouble(in: row, column: "real_value")
+    else {
+      return false
+    }
+    return SQLiteStoredValue.double(in: row, column: "one_value") == 1
+      && SQLiteStoredValue.double(in: row, column: "real_value") == 1.5
+      && SQLiteStoredValue.double(in: row, column: "text_value") == nil
+      && nullableInteger.value == 1
+      && nullableReal.value == 1.5
+  }
+
+  func isAbsent<Value>(_ value: Value?) -> Bool {
+    switch value {
+    case nil:
+      true
+    case .some:
+      false
+    }
+  }
+}

--- a/Tests/ClawDataTests/Database/V13MigrationTests.swift
+++ b/Tests/ClawDataTests/Database/V13MigrationTests.swift
@@ -1,0 +1,287 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct V13MigrationTests {
+  @Test func freshLatestMigrationInstallsOnlyTheLiveTrialIndexAndIsIdempotent() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+
+    // when
+    try ClawDatabase.migrate(queue)
+    try ClawDatabase.migrate(queue)
+
+    // then
+    let indexes = try indexSQL(queue)
+    #expect(indexes["idx_learning_trials_open_job"] == nil)
+    let sql = try #require(indexes["idx_learning_trials_live_job"])
+    #expect(sql.contains("UNIQUE INDEX"))
+    #expect(sql.contains("state IN ('open', 'draining')"))
+    #expect(try migrations(queue).last == "v13")
+  }
+
+  @Test func v13PreservesSeededV12LiveAndTerminalRows() throws {
+    // given
+    let queue = try v12Queue()
+    try seedJob(queue, jobId: 1)
+    try insertTrial(queue, jobId: 1, trialId: 1, state: .draining, candidateByte: "b")
+    try insertTrial(queue, jobId: 1, trialId: 2, state: .promoted, candidateByte: "c")
+    try insertTrial(queue, jobId: 1, trialId: 3, state: .fellBack, candidateByte: "d")
+
+    // when
+    try ClawDatabase.migrate(queue)
+
+    // then
+    let rows = try queue.read { db in
+      try Row.fetchAll(
+        db,
+        sql: "SELECT trial_id, state FROM learning_trials ORDER BY trial_id"
+      )
+      .map { row in
+        "\(row["trial_id"] as Int64):\(row["state"] as String)"
+      }
+    }
+    #expect(rows == ["1:draining", "2:promoted", "3:fell_back"])
+  }
+
+  @Test(arguments: LiveTrialPair.allCases)
+  func liveIndexRejectsEveryOpenAndDrainingPair(_ pair: LiveTrialPair) throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    try seedJob(queue, jobId: 1)
+    try insertTrial(
+      queue,
+      jobId: 1,
+      trialId: 1,
+      state: pair.first,
+      candidateByte: "b"
+    )
+
+    // when / then — every ordered pair independently reaches the partial-index predicate.
+    #expect {
+      try insertTrialMapped(
+        queue,
+        jobId: 1,
+        trialId: 2,
+        state: pair.second,
+        candidateByte: "c"
+      )
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+    #expect(try trialCount(queue) == 1)
+  }
+
+  @Test func liveIndexAllowsEveryTerminalHistoryShape() throws {
+    // given
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    try seedJob(queue, jobId: 1)
+
+    // when
+    try insertTrial(queue, jobId: 1, trialId: 1, state: .open, candidateByte: "b")
+    try insertTrial(queue, jobId: 1, trialId: 2, state: .promoted, candidateByte: "c")
+    try insertTrial(queue, jobId: 1, trialId: 3, state: .fellBack, candidateByte: "d")
+    try insertTrial(queue, jobId: 1, trialId: 4, state: .closed, candidateByte: "e")
+
+    // then — widening the predicate to any terminal state rejects one of these rows.
+    #expect(try trialCount(queue) == 4)
+  }
+
+  @Test func conflictingV12UpgradeRollsBackAndRetriesAfterRepair() throws {
+    // given
+    let queue = try v12Queue()
+    try seedJob(queue, jobId: 1)
+    try insertTrial(queue, jobId: 1, trialId: 1, state: .open, candidateByte: "b")
+    try insertTrial(queue, jobId: 1, trialId: 2, state: .draining, candidateByte: "c")
+
+    // when
+    #expect {
+      try ClawDatabase.migrate(queue)
+    } throws: { error in
+      guard case StoreError.migrationFailed = error else {
+        return false
+      }
+      return true
+    }
+
+    // then
+    var indexes = try indexSQL(queue)
+    #expect(indexes["idx_learning_trials_open_job"] != nil)
+    #expect(indexes["idx_learning_trials_live_job"] == nil)
+    #expect(try migrations(queue).contains("v13") == false)
+    #expect(try trialCount(queue) == 2)
+
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE learning_trials SET state = ? WHERE trial_id = 2",
+        arguments: [LearningTrialState.closed.rawValue]
+      )
+    }
+    try ClawDatabase.migrate(queue)
+    indexes = try indexSQL(queue)
+    #expect(indexes["idx_learning_trials_open_job"] == nil)
+    #expect(indexes["idx_learning_trials_live_job"] != nil)
+    #expect(try migrations(queue).last == "v13")
+  }
+}
+
+enum LiveTrialPair: CaseIterable {
+  case openOpen
+  case openDraining
+  case drainingOpen
+  case drainingDraining
+
+  var first: LearningTrialState {
+    switch self {
+    case .openOpen, .openDraining:
+      .open
+    case .drainingOpen, .drainingDraining:
+      .draining
+    }
+  }
+
+  var second: LearningTrialState {
+    switch self {
+    case .openOpen, .drainingOpen:
+      .open
+    case .openDraining, .drainingDraining:
+      .draining
+    }
+  }
+}
+
+// MARK: - Schema Fixtures
+
+private func v12Queue() throws -> DatabaseQueue {
+  let queue = try ClawDatabase.makeInMemoryQueue()
+  try ClawDatabase.migrator.migrate(queue, upTo: "v12")
+  return queue
+}
+
+private func seedJob(_ queue: DatabaseQueue, jobId: Int64) throws {
+  let base = String(repeating: "a", count: 64)
+  try queue.write { db in
+    try db.execute(
+      sql: """
+        INSERT INTO scheduled_jobs(id, owner_chat_id, label, prompt, recurrence, timezone,
+          next_occurrence, last_fired_at, status, session_id, created_ts, updated_ts)
+        VALUES (?, 1, 'job', 'prompt', '{}', 'UTC', NULL, NULL, 'active', NULL, 1, 1)
+        """,
+      arguments: [jobId]
+    )
+    try db.execute(
+      sql: """
+        INSERT INTO lesson_sets(job_id, digest, schema_version, canonical_bytes, source, created_at)
+        VALUES (?, ?, 1, X'00', 'canonical_empty', 1)
+        """,
+      arguments: [jobId, base]
+    )
+    try db.execute(
+      sql: """
+        INSERT INTO job_learning_state(job_id, learning_epoch, stable_lesson_set_digest,
+          stable_revision, open_trial_id, feedback_revision, armed_at)
+        VALUES (?, 1, ?, 0, NULL, 0, 1)
+        """,
+      arguments: [jobId, base]
+    )
+  }
+}
+
+private func insertTrial(
+  _ queue: DatabaseQueue,
+  jobId: Int64,
+  trialId: Int64,
+  state: LearningTrialState,
+  candidateByte: String
+) throws {
+  try queue.write { db in
+    try insertTrial(db, jobId: jobId, trialId: trialId, state: state, candidateByte: candidateByte)
+  }
+}
+
+private func insertTrialMapped(
+  _ queue: DatabaseQueue,
+  jobId: Int64,
+  trialId: Int64,
+  state: LearningTrialState,
+  candidateByte: String
+) throws(StoreError) {
+  try MappedDatabase(writer: queue).writeMapping { db in
+    try insertTrial(db, jobId: jobId, trialId: trialId, state: state, candidateByte: candidateByte)
+  }
+}
+
+private func insertTrial(
+  _ db: Database,
+  jobId: Int64,
+  trialId: Int64,
+  state: LearningTrialState,
+  candidateByte: String
+) throws {
+  let base = String(repeating: "a", count: 64)
+  let candidate = String(repeating: candidateByte, count: 64)
+  try db.execute(
+    sql: """
+      INSERT INTO learning_candidates(candidate_digest, job_id, learning_epoch,
+        replacement_digest, base_digest, base_revision, frozen_feedback_revision, origin,
+        source_manifest, predecessor_digest, algorithm, created_at)
+      VALUES (?, ?, 1, ?, ?, 0, 0, 'reflection', '{}', NULL, ?, 1)
+      """,
+    arguments: [candidate, jobId, base, base, LearningAlgorithm.v1.rawValue]
+  )
+  try db.execute(
+    sql: """
+      INSERT INTO learning_trials(trial_id, job_id, learning_epoch, base_digest,
+        candidate_digest, generation, admitted_at, assignment_deadline, decision_deadline,
+        max_assignments, consumed_assignments, cohort_cutoff, state, close_reason, algorithm)
+      VALUES (?, ?, 1, ?, ?, ?, 1, 2, 3, 3, 0, 1, ?, NULL, ?)
+      """,
+    arguments: [
+      trialId,
+      jobId,
+      base,
+      candidate,
+      Int(trialId),
+      state.rawValue,
+      LearningAlgorithm.v1.rawValue,
+    ]
+  )
+}
+
+private func indexSQL(_ queue: DatabaseQueue) throws -> [String: String] {
+  try queue.read { db in
+    let rows = try Row.fetchAll(
+      db,
+      sql:
+        "SELECT name, sql FROM sqlite_master WHERE type = 'index' AND tbl_name = 'learning_trials'"
+    )
+    return Dictionary(
+      uniqueKeysWithValues: rows.compactMap { row in
+        guard let name: String = row["name"], let sql: String = row["sql"] else {
+          return nil
+        }
+        return (name, sql)
+      }
+    )
+  }
+}
+
+private func migrations(_ queue: DatabaseQueue) throws -> [String] {
+  try queue.read { db in
+    try String.fetchAll(db, sql: "SELECT identifier FROM grdb_migrations ORDER BY rowid")
+  }
+}
+
+private func trialCount(_ queue: DatabaseQueue) throws -> Int {
+  try queue.read { db in
+    try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM learning_trials") ?? -1
+  }
+}

--- a/Tests/ClawDataTests/Stores/Learning/AdmissionStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/AdmissionStoreTests.swift
@@ -251,6 +251,7 @@ import Testing
     #expect(successor.manifest.predecessorCandidate == predecessor.digest)
     #expect(successor.manifest.predecessorFeedback == control)
     #expect(try fixture.trial(oldTrial).state == LearningTrialState.fellBack.rawValue)
+    #expect(try fixture.env.terminalDecisionCount() == 1)
     #expect(try fixture.env.learning.openTrial(jobId: fixture.env.jobId) == nil)
     #expect(try fixture.env.countRows(in: "learning_trials") == 1)
     #expect(try fixture.env.countRows(in: "learning_candidates") == 2)

--- a/Tests/ClawDataTests/Stores/Learning/AdmissionStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/AdmissionStoreTests.swift
@@ -568,12 +568,32 @@ struct AdmissionStoreFixture {
           competitor.manifest.baseDigest.rawValue,
           competitor.digest.rawValue,
           EpochSecondCodec.epoch(env.now),
-          EpochSecondCodec.epoch(env.now.addingTimeInterval(86_400)),
-          EpochSecondCodec.epoch(env.now.addingTimeInterval(172_800)),
+          EpochSecondCodec.epoch(
+            env.now.addingTimeInterval(TrialAdmissionPolicy.assignmentWindow)
+          ),
+          EpochSecondCodec.epoch(
+            env.now.addingTimeInterval(TrialAdmissionPolicy.decisionWindow)
+          ),
           EpochSecondCodec.epoch(env.now),
           LearningTrialState.draining.rawValue,
           LearningAlgorithm.v1.rawValue,
         ]
+      )
+      let trialId = db.lastInsertedRowID
+      try ScheduledLearningStoreGRDB.insertDecision(
+        db,
+        kind: AdmissionReceipt.kind,
+        jobId: env.jobId,
+        epoch: competitor.manifest.epoch,
+        inputs: AdmissionDecisionInputs(candidateDigest: competitor.digest),
+        result: AdmissionReceipt(
+          candidateDigest: competitor.digest,
+          replacementDigest: competitor.replacement.digest,
+          trialId: trialId,
+          generation: 1
+        ),
+        algorithm: .v1,
+        now: env.now
       )
     }
   }

--- a/Tests/ClawDataTests/Stores/Learning/BoundRunEnvironment+Reflection.swift
+++ b/Tests/ClawDataTests/Stores/Learning/BoundRunEnvironment+Reflection.swift
@@ -232,7 +232,7 @@ extension BoundRunEnvironment {
           INSERT INTO learning_trials(job_id, learning_epoch, base_digest, candidate_digest,
             generation, admitted_at, assignment_deadline, decision_deadline, max_assignments,
             consumed_assignments, cohort_cutoff, state, algorithm)
-          VALUES (?, ?, ?, ?, 1, ?, ?, ?, 5, 0, ?, ?, ?)
+          VALUES (?, ?, ?, ?, 1, ?, ?, ?, 3, 0, ?, ?, ?)
           """,
         arguments: [
           jobId,
@@ -240,12 +240,28 @@ extension BoundRunEnvironment {
           candidate.manifest.baseDigest.rawValue,
           candidate.digest.rawValue,
           EpochSecondCodec.epoch(now),
-          EpochSecondCodec.epoch(now.addingTimeInterval(3_600)),
-          EpochSecondCodec.epoch(now.addingTimeInterval(7_200)),
+          EpochSecondCodec.epoch(now.addingTimeInterval(TrialAdmissionPolicy.assignmentWindow)),
+          EpochSecondCodec.epoch(now.addingTimeInterval(TrialAdmissionPolicy.decisionWindow)),
           EpochSecondCodec.epoch(now),
           LearningTrialState.open.rawValue,
           LearningAlgorithm.v1.rawValue,
         ]
+      )
+      let trialId = db.lastInsertedRowID
+      try ScheduledLearningStoreGRDB.insertDecision(
+        db,
+        kind: AdmissionReceipt.kind,
+        jobId: jobId,
+        epoch: candidate.manifest.epoch,
+        inputs: AdmissionDecisionInputs(candidateDigest: candidate.digest),
+        result: AdmissionReceipt(
+          candidateDigest: candidate.digest,
+          replacementDigest: candidate.replacement.digest,
+          trialId: trialId,
+          generation: 1
+        ),
+        algorithm: .v1,
+        now: now
       )
     }
   }

--- a/Tests/ClawDataTests/Stores/Learning/BoundRunEnvironment.swift
+++ b/Tests/ClawDataTests/Stores/Learning/BoundRunEnvironment.swift
@@ -8,7 +8,7 @@ import GRDB
 /// settlement suites drive: the fire path that binds a run, the run store that terminates it, and
 /// the learning store that reads back its receipt.
 struct BoundRunEnvironment {
-  let queue: DatabaseQueue
+  let queue: any DatabaseWriter
   let jobs: ScheduledJobStoreGRDB
   let runs: RunStoreGRDB
   let learning: ScheduledLearningStoreGRDB
@@ -20,17 +20,24 @@ struct BoundRunEnvironment {
     learningEnabled: Bool = true,
     databasePath: String? = nil
   ) throws -> BoundRunEnvironment {
-    let queue: DatabaseQueue
+    let writer: any DatabaseWriter
     if let databasePath {
-      queue = try DatabaseQueue(
+      writer = try DatabaseQueue(
         path: databasePath,
         configuration: ClawDatabase.makeConfiguration()
       )
     } else {
-      queue = try ClawDatabase.makeInMemoryQueue()
+      writer = try ClawDatabase.makeInMemoryQueue()
     }
-    try ClawDatabase.migrate(queue)
-    let jobs = ScheduledJobStoreGRDB(writer: queue, learningEnabled: learningEnabled)
+    return try make(learningEnabled: learningEnabled, writer: writer)
+  }
+
+  static func make(
+    learningEnabled: Bool = true,
+    writer: any DatabaseWriter
+  ) throws -> BoundRunEnvironment {
+    try ClawDatabase.migrate(writer)
+    let jobs = ScheduledJobStoreGRDB(writer: writer, learningEnabled: learningEnabled)
     let now = Date(timeIntervalSince1970: 1_782_000_600)
     let job = try jobs.create(
       NewScheduledJob(
@@ -45,7 +52,7 @@ struct BoundRunEnvironment {
     )
     // The fire path creates the job's session lazily; establishing it up front lets the fixture
     // seed unbound runs on the same lane without firing first.
-    let sessionId = try queue.write { db in
+    let sessionId = try writer.write { db in
       let sessionId = try SessionMessageStoreGRDB.upsertSession(
         db,
         sessionKey: SessionKey.scheduledJob(id: job.id),
@@ -58,10 +65,10 @@ struct BoundRunEnvironment {
       return sessionId
     }
     return BoundRunEnvironment(
-      queue: queue,
+      queue: writer,
       jobs: jobs,
-      runs: RunStoreGRDB(writer: queue),
-      learning: ScheduledLearningStoreGRDB(writer: queue),
+      runs: RunStoreGRDB(writer: writer),
+      learning: ScheduledLearningStoreGRDB(writer: writer),
       jobId: job.id,
       sessionId: sessionId,
       now: now

--- a/Tests/ClawDataTests/Stores/Learning/FeedbackStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/FeedbackStoreTests.swift
@@ -372,6 +372,7 @@ import Testing
       }
       #expect(try env.learning.openTrial(jobId: env.jobId) == nil)
       #expect(try env.trialState(trial.trialId) == .fellBack)
+      #expect(try env.base.terminalDecisionCount() == 1)
       #expect(try env.feedbackRevision() == 1)
     }
   }
@@ -433,6 +434,7 @@ import Testing
       return
     }
     #expect(try env.learning.openTrial(jobId: env.jobId) == nil)
+    #expect(try env.base.terminalDecisionCount() == 1)
     #expect(try env.trialCloseReason(trial.trialId) == ScheduledLearningStoreGRDB.hardVetoReason)
   }
 

--- a/Tests/ClawDataTests/Stores/Learning/FeedbackStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/FeedbackStoreTests.swift
@@ -944,7 +944,7 @@ private struct FeedbackStoreEnvironment {
   let base: BoundRunEnvironment
   let state: JobLearningState
 
-  var queue: DatabaseQueue { base.queue }
+  var queue: any DatabaseWriter { base.queue }
   var learning: ScheduledLearningStoreGRDB { base.learning }
   var jobId: Int64 { base.jobId }
   var now: Date { base.now }
@@ -1272,44 +1272,34 @@ private struct FeedbackStoreEnvironment {
   }
 
   func seedOpenTrial() throws -> Trial {
-    let candidate = try LessonSet.canonical(jobId: jobId, lessons: ["Prefer exact evidence."])
-    let candidateDigest = SHA256Digest.hex("feedback-candidate-\(jobId)")
+    let replacement = try LessonSet.canonical(jobId: jobId, lessons: ["Prefer exact evidence."])
+    let manifest = CandidateSourceManifest(
+      origin: .reflection,
+      algorithm: .v1,
+      jobId: jobId,
+      epoch: state.epoch,
+      triggerDigest: TriggerDigest(rawValue: SHA256Digest.hex("feedback-trigger-\(jobId)")),
+      triggerReason: .ownerCorrection,
+      qualifyingIssueCodes: [],
+      operationId: LearningOperationID(rawValue: "feedback-operation"),
+      carrierDigest: CarrierDigest(rawValue: SHA256Digest.hex("feedback-carrier-\(jobId)")),
+      resultDigest: ReflectionResultDigest(rawValue: SHA256Digest.hex("feedback-result-\(jobId)")),
+      baseDigest: state.stableDigest,
+      baseRevision: state.stableRevision,
+      feedbackRevision: state.feedbackRevision,
+      evidence: [],
+      evaluations: [],
+      feedback: [],
+      predecessorCandidate: nil,
+      predecessorFeedback: nil
+    )
+    let artifact = try CandidateArtifact(replacement: replacement, manifest: manifest)
     let generation = 3
     return try queue.write { db in
-      try db.execute(
-        sql: """
-          INSERT INTO lesson_sets(job_id, digest, schema_version, canonical_bytes, source,
-            created_at) VALUES (?, ?, ?, ?, ?, ?)
-          """,
-        arguments: [
-          jobId,
-          candidate.digest.rawValue,
-          candidate.schemaVersion,
-          candidate.canonicalBytes,
-          LessonSetSource.reflectorCandidate.rawValue,
-          EpochSecondCodec.epoch(now),
-        ]
-      )
-      try db.execute(
-        sql: """
-          INSERT INTO learning_candidates(candidate_digest, job_id, learning_epoch,
-            replacement_digest, base_digest, base_revision, frozen_feedback_revision, origin,
-            source_manifest, algorithm, created_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-          """,
-        arguments: [
-          candidateDigest,
-          jobId,
-          state.epoch.value,
-          candidate.digest.rawValue,
-          state.stableDigest.rawValue,
-          state.stableRevision.value,
-          state.feedbackRevision.value,
-          LearningPhase.reflector.rawValue,
-          "{}",
-          LearningAlgorithm.v1.rawValue,
-          EpochSecondCodec.epoch(now),
-        ]
+      try ScheduledLearningStoreGRDB.recordCandidateArtifact(
+        db,
+        artifact: artifact,
+        now: now
       )
       try db.execute(
         sql: """
@@ -1322,25 +1312,40 @@ private struct FeedbackStoreEnvironment {
           jobId,
           state.epoch.value,
           state.stableDigest.rawValue,
-          candidateDigest,
+          artifact.digest.rawValue,
           generation,
           EpochSecondCodec.epoch(now),
-          EpochSecondCodec.epoch(now.addingTimeInterval(30 * 86_400)),
-          EpochSecondCodec.epoch(now.addingTimeInterval(37 * 86_400)),
+          EpochSecondCodec.epoch(now.addingTimeInterval(TrialAdmissionPolicy.assignmentWindow)),
+          EpochSecondCodec.epoch(now.addingTimeInterval(TrialAdmissionPolicy.decisionWindow)),
           EpochSecondCodec.epoch(now),
           LearningTrialState.open.rawValue,
           LearningAlgorithm.v1.rawValue,
         ]
       )
       let trialId = db.lastInsertedRowID
+      try ScheduledLearningStoreGRDB.insertDecision(
+        db,
+        kind: AdmissionReceipt.kind,
+        jobId: jobId,
+        epoch: state.epoch,
+        inputs: AdmissionDecisionInputs(candidateDigest: artifact.digest),
+        result: AdmissionReceipt(
+          candidateDigest: artifact.digest,
+          replacementDigest: replacement.digest,
+          trialId: trialId,
+          generation: generation
+        ),
+        algorithm: .v1,
+        now: now
+      )
       try db.execute(
         sql: "UPDATE job_learning_state SET open_trial_id = ? WHERE job_id = ?",
         arguments: [trialId, jobId]
       )
       return Trial(
         trialId: trialId,
-        candidateDigest: candidateDigest,
-        replacementDigest: candidate.digest.rawValue,
+        candidateDigest: artifact.digest.rawValue,
+        replacementDigest: replacement.digest.rawValue,
         generation: generation
       )
     }
@@ -1404,14 +1409,29 @@ private struct FeedbackStoreEnvironment {
           artifact.digest.rawValue,
           generation,
           EpochSecondCodec.epoch(now),
-          EpochSecondCodec.epoch(now.addingTimeInterval(30 * 86_400)),
-          EpochSecondCodec.epoch(now.addingTimeInterval(37 * 86_400)),
+          EpochSecondCodec.epoch(now.addingTimeInterval(TrialAdmissionPolicy.assignmentWindow)),
+          EpochSecondCodec.epoch(now.addingTimeInterval(TrialAdmissionPolicy.decisionWindow)),
           EpochSecondCodec.epoch(now),
           trialState.rawValue,
           LearningAlgorithm.v1.rawValue,
         ]
       )
       let trialId = db.lastInsertedRowID
+      try ScheduledLearningStoreGRDB.insertDecision(
+        db,
+        kind: AdmissionReceipt.kind,
+        jobId: jobId,
+        epoch: state.epoch,
+        inputs: AdmissionDecisionInputs(candidateDigest: artifact.digest),
+        result: AdmissionReceipt(
+          candidateDigest: artifact.digest,
+          replacementDigest: replacement.digest,
+          trialId: trialId,
+          generation: generation
+        ),
+        algorithm: .v1,
+        now: now
+      )
       try db.execute(
         sql: "UPDATE job_learning_state SET open_trial_id = ? WHERE job_id = ?",
         arguments: [trialId, jobId]

--- a/Tests/ClawDataTests/Stores/Learning/FireBindingTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/FireBindingTests.swift
@@ -123,10 +123,9 @@ import Testing
     #expect(trial.consumedAssignments == 1)
   }
 
-  @Test func aTrialPastItsAssignmentDeadlineDrainsWithoutConsuming() throws {
+  @Test func aTrialAtItsAssignmentDeadlineDrainsWithoutConsuming() throws {
     // given
     let env = try FireBindingEnvironment.make(withOpenTrial: true, consumedAssignments: 0)
-    let afterDeadline = env.assignmentDeadline.addingTimeInterval(1)
 
     // when
     let fired = try #require(
@@ -135,7 +134,7 @@ import Testing
         due: env.due,
         fireAt: env.due,
         nextOccurrence: nil,
-        now: afterDeadline
+        now: env.assignmentDeadline
       )
     )
 
@@ -175,6 +174,94 @@ import Testing
     let trial = try #require(try env.learning.openTrial(jobId: env.jobId))
     #expect(trial.state == .draining)
     #expect(trial.consumedAssignments == FireBindingEnvironment.assignmentLimit)
+  }
+
+  @Test func thirdFireAtomicallyConsumesAndDrains() throws {
+    // given
+    let env = try FireBindingEnvironment.make(withOpenTrial: true, consumedAssignments: 0)
+
+    // when
+    var bindings: [RunLearningBinding] = []
+    for offset in 0..<FireBindingEnvironment.assignmentLimit {
+      let fire = try #require(
+        try env.firedNow(at: env.due.addingTimeInterval(Double(offset)))
+      )
+      bindings.append(try #require(fire.binding))
+      try env.finishRun(fire.runId)
+    }
+
+    // then
+    let trial = try #require(try env.learning.openTrial(jobId: env.jobId))
+    #expect(bindings.allSatisfy { $0.trialId == trial.trialId })
+    #expect(trial.consumedAssignments == FireBindingEnvironment.assignmentLimit)
+    #expect(trial.state == .draining)
+    #expect(try env.assignmentCount() == FireBindingEnvironment.assignmentLimit)
+
+    let fourth = try #require(try env.firedNow(at: env.due.addingTimeInterval(4)))
+    #expect(fourth.binding?.trialId == nil)
+    #expect(fourth.binding?.effectiveDigest == fourth.binding?.stableDigest)
+  }
+
+  @Test func preAdmissionOccurrenceUsesStableAndConsumesNoExposure() throws {
+    // given
+    let env = try FireBindingEnvironment.make(withOpenTrial: true, consumedAssignments: 0)
+    try env.moveAdmission(to: env.due.addingTimeInterval(60))
+
+    // when
+    let fired = try #require(
+      try env.jobs.claimAndFire(
+        jobId: env.jobId,
+        due: env.due,
+        fireAt: env.due,
+        nextOccurrence: nil,
+        now: env.due.addingTimeInterval(120)
+      )
+    )
+
+    // then
+    #expect(fired.binding?.trialId == nil)
+    #expect(fired.binding?.effectiveDigest == fired.binding?.stableDigest)
+    let trial = try #require(try env.learning.openTrial(jobId: env.jobId))
+    #expect(trial.state == .open)
+    #expect(trial.consumedAssignments == 0)
+  }
+
+  @Test func assignmentInsertFailureRollsBackRunBindingCounterAndDrain() throws {
+    // given
+    let env = try FireBindingEnvironment.make(withOpenTrial: true, consumedAssignments: 2)
+    try env.rejectAssignmentInserts()
+
+    // when / then
+    #expect {
+      _ = try env.jobs.fireNow(jobId: env.jobId, now: env.due)
+    } throws: { _ in true }
+    let trial = try #require(try env.learning.openTrial(jobId: env.jobId))
+    #expect(trial.state == .open)
+    #expect(trial.consumedAssignments == 2)
+    #expect(try env.assignmentCount() == 0)
+    #expect(try env.bindingCount() == 0)
+    #expect(try env.runCount() == 0)
+  }
+
+  @Test(arguments: FireSourceCorruption.allCases)
+  func fireSelectionRequiresEveryCurrentTrialSource(
+    _ corruption: FireSourceCorruption
+  ) throws {
+    // given
+    let env = try FireBindingEnvironment.make(withOpenTrial: true, consumedAssignments: 0)
+    try env.apply(corruption)
+
+    // when / then
+    #expect {
+      _ = try env.jobs.fireNow(jobId: env.jobId, now: env.due)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+    #expect(try env.runCount() == 0)
+    #expect(try env.bindingCount() == 0)
   }
 
   @Test func pausingAndResumingNeitherExtendsTheDeadlineNorRevokesAnAssignment() throws {
@@ -232,6 +319,25 @@ import Testing
     #expect(try env.rowCount(in: "lesson_sets") == 0)
     #expect(try env.rowCount(in: "run_learning_bindings") == 0)
   }
+}
+
+enum FireSourceCorruption: CaseIterable {
+  case currentEpoch
+  case currentBase
+  case currentRevision
+  case trialBase
+  case trialGeneration
+  case trialAlgorithm
+  case assignmentDeadline
+  case decisionDeadline
+  case maximumAssignments
+  case consumedAssignments
+  case candidateEpoch
+  case candidateBase
+  case candidateBaseRevision
+  case candidateReplacement
+  case candidateAlgorithm
+  case admissionReceipt
 }
 
 // MARK: - Environment
@@ -343,6 +449,157 @@ private struct FireBindingEnvironment {
       try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)") ?? -1
     }
   }
+
+  func firedNow(at now: Date) throws -> ClaimedFire? {
+    guard case .fired(let fire) = try jobs.fireNow(jobId: jobId, now: now) else {
+      return nil
+    }
+    return fire
+  }
+
+  func finishRun(_ runId: Int64) throws {
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE runs SET state = ? WHERE id = ?",
+        arguments: [RunState.done.rawValue, runId]
+      )
+    }
+  }
+
+  func assignmentCount() throws -> Int { try rowCount(in: "trial_assignments") }
+  func bindingCount() throws -> Int { try rowCount(in: "run_learning_bindings") }
+  func runCount() throws -> Int { try rowCount(in: "runs") }
+
+  func moveAdmission(to admittedAt: Date) throws {
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          UPDATE learning_trials
+          SET admitted_at = ?, cohort_cutoff = ?, assignment_deadline = ?, decision_deadline = ?
+          WHERE job_id = ?
+          """,
+        arguments: [
+          EpochSecondCodec.epoch(admittedAt),
+          EpochSecondCodec.epoch(admittedAt),
+          EpochSecondCodec.epoch(admittedAt.addingTimeInterval(Self.assignmentWindow)),
+          EpochSecondCodec.epoch(admittedAt.addingTimeInterval(Self.decisionWindow)),
+          jobId,
+        ]
+      )
+    }
+  }
+
+  func rejectAssignmentInserts() throws {
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          CREATE TRIGGER reject_trial_assignment BEFORE INSERT ON trial_assignments
+          BEGIN SELECT RAISE(ABORT, 'injected assignment failure'); END
+          """
+      )
+    }
+  }
+
+  func apply(_ corruption: FireSourceCorruption) throws {
+    try queue.write { db in
+      let base = LessonSet.empty(jobId: jobId).digest.rawValue
+      switch corruption {
+      case .currentEpoch:
+        try db.execute(
+          sql: "UPDATE job_learning_state SET learning_epoch = 2 WHERE job_id = ?",
+          arguments: [jobId]
+        )
+      case .currentBase:
+        try db.execute(
+          sql: "UPDATE job_learning_state SET stable_lesson_set_digest = ? WHERE job_id = ?",
+          arguments: [candidateDigest.rawValue, jobId]
+        )
+      case .currentRevision:
+        try db.execute(
+          sql: "UPDATE job_learning_state SET stable_revision = 1 WHERE job_id = ?",
+          arguments: [jobId]
+        )
+      case .trialBase:
+        try db.execute(
+          sql: "UPDATE learning_trials SET base_digest = ? WHERE job_id = ?",
+          arguments: [candidateDigest.rawValue, jobId]
+        )
+      case .trialGeneration:
+        try db.execute(
+          sql: "UPDATE learning_trials SET generation = 2 WHERE job_id = ?",
+          arguments: [jobId]
+        )
+      case .trialAlgorithm:
+        try db.execute(
+          sql: "UPDATE learning_trials SET algorithm = 'unknown' WHERE job_id = ?",
+          arguments: [jobId]
+        )
+      case .assignmentDeadline:
+        try db.execute(
+          sql:
+            "UPDATE learning_trials SET assignment_deadline = assignment_deadline + 1 WHERE job_id = ?",
+          arguments: [jobId]
+        )
+      case .decisionDeadline:
+        try db.execute(
+          sql:
+            "UPDATE learning_trials SET decision_deadline = decision_deadline + 1 WHERE job_id = ?",
+          arguments: [jobId]
+        )
+      case .maximumAssignments:
+        try db.execute(
+          sql: "UPDATE learning_trials SET max_assignments = 4 WHERE job_id = ?",
+          arguments: [jobId]
+        )
+      case .consumedAssignments:
+        try db.execute(
+          sql: "UPDATE learning_trials SET consumed_assignments = 4 WHERE job_id = ?",
+          arguments: [jobId]
+        )
+      case .candidateEpoch:
+        try db.execute(sql: "UPDATE learning_candidates SET learning_epoch = 2")
+      case .candidateBase:
+        try db.execute(
+          sql: "UPDATE learning_candidates SET base_digest = replacement_digest"
+        )
+      case .candidateBaseRevision:
+        try db.execute(sql: "UPDATE learning_candidates SET base_revision = 99")
+      case .candidateReplacement:
+        try db.execute(
+          sql: "UPDATE learning_candidates SET replacement_digest = ?",
+          arguments: [base]
+        )
+      case .candidateAlgorithm:
+        try db.execute(sql: "UPDATE learning_candidates SET algorithm = 'unknown'")
+      case .admissionReceipt:
+        guard
+          let raw = try String.fetchOne(
+            db,
+            sql: "SELECT result FROM learning_decisions WHERE kind = ?",
+            arguments: [AdmissionReceipt.kind]
+          ),
+          let bytes = raw.data(using: .utf8),
+          let receipt = try? JSONDecoder().decode(AdmissionReceipt.self, from: bytes)
+        else {
+          throw StoreError.unexpected("fixture admission receipt is missing")
+        }
+        let changed = AdmissionReceipt(
+          candidateDigest: receipt.candidateDigest,
+          replacementDigest: receipt.replacementDigest,
+          trialId: receipt.trialId,
+          generation: receipt.generation + 1
+        )
+        let changedBytes = try CanonicalJSON.data(encoding: changed)
+        guard let changedRaw = String(bytes: changedBytes, encoding: .utf8) else {
+          throw StoreError.unexpected("fixture admission receipt is not UTF-8")
+        }
+        try db.execute(
+          sql: "UPDATE learning_decisions SET result = ? WHERE kind = ?",
+          arguments: [changedRaw, AdmissionReceipt.kind]
+        )
+      }
+    }
+  }
 }
 
 // MARK: - Trial Fixture
@@ -357,32 +614,33 @@ private extension FireBindingEnvironment {
     admittedAt: Date,
     consumedAssignments: Int
   ) throws {
-    let candidateDigest = SHA256Digest.hex("candidate-\(jobId)")
-    let baseDigest = LessonSet.empty(jobId: jobId).digest.rawValue
+    let baseDigest = LessonSet.empty(jobId: jobId).digest
+    let manifest = CandidateSourceManifest(
+      origin: .reflection,
+      algorithm: .v1,
+      jobId: jobId,
+      epoch: LearningEpoch(1),
+      triggerDigest: TriggerDigest(rawValue: SHA256Digest.hex("trigger-\(jobId)")),
+      triggerReason: .ownerCorrection,
+      qualifyingIssueCodes: [],
+      operationId: LearningOperationID(rawValue: "fixture-operation"),
+      carrierDigest: CarrierDigest(rawValue: SHA256Digest.hex("carrier-\(jobId)")),
+      resultDigest: ReflectionResultDigest(rawValue: SHA256Digest.hex("result-\(jobId)")),
+      baseDigest: baseDigest,
+      baseRevision: StableRevision(0),
+      feedbackRevision: FeedbackRevision(0),
+      evidence: [],
+      evaluations: [],
+      feedback: [],
+      predecessorCandidate: nil,
+      predecessorFeedback: nil
+    )
+    let artifact = try CandidateArtifact(replacement: candidate, manifest: manifest)
     try queue.write { db in
-      try db.execute(
-        sql: """
-          INSERT INTO lesson_sets(job_id, digest, schema_version, canonical_bytes, source,
-            created_at)
-          VALUES (?, ?, ?, ?, ?, ?)
-          """,
-        arguments: [
-          jobId, candidate.digest.rawValue, candidate.schemaVersion, candidate.canonicalBytes,
-          LessonSetSource.reflectorCandidate.rawValue, EpochSecondCodec.epoch(admittedAt),
-        ]
-      )
-      try db.execute(
-        sql: """
-          INSERT INTO learning_candidates(candidate_digest, job_id, learning_epoch,
-            replacement_digest, base_digest, base_revision, frozen_feedback_revision, origin,
-            source_manifest, algorithm, created_at)
-          VALUES (?, ?, 1, ?, ?, 0, 0, ?, '{}', ?, ?)
-          """,
-        arguments: [
-          candidateDigest, jobId, candidate.digest.rawValue, baseDigest,
-          LearningPhase.reflector.rawValue, LearningAlgorithm.v1.rawValue,
-          EpochSecondCodec.epoch(admittedAt),
-        ]
+      try ScheduledLearningStoreGRDB.recordCandidateArtifact(
+        db,
+        artifact: artifact,
+        now: admittedAt
       )
       try db.execute(
         sql: """
@@ -392,7 +650,7 @@ private extension FireBindingEnvironment {
           VALUES (?, 1, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)
           """,
         arguments: [
-          jobId, baseDigest, candidateDigest,
+          jobId, baseDigest.rawValue, artifact.digest.rawValue,
           EpochSecondCodec.epoch(admittedAt),
           EpochSecondCodec.epoch(admittedAt.addingTimeInterval(assignmentWindow)),
           EpochSecondCodec.epoch(admittedAt.addingTimeInterval(decisionWindow)),
@@ -400,9 +658,25 @@ private extension FireBindingEnvironment {
           LearningTrialState.open.rawValue, LearningAlgorithm.v1.rawValue,
         ]
       )
+      let trialId = db.lastInsertedRowID
       try db.execute(
         sql: "UPDATE job_learning_state SET open_trial_id = ? WHERE job_id = ?",
-        arguments: [db.lastInsertedRowID, jobId]
+        arguments: [trialId, jobId]
+      )
+      try ScheduledLearningStoreGRDB.insertDecision(
+        db,
+        kind: AdmissionReceipt.kind,
+        jobId: jobId,
+        epoch: LearningEpoch(1),
+        inputs: AdmissionDecisionInputs(candidateDigest: artifact.digest),
+        result: AdmissionReceipt(
+          candidateDigest: artifact.digest,
+          replacementDigest: candidate.digest,
+          trialId: trialId,
+          generation: 1
+        ),
+        algorithm: .v1,
+        now: admittedAt
       )
     }
   }

--- a/Tests/ClawDataTests/Stores/Learning/LearningViewStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/LearningViewStoreTests.swift
@@ -49,6 +49,64 @@ import Testing
     #expect(readable.stableRevision == StableRevision(7))
   }
 
+  @Test(arguments: StableViewCorruption.allCases)
+  func stableStateTrustBoundariesFailClosed(_ corruption: StableViewCorruption) throws {
+    // given
+    let fixture = try LearningViewFixture.make()
+    let job = try fixture.createJob(label: "damaged stable state")
+    _ = try fixture.learning.armJob(jobId: job.id, now: fixture.now)
+    try fixture.applyStableCorruption(corruption, jobId: job.id)
+
+    // when
+    let view = try fixture.learning.learningView(jobId: job.id)
+
+    // then — substituting a missing, foreign, noncanonical, digest-mismatched set, or malformed
+    // job identity would survive the positive exact-set test for correctly stored rows.
+    #expect(view.isOnlyUnreadable)
+  }
+
+  @Test func listKeepsHealthyJobsBesideUnreadableJobs() throws {
+    // given
+    let fixture = try LearningViewFixture.make()
+    let healthy = try fixture.createJob(label: "healthy")
+    let damaged = try fixture.createJob(label: "damaged")
+    _ = try fixture.learning.armJob(jobId: healthy.id, now: fixture.now)
+    _ = try fixture.learning.armJob(jobId: damaged.id, now: fixture.now)
+    try fixture.invalidateTimezone(jobId: damaged.id)
+
+    // when
+    let view = try fixture.learning.learningView(jobId: nil)
+
+    // then — failing the whole list on one semantic row would hide the preceding healthy job;
+    // the nearest list test has no corrupt state to exercise per-job isolation.
+    #expect(view.count == 2)
+    #expect(view.readableJobIds == [healthy.id])
+    #expect(view.unreadableJobIds == [damaged.id])
+  }
+
+  @Test func operationalReadFailureLeavesThroughTheStoreSeam() throws {
+    // given
+    let fixture = try LearningViewFixture.make()
+    let job = try fixture.createJob(label: "operational failure")
+    _ = try fixture.learning.armJob(jobId: job.id, now: fixture.now)
+    try fixture.queue.write { db in
+      try db.drop(table: "job_learning_state")
+    }
+
+    // when
+    do {
+      _ = try fixture.learning.learningView(jobId: job.id)
+      Issue.record("expected a mapped store failure")
+    } catch let error {
+      // then — catching all read errors as row corruption would return unreadable and acknowledge
+      // a retryable database failure; the group refusal test never reaches its dropped table.
+      guard case .unexpected = error else {
+        Issue.record("expected StoreError.unexpected, got \(error)")
+        return
+      }
+    }
+  }
+
   @Test(arguments: LiveTrialCorruption.allCases)
   func liveTrialRejectsMultiplicityAndUsesExactIdentity(
     _ corruption: LiveTrialCorruption
@@ -82,13 +140,59 @@ import Testing
     }
     #expect(inputs.candidateDigest == artifact.digest)
     #expect(decisionReceipt == receipt)
-    try fixture.corruptViewTrial(corruption, trialId: receipt.trialId)
+    try fixture.corruptViewTrial(
+      corruption,
+      artifact: artifact,
+      trialId: receipt.trialId
+    )
 
     // when
     let view = try fixture.env.learning.learningView(jobId: fixture.env.jobId)
 
     // then — following the convenience pointer or omitting assignment identity hides corruption.
     #expect(view.isOnlyUnreadable)
+  }
+
+  @Test(arguments: LiveWorkflowMutation.allCases)
+  func liveWorkflowStatusAndPointerStayReadOnly(
+    _ mutation: LiveWorkflowMutation
+  ) throws {
+    // given
+    let fixture = try AdmissionStoreFixture.make()
+    defer { fixture.remove() }
+    let artifact = try fixture.persistedCandidate()
+    let admitted = try fixture.env.learning.admitCandidate(
+      digest: artifact.digest,
+      redactor: SecretRedactor(secretValues: []),
+      now: fixture.env.now
+    )
+    guard case .admitted(let receipt) = admitted else {
+      Issue.record("expected fixture candidate admission")
+      return
+    }
+    try fixture.applyLiveWorkflowMutation(mutation, trialId: receipt.trialId)
+    let before = try fixture.durableLearningSnapshot()
+
+    // when
+    let detail = try fixture.env.learning.learningView(jobId: fixture.env.jobId)
+    let list = try fixture.env.learning.learningView(jobId: nil)
+    let after = try fixture.durableLearningSnapshot()
+
+    // then — admitting a cancelled job's stale trial or repairing the pointer during a read would
+    // survive the positive live-trial test; its nearest tests never snapshot all touched domains.
+    #expect(after == before)
+    switch mutation {
+    case .cancelledJob:
+      #expect(detail.isOnlyUnreadable)
+      #expect(list.isOnlyUnreadable)
+    case .stalePointer:
+      let detailed = try #require(detail.onlyReadable)
+      let listed = try #require(list.onlyReadable)
+      #expect(detailed.liveTrial?.trialId == receipt.trialId)
+      #expect(detailed.warnings == [.trialPointerMismatch])
+      #expect(listed.liveTrial?.trialId == receipt.trialId)
+      #expect(listed.warnings == [.trialPointerMismatch])
+    }
   }
 
   @Test func lastDecisionIsTypedCurrentEpochAndUsesTheStableTieBreak() throws {
@@ -121,12 +225,94 @@ import Testing
     // then — omitting decision_id from the tie break can hide the latest malformed receipt.
     #expect(corrupt.isOnlyUnreadable)
   }
+
+  @Test(arguments: CurrentDecisionCorruption.allCases)
+  func currentDecisionTrustBoundariesFailClosed(
+    _ corruption: CurrentDecisionCorruption
+  ) throws {
+    // given
+    let fixture = try AdmissionStoreFixture.make()
+    defer { fixture.remove() }
+    let artifact = try fixture.persistedCandidate()
+    let admitted = try fixture.env.learning.admitCandidate(
+      digest: artifact.digest,
+      redactor: SecretRedactor(secretValues: []),
+      now: fixture.env.now
+    )
+    guard case .admitted(let receipt) = admitted else {
+      Issue.record("expected fixture candidate admission")
+      return
+    }
+    try fixture.closeTrialForDecisionView(trialId: receipt.trialId)
+    try fixture.corruptCurrentDecision(corruption, receipt: receipt)
+
+    // when
+    let view = try fixture.env.learning.learningView(jobId: fixture.env.jobId)
+
+    // then — treating an unknown kind as absent or trusting receipt fields without their durable
+    // identity would survive the current-epoch ordering test's otherwise valid receipt.
+    #expect(view.isOnlyUnreadable)
+  }
+
+  @Test(arguments: ViewPrimitiveCorruption.allCases)
+  func incompatibleStoredPrimitivesArePerJobUnreadable(
+    _ corruption: ViewPrimitiveCorruption
+  ) throws {
+    // given
+    let fixture = try AdmissionStoreFixture.make()
+    defer { fixture.remove() }
+    let artifact = try fixture.persistedCandidate()
+    let admitted = try fixture.env.learning.admitCandidate(
+      digest: artifact.digest,
+      redactor: SecretRedactor(secretValues: []),
+      now: fixture.env.now
+    )
+    guard case .admitted(let receipt) = admitted else {
+      Issue.record("expected fixture candidate admission")
+      return
+    }
+    _ = try fixture.env.pendingBoundRun()
+    try fixture.corruptStoredPrimitive(corruption, trialId: receipt.trialId)
+
+    // when
+    let view = try fixture.env.learning.learningView(jobId: fixture.env.jobId)
+
+    // then — a non-optional typed Row subscript can abort instead of isolating a bad job;
+    // existing semantic tests keep the expected SQLite storage classes and cannot kill it.
+    #expect(view.isOnlyUnreadable)
+  }
 }
 
 enum LiveTrialCorruption: CaseIterable, Sendable {
   case secondLiveTrial
   case assignmentEpoch
   case assignmentGeneration
+}
+
+enum LiveWorkflowMutation: CaseIterable, Sendable {
+  case cancelledJob
+  case stalePointer
+}
+
+enum StableViewCorruption: CaseIterable, Sendable {
+  case missingSet
+  case crossJobSet
+  case noncanonicalSet
+  case digestMismatch
+  case invalidJobMetadata
+}
+
+enum CurrentDecisionCorruption: CaseIterable, Sendable {
+  case unknownKind
+  case receiptIdentity
+}
+
+enum ViewPrimitiveCorruption: CaseIterable, Sendable {
+  case job
+  case state
+  case trial
+  case assignment
+  case decision
 }
 
 private extension Array where Element == JobLearningView {
@@ -151,6 +337,15 @@ private extension Array where Element == JobLearningView {
       return false
     }
     return true
+  }
+
+  var unreadableJobIds: [Int64] {
+    compactMap { item in
+      guard case .unreadable(let job) = item else {
+        return nil
+      }
+      return job.jobId
+    }
   }
 }
 
@@ -242,42 +437,211 @@ private struct LearningViewFixture {
     }
     return set
   }
+
+  func applyStableCorruption(_ corruption: StableViewCorruption, jobId: Int64) throws {
+    switch corruption {
+    case .missingSet:
+      try pointStableState(jobId: jobId, digest: String(repeating: "d", count: 64))
+    case .crossJobSet:
+      let other = try createJob(label: "foreign stable owner")
+      _ = try learning.armJob(jobId: other.id, now: now)
+      let foreign = try installStableLessons(["Only the other job owns this."], jobId: other.id)
+      try pointStableState(jobId: jobId, digest: foreign.digest.rawValue)
+    case .noncanonicalSet:
+      try replaceStableBytes(jobId: jobId, bytes: Data("{".utf8))
+    case .digestMismatch:
+      let different = try LessonSet.canonical(jobId: jobId, lessons: ["Different bytes."])
+      try replaceStableBytes(jobId: jobId, bytes: different.canonicalBytes)
+    case .invalidJobMetadata:
+      try invalidateTimezone(jobId: jobId)
+    }
+  }
+
+  func invalidateTimezone(jobId: Int64) throws {
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE scheduled_jobs SET timezone = 'not/a-zone' WHERE id = ?",
+        arguments: [jobId]
+      )
+    }
+  }
+
+  private func pointStableState(jobId: Int64, digest: String) throws {
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE job_learning_state SET stable_lesson_set_digest = ? WHERE job_id = ?",
+        arguments: [digest, jobId]
+      )
+    }
+  }
+
+  private func replaceStableBytes(jobId: Int64, bytes: Data) throws {
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          UPDATE lesson_sets SET canonical_bytes = ?
+          WHERE job_id = ? AND digest = (
+            SELECT stable_lesson_set_digest FROM job_learning_state WHERE job_id = ?
+          )
+          """,
+        arguments: [bytes, jobId, jobId]
+      )
+    }
+  }
 }
 
 private extension AdmissionStoreFixture {
   func corruptViewTrial(
     _ corruption: LiveTrialCorruption,
+    artifact: CandidateArtifact,
     trialId: Int64
   ) throws {
+    let sql: String
+    switch corruption {
+    case .secondLiveTrial:
+      try insertCompetingDrainingTrial(from: artifact)
+      return
+    case .assignmentEpoch:
+      sql = "UPDATE trial_assignments SET learning_epoch = learning_epoch + 1 WHERE trial_id = ?"
+    case .assignmentGeneration:
+      sql = "UPDATE trial_assignments SET trial_generation = 99 WHERE trial_id = ?"
+    }
     try env.queue.write { db in
-      switch corruption {
-      case .secondLiveTrial:
+      try db.execute(sql: sql, arguments: [trialId])
+    }
+  }
+
+  func applyLiveWorkflowMutation(
+    _ mutation: LiveWorkflowMutation,
+    trialId: Int64
+  ) throws {
+    switch mutation {
+    case .cancelledJob:
+      try env.cancelJob()
+    case .stalePointer:
+      try env.queue.write { db in
         try db.execute(
-          sql: """
-            INSERT INTO learning_trials(job_id, learning_epoch, base_digest, candidate_digest,
-              generation, admitted_at, assignment_deadline, decision_deadline, max_assignments,
-              consumed_assignments, cohort_cutoff, state, algorithm)
-            SELECT job_id, learning_epoch, base_digest, candidate_digest, generation + 1,
-              admitted_at, assignment_deadline, decision_deadline, max_assignments, 0,
-              cohort_cutoff, ?, algorithm
-            FROM learning_trials WHERE trial_id = ?
-            """,
-          arguments: [LearningTrialState.draining.rawValue, trialId]
-        )
-      case .assignmentEpoch:
-        try db.execute(
-          sql:
-            "UPDATE trial_assignments SET learning_epoch = learning_epoch + 1 WHERE trial_id = ?",
-          arguments: [trialId]
-        )
-      case .assignmentGeneration:
-        try db.execute(
-          sql: "UPDATE trial_assignments SET trial_generation = 99 WHERE trial_id = ?",
-          arguments: [trialId]
+          sql: "UPDATE job_learning_state SET open_trial_id = ? WHERE job_id = ?",
+          arguments: [trialId + 10_000, env.jobId]
         )
       }
     }
   }
+
+  func durableLearningSnapshot() throws -> DurableLearningSnapshot {
+    let tableNames = [
+      "scheduled_jobs",
+      "job_learning_state",
+      "lesson_sets",
+      "learning_candidates",
+      "learning_trials",
+      "trial_assignments",
+      "learning_decisions",
+      "audit_events",
+      "feedback_targets",
+      "outbound_deliveries",
+    ]
+    return try env.queue.read { db in
+      let tables = try tableNames.map { tableName in
+        let columnRows = try Row.fetchAll(db, sql: "PRAGMA table_info(\(tableName))")
+        let columns = columnRows.map { row in row["name"] as String }
+        let rows = try Row.fetchAll(db, sql: "SELECT * FROM \(tableName) ORDER BY rowid")
+        let values = rows.map { row in
+          columns.map { column in row[column] as DatabaseValue }
+        }
+        return DurableTableSnapshot(name: tableName, columns: columns, rows: values)
+      }
+      return DurableLearningSnapshot(tables: tables)
+    }
+  }
+
+  func corruptCurrentDecision(
+    _ corruption: CurrentDecisionCorruption,
+    receipt: AdmissionReceipt
+  ) throws {
+    try env.queue.write { db in
+      switch corruption {
+      case .unknownKind:
+        try db.execute(
+          sql: "UPDATE learning_decisions SET kind = 'unknown' WHERE decision_id = 1"
+        )
+      case .receiptIdentity:
+        let altered = AdmissionReceipt(
+          candidateDigest: receipt.candidateDigest,
+          replacementDigest: receipt.replacementDigest,
+          trialId: receipt.trialId,
+          generation: receipt.generation + 1
+        )
+        let bytes = try CanonicalJSON.data(encoding: altered)
+        guard let result = String(bytes: bytes, encoding: .utf8) else {
+          throw StoreError.unexpected("fixture receipt was not UTF-8")
+        }
+        try db.execute(
+          sql: "UPDATE learning_decisions SET result = ? WHERE decision_id = 1",
+          arguments: [result]
+        )
+      }
+    }
+  }
+
+  func closeTrialForDecisionView(trialId: Int64) throws {
+    try env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE learning_trials SET state = ?, close_reason = ? WHERE trial_id = ?",
+        arguments: [LearningTrialState.closed.rawValue, "fixture close", trialId]
+      )
+      try db.execute(
+        sql: "UPDATE job_learning_state SET open_trial_id = NULL WHERE job_id = ?",
+        arguments: [env.jobId]
+      )
+    }
+  }
+
+  func corruptStoredPrimitive(
+    _ corruption: ViewPrimitiveCorruption,
+    trialId: Int64
+  ) throws {
+    let invalid = Data([0xFF])
+    try env.queue.write { db in
+      switch corruption {
+      case .job:
+        try db.execute(
+          sql: "UPDATE scheduled_jobs SET timezone = ? WHERE id = ?",
+          arguments: [invalid, env.jobId]
+        )
+      case .state:
+        try db.execute(
+          sql: "UPDATE job_learning_state SET learning_epoch = ? WHERE job_id = ?",
+          arguments: [invalid, env.jobId]
+        )
+      case .trial:
+        try db.execute(
+          sql: "UPDATE learning_trials SET generation = ? WHERE trial_id = ?",
+          arguments: [invalid, trialId]
+        )
+      case .assignment:
+        try db.execute(
+          sql: "UPDATE trial_assignments SET trial_generation = ? WHERE trial_id = ?",
+          arguments: [invalid, trialId]
+        )
+      case .decision:
+        try db.execute(
+          sql: "UPDATE learning_decisions SET decided_at = ? WHERE decision_id = 1",
+          arguments: [invalid]
+        )
+      }
+    }
+  }
+}
+
+private struct DurableLearningSnapshot: Equatable {
+  let tables: [DurableTableSnapshot]
+}
+
+private struct DurableTableSnapshot: Equatable {
+  let name: String
+  let columns: [String]
+  let rows: [[DatabaseValue]]
 }
 
 private extension BoundRunEnvironment {

--- a/Tests/ClawDataTests/Stores/Learning/LearningViewStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/LearningViewStoreTests.swift
@@ -132,7 +132,17 @@ import Testing
     #expect(trial.candidateDigest == artifact.digest)
     #expect(trial.baseDigest == artifact.manifest.baseDigest)
     #expect(trial.replacementDigest == artifact.replacement.digest)
-    #expect(trial.counts == LearningTrialCounts(consumed: 1, maximum: 3, unresolved: 1))
+    #expect(
+      trial.counts
+        == LearningTrialCounts(
+          consumed: 1,
+          maximum: 3,
+          positive: 0,
+          negative: 0,
+          neutral: 0,
+          unresolved: 1
+        )
+    )
     guard case .candidateAdmission(let inputs, let decisionReceipt) = baseline.lastDecision?.detail
     else {
       Issue.record("expected the typed admission receipt")
@@ -151,6 +161,142 @@ import Testing
 
     // then — following the convenience pointer or omitting assignment identity hides corruption.
     #expect(view.isOnlyUnreadable)
+  }
+
+  @Test func liveTrialCountsAuthoritativeFourWayOutcomesWithoutWriting() throws {
+    // given
+    let env = try BoundRunEnvironment.make()
+    try env.makeRepeatable()
+    try env.installTrial()
+    let verdicts = [
+      env.verdict(outcome: .noIssue, issueCodes: []),
+      env.verdict(outcome: .reusableIssue, issueCodes: ["wrong_fact"]),
+      env.verdict(outcome: .transientIssue, issueCodes: []),
+    ]
+    var operations: [ClaimedOperation] = []
+    for _ in verdicts {
+      let evidence = try env.sealedTrialEvidence()
+      operations.append(try env.startedOperation(env.evaluatorKey(for: evidence)))
+    }
+    for (operation, verdict) in zip(operations, verdicts) {
+      _ = try env.learning.finishOperation(
+        env.result(for: operation.id, evaluation: verdict),
+        now: env.now
+      )
+    }
+    let identities = try env.learning.liveTrialIdentities()
+    #expect(identities.count == 1)
+    let identity = try #require(identities.first)
+    _ = try env.learning.reconcileTrial(identity, now: env.now)
+    let before = try env.trialAssignmentSnapshot()
+
+    // when
+    let view = try #require(try env.learning.learningView(jobId: env.jobId).onlyReadable)
+    let after = try env.trialAssignmentSnapshot()
+
+    // then — counting cache state or mutating it during the read would survive the unresolved-only
+    // fixture because every stored and derived row agrees there.
+    #expect(after == before)
+    #expect(
+      view.liveTrial?.counts
+        == LearningTrialCounts(
+          consumed: 3,
+          maximum: 3,
+          positive: 1,
+          negative: 1,
+          neutral: 1,
+          unresolved: 0
+        )
+    )
+  }
+
+  @Test func liveTrialViewDerivesAResolvedOutcomeFromSourcesDespiteLaggingCache() throws {
+    // given
+    let env = try BoundRunEnvironment.make()
+    try env.makeRepeatable()
+    try env.installTrial()
+    let evidence = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: evidence))
+    _ = try env.learning.finishOperation(env.result(for: operation.id), now: env.now)
+    try env.resetAssignmentCache(runId: evidence.runId, state: .learningOutcomeUnresolved)
+    let before = try env.trialAssignmentSnapshot()
+
+    // when
+    let view = try #require(try env.learning.learningView(jobId: env.jobId).onlyReadable)
+    let after = try env.trialAssignmentSnapshot()
+
+    // then — the cache says unresolved, but the succeeded exact evaluation says positive.
+    #expect(after == before)
+    #expect(
+      view.liveTrial?.counts
+        == LearningTrialCounts(
+          consumed: 1,
+          maximum: 3,
+          positive: 1,
+          negative: 0,
+          neutral: 0,
+          unresolved: 0
+        )
+    )
+  }
+
+  @Test func liveTrialViewUsesNewerFeedbackWithoutRepairingTheCache() throws {
+    // given
+    let env = try BoundRunEnvironment.make()
+    try env.makeRepeatable()
+    try env.installTrial()
+    let evidence = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: evidence))
+    _ = try env.learning.finishOperation(env.result(for: operation.id), now: env.now)
+    _ = try env.appendFeedback(
+      subjectKind: .run,
+      subjectDigest: String(evidence.runId),
+      signal: .resultNotUseful
+    )
+    let before = try env.trialAssignmentSnapshot()
+
+    // when
+    let view = try #require(try env.learning.learningView(jobId: env.jobId).onlyReadable)
+    let after = try env.trialAssignmentSnapshot()
+
+    // then — reading cached positive would hide the newer current owner verdict.
+    #expect(after == before)
+    #expect(
+      view.liveTrial?.counts
+        == LearningTrialCounts(
+          consumed: 1,
+          maximum: 3,
+          positive: 0,
+          negative: 1,
+          neutral: 0,
+          unresolved: 0
+        )
+    )
+  }
+
+  @Test func liveTrialViewRejectsAResolvedCacheWithoutItsAuthoritativeEvaluation() throws {
+    // given
+    let env = try BoundRunEnvironment.make()
+    try env.makeRepeatable()
+    try env.installTrial()
+    let evidence = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: evidence))
+    _ = try env.learning.finishOperation(env.result(for: operation.id), now: env.now)
+    try env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE learning_operations SET key_digest = ? WHERE operation_id = ?",
+        arguments: [String(repeating: "f", count: 64), operation.id.rawValue]
+      )
+    }
+    let before = try env.trialAssignmentSnapshot()
+
+    // when
+    let view = try env.learning.learningView(jobId: env.jobId)
+    let after = try env.trialAssignmentSnapshot()
+
+    // then — guessing from the cached outcome would expose unsupported quality evidence.
+    #expect(view.isOnlyUnreadable)
+    #expect(after == before)
   }
 
   @Test(arguments: LiveWorkflowMutation.allCases)
@@ -557,6 +703,9 @@ private extension AdmissionStoreFixture {
     let sql: String
     switch corruption {
     case .secondLiveTrial:
+      try env.queue.write { db in
+        try db.execute(sql: "DROP INDEX idx_learning_trials_live_job")
+      }
       try insertCompetingDrainingTrial(from: artifact)
       return
     case .assignmentEpoch:
@@ -703,6 +852,24 @@ private struct DurableTableSnapshot: Equatable {
 }
 
 private extension BoundRunEnvironment {
+  func trialAssignmentSnapshot() throws -> [[DatabaseValue]] {
+    try queue.read { db in
+      let columns = try String.fetchAll(
+        db,
+        sql: "SELECT name FROM pragma_table_info('trial_assignments') ORDER BY cid"
+      )
+      let rows = try Row.fetchAll(
+        db,
+        sql: "SELECT * FROM trial_assignments ORDER BY run_id"
+      )
+      return rows.map { row in
+        columns.map { column in
+          row[column] as DatabaseValue
+        }
+      }
+    }
+  }
+
   func insertNonCurrentDecision(decidedAt: Date) throws {
     try queue.write { db in
       try db.execute(

--- a/Tests/ClawDataTests/Stores/Learning/LearningViewStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/LearningViewStoreTests.swift
@@ -281,6 +281,46 @@ import Testing
     // existing semantic tests keep the expected SQLite storage classes and cannot kill it.
     #expect(view.isOnlyUnreadable)
   }
+
+  @Test func wrongClassNullableJobFieldIsPerJobUnreadable() throws {
+    // given
+    let fixture = try LearningViewFixture.make()
+    let job = try fixture.createJob(label: "wrong nullable class")
+    _ = try fixture.learning.armJob(jobId: job.id, now: fixture.now)
+    try fixture.storeBlobAsRecurrence(jobId: job.id)
+
+    // when
+    let view = try fixture.learning.learningView(jobId: job.id)
+
+    // then — accepting a wrong-class nullable value as SQL NULL makes this job readable; the
+    // nearest primitive matrix reaches only non-optional fields.
+    #expect(view.isOnlyUnreadable)
+  }
+
+  @Test func outOfDomainAssignmentBooleanIsPerJobUnreadable() throws {
+    // given
+    let fixture = try AdmissionStoreFixture.make()
+    defer { fixture.remove() }
+    let artifact = try fixture.persistedCandidate()
+    let admitted = try fixture.env.learning.admitCandidate(
+      digest: artifact.digest,
+      redactor: SecretRedactor(secretValues: []),
+      now: fixture.env.now
+    )
+    guard case .admitted(let receipt) = admitted else {
+      Issue.record("expected fixture candidate admission")
+      return
+    }
+    _ = try fixture.env.pendingBoundRun()
+    try fixture.storeOutOfDomainEvaluationRequired(trialId: receipt.trialId)
+
+    // when
+    let view = try fixture.env.learning.learningView(jobId: fixture.env.jobId)
+
+    // then — treating every nonzero INTEGER as true accepts the damaged assignment; the nearest
+    // primitive matrix changes an integer's storage class and never tests the Boolean domain.
+    #expect(view.isOnlyUnreadable)
+  }
 }
 
 enum LiveTrialCorruption: CaseIterable, Sendable {
@@ -466,6 +506,15 @@ private struct LearningViewFixture {
     }
   }
 
+  func storeBlobAsRecurrence(jobId: Int64) throws {
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE scheduled_jobs SET recurrence = ? WHERE id = ?",
+        arguments: [Data([0xFF]), jobId]
+      )
+    }
+  }
+
   private func pointStableState(jobId: Int64, digest: String) throws {
     try queue.write { db in
       try db.execute(
@@ -491,6 +540,15 @@ private struct LearningViewFixture {
 }
 
 private extension AdmissionStoreFixture {
+  func storeOutOfDomainEvaluationRequired(trialId: Int64) throws {
+    try env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE trial_assignments SET evaluation_required = 2 WHERE trial_id = ?",
+        arguments: [trialId]
+      )
+    }
+  }
+
   func corruptViewTrial(
     _ corruption: LiveTrialCorruption,
     artifact: CandidateArtifact,

--- a/Tests/ClawDataTests/Stores/Learning/LearningViewStoreTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/LearningViewStoreTests.swift
@@ -1,0 +1,312 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct LearningViewStoreTests {
+  @Test func listUsesOnlyExistingStateWithoutWrites() throws {
+    // given
+    let fixture = try LearningViewFixture.make()
+    let first = try fixture.createJob(label: "first")
+    _ = try fixture.createJob(label: "unarmed")
+    let third = try fixture.createJob(label: "third")
+    _ = try fixture.learning.armJob(jobId: third.id, now: fixture.now)
+    _ = try fixture.learning.armJob(jobId: first.id, now: fixture.now)
+    let before = try fixture.learningStateCount()
+
+    // when
+    let view = try fixture.learning.learningView(jobId: nil)
+
+    // then — driving the list from schedules, or arming while reading, invents learning state.
+    #expect(view.count == 2)
+    #expect(view.readableJobIds == [first.id, third.id])
+    #expect(try fixture.learningStateCount() == before)
+  }
+
+  @Test func detailDistinguishesMissingUnarmedAndExactStableSet() throws {
+    // given
+    let fixture = try LearningViewFixture.make()
+    let unarmed = try fixture.createJob(label: "unarmed")
+    let armed = try fixture.createJob(label: "armed")
+    _ = try fixture.learning.armJob(jobId: armed.id, now: fixture.now)
+    let stable = try fixture.installStableLessons(
+      ["Keep the first fact.", "Keep the second fact."],
+      jobId: armed.id
+    )
+
+    // when
+    let missingView = try fixture.learning.learningView(jobId: 9_999)
+    let unarmedView = try fixture.learning.learningView(jobId: unarmed.id)
+    let armedView = try fixture.learning.learningView(jobId: armed.id)
+
+    // then — substituting an empty/newest set erases the requested pointer's exact state.
+    #expect(missingView == [.notFound(jobId: 9_999)])
+    #expect(unarmedView == [.unarmed(fixture.identity(for: unarmed))])
+    let readable = try #require(armedView.onlyReadable)
+    #expect(readable.stableLessons == stable)
+    #expect(readable.stableRevision == StableRevision(7))
+  }
+
+  @Test(arguments: LiveTrialCorruption.allCases)
+  func liveTrialRejectsMultiplicityAndUsesExactIdentity(
+    _ corruption: LiveTrialCorruption
+  ) throws {
+    // given
+    let fixture = try AdmissionStoreFixture.make()
+    defer { fixture.remove() }
+    let artifact = try fixture.persistedCandidate()
+    let admitted = try fixture.env.learning.admitCandidate(
+      digest: artifact.digest,
+      redactor: SecretRedactor(secretValues: []),
+      now: fixture.env.now
+    )
+    guard case .admitted(let receipt) = admitted else {
+      Issue.record("expected fixture candidate admission")
+      return
+    }
+    _ = try fixture.env.pendingBoundRun()
+    let baseline = try #require(
+      try fixture.env.learning.learningView(jobId: fixture.env.jobId).onlyReadable
+    )
+    let trial = try #require(baseline.liveTrial)
+    #expect(trial.candidateDigest == artifact.digest)
+    #expect(trial.baseDigest == artifact.manifest.baseDigest)
+    #expect(trial.replacementDigest == artifact.replacement.digest)
+    #expect(trial.counts == LearningTrialCounts(consumed: 1, maximum: 3, unresolved: 1))
+    guard case .candidateAdmission(let inputs, let decisionReceipt) = baseline.lastDecision?.detail
+    else {
+      Issue.record("expected the typed admission receipt")
+      return
+    }
+    #expect(inputs.candidateDigest == artifact.digest)
+    #expect(decisionReceipt == receipt)
+    try fixture.corruptViewTrial(corruption, trialId: receipt.trialId)
+
+    // when
+    let view = try fixture.env.learning.learningView(jobId: fixture.env.jobId)
+
+    // then — following the convenience pointer or omitting assignment identity hides corruption.
+    #expect(view.isOnlyUnreadable)
+  }
+
+  @Test func lastDecisionIsTypedCurrentEpochAndUsesTheStableTieBreak() throws {
+    // given
+    let env = try BoundRunEnvironment.make()
+    let reflection = try env.reflectionFixture()
+    let operation = try env.startReflector(reflection)
+    let noCandidate = try env.noCandidate(fixture: reflection, operation: operation)
+    _ = try env.learning.finishOperation(
+      env.reflectionResult(operation: operation, product: .noCandidate(noCandidate)),
+      now: env.now
+    )
+    try env.insertNonCurrentDecision(decidedAt: env.now.addingTimeInterval(60))
+
+    // when
+    let current = try #require(try env.learning.learningView(jobId: env.jobId).onlyReadable)
+
+    // then — dropping the epoch predicate lets a newer receipt from another epoch win.
+    guard case .reflectionNoCandidate(let inputs, let result) = current.lastDecision?.detail else {
+      Issue.record("expected the typed no-candidate receipt")
+      return
+    }
+    #expect(inputs.operationId == operation.id)
+    #expect(result.resultDigest == noCandidate.resultDigest)
+
+    // when
+    try env.insertMalformedTiedCurrentDecision(decidedAt: env.now)
+    let corrupt = try env.learning.learningView(jobId: env.jobId)
+
+    // then — omitting decision_id from the tie break can hide the latest malformed receipt.
+    #expect(corrupt.isOnlyUnreadable)
+  }
+}
+
+enum LiveTrialCorruption: CaseIterable, Sendable {
+  case secondLiveTrial
+  case assignmentEpoch
+  case assignmentGeneration
+}
+
+private extension Array where Element == JobLearningView {
+  var readableJobIds: [Int64] {
+    compactMap { item in
+      guard case .readable(let view) = item else {
+        return nil
+      }
+      return view.job.jobId
+    }
+  }
+
+  var onlyReadable: ReadableJobLearningView? {
+    guard count == 1, case .readable(let view) = self[0] else {
+      return nil
+    }
+    return view
+  }
+
+  var isOnlyUnreadable: Bool {
+    guard count == 1, case .unreadable = self[0] else {
+      return false
+    }
+    return true
+  }
+}
+
+private struct LearningViewFixture {
+  let queue: DatabaseQueue
+  let jobs: ScheduledJobStoreGRDB
+  let learning: ScheduledLearningStoreGRDB
+  let now = Date(timeIntervalSince1970: 1_782_000_600)
+
+  static func make() throws -> LearningViewFixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    return LearningViewFixture(
+      queue: queue,
+      jobs: ScheduledJobStoreGRDB(writer: queue, learningEnabled: false),
+      learning: ScheduledLearningStoreGRDB(writer: queue)
+    )
+  }
+
+  func createJob(label: String) throws -> ScheduledJob {
+    try jobs.create(
+      NewScheduledJob(
+        ownerChatId: 777,
+        label: label,
+        prompt: "Summarize",
+        recurrence: nil,
+        timezone: "Europe/Berlin",
+        nextOccurrence: now
+      ),
+      now: now
+    )
+  }
+
+  func identity(for job: ScheduledJob) -> LearningJobIdentity {
+    LearningJobIdentity(
+      jobId: job.id,
+      label: job.label,
+      status: job.status,
+      timezone: job.timezone
+    )
+  }
+
+  func learningStateCount() throws -> Int {
+    try queue.read { db in
+      try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM job_learning_state") ?? -1
+    }
+  }
+
+  func installStableLessons(_ lessons: [String], jobId: Int64) throws -> LessonSet {
+    let set = try LessonSet.canonical(jobId: jobId, lessons: lessons)
+    let decoy = try LessonSet.canonical(jobId: jobId, lessons: ["Do not select the newest set."])
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO lesson_sets(job_id, digest, schema_version, canonical_bytes, source,
+            created_at) VALUES (?, ?, ?, ?, ?, ?)
+          """,
+        arguments: [
+          jobId,
+          set.digest.rawValue,
+          set.schemaVersion,
+          set.canonicalBytes,
+          LessonSetSource.reflectorCandidate.rawValue,
+          EpochSecondCodec.epoch(now),
+        ]
+      )
+      try db.execute(
+        sql: """
+          UPDATE job_learning_state
+          SET stable_lesson_set_digest = ?, stable_revision = 7
+          WHERE job_id = ?
+          """,
+        arguments: [set.digest.rawValue, jobId]
+      )
+      try db.execute(
+        sql: """
+          INSERT INTO lesson_sets(job_id, digest, schema_version, canonical_bytes, source,
+            created_at) VALUES (?, ?, ?, ?, ?, ?)
+          """,
+        arguments: [
+          jobId,
+          decoy.digest.rawValue,
+          decoy.schemaVersion,
+          decoy.canonicalBytes,
+          LessonSetSource.reflectorCandidate.rawValue,
+          EpochSecondCodec.epoch(now.addingTimeInterval(60)),
+        ]
+      )
+    }
+    return set
+  }
+}
+
+private extension AdmissionStoreFixture {
+  func corruptViewTrial(
+    _ corruption: LiveTrialCorruption,
+    trialId: Int64
+  ) throws {
+    try env.queue.write { db in
+      switch corruption {
+      case .secondLiveTrial:
+        try db.execute(
+          sql: """
+            INSERT INTO learning_trials(job_id, learning_epoch, base_digest, candidate_digest,
+              generation, admitted_at, assignment_deadline, decision_deadline, max_assignments,
+              consumed_assignments, cohort_cutoff, state, algorithm)
+            SELECT job_id, learning_epoch, base_digest, candidate_digest, generation + 1,
+              admitted_at, assignment_deadline, decision_deadline, max_assignments, 0,
+              cohort_cutoff, ?, algorithm
+            FROM learning_trials WHERE trial_id = ?
+            """,
+          arguments: [LearningTrialState.draining.rawValue, trialId]
+        )
+      case .assignmentEpoch:
+        try db.execute(
+          sql:
+            "UPDATE trial_assignments SET learning_epoch = learning_epoch + 1 WHERE trial_id = ?",
+          arguments: [trialId]
+        )
+      case .assignmentGeneration:
+        try db.execute(
+          sql: "UPDATE trial_assignments SET trial_generation = 99 WHERE trial_id = ?",
+          arguments: [trialId]
+        )
+      }
+    }
+  }
+}
+
+private extension BoundRunEnvironment {
+  func insertNonCurrentDecision(decidedAt: Date) throws {
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO learning_decisions(kind, job_id, learning_epoch, inputs, result, algorithm,
+            decided_at) VALUES ('unknown', ?, 0, '{}', '{}', ?, ?)
+          """,
+        arguments: [jobId, LearningAlgorithm.v1.rawValue, EpochSecondCodec.epoch(decidedAt)]
+      )
+    }
+  }
+
+  func insertMalformedTiedCurrentDecision(decidedAt: Date) throws {
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO learning_decisions(kind, job_id, learning_epoch, inputs, result, algorithm,
+            decided_at) VALUES (?, ?, 1, '{}', '{}', ?, ?)
+          """,
+        arguments: [
+          ReflectionNoCandidateReceipt.kind,
+          jobId,
+          LearningAlgorithm.v1.rawValue,
+          EpochSecondCodec.epoch(decidedAt),
+        ]
+      )
+    }
+  }
+}

--- a/Tests/ClawDataTests/Stores/Learning/PromotionReplyTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/PromotionReplyTests.swift
@@ -1,0 +1,161 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct PromotionReplyTests {
+  @Test func exactCurrentTargetAndFinalChunkCommitTogether() throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    _ = try env.positiveTrialRun()
+    _ = try env.positiveTrialRun()
+    let promotion = try env.promoteTrial()
+    let target = env.promotionReplyTarget(promotion)
+    let chunks = env.promotionReplyChunks(target)
+
+    // when
+    let first = try env.learning.commitPromotionReply(
+      updateId: 950,
+      target: target,
+      chunks: chunks,
+      now: env.now
+    )
+    let replay = try env.learning.commitPromotionReply(
+      updateId: 950,
+      target: target,
+      chunks: chunks,
+      now: env.now
+    )
+
+    // then
+    #expect(first == .committed)
+    #expect(replay == .duplicate)
+    let stored = try #require(try env.learning.feedbackTarget(nonce: target.nonce))
+    #expect(stored.subjectKind == .promotion)
+    #expect(stored.subjectDigest == promotion.promotionSubject)
+    let markup = try env.queue.read { db in
+      try Row.fetchAll(
+        db,
+        sql:
+          "SELECT reply_markup FROM outbound_deliveries WHERE dedup_key IN (?, ?) ORDER BY step_index",
+        arguments: StatementArguments(
+          chunks.map { chunk in
+            OutboxDedupKey.make(subjectDigest: chunk.subjectDigest, ordinal: chunk.ordinal)
+          }
+        )
+      )
+    }
+    #expect(markup.count == chunks.count)
+    #expect(
+      markup.dropLast().allSatisfy { row in
+        (row["reply_markup"] as String?) == nil
+      }
+    )
+    #expect((markup.last?["reply_markup"] as String?) == chunks.last?.replyMarkup)
+  }
+
+  @Test func stalePromotionExposesNoTarget() throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    _ = try env.positiveTrialRun()
+    _ = try env.positiveTrialRun()
+    let promotion = try env.promoteTrial()
+    let target = env.promotionReplyTarget(promotion)
+    _ = try env.learning.rollback(
+      .safety(
+        promotionId: promotion.decisionId,
+        receiptDigest: SHA256Digest.hex("bad"),
+        failure: .security
+      ),
+      now: env.now
+    )
+
+    // when
+    let outcome = try env.learning.commitPromotionReply(
+      updateId: 951,
+      target: target,
+      chunks: env.promotionReplyChunks(target),
+      now: env.now
+    )
+
+    // then
+    #expect(outcome == .stale)
+    #expect(try env.learning.feedbackTarget(nonce: target.nonce) == nil)
+  }
+
+  @Test func lateOutboxFailureRollsBackTargetAndUpdateClaim() throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    _ = try env.positiveTrialRun()
+    _ = try env.positiveTrialRun()
+    let promotion = try env.promoteTrial()
+    let target = env.promotionReplyTarget(promotion)
+    let chunks = env.promotionReplyChunks(target)
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          CREATE TRIGGER fail_promotion_reply BEFORE INSERT ON outbound_deliveries
+          WHEN NEW.step_index = 1 BEGIN SELECT RAISE(ABORT, 'outbox failure'); END
+          """
+      )
+    }
+
+    // when
+    #expect(throws: StoreError.self) {
+      try env.learning.commitPromotionReply(
+        updateId: 952,
+        target: target,
+        chunks: chunks,
+        now: env.now
+      )
+    }
+    try env.queue.write { db in
+      try db.execute(sql: "DROP TRIGGER fail_promotion_reply")
+    }
+    let retry = try env.learning.commitPromotionReply(
+      updateId: 952,
+      target: target,
+      chunks: chunks,
+      now: env.now
+    )
+
+    // then
+    #expect(retry == .committed)
+  }
+}
+
+private extension BoundRunEnvironment {
+  func promotionReplyTarget(_ promotion: DecisionReceipt) -> NewFeedbackTarget {
+    NewFeedbackTarget(
+      nonce: "promotion-reply",
+      jobId: jobId,
+      epoch: promotion.inputs.identity.epoch,
+      subjectKind: .promotion,
+      subjectDigest: promotion.promotionSubject,
+      allowedActions: [.promotionRollback],
+      ownerUserId: 42,
+      chatId: 777,
+      expiresAt: now.addingTimeInterval(3_600)
+    )
+  }
+
+  func promotionReplyChunks(_ target: NewFeedbackTarget) -> [LearningNoticeChunk] {
+    let markup = FeedbackKeyboard.markup(rows: [
+      [
+        FeedbackKeyboard.Button(text: "Rollback", nonce: target.nonce, action: .promotionRollback)
+      ]
+    ])
+    return ["Current learned set", "Current promotion"].enumerated().map { index, payload in
+      LearningNoticeChunk(
+        subjectDigest: SHA256Digest.hex("promotion reply"),
+        ordinal: index,
+        chatId: 777,
+        payload: payload,
+        payloadHash: ContentHash.fnv1a(payload),
+        replyMarkup: index == 1 ? markup : nil
+      )
+    }
+  }
+}

--- a/Tests/ClawDataTests/Stores/Learning/PromotionTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/PromotionTests.swift
@@ -1,0 +1,302 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct PromotionTests {
+  @Test func completeCohortAndReplay() throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    let first = try env.positiveTrialRun()
+    let second = try env.positiveTrialRun()
+    try env.recordRunFeedback(runId: first, signal: .resultUseful, updateId: 799)
+    let trial = try #require(try env.learning.openTrial(jobId: env.jobId))
+    let revision = try env.currentLearningState().feedbackRevision
+
+    // when
+    let receipt = try #require(
+      try env.learning.applyTrialDecision(
+        .promote,
+        trial: trial,
+        feedbackRevision: revision,
+        now: env.now
+      )
+    )
+    let replay = try env.learning.applyTrialDecision(
+      .promote,
+      trial: trial,
+      feedbackRevision: revision,
+      now: env.now
+    )
+
+    // then
+    #expect(receipt.result == .promoted)
+    #expect(Set(receipt.cohort.map(\.runId)) == [first, second])
+    #expect(
+      receipt.cohort.allSatisfy { support in
+        support.outcome == .positive
+      }
+    )
+    let ownerSupport = receipt.cohort.first { support in
+      support.runId == first
+    }
+    #expect(ownerSupport?.evaluationRequired == false)
+    #expect(replay == receipt)
+    #expect(try env.currentLearningState().stableDigest == trial.replacementDigest)
+    #expect(try env.learning.openTrial(jobId: env.jobId) == nil)
+  }
+  @Test func waitsForEveryAssignedRun() throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    _ = try env.positiveTrialRun()
+    let pending = try env.settledBoundRun()
+    _ = try env.positiveTrialRun()
+    let trial = try #require(try env.learning.openTrial(jobId: env.jobId))
+
+    // when
+    let result = try env.learning.applyTrialDecision(
+      .promote,
+      trial: trial,
+      feedbackRevision: FeedbackRevision(0),
+      now: env.now
+    )
+
+    // then
+    #expect(result == nil)
+    #expect(try env.currentLearningState().stableDigest == trial.baseDigest)
+    #expect(try env.assignment(runId: pending)?.resolvedEvidence == nil)
+  }
+
+  @Test(arguments: StalePromotionPredicate.allCases)
+  func staleReviewedPredicates(_ predicate: StalePromotionPredicate) throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    let run = try env.positiveTrialRun()
+    _ = try env.positiveTrialRun()
+    let trial = try #require(try env.learning.openTrial(jobId: env.jobId))
+    let request = trial.reviewedMutation(predicate)
+    switch predicate {
+    case .feedback:
+      try env.recordRunFeedback(runId: run, signal: .resultUseful, updateId: 800)
+    case .epoch:
+      _ = try env.learning.applyReset(updateId: 801, jobId: env.jobId, now: env.now)
+    case .cancelled:
+      _ = try env.jobs.cancel(id: env.jobId, now: env.now)
+    case .baseRevision, .baseDigest, .candidate, .replacement, .generation, .algorithm:
+      break
+    }
+    let before = try env.currentLearningState()
+
+    // when
+    let receipt = try #require(
+      try env.learning.applyTrialDecision(
+        .promote,
+        trial: request,
+        feedbackRevision: FeedbackRevision(0),
+        now: env.now
+      )
+    )
+
+    // then
+    #expect(receipt.result == .stale)
+    let after = try env.currentLearningState()
+    #expect(after.stableDigest == before.stableDigest)
+    #expect(after.stableRevision == before.stableRevision)
+    #expect(after.epoch == before.epoch)
+  }
+
+  @Test func fallbackReceipt() throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    let run = try env.positiveTrialRun()
+    let trial = try #require(try env.learning.openTrial(jobId: env.jobId))
+    try env.recordRunFeedback(runId: run, signal: .resultNotUseful, updateId: 810)
+
+    // when
+    let receipt = try #require(
+      try env.learning.applyTrialDecision(
+        .fallback(reason: .negativeOutcome),
+        trial: trial,
+        feedbackRevision: try env.currentLearningState().feedbackRevision,
+        now: env.now
+      )
+    )
+
+    // then
+    #expect(receipt.result == .fallback)
+    #expect(receipt.cohort.first?.outcome == .negative)
+    #expect(try env.currentLearningState().stableDigest == trial.baseDigest)
+    #expect(try env.learning.openTrial(jobId: env.jobId) == nil)
+    guard case .readable(let view) = try env.learning.learningView(jobId: env.jobId)[0],
+      case .terminal(let shown) = view.lastDecision?.detail
+    else {
+      Issue.record("terminal receipt must remain readable")
+      return
+    }
+    #expect(shown == receipt)
+  }
+
+  @Test(arguments: [false, true])
+  func closedReplacementCannotRetry(rolledBack: Bool) throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    let trial = try #require(try env.learning.openTrial(jobId: env.jobId))
+    if rolledBack {
+      _ = try env.positiveTrialRun()
+      _ = try env.positiveTrialRun()
+      let promotion = try env.promoteTrial()
+      _ = try env.learning.rollback(
+        .safety(
+          promotionId: promotion.decisionId,
+          receiptDigest: SHA256Digest.hex("safety"),
+          failure: .security
+        ),
+        now: env.now
+      )
+    } else {
+      _ = try env.learning.applyTrialDecision(
+        .fallback(reason: .insufficientSupport),
+        trial: trial,
+        feedbackRevision: FeedbackRevision(0),
+        now: trial.assignmentDeadline
+      )
+    }
+    let fixture = AdmissionStoreFixture(path: "", env: env)
+    let replacement = try #require(
+      try env.learning.lessonSet(jobId: env.jobId, digest: trial.replacementDigest)
+    )
+    let retry = try fixture.persistedCandidate(lessons: replacement.lessons)
+
+    // when
+    let outcome = try env.learning.admitCandidate(
+      digest: retry.digest,
+      redactor: SecretRedactor(secretValues: []),
+      now: env.now
+    )
+
+    // then
+    #expect(retry.digest != trial.candidateDigest)
+    #expect(outcome == .rejected(.replacementAlreadyClosed))
+    #expect(try env.learning.openTrial(jobId: env.jobId) == nil)
+  }
+
+  @Test func promotionIsAtomic() throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    _ = try env.positiveTrialRun()
+    _ = try env.positiveTrialRun()
+    let trial = try #require(try env.learning.openTrial(jobId: env.jobId))
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          CREATE TRIGGER fail_promotion BEFORE UPDATE OF stable_lesson_set_digest
+          ON job_learning_state BEGIN SELECT RAISE(ABORT, 'injected disk failure'); END
+          """
+      )
+    }
+
+    // when
+    #expect(throws: StoreError.self) {
+      try env.learning.applyTrialDecision(
+        .promote,
+        trial: trial,
+        feedbackRevision: FeedbackRevision(0),
+        now: env.now
+      )
+    }
+
+    // then
+    #expect(try env.currentLearningState().stableDigest == trial.baseDigest)
+    #expect(try env.learning.openTrial(jobId: env.jobId) != nil)
+    #expect(try env.terminalDecisionCount() == 0)
+  }
+}
+
+extension BoundRunEnvironment {
+  static func promotionEnvironment() throws -> Self {
+    let env = try make()
+    let fixture = AdmissionStoreFixture(path: "", env: env)
+    let artifact = try fixture.persistedCandidate()
+    guard
+      case .admitted = try env.learning.admitCandidate(
+        digest: artifact.digest,
+        redactor: SecretRedactor(secretValues: []),
+        now: env.now
+      )
+    else {
+      throw StoreError.unexpected("promotion fixture admission failed")
+    }
+    return env
+  }
+
+  func positiveTrialRun() throws -> Int64 {
+    let sealed = try sealedTrialEvidence()
+    let operation = try startedOperation(evaluatorKey(for: sealed))
+    _ = try learning.finishOperation(
+      result(for: operation.id, evaluation: verdict(outcome: .noIssue, issueCodes: [])),
+      now: now
+    )
+    return sealed.runId
+  }
+}
+
+enum StalePromotionPredicate: CaseIterable {
+  case baseRevision, baseDigest, candidate, replacement, feedback, epoch, generation, cancelled,
+    algorithm
+}
+
+private extension LearningTrial {
+  func reviewedMutation(_ predicate: StalePromotionPredicate) -> LearningTrial {
+    let other = SHA256Digest.hex("other reviewed identity")
+    return LearningTrial(
+      identity: LearningTrialIdentity(
+        trialId: trialId,
+        jobId: jobId,
+        epoch: epoch,
+        generation: predicate == .generation ? generation + 1 : generation
+      ),
+      baseDigest: predicate == .baseDigest ? LessonSetDigest(rawValue: other) : baseDigest,
+      baseRevision: predicate == .baseRevision
+        ? StableRevision(baseRevision.value + 1) : baseRevision,
+      candidateDigest: predicate == .candidate ? CandidateDigest(rawValue: other) : candidateDigest,
+      replacementDigest: predicate == .replacement
+        ? LessonSetDigest(rawValue: other) : replacementDigest,
+      algorithm: predicate == .algorithm
+        ? LearningAlgorithm(rawValue: "scheduled-learning/v2") : algorithm,
+      admittedAt: admittedAt,
+      cohortCutoff: cohortCutoff,
+      maxAssignments: maxAssignments,
+      consumedAssignments: consumedAssignments,
+      assignmentDeadline: assignmentDeadline,
+      decisionDeadline: decisionDeadline,
+      state: state,
+      hardVetoes: hardVetoes
+    )
+  }
+}
+
+extension BoundRunEnvironment {
+  func terminalDecisionCount() throws -> Int {
+    try queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM learning_decisions WHERE kind = ?",
+        arguments: [LearningDecisionKind.trial.rawValue]
+      ) ?? 0
+    }
+  }
+
+  func promoteTrial() throws -> DecisionReceipt {
+    let trial = try #require(try learning.openTrial(jobId: jobId))
+    return try #require(
+      try learning.applyTrialDecision(
+        .promote,
+        trial: trial,
+        feedbackRevision: try currentLearningState().feedbackRevision,
+        now: now
+      )
+    )
+  }
+}

--- a/Tests/ClawDataTests/Stores/Learning/ResetTestSupport.swift
+++ b/Tests/ClawDataTests/Stores/Learning/ResetTestSupport.swift
@@ -115,6 +115,16 @@ struct ResetFixture {
     let resetAuditCount: Int
   }
 
+  struct DurableProjection: Equatable {
+    let tables: [DurableTableProjection]
+  }
+
+  struct DurableTableProjection: Equatable {
+    let name: String
+    let columns: [String]
+    let rows: [[DatabaseValue]]
+  }
+
   let env: BoundRunEnvironment
 
   static func make() throws -> ResetFixture {
@@ -620,6 +630,45 @@ struct ResetFixture {
       resetDecisionCount: try resetDecisionCount(),
       resetAuditCount: try resetAuditCount()
     )
+  }
+
+  func durableProjection() throws -> DurableProjection {
+    let tableNames = [
+      "processed_updates",
+      "scheduled_jobs",
+      "job_learning_state",
+      "lesson_sets",
+      "run_learning_bindings",
+      "run_compatibility",
+      "learning_evidence",
+      "learning_operations",
+      "learning_evaluations",
+      "feedback_targets",
+      "feedback_challenges",
+      "feedback_events",
+      "learning_candidates",
+      "learning_trials",
+      "trial_assignments",
+      "learning_decisions",
+      "audit_events",
+    ]
+    return try env.queue.read { db in
+      let tables = try tableNames.map { tableName in
+        let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(\(tableName))").map { row in
+          row["name"] as String
+        }
+        let rows = try Row.fetchAll(
+          db,
+          sql: "SELECT * FROM \(tableName) ORDER BY rowid"
+        ).map { row in
+          columns.map { column in
+            row[column] as DatabaseValue
+          }
+        }
+        return DurableTableProjection(name: tableName, columns: columns, rows: rows)
+      }
+      return DurableProjection(tables: tables)
+    }
   }
 
   func resetDecisionCount() throws -> Int {

--- a/Tests/ClawDataTests/Stores/Learning/ResetTestSupport.swift
+++ b/Tests/ClawDataTests/Stores/Learning/ResetTestSupport.swift
@@ -171,6 +171,7 @@ struct ResetFixture {
 
   func seedOpenAndDrainingTrials(base: LessonSetDigest) throws -> [Int64] {
     try env.queue.write { db in
+      try db.execute(sql: "DROP INDEX idx_learning_trials_live_job")
       var ids: [Int64] = []
       for (index, state) in [LearningTrialState.open, .draining].enumerated() {
         let candidateDigest = String(repeating: index == 0 ? "a" : "b", count: 64)

--- a/Tests/ClawDataTests/Stores/Learning/ResetTestSupport.swift
+++ b/Tests/ClawDataTests/Stores/Learning/ResetTestSupport.swift
@@ -1,0 +1,978 @@
+import ClawCore
+import Foundation
+import GRDB
+
+@testable import ClawData
+
+enum ResetCurrentEpochActivity: CaseIterable {
+  case binding
+  case compatibility
+  case evidence
+  case operation
+  case evaluation
+  case target
+  case challenge
+  case feedbackEvent
+  case candidate
+  case trial
+  case assignment
+}
+
+enum ResetDirtyEffect: CaseIterable {
+  case liveTrial
+  case target
+  case challenge
+  case pendingOperation
+  case unlistedStartedOperation
+}
+
+enum ResetEmptyCollision: CaseIterable {
+  case schemaVersion
+  case canonicalBytes
+  case source
+}
+
+enum ResetReceiptCorruption: CaseIterable {
+  case noncanonicalJSON
+  case wrongStableRevision
+}
+
+struct ResetFixture {
+  struct OperationProjection: Equatable {
+    let state: LearningOperationState
+    let failure: LearningOperationFailure?
+    let reservation: LearningReservationState?
+    let reservedTokens: Int?
+    let reservedCostUSD: Double?
+    let route: String?
+    let providerCallId: String?
+
+    static let staleNoCall = OperationProjection(
+      state: .failedNoCall,
+      failure: .staleEpoch,
+      reservation: .closed,
+      reservedTokens: 0,
+      reservedCostUSD: 0,
+      route: nil,
+      providerCallId: nil
+    )
+
+    static let started = OperationProjection(
+      state: .started,
+      failure: nil,
+      reservation: .open,
+      reservedTokens: 300,
+      reservedCostUSD: 0.5,
+      route: "route",
+      providerCallId: "provider-secret-call"
+    )
+
+    static let claimed = OperationProjection(
+      state: .claimed,
+      failure: nil,
+      reservation: nil,
+      reservedTokens: nil,
+      reservedCostUSD: nil,
+      route: nil,
+      providerCallId: nil
+    )
+  }
+
+  struct AuditProjection {
+    let actor: String
+    let action: String
+    let tool: String?
+    let args: String
+    let resultSize: Int
+    let decision: String
+    let runId: Int64?
+    let sessionId: Int64?
+  }
+
+  let env: BoundRunEnvironment
+
+  static func make() throws -> ResetFixture {
+    ResetFixture(env: try BoundRunEnvironment.make())
+  }
+
+  func installStableLessons(_ lessons: [String]) throws -> LessonSet {
+    _ = try env.learning.armJob(jobId: env.jobId, now: env.now)
+    let set = try LessonSet.canonical(jobId: env.jobId, lessons: lessons)
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO lesson_sets(job_id, digest, schema_version, canonical_bytes, source,
+            created_at) VALUES (?, ?, ?, ?, ?, ?)
+          """,
+        arguments: [
+          set.jobId,
+          set.digest.rawValue,
+          set.schemaVersion,
+          set.canonicalBytes,
+          LessonSetSource.reflectorCandidate.rawValue,
+          EpochSecondCodec.epoch(env.now),
+        ]
+      )
+      try db.execute(
+        sql: """
+          UPDATE job_learning_state SET stable_lesson_set_digest = ?, stable_revision = 4
+          WHERE job_id = ?
+          """,
+        arguments: [set.digest.rawValue, env.jobId]
+      )
+    }
+    return set
+  }
+
+  func setFeedbackRevision(_ revision: Int64) throws {
+    try env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE job_learning_state SET feedback_revision = ? WHERE job_id = ?",
+        arguments: [revision, env.jobId]
+      )
+    }
+  }
+
+  func seedOpenAndDrainingTrials(base: LessonSetDigest) throws -> [Int64] {
+    try env.queue.write { db in
+      var ids: [Int64] = []
+      for (index, state) in [LearningTrialState.open, .draining].enumerated() {
+        let candidateDigest = String(repeating: index == 0 ? "a" : "b", count: 64)
+        let replacement = try LessonSet.canonical(
+          jobId: env.jobId,
+          lessons: ["replacement-\(index)"]
+        )
+        try db.execute(
+          sql: """
+            INSERT INTO lesson_sets(job_id, digest, schema_version, canonical_bytes, source,
+              created_at) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+          arguments: [
+            env.jobId,
+            replacement.digest.rawValue,
+            replacement.schemaVersion,
+            replacement.canonicalBytes,
+            LessonSetSource.reflectorCandidate.rawValue,
+            EpochSecondCodec.epoch(env.now),
+          ]
+        )
+        try db.execute(
+          sql: """
+            INSERT INTO learning_candidates(candidate_digest, job_id, learning_epoch,
+              replacement_digest, base_digest, base_revision, frozen_feedback_revision, origin,
+              source_manifest, algorithm, created_at)
+            VALUES (?, ?, 1, ?, ?, 4, 7, 'reflection', '{}', ?, ?)
+            """,
+          arguments: [
+            candidateDigest,
+            env.jobId,
+            replacement.digest.rawValue,
+            base.rawValue,
+            LearningAlgorithm.v1.rawValue,
+            EpochSecondCodec.epoch(env.now),
+          ]
+        )
+        try db.execute(
+          sql: """
+            INSERT INTO learning_trials(job_id, learning_epoch, base_digest, candidate_digest,
+              generation, admitted_at, assignment_deadline, decision_deadline, max_assignments,
+              consumed_assignments, cohort_cutoff, state, algorithm)
+            VALUES (?, 1, ?, ?, ?, ?, ?, ?, 3, 0, ?, ?, ?)
+            """,
+          arguments: [
+            env.jobId,
+            base.rawValue,
+            candidateDigest,
+            index + 1,
+            EpochSecondCodec.epoch(env.now),
+            EpochSecondCodec.epoch(env.now.addingTimeInterval(60)),
+            EpochSecondCodec.epoch(env.now.addingTimeInterval(120)),
+            EpochSecondCodec.epoch(env.now),
+            state.rawValue,
+            LearningAlgorithm.v1.rawValue,
+          ]
+        )
+        ids.append(db.lastInsertedRowID)
+      }
+      try db.execute(
+        sql: "UPDATE job_learning_state SET open_trial_id = ? WHERE job_id = ?",
+        arguments: [ids[0], env.jobId]
+      )
+      return ids
+    }
+  }
+
+  func clearTrialPointer() throws {
+    try env.queue.write { db in
+      try db.execute(
+        sql: "UPDATE job_learning_state SET open_trial_id = NULL WHERE job_id = ?",
+        arguments: [env.jobId]
+      )
+    }
+  }
+
+  func corruptFirstLiveTrialBaseDigest() throws {
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          UPDATE learning_trials SET base_digest = 'corrupt'
+          WHERE trial_id = (
+            SELECT trial_id FROM learning_trials WHERE job_id = ? ORDER BY trial_id LIMIT 1
+          )
+          """,
+        arguments: [env.jobId]
+      )
+    }
+  }
+
+  func createOtherJob() throws -> Int64 {
+    let job = try env.jobs.create(
+      NewScheduledJob(
+        ownerChatId: 888,
+        label: "other",
+        prompt: "Other job",
+        recurrence: nil,
+        timezone: "Europe/Berlin",
+        nextOccurrence: env.now
+      ),
+      now: env.now
+    )
+    return job.id
+  }
+
+  func seedFeedbackControls(otherJobId: Int64) throws {
+    try env.queue.write { db in
+      for (nonce, jobId, epoch) in [
+        ("target-secret-nonce-current", env.jobId, 1),
+        ("target-secret-nonce-old", env.jobId, 0),
+        ("target-secret-nonce-other", otherJobId, 1),
+      ] {
+        try db.execute(
+          sql: """
+            INSERT INTO feedback_targets(nonce, job_id, learning_epoch, subject_kind,
+              subject_digest, allowed_actions, owner_user_id, chat_id, expires_at)
+            VALUES (?, ?, ?, 'run', 'subject', '["result_useful"]', ?, ?, ?)
+            """,
+          arguments: [nonce, jobId, epoch, jobId + 100, jobId + 200, 1]
+        )
+      }
+      for (owner, chat, jobId, epoch) in [
+        (100, 200, env.jobId, 1),
+        (101, 201, env.jobId, 0),
+        (102, 202, otherJobId, 1),
+      ] {
+        try db.execute(
+          sql: """
+            INSERT INTO feedback_challenges(owner_user_id, chat_id, job_id, learning_epoch,
+              subject_kind, subject_digest, expires_at)
+            VALUES (?, ?, ?, ?, 'run', 'subject', 1)
+            """,
+          arguments: [owner, chat, jobId, epoch]
+        )
+      }
+      try db.execute(
+        sql: """
+          INSERT INTO feedback_challenges(owner_user_id, chat_id, job_id, learning_epoch,
+            subject_kind, subject_digest, expires_at)
+          VALUES (103, 203, ?, 0, 'run', 'history', 1)
+          """,
+        arguments: [env.jobId]
+      )
+      let historyId = db.lastInsertedRowID
+      try db.execute(
+        sql: "UPDATE feedback_challenges SET superseded_by = ? WHERE challenge_id = ?",
+        arguments: [historyId, historyId]
+      )
+    }
+  }
+
+  func seedOperations(otherJobId: Int64) throws {
+    try env.queue.write { db in
+      try insertOperation(db, id: "op-pending", jobId: env.jobId, state: .pending)
+      try insertOperation(db, id: "op-claimed", jobId: env.jobId, state: .claimed)
+      try insertOperation(db, id: "op-started", jobId: env.jobId, state: .started)
+      try insertOperation(db, id: "op-other", jobId: otherJobId, state: .claimed)
+    }
+  }
+
+  func insertOperation(
+    _ db: Database,
+    id: String,
+    jobId: Int64,
+    state: LearningOperationState
+  ) throws {
+    let started = state == .started
+    try db.execute(
+      sql: """
+        INSERT INTO learning_operations(operation_id, job_id, learning_epoch, phase,
+          source_digest, carrier_digest, route, provider_call_id, attempt_generation, state,
+          reserved_tokens, reserved_cost_usd, reservation_state, created_at, key_digest)
+        VALUES (?, ?, 1, 'evaluator', ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)
+        """,
+      arguments: [
+        id,
+        jobId,
+        "source-\(id)",
+        started ? "carrier-\(id)" : nil,
+        started ? "route" : nil,
+        started ? "provider-secret-call" : nil,
+        state.rawValue,
+        started ? 300 : nil,
+        started ? 0.5 : nil,
+        started ? LearningReservationState.open.rawValue : nil,
+        EpochSecondCodec.epoch(env.now),
+        "key-\(id)",
+      ]
+    )
+  }
+
+  func state() throws -> JobLearningState {
+    try env.currentLearningState()
+  }
+
+  func closedTrialIds() throws -> [Int64] {
+    try trialIds(state: .closed)
+  }
+
+  func closedTrialReasons() throws -> [String] {
+    try env.queue.read { db in
+      let rows = try Row.fetchAll(
+        db,
+        sql: "SELECT close_reason FROM learning_trials WHERE job_id = ? ORDER BY trial_id",
+        arguments: [env.jobId]
+      )
+      return try rows.map { row in
+        guard let reason = SQLiteStoredValue.string(in: row, column: "close_reason") else {
+          throw StoreError.unexpected("fixture trial close reason is unreadable")
+        }
+        return reason
+      }
+    }
+  }
+
+  func liveTrialIds() throws -> [Int64] {
+    try env.queue.read { db in
+      try Int64.fetchAll(
+        db,
+        sql: """
+          SELECT trial_id FROM learning_trials
+          WHERE job_id = ? AND state IN (?, ?) ORDER BY trial_id
+          """,
+        arguments: [
+          env.jobId,
+          LearningTrialState.open.rawValue,
+          LearningTrialState.draining.rawValue,
+        ]
+      )
+    }
+  }
+
+  func trialIds(state: LearningTrialState) throws -> [Int64] {
+    try env.queue.read { db in
+      try Int64.fetchAll(
+        db,
+        sql: """
+          SELECT trial_id FROM learning_trials
+          WHERE job_id = ? AND state = ? ORDER BY trial_id
+          """,
+        arguments: [env.jobId, state.rawValue]
+      )
+    }
+  }
+
+  func unconsumedTargetCount(jobId: Int64) throws -> Int {
+    try count(
+      "feedback_targets",
+      predicate: "job_id = ? AND consumed_at IS NULL",
+      arguments: [jobId]
+    )
+  }
+
+  func targetConsumptionEpochs(jobId: Int64) throws -> [Int64] {
+    try consumptionEpochs(
+      table: "feedback_targets",
+      id: "nonce",
+      predicate: "job_id = ?",
+      arguments: [jobId]
+    )
+  }
+
+  func liveChallengeCount(jobId: Int64) throws -> Int {
+    try count(
+      "feedback_challenges",
+      predicate: "job_id = ? AND superseded_by IS NULL AND consumed_at IS NULL",
+      arguments: [jobId]
+    )
+  }
+
+  func challengeConsumptionEpochs(jobId: Int64) throws -> [Int64] {
+    try consumptionEpochs(
+      table: "feedback_challenges",
+      id: "challenge_id",
+      predicate: "job_id = ? AND superseded_by IS NULL",
+      arguments: [jobId]
+    )
+  }
+
+  func unconsumedSupersededChallengeCount() throws -> Int {
+    try count(
+      "feedback_challenges",
+      predicate: "job_id = ? AND superseded_by IS NOT NULL AND consumed_at IS NULL",
+      arguments: [env.jobId]
+    )
+  }
+
+  func operation(_ id: String) throws -> OperationProjection? {
+    try env.queue.read { db in
+      guard
+        let row = try Row.fetchOne(
+          db,
+          sql: """
+            SELECT state, failure_code, reservation_state, reserved_tokens, reserved_cost_usd,
+              route, provider_call_id
+            FROM learning_operations WHERE operation_id = ?
+            """,
+          arguments: [id]
+        ),
+        let state = LearningOperationState(rawValue: row["state"])
+      else {
+        return nil
+      }
+      let failureRaw: String? = row["failure_code"]
+      let reservationRaw: String? = row["reservation_state"]
+      return OperationProjection(
+        state: state,
+        failure: failureRaw.flatMap(LearningOperationFailure.init(rawValue:)),
+        reservation: reservationRaw.flatMap(LearningReservationState.init(rawValue:)),
+        reservedTokens: row["reserved_tokens"],
+        reservedCostUSD: row["reserved_cost_usd"],
+        route: row["route"],
+        providerCallId: row["provider_call_id"]
+      )
+    }
+  }
+
+  func resetAudit() throws -> AuditProjection {
+    let row = try env.queue.read { db in
+      try Row.fetchOne(
+        db,
+        sql: """
+          SELECT actor, action, tool, args_redacted, result_size, decision, run_id, session_id
+          FROM audit_events WHERE action = ?
+          """,
+        arguments: [AuditAction.learningReset.rawValue]
+      )
+    }
+    guard let row else {
+      throw StoreError.unexpected("fixture reset audit is missing")
+    }
+    return AuditProjection(
+      actor: row["actor"],
+      action: row["action"],
+      tool: row["tool"],
+      args: row["args_redacted"],
+      resultSize: row["result_size"],
+      decision: row["decision"],
+      runId: row["run_id"],
+      sessionId: row["session_id"]
+    )
+  }
+
+  func corruptCanonicalEmpty(_ collision: ResetEmptyCollision) throws {
+    let empty = LessonSet.empty(jobId: env.jobId)
+    try env.queue.write { db in
+      switch collision {
+      case .schemaVersion:
+        try db.execute(
+          sql: "UPDATE lesson_sets SET schema_version = ? WHERE job_id = ? AND digest = ?",
+          arguments: [empty.schemaVersion + 1, env.jobId, empty.digest.rawValue]
+        )
+      case .canonicalBytes:
+        try db.execute(
+          sql: "UPDATE lesson_sets SET canonical_bytes = ? WHERE job_id = ? AND digest = ?",
+          arguments: [Data("reset-corrupt".utf8), env.jobId, empty.digest.rawValue]
+        )
+      case .source:
+        try db.execute(
+          sql: "UPDATE lesson_sets SET source = ? WHERE job_id = ? AND digest = ?",
+          arguments: [LessonSetSource.ownerEdit.rawValue, env.jobId, empty.digest.rawValue]
+        )
+      }
+    }
+  }
+
+  func dropLearningStateTable() throws {
+    try env.queue.write { db in
+      try db.drop(table: "job_learning_state")
+    }
+  }
+
+  func processed(updateId: Int64) throws -> Bool {
+    try count("processed_updates", predicate: "update_id = ?", arguments: [updateId]) == 1
+  }
+
+  func resetDecisionCount() throws -> Int {
+    try count(
+      "learning_decisions",
+      predicate: "kind = ?",
+      arguments: [ResetReceipt.kind]
+    )
+  }
+
+  func resetAuditCount() throws -> Int {
+    try count(
+      "audit_events",
+      predicate: "action = ?",
+      arguments: [AuditAction.learningReset.rawValue]
+    )
+  }
+
+  func learningStateCount() throws -> Int {
+    try count("job_learning_state", predicate: "1", arguments: [])
+  }
+
+  func lessonSetCount() throws -> Int {
+    try count("lesson_sets", predicate: "1", arguments: [])
+  }
+
+  func failResetAudit() throws {
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          CREATE TRIGGER fail_reset_audit BEFORE INSERT ON audit_events
+          WHEN NEW.action = '\(AuditAction.learningReset.rawValue)'
+          BEGIN SELECT RAISE(ABORT, 'forced reset audit failure'); END
+          """
+      )
+    }
+  }
+
+  func allowResetAudit() throws {
+    try env.queue.write { db in
+      try db.execute(sql: "DROP TRIGGER fail_reset_audit")
+    }
+  }
+
+  func corruptResetResult(_ corruption: ResetReceiptCorruption) throws {
+    try env.queue.write { db in
+      let result = try String.fetchOne(
+        db,
+        sql: "SELECT result FROM learning_decisions WHERE kind = ?",
+        arguments: [ResetReceipt.kind]
+      )
+      guard let result else {
+        throw StoreError.unexpected("fixture reset decision is missing")
+      }
+      let corrupted: String
+      switch corruption {
+      case .noncanonicalJSON:
+        corrupted = " \(result)"
+      case .wrongStableRevision:
+        let decoded: LearningResetDecisionResult =
+          try ScheduledLearningStoreGRDB.decodeCanonicalDecision(result)
+        let changed = LearningResetDecisionResult(
+          newEpoch: decoded.newEpoch,
+          emptyStableDigest: decoded.emptyStableDigest,
+          newStableRevision: decoded.newStableRevision.next(),
+          closedTrials: decoded.closedTrials,
+          invalidatedTargetCount: decoded.invalidatedTargetCount,
+          invalidatedChallengeCount: decoded.invalidatedChallengeCount,
+          staleNoCallOperationIds: decoded.staleNoCallOperationIds,
+          inFlightOperationIds: decoded.inFlightOperationIds
+        )
+        corrupted = try ScheduledLearningStoreGRDB.canonicalDecisionJSON(changed)
+      }
+      try db.execute(
+        sql: "UPDATE learning_decisions SET result = ? WHERE kind = ?",
+        arguments: [corrupted, ResetReceipt.kind]
+      )
+    }
+  }
+
+  func duplicateCurrentResetDecision() throws {
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO learning_decisions(kind, job_id, learning_epoch, inputs, result, algorithm,
+            decided_at)
+          SELECT kind, job_id, learning_epoch, inputs, result, algorithm, decided_at
+          FROM learning_decisions WHERE kind = ? ORDER BY decision_id DESC LIMIT 1
+          """,
+        arguments: [ResetReceipt.kind]
+      )
+    }
+  }
+
+  func seedCurrentEpochActivity(_ activity: ResetCurrentEpochActivity) throws {
+    let epoch = try state().epoch
+    switch activity {
+    case .binding:
+      _ = try env.pendingBoundRun()
+    case .compatibility:
+      try seedCompatibility(epoch: epoch)
+    case .evidence:
+      try seedEvidence(epoch: epoch)
+    case .operation:
+      try env.queue.write { db in
+        try insertOperation(
+          db,
+          id: "current-terminal-operation",
+          jobId: env.jobId,
+          epoch: epoch,
+          state: .failed
+        )
+      }
+    case .evaluation:
+      try seedEvaluation(epoch: epoch)
+    case .target:
+      try seedTarget(epoch: epoch)
+    case .challenge:
+      try seedChallenge(epoch: epoch)
+    case .feedbackEvent:
+      try seedFeedbackEvent(epoch: epoch)
+    case .candidate:
+      _ = try seedCandidate(epoch: epoch)
+    case .trial:
+      try seedTrialActivity(epoch: epoch)
+    case .assignment:
+      try seedAssignmentActivity(epoch: epoch)
+    }
+  }
+
+  func seedDirtyOldEpochEffect(_ effect: ResetDirtyEffect) throws {
+    let oldEpoch = LearningEpoch(1)
+    switch effect {
+    case .liveTrial:
+      let candidate = try seedCandidate(epoch: oldEpoch)
+      try seedLiveTrial(candidate: candidate, epoch: oldEpoch)
+    case .target:
+      try seedTarget(epoch: oldEpoch, consumed: false)
+    case .challenge:
+      try seedChallenge(epoch: oldEpoch, consumed: false)
+    case .pendingOperation:
+      try env.queue.write { db in
+        try insertOperation(
+          db,
+          id: "late-old-pending",
+          jobId: env.jobId,
+          epoch: oldEpoch,
+          state: .pending
+        )
+      }
+    case .unlistedStartedOperation:
+      try env.queue.write { db in
+        try insertStartedOperation(
+          db,
+          id: "late-old-started",
+          jobId: env.jobId,
+          epoch: oldEpoch
+        )
+      }
+    }
+  }
+
+  func consumptionEpochs(
+    table: String,
+    id: String,
+    predicate: String,
+    arguments: StatementArguments
+  ) throws -> [Int64] {
+    try env.queue.read { db in
+      let rows = try Row.fetchAll(
+        db,
+        sql: "SELECT consumed_at FROM \(table) WHERE \(predicate) ORDER BY \(id)",
+        arguments: arguments
+      )
+      return try rows.map { row in
+        guard let epoch = SQLiteStoredValue.int64(in: row, column: "consumed_at") else {
+          throw StoreError.unexpected("fixture consumption time is unreadable")
+        }
+        return epoch
+      }
+    }
+  }
+
+  func count(
+    _ table: String,
+    predicate: String,
+    arguments: StatementArguments
+  ) throws -> Int {
+    try env.queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM \(table) WHERE \(predicate)",
+        arguments: arguments
+      ) ?? -1
+    }
+  }
+}
+
+// MARK: - Current-Epoch Activity Fixtures
+
+private extension ResetFixture {
+  func insertOperation(
+    _ db: Database,
+    id: String,
+    jobId: Int64,
+    epoch: LearningEpoch,
+    state: LearningOperationState
+  ) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO learning_operations(operation_id, job_id, learning_epoch, phase,
+          source_digest, attempt_generation, state, created_at, key_digest)
+        VALUES (?, ?, ?, 'evaluator', ?, 1, ?, ?, ?)
+        """,
+      arguments: [
+        id,
+        jobId,
+        epoch.value,
+        "source-\(id)",
+        state.rawValue,
+        EpochSecondCodec.epoch(env.now),
+        "key-\(id)",
+      ]
+    )
+  }
+
+  func seedCompatibility(epoch: LearningEpoch) throws {
+    let runId = try env.unboundRun()
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO run_compatibility(run_id, job_id, learning_epoch)
+          VALUES (?, ?, ?)
+          """,
+        arguments: [runId, env.jobId, epoch.value]
+      )
+    }
+  }
+
+  func seedEvidence(epoch: LearningEpoch) throws {
+    let runId = try env.unboundRun()
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO learning_evidence(run_id, job_id, learning_epoch, evidence_digest,
+            eligibility, classifier_version, sealed_at)
+          VALUES (?, ?, ?, 'current-evidence', 'insufficient_evidence', '1', ?)
+          """,
+        arguments: [runId, env.jobId, epoch.value, EpochSecondCodec.epoch(env.now)]
+      )
+    }
+  }
+
+  func seedEvaluation(epoch: LearningEpoch) throws {
+    let runId = try env.unboundRun()
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO learning_evaluations(evaluation_digest, job_id, learning_epoch, run_id,
+            evidence_digest, outcome, issue_codes, rubric_version, evaluator_prompt_version,
+            evaluator_schema_version, compatibility_digest, created_at)
+          VALUES ('current-evaluation', ?, ?, ?, 'evidence', 'no_issue', '[]', '1', '1', '1',
+            'compatibility', ?)
+          """,
+        arguments: [env.jobId, epoch.value, runId, EpochSecondCodec.epoch(env.now)]
+      )
+    }
+  }
+
+  func seedTarget(epoch: LearningEpoch, consumed: Bool = true) throws {
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO feedback_targets(nonce, job_id, learning_epoch, subject_kind,
+            subject_digest, allowed_actions, owner_user_id, chat_id, expires_at, consumed_at)
+          VALUES (?, ?, ?, 'run', 'subject', '["result_useful"]', 1, 1, 1, ?)
+          """,
+        arguments: [
+          consumed ? "current-consumed-target" : "late-old-live-target",
+          env.jobId,
+          epoch.value,
+          consumed ? 1 : nil,
+        ]
+      )
+    }
+  }
+
+  func seedChallenge(epoch: LearningEpoch, consumed: Bool = true) throws {
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO feedback_challenges(owner_user_id, chat_id, job_id, learning_epoch,
+            subject_kind, subject_digest, consumed_at, expires_at)
+          VALUES (?, ?, ?, ?, 'run', 'subject', ?, 1)
+          """,
+        arguments: [
+          consumed ? 1 : 2,
+          consumed ? 1 : 2,
+          env.jobId,
+          epoch.value,
+          consumed ? 1 : nil,
+        ]
+      )
+    }
+  }
+
+  func seedFeedbackEvent(epoch: LearningEpoch) throws {
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO feedback_events(job_id, learning_epoch, subject_kind, subject_digest,
+            signal, actor, feedback_revision, occurred_at)
+          VALUES (?, ?, 'run', 'subject', 'result_useful', 'owner', 1, 1)
+          """,
+        arguments: [env.jobId, epoch.value]
+      )
+    }
+  }
+
+  func seedCandidate(epoch: LearningEpoch) throws -> String {
+    let digest = String(repeating: "c", count: 64)
+    let replacement = try LessonSet.canonical(jobId: env.jobId, lessons: ["current candidate"])
+    let state = try state()
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT OR IGNORE INTO lesson_sets(job_id, digest, schema_version, canonical_bytes,
+            source, created_at) VALUES (?, ?, ?, ?, ?, ?)
+          """,
+        arguments: [
+          env.jobId,
+          replacement.digest.rawValue,
+          replacement.schemaVersion,
+          replacement.canonicalBytes,
+          LessonSetSource.reflectorCandidate.rawValue,
+          EpochSecondCodec.epoch(env.now),
+        ]
+      )
+      try db.execute(
+        sql: """
+          INSERT INTO learning_candidates(candidate_digest, job_id, learning_epoch,
+            replacement_digest, base_digest, base_revision, frozen_feedback_revision, origin,
+            source_manifest, algorithm, created_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, 'reflection', '{}', ?, ?)
+          """,
+        arguments: [
+          digest,
+          env.jobId,
+          epoch.value,
+          replacement.digest.rawValue,
+          state.stableDigest.rawValue,
+          state.stableRevision.value,
+          state.feedbackRevision.value,
+          LearningAlgorithm.v1.rawValue,
+          EpochSecondCodec.epoch(env.now),
+        ]
+      )
+    }
+    return digest
+  }
+
+  func seedTrialActivity(epoch: LearningEpoch) throws {
+    let candidate = try seedCandidate(epoch: LearningEpoch(epoch.value - 1))
+    _ = try seedClosedTrial(candidate: candidate, epoch: epoch)
+  }
+
+  func seedAssignmentActivity(epoch: LearningEpoch) throws {
+    let candidate = try seedCandidate(epoch: LearningEpoch(epoch.value - 1))
+    let trialId = try seedClosedTrial(
+      candidate: candidate,
+      epoch: LearningEpoch(epoch.value - 1)
+    )
+    let runId = try env.unboundRun()
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO trial_assignments(run_id, trial_id, job_id, learning_epoch,
+            trial_generation, assigned_at, state, evaluation_required)
+          VALUES (?, ?, ?, ?, 1, ?, 'created', 1)
+          """,
+        arguments: [
+          runId,
+          trialId,
+          env.jobId,
+          epoch.value,
+          EpochSecondCodec.epoch(env.now),
+        ]
+      )
+    }
+  }
+
+  func seedClosedTrial(candidate: String, epoch: LearningEpoch) throws -> Int64 {
+    let state = try state()
+    return try env.queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO learning_trials(job_id, learning_epoch, base_digest, candidate_digest,
+            generation, admitted_at, assignment_deadline, decision_deadline, max_assignments,
+            consumed_assignments, cohort_cutoff, state, close_reason, algorithm)
+          VALUES (?, ?, ?, ?, 1, ?, ?, ?, 3, 0, ?, 'closed', 'fixture', ?)
+          """,
+        arguments: [
+          env.jobId,
+          epoch.value,
+          state.stableDigest.rawValue,
+          candidate,
+          EpochSecondCodec.epoch(env.now),
+          EpochSecondCodec.epoch(env.now),
+          EpochSecondCodec.epoch(env.now),
+          EpochSecondCodec.epoch(env.now),
+          LearningAlgorithm.v1.rawValue,
+        ]
+      )
+      return db.lastInsertedRowID
+    }
+  }
+
+  func seedLiveTrial(candidate: String, epoch: LearningEpoch) throws {
+    let state = try state()
+    try env.queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO learning_trials(job_id, learning_epoch, base_digest, candidate_digest,
+            generation, admitted_at, assignment_deadline, decision_deadline, max_assignments,
+            consumed_assignments, cohort_cutoff, state, algorithm)
+          VALUES (?, ?, ?, ?, 1, ?, ?, ?, 3, 0, ?, 'open', ?)
+          """,
+        arguments: [
+          env.jobId,
+          epoch.value,
+          state.stableDigest.rawValue,
+          candidate,
+          EpochSecondCodec.epoch(env.now),
+          EpochSecondCodec.epoch(env.now),
+          EpochSecondCodec.epoch(env.now),
+          EpochSecondCodec.epoch(env.now),
+          LearningAlgorithm.v1.rawValue,
+        ]
+      )
+    }
+  }
+
+  func insertStartedOperation(
+    _ db: Database,
+    id: String,
+    jobId: Int64,
+    epoch: LearningEpoch
+  ) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO learning_operations(operation_id, job_id, learning_epoch, phase,
+          source_digest, carrier_digest, route, provider_call_id, attempt_generation, state,
+          reserved_tokens, reserved_cost_usd, reservation_state, created_at, key_digest)
+        VALUES (?, ?, ?, 'evaluator', ?, 'carrier', 'route', 'call', 1, 'started',
+          1, 0.1, 'open', ?, ?)
+        """,
+      arguments: [
+        id,
+        jobId,
+        epoch.value,
+        "source-\(id)",
+        EpochSecondCodec.epoch(env.now),
+        "key-\(id)",
+      ]
+    )
+  }
+}

--- a/Tests/ClawDataTests/Stores/Learning/ResetTestSupport.swift
+++ b/Tests/ClawDataTests/Stores/Learning/ResetTestSupport.swift
@@ -37,6 +37,19 @@ enum ResetReceiptCorruption: CaseIterable {
   case wrongStableRevision
 }
 
+enum ResetStartedOperationCorruption: CaseIterable {
+  case missingProviderCallID
+  case emptyProviderCallID
+  case missingRoute
+  case emptyRoute
+  case closedReservation
+  case missingReservedTokens
+  case negativeReservedTokens
+  case missingReservedCost
+  case negativeReservedCost
+  case nonFiniteReservedCost
+}
+
 struct ResetFixture {
   struct OperationProjection: Equatable {
     let state: LearningOperationState
@@ -87,6 +100,19 @@ struct ResetFixture {
     let decision: String
     let runId: Int64?
     let sessionId: Int64?
+  }
+
+  struct ProcessedUpdateProjection: Equatable {
+    let updateId: Int64
+    let claimedAt: Date
+  }
+
+  struct AbsenceProjection: Equatable {
+    let processedUpdates: [ProcessedUpdateProjection]
+    let learningStateCount: Int
+    let lessonSetCount: Int
+    let resetDecisionCount: Int
+    let resetAuditCount: Int
   }
 
   let env: BoundRunEnvironment
@@ -222,6 +248,66 @@ struct ResetFixture {
           """,
         arguments: [env.jobId]
       )
+    }
+  }
+
+  func corruptStartedOperation(
+    _ corruption: ResetStartedOperationCorruption,
+    id: String = "op-started"
+  ) throws {
+    try env.queue.write { db in
+      switch corruption {
+      case .missingProviderCallID:
+        try db.execute(
+          sql: "UPDATE learning_operations SET provider_call_id = NULL WHERE operation_id = ?",
+          arguments: [id]
+        )
+      case .emptyProviderCallID:
+        try db.execute(
+          sql: "UPDATE learning_operations SET provider_call_id = '' WHERE operation_id = ?",
+          arguments: [id]
+        )
+      case .missingRoute:
+        try db.execute(
+          sql: "UPDATE learning_operations SET route = NULL WHERE operation_id = ?",
+          arguments: [id]
+        )
+      case .emptyRoute:
+        try db.execute(
+          sql: "UPDATE learning_operations SET route = '' WHERE operation_id = ?",
+          arguments: [id]
+        )
+      case .closedReservation:
+        try db.execute(
+          sql: "UPDATE learning_operations SET reservation_state = ? WHERE operation_id = ?",
+          arguments: [LearningReservationState.closed.rawValue, id]
+        )
+      case .missingReservedTokens:
+        try db.execute(
+          sql: "UPDATE learning_operations SET reserved_tokens = NULL WHERE operation_id = ?",
+          arguments: [id]
+        )
+      case .negativeReservedTokens:
+        try db.execute(
+          sql: "UPDATE learning_operations SET reserved_tokens = -1 WHERE operation_id = ?",
+          arguments: [id]
+        )
+      case .missingReservedCost:
+        try db.execute(
+          sql: "UPDATE learning_operations SET reserved_cost_usd = NULL WHERE operation_id = ?",
+          arguments: [id]
+        )
+      case .negativeReservedCost:
+        try db.execute(
+          sql: "UPDATE learning_operations SET reserved_cost_usd = -0.5 WHERE operation_id = ?",
+          arguments: [id]
+        )
+      case .nonFiniteReservedCost:
+        try db.execute(
+          sql: "UPDATE learning_operations SET reserved_cost_usd = ? WHERE operation_id = ?",
+          arguments: [Double.infinity, id]
+        )
+      }
     }
   }
 
@@ -509,6 +595,31 @@ struct ResetFixture {
 
   func processed(updateId: Int64) throws -> Bool {
     try count("processed_updates", predicate: "update_id = ?", arguments: [updateId]) == 1
+  }
+
+  func absenceProjection() throws -> AbsenceProjection {
+    let processedUpdates = try env.queue.read { db in
+      let rows = try Row.fetchAll(
+        db,
+        sql: "SELECT update_id, claimed_at FROM processed_updates ORDER BY update_id"
+      )
+      return try rows.map { row in
+        guard
+          let updateId = SQLiteStoredValue.int64(in: row, column: "update_id"),
+          let claimedAt: Date = row["claimed_at"]
+        else {
+          throw StoreError.unexpected("fixture processed update is unreadable")
+        }
+        return ProcessedUpdateProjection(updateId: updateId, claimedAt: claimedAt)
+      }
+    }
+    return AbsenceProjection(
+      processedUpdates: processedUpdates,
+      learningStateCount: try learningStateCount(),
+      lessonSetCount: try lessonSetCount(),
+      resetDecisionCount: try resetDecisionCount(),
+      resetAuditCount: try resetAuditCount()
+    )
   }
 
   func resetDecisionCount() throws -> Int {

--- a/Tests/ClawDataTests/Stores/Learning/ResetTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/ResetTests.swift
@@ -160,6 +160,76 @@ import Testing
     #expect(try fixture.resetAuditCount() == 0)
   }
 
+  @Test(arguments: ResetStartedOperationCorruption.allCases)
+  func unreadableStartedOperationRollsBackTheBarrierAndClaim(
+    _ corruption: ResetStartedOperationCorruption
+  ) throws {
+    // given
+    let fixture = try ResetFixture.make()
+    _ = try fixture.env.learning.armJob(jobId: fixture.env.jobId, now: fixture.env.now)
+    let otherJobId = try fixture.createOtherJob()
+    try fixture.seedOperations(otherJobId: otherJobId)
+    try fixture.corruptStartedOperation(corruption)
+    let stateBefore = try fixture.state()
+    let pendingBefore = try fixture.operation("op-pending")
+    let claimedBefore = try fixture.operation("op-claimed")
+    let startedBefore = try fixture.operation("op-started")
+    let otherBefore = try fixture.operation("op-other")
+
+    // when
+    #expect(throws: StoreError.self) {
+      _ = try fixture.env.learning.applyReset(
+        updateId: 9_024,
+        jobId: fixture.env.jobId,
+        now: fixture.env.now
+      )
+    }
+
+    // then — accepting any incomplete started-call reservation makes the receipt promise a
+    // usage-only finish that the operation lifecycle cannot safely perform.
+    #expect(try fixture.state() == stateBefore)
+    #expect(try fixture.operation("op-pending") == pendingBefore)
+    #expect(try fixture.operation("op-claimed") == claimedBefore)
+    #expect(try fixture.operation("op-started") == startedBefore)
+    #expect(try fixture.operation("op-other") == otherBefore)
+    #expect(try fixture.processed(updateId: 9_024) == false)
+    #expect(try fixture.resetDecisionCount() == 0)
+    #expect(try fixture.resetAuditCount() == 0)
+  }
+
+  @Test func unreadableReceiptNamedStartedOperationRollsBackReplayClaim() throws {
+    // given
+    let fixture = try ResetFixture.make()
+    _ = try fixture.env.learning.armJob(jobId: fixture.env.jobId, now: fixture.env.now)
+    let otherJobId = try fixture.createOtherJob()
+    try fixture.seedOperations(otherJobId: otherJobId)
+    _ = try fixture.env.learning.applyReset(
+      updateId: 9_025,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+    try fixture.corruptStartedOperation(.missingProviderCallID)
+    let stateBefore = try fixture.state()
+    let startedBefore = try fixture.operation("op-started")
+
+    // when
+    #expect(throws: StoreError.self) {
+      _ = try fixture.env.learning.applyReset(
+        updateId: 9_026,
+        jobId: fixture.env.jobId,
+        now: fixture.env.now
+      )
+    }
+
+    // then — clean replay must revalidate a still-started receipt row, while terminal late-result
+    // rows remain covered by the separate usage-only settlement test.
+    #expect(try fixture.state() == stateBefore)
+    #expect(try fixture.operation("op-started") == startedBefore)
+    #expect(try fixture.processed(updateId: 9_026) == false)
+    #expect(try fixture.resetDecisionCount() == 1)
+    #expect(try fixture.resetAuditCount() == 1)
+  }
+
   @Test func resetClearsTheConvenienceTrialPointer() throws {
     // given
     let fixture = try ResetFixture.make()
@@ -201,7 +271,7 @@ import Testing
     #expect(duplicate == .duplicate)
   }
 
-  @Test func cleanRepeatReplaysButCurrentEpochActivityRaisesAnotherBarrier() throws {
+  @Test func cleanRepeatReplaysTheExactBarrier() throws {
     // given
     let fixture = try ResetFixture.make()
     _ = try fixture.env.learning.armJob(jobId: fixture.env.jobId, now: fixture.env.now)
@@ -219,24 +289,11 @@ import Testing
       now: fixture.env.now.addingTimeInterval(1)
     )
 
-    // then
+    // then — always advancing for a fresh update would duplicate the barrier despite no new
+    // activity or live effect.
     #expect(cleanRepeat.alreadyResetReceipt == firstReceipt)
     #expect(try fixture.resetDecisionCount() == 1)
     #expect(try fixture.resetAuditCount() == 1)
-
-    // when — a fire in the reset epoch is activity even though it still binds the empty set.
-    _ = try fixture.env.pendingBoundRun()
-    let dirtyRepeat = try fixture.env.learning.applyReset(
-      updateId: 9_006,
-      jobId: fixture.env.jobId,
-      now: fixture.env.now.addingTimeInterval(2)
-    )
-
-    // then — treating `stable == empty` as clean would incorrectly replay the first barrier.
-    let secondReceipt = try #require(dirtyRepeat.appliedReceipt)
-    #expect(secondReceipt.result.newEpoch == firstReceipt.result.newEpoch.next())
-    #expect(try fixture.resetDecisionCount() == 2)
-    #expect(try fixture.resetAuditCount() == 2)
   }
 
   @Test(arguments: ResetCurrentEpochActivity.allCases)
@@ -311,18 +368,66 @@ import Testing
       jobId: 99_999,
       now: fixture.env.now
     )
+
+    // then — returning a semantic outcome before the durable claim permits endless redelivery.
+    #expect(missing.newlyClaimed)
+    #expect(missing.outcome == .notFound)
+    let afterMissing = try fixture.absenceProjection()
+    #expect(
+      afterMissing.processedUpdates
+        == [.init(updateId: 9_007, claimedAt: fixture.env.now)]
+    )
+    #expect(afterMissing.learningStateCount == 0)
+    #expect(afterMissing.lessonSetCount == 0)
+    #expect(afterMissing.resetDecisionCount == 0)
+    #expect(afterMissing.resetAuditCount == 0)
+
+    // when
+    let missingReplay = try fixture.env.learning.applyReset(
+      updateId: 9_007,
+      jobId: 99_999,
+      now: fixture.env.now
+    )
+
+    // then
+    #expect(missingReplay.newlyClaimed == false)
+    #expect(missingReplay.outcome == nil)
+    #expect(try fixture.absenceProjection() == afterMissing)
+
+    // when
     let unarmed = try fixture.env.learning.applyReset(
       updateId: 9_008,
       jobId: fixture.env.jobId,
       now: fixture.env.now
     )
 
-    // then — the reset port must not arm a job merely to report an outcome.
-    #expect(missing.outcome == .notFound)
+    // then — the reset port claims but must not arm a job merely to report an outcome.
+    #expect(unarmed.newlyClaimed)
     #expect(unarmed.outcome == .unarmed)
-    #expect(try fixture.learningStateCount() == 0)
-    #expect(try fixture.lessonSetCount() == 0)
-    #expect(try fixture.resetAuditCount() == 0)
+    let afterUnarmed = try fixture.absenceProjection()
+    #expect(
+      afterUnarmed.processedUpdates
+        == [
+          .init(updateId: 9_007, claimedAt: fixture.env.now),
+          .init(updateId: 9_008, claimedAt: fixture.env.now),
+        ]
+    )
+    #expect(afterUnarmed.learningStateCount == 0)
+    #expect(afterUnarmed.lessonSetCount == 0)
+    #expect(afterUnarmed.resetDecisionCount == 0)
+    #expect(afterUnarmed.resetAuditCount == 0)
+
+    // when
+    let unarmedReplay = try fixture.env.learning.applyReset(
+      updateId: 9_008,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+
+    // then
+    #expect(unarmedReplay.newlyClaimed == false)
+    #expect(unarmedReplay.outcome == nil)
+    #expect(try fixture.absenceProjection() == afterUnarmed)
   }
 
   @Test func cancelledJobWithRetainedStateRemainsResettable() throws {

--- a/Tests/ClawDataTests/Stores/Learning/ResetTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/ResetTests.swift
@@ -1,0 +1,650 @@
+import ClawCore
+import Foundation
+import Testing
+
+@testable import ClawData
+
+@Suite struct ResetTests {
+  @Test func firstResetRaisesTheExactBarrierAndInvalidatesOnlyTheJobScope() throws {
+    // given
+    let fixture = try ResetFixture.make()
+    let stable = try fixture.installStableLessons(["Keep reset-secret-lesson out of receipts."])
+    try fixture.setFeedbackRevision(7)
+    let trialIds = try fixture.seedOpenAndDrainingTrials(base: stable.digest)
+    try fixture.clearTrialPointer()
+    let otherJobId = try fixture.createOtherJob()
+    try fixture.seedFeedbackControls(otherJobId: otherJobId)
+    try fixture.seedOperations(otherJobId: otherJobId)
+    let before = try fixture.state()
+
+    // when
+    let confirmed = try fixture.env.learning.applyReset(
+      updateId: 9_001,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+
+    // then — closing only the convenience pointer, current epoch, or current feedback rows leaves
+    // an independently live path behind; the receipt also has to identify every operation class.
+    let receipt = try #require(confirmed.appliedReceipt)
+    let after = try fixture.state()
+    #expect(confirmed.newlyClaimed)
+    #expect(receipt.inputs.oldEpoch == before.epoch)
+    #expect(receipt.inputs.oldStableDigest == stable.digest)
+    #expect(receipt.inputs.oldStableRevision == before.stableRevision)
+    #expect(receipt.inputs.feedbackRevisionAtCut == FeedbackRevision(7))
+    #expect(receipt.inputs.priorOpenTrialId == nil)
+    #expect(receipt.result.newEpoch == before.epoch.next())
+    #expect(receipt.result.newStableRevision == before.stableRevision.next())
+    #expect(receipt.result.emptyStableDigest == LessonSet.empty(jobId: fixture.env.jobId).digest)
+    #expect(receipt.result.closedTrials.map(\.trialId) == trialIds)
+    #expect(receipt.result.invalidatedTargetCount == 2)
+    #expect(receipt.result.invalidatedChallengeCount == 2)
+    #expect(receipt.result.staleNoCallOperationIds.map(\.rawValue) == ["op-claimed", "op-pending"])
+    #expect(receipt.result.inFlightOperationIds.map(\.rawValue) == ["op-started"])
+    #expect(after.epoch == before.epoch.next())
+    #expect(after.stableDigest == LessonSet.empty(jobId: fixture.env.jobId).digest)
+    #expect(after.stableRevision == before.stableRevision.next())
+    #expect(after.feedbackRevision == FeedbackRevision(7))
+    #expect(after.openTrialId == nil)
+    #expect(try fixture.closedTrialIds() == trialIds)
+    #expect(
+      try fixture.closedTrialReasons()
+        == Array(repeating: LearningTrialCloseReason.learningReset.rawValue, count: 2)
+    )
+    #expect(try fixture.unconsumedTargetCount(jobId: fixture.env.jobId) == 0)
+    #expect(
+      try fixture.targetConsumptionEpochs(jobId: fixture.env.jobId)
+        == Array(repeating: EpochSecondCodec.epoch(fixture.env.now), count: 2)
+    )
+    #expect(try fixture.unconsumedTargetCount(jobId: otherJobId) == 1)
+    #expect(try fixture.liveChallengeCount(jobId: fixture.env.jobId) == 0)
+    #expect(
+      try fixture.challengeConsumptionEpochs(jobId: fixture.env.jobId)
+        == Array(repeating: EpochSecondCodec.epoch(fixture.env.now), count: 2)
+    )
+    #expect(try fixture.unconsumedSupersededChallengeCount() == 1)
+    #expect(try fixture.liveChallengeCount(jobId: otherJobId) == 1)
+    #expect(try fixture.operation("op-pending") == .staleNoCall)
+    #expect(try fixture.operation("op-claimed") == .staleNoCall)
+    #expect(try fixture.operation("op-started") == .started)
+    #expect(try fixture.operation("op-other") == .claimed)
+
+    let audit = try fixture.resetAudit()
+    #expect(audit.actor == AuditActor.owner.rawValue)
+    #expect(audit.action == AuditAction.learningReset.rawValue)
+    #expect(audit.tool == "/learning reset")
+    #expect(audit.decision == "applied")
+    #expect(audit.resultSize == 0)
+    #expect(audit.runId == nil)
+    #expect(audit.sessionId == fixture.env.sessionId)
+    let auditArguments = try JSONDecoder().decode(
+      ResetAuditArguments.self,
+      from: Data(audit.args.utf8)
+    )
+    #expect(auditArguments.decisionId == receipt.decisionId)
+    #expect(auditArguments.kind == ResetReceipt.kind)
+    #expect(auditArguments.jobId == receipt.jobId)
+    #expect(auditArguments.algorithm == receipt.algorithm)
+    #expect(auditArguments.decidedAt == EpochSecondCodec.epoch(receipt.decidedAt))
+    #expect(auditArguments.inputs == receipt.inputs)
+    #expect(auditArguments.result == receipt.result)
+    let auditObject = try #require(
+      JSONSerialization.jsonObject(with: Data(audit.args.utf8)) as? [String: Any]
+    )
+    #expect(
+      Set(auditObject.keys)
+        == ["algorithm", "decided_at", "decision_id", "inputs", "job_id", "kind", "result"]
+    )
+    #expect(audit.args.contains("reset-secret-lesson") == false)
+    #expect(audit.args.contains("target-secret-nonce") == false)
+    #expect(audit.args.contains("provider-secret-call") == false)
+    let replay = try fixture.env.learning.applyReset(
+      updateId: 9_018,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+    #expect(replay.alreadyResetReceipt == receipt)
+    #expect(try fixture.resetAuditCount() == 1)
+  }
+
+  @Test(arguments: ResetEmptyCollision.allCases)
+  func canonicalEmptyCollisionRollsBackTheConfirmationClaim(
+    _ collision: ResetEmptyCollision
+  ) throws {
+    // given
+    let fixture = try ResetFixture.make()
+    _ = try fixture.env.learning.armJob(jobId: fixture.env.jobId, now: fixture.env.now)
+    try fixture.corruptCanonicalEmpty(collision)
+    let before = try fixture.state()
+
+    // when
+    #expect(throws: StoreError.self) {
+      _ = try fixture.env.learning.applyReset(
+        updateId: 9_002,
+        jobId: fixture.env.jobId,
+        now: fixture.env.now
+      )
+    }
+
+    // then — omitting this field's exact check silently blesses a noncanonical empty-set
+    // identity.
+    #expect(try fixture.state() == before)
+    #expect(try fixture.processed(updateId: 9_002) == false)
+    #expect(try fixture.resetDecisionCount() == 0)
+  }
+
+  @Test func unreadableLiveTrialIdentityRollsBackTheBarrierAndClaim() throws {
+    // given
+    let fixture = try ResetFixture.make()
+    let stable = try fixture.installStableLessons(["Keep the state when identity is corrupt."])
+    let trialIds = try fixture.seedOpenAndDrainingTrials(base: stable.digest)
+    try fixture.corruptFirstLiveTrialBaseDigest()
+    let before = try fixture.state()
+
+    // when
+    #expect(throws: StoreError.self) {
+      _ = try fixture.env.learning.applyReset(
+        updateId: 9_020,
+        jobId: fixture.env.jobId,
+        now: fixture.env.now
+      )
+    }
+
+    // then — accepting an unreadable identity would write a receipt that cannot truthfully name
+    // the historical trial closed by the barrier.
+    #expect(try fixture.state() == before)
+    #expect(try fixture.liveTrialIds() == trialIds)
+    #expect(try fixture.processed(updateId: 9_020) == false)
+    #expect(try fixture.resetDecisionCount() == 0)
+    #expect(try fixture.resetAuditCount() == 0)
+  }
+
+  @Test func resetClearsTheConvenienceTrialPointer() throws {
+    // given
+    let fixture = try ResetFixture.make()
+    let stable = try fixture.installStableLessons(["Pointer fixture."])
+    let trialIds = try fixture.seedOpenAndDrainingTrials(base: stable.digest)
+    #expect(try fixture.state().openTrialId == trialIds.first)
+
+    // when
+    _ = try fixture.env.learning.applyReset(
+      updateId: 9_021,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+
+    // then — closing the authoritative rows without clearing the denormalized pointer leaves a
+    // stale owner-facing state identity.
+    #expect(try fixture.state().openTrialId == nil)
+  }
+
+  @Test func transportReplayReturnsBeforeReadingResetState() throws {
+    // given
+    let fixture = try ResetFixture.make()
+    _ = try fixture.env.learning.armJob(jobId: fixture.env.jobId, now: fixture.env.now)
+    _ = try fixture.env.learning.applyReset(
+      updateId: 9_003,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+    try fixture.dropLearningStateTable()
+
+    // when
+    let duplicate = try fixture.env.learning.applyReset(
+      updateId: 9_003,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+
+    // then — reading the job or receipt before the claim would fail on the dropped table.
+    #expect(duplicate == .duplicate)
+  }
+
+  @Test func cleanRepeatReplaysButCurrentEpochActivityRaisesAnotherBarrier() throws {
+    // given
+    let fixture = try ResetFixture.make()
+    _ = try fixture.env.learning.armJob(jobId: fixture.env.jobId, now: fixture.env.now)
+    let first = try fixture.env.learning.applyReset(
+      updateId: 9_004,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now.addingTimeInterval(0.75)
+    )
+    let firstReceipt = try #require(first.appliedReceipt)
+
+    // when
+    let cleanRepeat = try fixture.env.learning.applyReset(
+      updateId: 9_005,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now.addingTimeInterval(1)
+    )
+
+    // then
+    #expect(cleanRepeat.alreadyResetReceipt == firstReceipt)
+    #expect(try fixture.resetDecisionCount() == 1)
+    #expect(try fixture.resetAuditCount() == 1)
+
+    // when — a fire in the reset epoch is activity even though it still binds the empty set.
+    _ = try fixture.env.pendingBoundRun()
+    let dirtyRepeat = try fixture.env.learning.applyReset(
+      updateId: 9_006,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now.addingTimeInterval(2)
+    )
+
+    // then — treating `stable == empty` as clean would incorrectly replay the first barrier.
+    let secondReceipt = try #require(dirtyRepeat.appliedReceipt)
+    #expect(secondReceipt.result.newEpoch == firstReceipt.result.newEpoch.next())
+    #expect(try fixture.resetDecisionCount() == 2)
+    #expect(try fixture.resetAuditCount() == 2)
+  }
+
+  @Test(arguments: ResetCurrentEpochActivity.allCases)
+  func everyCurrentEpochActivitySourceMakesTheNextResetEffective(
+    _ activity: ResetCurrentEpochActivity
+  ) throws {
+    // given
+    let fixture = try ResetFixture.make()
+    _ = try fixture.env.learning.armJob(jobId: fixture.env.jobId, now: fixture.env.now)
+    let first = try #require(
+      try fixture.env.learning.applyReset(
+        updateId: 9_100,
+        jobId: fixture.env.jobId,
+        now: fixture.env.now
+      ).appliedReceipt
+    )
+    try fixture.seedCurrentEpochActivity(activity)
+
+    // when
+    let next = try fixture.env.learning.applyReset(
+      updateId: 9_101,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+
+    // then — each source is isolated from the other ten, so removing its own gate survives no
+    // independent source barrier and would incorrectly replay the prior reset.
+    #expect(next.appliedReceipt?.result.newEpoch == first.result.newEpoch.next())
+  }
+
+  @Test(arguments: ResetDirtyEffect.allCases)
+  func everyDirtyOldEpochEffectMakesTheNextResetEffective(_ effect: ResetDirtyEffect) throws {
+    // given
+    let fixture = try ResetFixture.make()
+    _ = try fixture.env.learning.armJob(jobId: fixture.env.jobId, now: fixture.env.now)
+    let first = try #require(
+      try fixture.env.learning.applyReset(
+        updateId: 9_110,
+        jobId: fixture.env.jobId,
+        now: fixture.env.now
+      ).appliedReceipt
+    )
+    try fixture.seedDirtyOldEpochEffect(effect)
+
+    // when
+    let next = try fixture.env.learning.applyReset(
+      updateId: 9_111,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+
+    // then — none of these rows are current-epoch activity, so only its dedicated clean-repeat
+    // guard can prevent a false replay. A third reset proves the effective barrier either removed
+    // the live effect or recorded the in-flight exception truthfully.
+    let nextReceipt = try #require(next.appliedReceipt)
+    #expect(nextReceipt.result.newEpoch == first.result.newEpoch.next())
+    let clean = try fixture.env.learning.applyReset(
+      updateId: 9_112,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+    #expect(clean.alreadyResetReceipt == nextReceipt)
+  }
+
+  @Test func missingAndUnarmedJobsClaimWithoutInventingLearningState() throws {
+    // given
+    let fixture = try ResetFixture.make()
+
+    // when
+    let missing = try fixture.env.learning.applyReset(
+      updateId: 9_007,
+      jobId: 99_999,
+      now: fixture.env.now
+    )
+    let unarmed = try fixture.env.learning.applyReset(
+      updateId: 9_008,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+
+    // then — the reset port must not arm a job merely to report an outcome.
+    #expect(missing.outcome == .notFound)
+    #expect(unarmed.outcome == .unarmed)
+    #expect(try fixture.learningStateCount() == 0)
+    #expect(try fixture.lessonSetCount() == 0)
+    #expect(try fixture.resetAuditCount() == 0)
+  }
+
+  @Test func cancelledJobWithRetainedStateRemainsResettable() throws {
+    // given
+    let fixture = try ResetFixture.make()
+    _ = try fixture.env.learning.armJob(jobId: fixture.env.jobId, now: fixture.env.now)
+    try fixture.env.cancelJob()
+
+    // when
+    let confirmed = try fixture.env.learning.applyReset(
+      updateId: 9_009,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+
+    // then — gating on active schedule status strands retained derived state after cancellation.
+    #expect(confirmed.appliedReceipt != nil)
+    #expect(try fixture.state().epoch == LearningEpoch(2))
+  }
+
+  @Test func finalAuditFailureRollsBackEveryResetEffectAndClaim() throws {
+    // given
+    let fixture = try ResetFixture.make()
+    let stable = try fixture.installStableLessons(["Keep this until the transaction commits."])
+    let trials = try fixture.seedOpenAndDrainingTrials(base: stable.digest)
+    try fixture.failResetAudit()
+    let before = try fixture.state()
+
+    // when
+    #expect(throws: StoreError.self) {
+      _ = try fixture.env.learning.applyReset(
+        updateId: 9_010,
+        jobId: fixture.env.jobId,
+        now: fixture.env.now
+      )
+    }
+
+    // then — a reset decision or update claim committed before the audit cannot be retried
+    // safely.
+    #expect(try fixture.state() == before)
+    #expect(try fixture.liveTrialIds() == trials)
+    #expect(try fixture.processed(updateId: 9_010) == false)
+    #expect(try fixture.resetDecisionCount() == 0)
+    try fixture.allowResetAudit()
+    #expect(
+      try fixture.env.learning.applyReset(
+        updateId: 9_010,
+        jobId: fixture.env.jobId,
+        now: fixture.env.now
+      ).appliedReceipt != nil
+    )
+  }
+
+  @Test func lateEvaluatorResultClosesAndChargesWithoutPersistingItsProduct() throws {
+    // given
+    let fixture = try ResetFixture.make()
+    let evidence = try fixture.env.sealedEvidence()
+    let started = try fixture.env.startedOperation(fixture.env.evaluatorKey(for: evidence))
+    let reset = try #require(
+      try fixture.env.learning.applyReset(
+        updateId: 9_011,
+        jobId: fixture.env.jobId,
+        now: fixture.env.now
+      ).appliedReceipt
+    )
+    let result = fixture.env.result(
+      for: started.id,
+      evaluation: fixture.env.verdict(outcome: .reusableIssue)
+    )
+
+    // when
+    let committed = try fixture.env.learning.finishOperation(result, now: fixture.env.now)
+    let duplicate = try fixture.env.learning.finishOperation(result, now: fixture.env.now)
+
+    // then — moving the epoch fence before usage loses real spend; omitting it stores stale
+    // truth.
+    #expect(committed)
+    #expect(duplicate == false)
+    #expect(try fixture.env.operationState(started.id) == .succeeded)
+    #expect(try fixture.env.learningUsage(operationId: started.id).count == 1)
+    #expect(try fixture.env.learning.evaluation(runId: evidence.runId) == nil)
+    let repeatReset = try fixture.env.learning.applyReset(
+      updateId: 9_019,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+    #expect(repeatReset.alreadyResetReceipt == reset)
+  }
+
+  @Test func finishBeforeResetKeepsHistoricalProductAndResetStillApplies() throws {
+    // given
+    let fixture = try ResetFixture.make()
+    let evidence = try fixture.env.sealedEvidence()
+    let started = try fixture.env.startedOperation(fixture.env.evaluatorKey(for: evidence))
+    _ = try fixture.env.learning.finishOperation(
+      fixture.env.result(for: started.id, evaluation: fixture.env.verdict()),
+      now: fixture.env.now
+    )
+
+    // when
+    let reset = try fixture.env.learning.applyReset(
+      updateId: 9_012,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+
+    // then — reset is a barrier, not a history purge.
+    #expect(reset.appliedReceipt != nil)
+    #expect(try fixture.env.learning.evaluation(runId: evidence.runId) != nil)
+    #expect(try fixture.env.learningUsage(operationId: started.id).count == 1)
+  }
+
+  @Test func oldBindingStaysPinnedAndNextFireUsesTheEmptyNewEpoch() throws {
+    // given
+    let fixture = try ResetFixture.make()
+    let stable = try fixture.installStableLessons(["Use this only before reset."])
+    let oldRun = try fixture.env.runningBoundRun()
+    let oldBinding = try #require(try fixture.env.learning.binding(runId: oldRun))
+    _ = try fixture.env.runs.commitAssistantTurn(
+      fixture.env.assistantTurn(runId: oldRun),
+      now: fixture.env.now
+    )
+
+    // when
+    let reset = try #require(
+      try fixture.env.learning.applyReset(
+        updateId: 9_013,
+        jobId: fixture.env.jobId,
+        now: fixture.env.now
+      ).appliedReceipt
+    )
+    let newRun = try fixture.env.pendingBoundRun()
+
+    // then — retargeting the old row rewrites what that run actually saw.
+    #expect(try fixture.env.learning.binding(runId: oldRun) == oldBinding)
+    #expect(oldBinding.effectiveDigest == stable.digest)
+    let newBinding = try #require(try fixture.env.learning.binding(runId: newRun))
+    #expect(newBinding.epoch == reset.result.newEpoch)
+    #expect(newBinding.stableDigest == reset.result.emptyStableDigest)
+    #expect(newBinding.effectiveDigest == reset.result.emptyStableDigest)
+  }
+
+  @Test func resetSeparatesNeverAdmittedCandidateFromAdmittedReplay() throws {
+    // given — a persisted candidate that has never opened a trial
+    let staleFixture = try AdmissionStoreFixture.make()
+    defer { staleFixture.remove() }
+    let staleCandidate = try staleFixture.persistedCandidate()
+    _ = try staleFixture.env.learning.applyReset(
+      updateId: 9_014,
+      jobId: staleFixture.env.jobId,
+      now: staleFixture.env.now
+    )
+
+    // when
+    let staleAdmission = try staleFixture.env.learning.admitCandidate(
+      digest: staleCandidate.digest,
+      redactor: SecretRedactor(secretValues: []),
+      now: staleFixture.env.now
+    )
+
+    // then
+    #expect(staleAdmission == .rejected(.staleEpoch))
+
+    // given — an already-admitted candidate has an immutable idempotency receipt.
+    let replayFixture = try AdmissionStoreFixture.make()
+    defer { replayFixture.remove() }
+    let admittedCandidate = try replayFixture.persistedCandidate()
+    let admitted = try replayFixture.env.learning.admitCandidate(
+      digest: admittedCandidate.digest,
+      redactor: SecretRedactor(secretValues: []),
+      now: replayFixture.env.now
+    )
+    let admittedReceipt = try #require(admitted.admissionReceipt)
+    _ = try replayFixture.env.learning.applyReset(
+      updateId: 9_015,
+      jobId: replayFixture.env.jobId,
+      now: replayFixture.env.now
+    )
+
+    // when
+    let replay = try replayFixture.env.learning.admitCandidate(
+      digest: admittedCandidate.digest,
+      redactor: SecretRedactor(secretValues: []),
+      now: replayFixture.env.now
+    )
+
+    // then — replaying the old receipt must not reopen the reset-closed trial.
+    #expect(replay.admissionReceipt == admittedReceipt)
+    #expect(try replayFixture.env.learning.openTrial(jobId: replayFixture.env.jobId) == nil)
+    #expect(
+      try replayFixture.trial(admittedReceipt.trialId).state
+        == LearningTrialState.closed.rawValue
+    )
+  }
+
+  @Test(arguments: ResetReceiptCorruption.allCases)
+  func resetDecisionIsImmediatelyReadableAndMalformedReplayRaisesAFreshBarrier(
+    _ corruption: ResetReceiptCorruption
+  ) throws {
+    // given
+    let fixture = try ResetFixture.make()
+    _ = try fixture.env.learning.armJob(jobId: fixture.env.jobId, now: fixture.env.now)
+    let first = try #require(
+      try fixture.env.learning.applyReset(
+        updateId: 9_016,
+        jobId: fixture.env.jobId,
+        now: fixture.env.now
+      ).appliedReceipt
+    )
+
+    // when
+    let view = try #require(
+      try fixture.env.learning.learningView(jobId: fixture.env.jobId).onlyReadable
+    )
+
+    // then — an unknown reset decision kind would make the successful reset unreadable.
+    guard case .learningReset(let inputs, let result) = view.lastDecision?.detail else {
+      Issue.record("expected a typed reset decision")
+      return
+    }
+    #expect(inputs == first.inputs)
+    #expect(result == first.result)
+
+    // when
+    try fixture.corruptResetResult(corruption)
+    #expect(try fixture.env.learning.learningView(jobId: fixture.env.jobId).isOnlyUnreadable)
+    let repaired = try fixture.env.learning.applyReset(
+      updateId: 9_017,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now.addingTimeInterval(1)
+    )
+
+    // then — malformed current receipt is not a clean-repeat proof.
+    #expect(repaired.appliedReceipt?.result.newEpoch == first.result.newEpoch.next())
+    #expect(try fixture.env.learning.learningView(jobId: fixture.env.jobId).onlyReadable != nil)
+  }
+
+  @Test func ambiguousCurrentResetReceiptsRaiseAFreshBarrier() throws {
+    // given
+    let fixture = try ResetFixture.make()
+    _ = try fixture.env.learning.armJob(jobId: fixture.env.jobId, now: fixture.env.now)
+    let first = try #require(
+      try fixture.env.learning.applyReset(
+        updateId: 9_022,
+        jobId: fixture.env.jobId,
+        now: fixture.env.now
+      ).appliedReceipt
+    )
+    try fixture.duplicateCurrentResetDecision()
+
+    // when
+    let repaired = try fixture.env.learning.applyReset(
+      updateId: 9_023,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+
+    // then — choosing either of two otherwise valid rows would turn ambiguous history into a
+    // false clean replay.
+    #expect(repaired.appliedReceipt?.result.newEpoch == first.result.newEpoch.next())
+    #expect(try fixture.resetDecisionCount() == 3)
+    #expect(try fixture.resetAuditCount() == 2)
+  }
+}
+
+private extension ConfirmedLearningResetResult {
+  var appliedReceipt: ResetReceipt? {
+    guard case .applied(let receipt) = outcome else {
+      return nil
+    }
+    return receipt
+  }
+
+  var alreadyResetReceipt: ResetReceipt? {
+    guard case .alreadyReset(let receipt) = outcome else {
+      return nil
+    }
+    return receipt
+  }
+}
+
+private struct ResetAuditArguments: Decodable {
+  let decisionId: Int64
+  let kind: String
+  let jobId: Int64
+  let algorithm: LearningAlgorithm
+  let decidedAt: Int64
+  let inputs: LearningResetDecisionInputs
+  let result: LearningResetDecisionResult
+
+  enum CodingKeys: String, CodingKey {
+    case decisionId = "decision_id"
+    case kind
+    case jobId = "job_id"
+    case algorithm
+    case decidedAt = "decided_at"
+    case inputs
+    case result
+  }
+}
+
+private extension AdmissionOutcome {
+  var admissionReceipt: AdmissionReceipt? {
+    guard case .admitted(let receipt) = self else {
+      return nil
+    }
+    return receipt
+  }
+}
+
+private extension Array where Element == JobLearningView {
+  var onlyReadable: ReadableJobLearningView? {
+    guard count == 1, case .readable(let view) = self[0] else {
+      return nil
+    }
+    return view
+  }
+
+  var isOnlyUnreadable: Bool {
+    guard count == 1, case .unreadable = self[0] else {
+      return false
+    }
+    return true
+  }
+}

--- a/Tests/ClawDataTests/Stores/Learning/ResetTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/ResetTests.swift
@@ -230,6 +230,40 @@ import Testing
     #expect(try fixture.resetAuditCount() == 1)
   }
 
+  @Test func ownerViewRejectsResetReceiptWhoseStartedCallIdentityIsUnreadable() throws {
+    // given
+    let fixture = try ResetFixture.make()
+    _ = try fixture.env.learning.armJob(jobId: fixture.env.jobId, now: fixture.env.now)
+    let otherJobId = try fixture.createOtherJob()
+    try fixture.seedOperations(otherJobId: otherJobId)
+    _ = try fixture.env.learning.applyReset(
+      updateId: 9_027,
+      jobId: fixture.env.jobId,
+      now: fixture.env.now
+    )
+    let readable = try #require(
+      try fixture.env.learning.learningView(jobId: fixture.env.jobId).onlyReadable
+    )
+    guard case .learningReset(_, let result) = readable.lastDecision?.detail else {
+      Issue.record("expected a readable reset receipt")
+      return
+    }
+    #expect(
+      result.inFlightOperationIds == [LearningOperationID(rawValue: "op-started")]
+    )
+    try fixture.corruptStartedOperation(.missingProviderCallID)
+    let before = try fixture.durableProjection()
+
+    // when
+    let view = try fixture.env.learning.learningView(jobId: fixture.env.jobId)
+    let after = try fixture.durableProjection()
+
+    // then — bypassing started-reservation validation in the shared receipt matcher survives the
+    // effective-reset and clean-replay tests because neither calls the owner view after corruption.
+    #expect(view.isOnlyUnreadable)
+    #expect(after == before)
+  }
+
   @Test func resetClearsTheConvenienceTrialPointer() throws {
     // given
     let fixture = try ResetFixture.make()

--- a/Tests/ClawDataTests/Stores/Learning/RollbackTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/RollbackTests.swift
@@ -1,0 +1,257 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct RollbackTests {
+  @Test(arguments: [OwnerSignal.promotionRollback, .candidateReject])
+  func ownerTriggers(_ signal: OwnerSignal) throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    _ = try env.positiveTrialRun()
+    _ = try env.positiveTrialRun()
+    let promotion = try env.promoteTrial()
+    let event = try env.promotionFeedback(promotion, signal: signal)
+
+    // when
+    let receipt = try #require(
+      try env.learning.rollback(
+        .ownerFeedback(promotionId: promotion.decisionId, eventId: event.id),
+        now: env.now
+      )
+    )
+
+    // then
+    #expect(receipt.result == .rolledBack)
+    #expect(try env.currentLearningState().stableDigest == promotion.inputs.baseDigest)
+    #expect(try env.currentLearningState().epoch == promotion.inputs.identity.epoch)
+    #expect(try env.learning.currentPromotion(jobId: env.jobId) == nil)
+  }
+
+  @Test(arguments: [OwnerSignal.resultNotUseful, .evaluationDispute, .resultCorrection])
+  func supportWithdrawal(_ signal: OwnerSignal) throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    let first = try env.positiveTrialRun()
+    let pending = try env.settledBoundRun()
+    _ = try env.positiveTrialRun()
+    let sealed = try env.seal(runId: pending)
+    let operation = try env.startedOperation(env.evaluatorKey(for: sealed))
+    _ = try env.learning.finishOperation(
+      env.result(for: operation.id, evaluation: env.verdict(outcome: .noIssue, issueCodes: [])),
+      now: env.now
+    )
+    let promotion = try env.promoteTrial()
+    let firstEvent = try env.withdrawalFeedback(runId: first, signal: signal, updateId: 901)
+
+    // when — one withdrawal from three supports still leaves two
+    let stillSupported = try env.learning.rollback(
+      .supportWithdrawal(promotionId: promotion.decisionId, eventId: firstEvent.id),
+      now: env.now
+    )
+    let secondEvent = try env.withdrawalFeedback(
+      runId: pending,
+      signal: .resultNotUseful,
+      updateId: 902
+    )
+    let rollback = try env.learning.rollback(
+      .supportWithdrawal(promotionId: promotion.decisionId, eventId: secondEvent.id),
+      now: env.now
+    )
+
+    // then
+    #expect(stillSupported?.result == .stale)
+    #expect(rollback?.result == .rolledBack)
+    #expect(promotion.cohort.count == 3)
+    #expect(try env.currentLearningState().stableDigest == promotion.inputs.baseDigest)
+  }
+
+  @Test func laterIssueIsInert() throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    _ = try env.positiveTrialRun()
+    _ = try env.positiveTrialRun()
+    let promotion = try env.promoteTrial()
+
+    // when
+    let later = try env.evaluatedEvidence(issueCode: "later.issue")
+    let event = try env.withdrawalFeedback(
+      runId: later.evidence.runId,
+      signal: .resultNotUseful,
+      updateId: 920
+    )
+    let receipt = try env.learning.rollback(
+      .supportWithdrawal(promotionId: promotion.decisionId, eventId: event.id),
+      now: env.now
+    )
+
+    // then
+    #expect(receipt?.result == .stale)
+    #expect(try env.learning.currentPromotion(jobId: env.jobId) == promotion)
+  }
+
+  @Test func stalePromotion() throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    _ = try env.positiveTrialRun()
+    _ = try env.positiveTrialRun()
+    let promotion = try env.promoteTrial()
+    let fixture = AdmissionStoreFixture(path: "", env: env)
+    let next = try fixture.persistedCandidate(lessons: [
+      "Compare every material change with the archive."
+    ])
+    _ = try env.learning.admitCandidate(
+      digest: next.digest,
+      redactor: SecretRedactor(secretValues: []),
+      now: env.now
+    )
+    _ = try env.positiveTrialRun()
+    _ = try env.positiveTrialRun()
+    _ = try env.promoteTrial()
+    let event = try env.promotionFeedback(promotion, signal: .promotionRollback)
+    let before = try env.currentLearningState()
+
+    // when
+    let receipt = try env.learning.rollback(
+      .ownerFeedback(promotionId: promotion.decisionId, eventId: event.id),
+      now: env.now
+    )
+
+    // then
+    #expect(receipt?.result == .stale)
+    #expect(try env.currentLearningState() == before)
+  }
+
+  @Test func rollbackClosesATrialDependingOnTheWithdrawnBase() throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    _ = try env.positiveTrialRun()
+    _ = try env.positiveTrialRun()
+    let promotion = try env.promoteTrial()
+    let fixture = AdmissionStoreFixture(path: "", env: env)
+    let next = try fixture.persistedCandidate(lessons: ["Consult the complete archive."])
+    _ = try env.learning.admitCandidate(
+      digest: next.digest,
+      redactor: SecretRedactor(secretValues: []),
+      now: env.now
+    )
+
+    let inFlight = try env.runningBoundRun()
+
+    // when
+    let rollback = try env.learning.rollback(
+      .safety(
+        promotionId: promotion.decisionId,
+        receiptDigest: SHA256Digest.hex("bad base"),
+        failure: .security
+      ),
+      now: env.now
+    )
+
+    // then
+    #expect(rollback?.result == .rolledBack)
+    #expect(try env.learning.openTrial(jobId: env.jobId) == nil)
+    #expect(try env.learning.binding(runId: inFlight)?.effectiveDigest == next.replacement.digest)
+    _ = try env.runs.commitAssistantTurn(env.assistantTurn(runId: inFlight), now: env.now)
+    let nextRun = try env.runningBoundRun()
+    #expect(
+      try env.learning.binding(runId: nextRun)?.effectiveDigest == promotion.inputs.baseDigest
+    )
+  }
+
+  @Test func hardReceipts() throws {
+    // given
+    let env = try BoundRunEnvironment.promotionEnvironment()
+    _ = try env.positiveTrialRun()
+    _ = try env.positiveTrialRun()
+    let promotion = try env.promoteTrial()
+
+    // when
+    let adapter = try env.learning.rollback(
+      .adapter(promotionId: promotion.decisionId, adapterId: "unfrozen", outcome: .critical),
+      now: env.now
+    )
+    let safety = try env.learning.rollback(
+      .safety(
+        promotionId: promotion.decisionId,
+        receiptDigest: SHA256Digest.hex("security receipt"),
+        failure: .security
+      ),
+      now: env.now
+    )
+
+    // then
+    #expect(adapter?.result == .stale)
+    #expect(safety?.result == .rolledBack)
+    #expect(try env.currentLearningState().stableDigest == promotion.inputs.baseDigest)
+  }
+}
+
+extension BoundRunEnvironment {
+  func promotionFeedback(_ promotion: DecisionReceipt, signal: OwnerSignal) throws -> FeedbackEvent
+  {
+    let target = NewFeedbackTarget(
+      nonce: "promotion-owner-feedback",
+      jobId: jobId,
+      epoch: promotion.inputs.identity.epoch,
+      subjectKind: signal.feedbackSubjectKind,
+      subjectDigest: signal == .promotionRollback
+        ? promotion.promotionSubject : promotion.inputs.candidateDigest.rawValue,
+      allowedActions: [signal],
+      ownerUserId: 42,
+      chatId: 777,
+      expiresAt: now.addingTimeInterval(3_600)
+    )
+    try learning.createTargets([target], chunks: [], now: now)
+    guard
+      case .recorded(let event) = try learning.consumeAndAppendEvent(
+        feedbackTap(target, updateId: 900),
+        now: now
+      )
+    else {
+      throw StoreError.unexpected("fixture owner trigger was not recorded")
+    }
+    return event
+  }
+
+  func withdrawalFeedback(runId: Int64, signal: OwnerSignal, updateId: Int64) throws
+    -> FeedbackEvent
+  {
+    let target: NewFeedbackTarget
+    if signal == .evaluationDispute {
+      let assignment = try #require(try assignment(runId: runId))
+      let digest = try #require(assignment.resolvedEvidence?.evaluationDigest)
+      target = evaluationFeedbackTarget(digest: digest, signal: signal)
+    } else {
+      target = runFeedbackTarget(runId: runId, signal: signal)
+    }
+    try learning.createTargets([target], chunks: [], now: now)
+    let outcome: FeedbackOutcome
+    if signal.opensFeedbackChallenge {
+      let opened = try learning.consumeAndOpenChallenge(
+        feedbackTap(target, updateId: updateId),
+        prompt: challengePrompt(target),
+        now: now
+      )
+      guard case .challengeOpened(let challenge) = opened else {
+        throw StoreError.unexpected("fixture correction challenge was not opened")
+      }
+      outcome = try learning.consumeChallenge(
+        id: challenge.id,
+        payload: "The answer missed the archive",
+        now: now
+      )
+    } else {
+      outcome = try learning.consumeAndAppendEvent(
+        feedbackTap(target, updateId: updateId),
+        now: now
+      )
+    }
+    guard case .recorded(let event) = outcome else {
+      throw StoreError.unexpected("fixture withdrawal was not recorded")
+    }
+    return event
+  }
+}

--- a/Tests/ClawDataTests/Stores/Learning/TrialAssignmentResolutionTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/TrialAssignmentResolutionTests.swift
@@ -1,0 +1,1387 @@
+import ClawCore
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+
+@Suite struct TrialAssignmentResolutionTests {
+  @Test func primarySettledUnevaluatedAssignmentsDrainAtLimitButDoNotFallback() throws {
+    // given
+    let env = try trialEnvironment()
+    var runIds: [Int64] = []
+    for _ in 0..<TrialAdmissionPolicy.maximumAssignments {
+      runIds.append(try env.settledBoundRun())
+    }
+    let identity = try #require(try env.learning.liveTrialIdentities().first)
+
+    // when
+    let result = try env.learning.reconcileTrial(identity, now: env.now)
+
+    // then — primary settlement is not a learning outcome and cannot become neutral support.
+    guard case .reconciled(let reconciliation) = result else {
+      Issue.record("expected live reconciliation")
+      return
+    }
+    #expect(reconciliation.decision == .wait)
+    #expect(reconciliation.didDrain == false)
+    #expect(
+      reconciliation.assignments.map(\.state) == Array(repeating: .primaryRunSettled, count: 3)
+    )
+    #expect(reconciliation.assignments.allSatisfy { $0.resolvedEvidence == nil })
+    #expect(try env.trialState(trialId: identity.trialId) == .draining)
+    #expect(Set(runIds) == Set(reconciliation.assignments.map(\.identity.runId)))
+  }
+
+  @Test func sealClaimAndPermanentFailureAdvanceExactStatesInTheirTransactions() throws {
+    // given
+    let env = try trialEnvironment()
+    let runId = try env.settledBoundRun()
+    #expect(try env.assignmentState(runId: runId) == .created)
+
+    // when — sealing is settled but has no evaluator operation yet
+    let sealed = try env.seal(runId: runId)
+
+    // then
+    #expect(try env.assignmentState(runId: runId) == .primaryRunSettled)
+
+    // when — a claim creates the live resolution event
+    let claim = try env.claim(env.evaluatorKey(for: sealed))
+
+    // then
+    #expect(try env.assignmentState(runId: runId) == .learningOutcomeUnresolved)
+
+    // when — privacy permanently refuses that evaluator call
+    let denied = env.authorization(
+      for: claim,
+      carrier: CarrierAuthorization(
+        sourceDigest: claim.key.sourceDigest,
+        digest: CarrierDigest(rawValue: "denied"),
+        isPermitted: false
+      )
+    )
+    #expect(try env.learning.authorizeAndStartOperation(denied, now: env.now) != .superseded)
+
+    // then
+    #expect(try env.assignmentState(runId: runId) == .learningOutcomeResolved)
+    let assignment = try #require(try env.assignment(runId: runId))
+    #expect(assignment.state == .learningOutcomeResolved)
+    #expect(assignment.resolvedEvidence?.outcome == .neutral)
+    #expect(assignment.resolvedEvidence?.evaluationRequired == false)
+  }
+
+  @Test func evaluationCommitPersistsExactCurrentResolutionAtomically() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let claim = try env.startedOperation(env.evaluatorKey(for: sealed))
+
+    // when
+    let committed = try env.learning.finishOperation(
+      env.result(
+        for: claim.id,
+        evaluation: env.verdict(outcome: .noIssue, issueCodes: [])
+      ),
+      now: env.now.addingTimeInterval(1)
+    )
+
+    // then
+    #expect(committed)
+    let assignment = try #require(try env.assignment(runId: sealed.runId))
+    #expect(assignment.state == .learningOutcomeResolved)
+    #expect(assignment.resolvedEvidence?.outcome == .positive)
+    #expect(assignment.resolvedEvidence?.evaluationDigest != nil)
+    #expect(assignment.resolvedAt == env.now.addingTimeInterval(1))
+  }
+
+  @Test func feedbackBeforeEvaluationDoesNotCreateAFifthResolutionEvent() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let target = env.runFeedbackTarget(runId: sealed.runId, signal: .resultUseful)
+    try env.learning.createTargets([target], chunks: [], now: env.now)
+
+    // when
+    let outcome = try env.learning.consumeAndAppendEvent(
+      FeedbackTap(
+        nonce: target.nonce,
+        signal: .resultUseful,
+        ownerUserId: target.ownerUserId,
+        chatId: target.chatId,
+        transportUpdateId: 1
+      ),
+      now: env.now.addingTimeInterval(1)
+    )
+
+    // then
+    guard case .recorded = outcome else {
+      Issue.record("expected recorded feedback")
+      return
+    }
+    let assignment = try #require(try env.assignment(runId: sealed.runId))
+    #expect(assignment.state == .primaryRunSettled)
+    #expect(assignment.resolvedEvidence == nil)
+  }
+
+  @Test func terminallyIneligibleSealResolvesNeutralWithoutEvaluationDependency() throws {
+    // given
+    let env = try trialEnvironment()
+
+    // when
+    let sealed = try env.ineligibleSealedEvidence()
+
+    // then
+    let assignment = try #require(try env.assignment(runId: sealed.runId))
+    #expect(assignment.state == .learningOutcomeResolved)
+    #expect(assignment.resolvedEvidence?.outcome == .neutral)
+    #expect(assignment.resolvedEvidence?.evaluationRequired == false)
+  }
+
+  @Test func tombstoneSealResolvesNeutralAndAlreadySealedRepairsLaggingCache() throws {
+    // given
+    let env = try trialEnvironment()
+    let runId = try env.settledBoundRun()
+    try env.queue.write { db in
+      try db.execute(
+        sql: "DELETE FROM run_compatibility WHERE run_id = ?",
+        arguments: [runId]
+      )
+    }
+
+    // when — a missing frozen surface creates a terminal ineligible receipt.
+    let first = try env.learning.sealEvidence(runId: runId, now: env.now)
+
+    // then
+    #expect(first == .excluded(.compatibilityUnavailable))
+    #expect(try env.assignmentState(runId: runId) == .learningOutcomeResolved)
+    #expect(try env.assignment(runId: runId)?.resolvedEvidence?.outcome == .neutral)
+
+    // given — simulate the crash-era lag that the already-sealed branch must repair.
+    try env.resetAssignmentCache(runId: runId, state: .created)
+
+    // when
+    let second = try env.learning.sealEvidence(
+      runId: runId,
+      now: env.now.addingTimeInterval(1)
+    )
+
+    // then — returning early without the backstop leaves this cache permanently stale.
+    #expect(second == .alreadySealed)
+    #expect(try env.assignmentState(runId: runId) == .learningOutcomeResolved)
+    #expect(try env.assignment(runId: runId)?.resolvedEvidence?.outcome == .neutral)
+  }
+
+  @Test func interruptedEvaluatorRemainsUnresolved() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    _ = try env.startedOperation(env.evaluatorKey(for: sealed))
+
+    // when
+    _ = try env.learning.reconcileOperationsAtBoot(now: env.now.addingTimeInterval(1))
+
+    // then
+    let assignment = try #require(try env.assignment(runId: sealed.runId))
+    #expect(assignment.state == .learningOutcomeUnresolved)
+    #expect(assignment.resolvedEvidence == nil)
+  }
+
+  @Test func bootProjectsClaimedAndStartedAttemptsAsUnresolvedAfterRecovery() throws {
+    // given
+    let claimed = try trialEnvironment()
+    let claimedEvidence = try claimed.sealedTrialEvidence()
+    _ = try claimed.claim(claimed.evaluatorKey(for: claimedEvidence))
+    try claimed.resetAssignmentCache(runId: claimedEvidence.runId, state: .primaryRunSettled)
+
+    let started = try trialEnvironment()
+    let startedEvidence = try started.sealedTrialEvidence()
+    _ = try started.startedOperation(started.evaluatorKey(for: startedEvidence))
+    try started.resetAssignmentCache(runId: startedEvidence.runId, state: .primaryRunSettled)
+
+    // when
+    _ = try claimed.learning.reconcileOperationsAtBoot(now: claimed.now.addingTimeInterval(1))
+    _ = try started.learning.reconcileOperationsAtBoot(now: started.now.addingTimeInterval(1))
+
+    // then — pending and interrupted-unknown are distinct operation states but neither settles
+    // learning quality as neutral.
+    #expect(try claimed.assignmentState(runId: claimedEvidence.runId) == .learningOutcomeUnresolved)
+    #expect(try started.assignmentState(runId: startedEvidence.runId) == .learningOutcomeUnresolved)
+  }
+
+  @Test func reclaimAndStartRepairTheirAssignmentInsideTheOperationTransaction() throws {
+    // given — a boot-recovered claim is pending, while a fresh claim has not started its call.
+    let reclaiming = try trialEnvironment()
+    let reclaimedEvidence = try reclaiming.sealedTrialEvidence()
+    let reclaimedKey = reclaiming.evaluatorKey(for: reclaimedEvidence)
+    _ = try reclaiming.claim(reclaimedKey)
+    _ = try reclaiming.learning.reconcileOperationsAtBoot(now: reclaiming.now)
+    try reclaiming.resetAssignmentCache(
+      runId: reclaimedEvidence.runId,
+      state: .primaryRunSettled
+    )
+
+    let starting = try trialEnvironment()
+    let startedEvidence = try starting.sealedTrialEvidence()
+    let claim = try starting.claim(starting.evaluatorKey(for: startedEvidence))
+    try starting.resetAssignmentCache(runId: startedEvidence.runId, state: .primaryRunSettled)
+
+    // when
+    _ = try reclaiming.claim(reclaimedKey)
+    _ = try starting.learning.authorizeAndStartOperation(
+      starting.authorization(for: claim),
+      now: starting.now
+    )
+
+    // then — omitting either hook leaves its deliberately lagging cache at primary-settled.
+    #expect(
+      try reclaiming.assignmentState(runId: reclaimedEvidence.runId)
+        == .learningOutcomeUnresolved
+    )
+    #expect(
+      try starting.assignmentState(runId: startedEvidence.runId)
+        == .learningOutcomeUnresolved
+    )
+  }
+
+  @Test func terminalProviderFailureResolvesNeutralWithoutEvaluationDependency() throws {
+    // given
+    let env = try trialEnvironment()
+    let evidence = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: evidence))
+
+    // when
+    _ = try env.learning.finishOperation(
+      env.result(for: operation.id, failure: .providerTerminal),
+      now: env.now.addingTimeInterval(1)
+    )
+
+    // then — permanent failure closes learning quality without fabricating an evaluator verdict.
+    let assignment = try #require(try env.assignment(runId: evidence.runId))
+    #expect(assignment.resolvedEvidence?.outcome == .neutral)
+    #expect(assignment.resolvedEvidence?.evaluationDigest == nil)
+    #expect(assignment.resolvedEvidence?.evaluationRequired == false)
+  }
+
+  @Test(arguments: OperationProjectionFault.allCases)
+  func operationProjectionFailureRollsBackEveryHookedLifecycleWrite(
+    _ fault: OperationProjectionFault
+  ) throws {
+    // given
+    let env = try trialEnvironment()
+    let evidence = try env.sealedTrialEvidence()
+    let key = env.evaluatorKey(for: evidence)
+    let operation: ClaimedOperation?
+    switch fault {
+    case .claim:
+      operation = nil
+    case .start, .denial, .bootClaimed:
+      operation = try env.claim(key)
+    case .bootStarted:
+      operation = try env.startedOperation(key)
+    }
+    try env.corruptAssignmentGeneration(runId: evidence.runId)
+
+    // when / then
+    #expect {
+      switch fault {
+      case .claim:
+        _ = try env.learning.claimOperation(key, now: env.now)
+      case .start:
+        _ = try env.learning.authorizeAndStartOperation(
+          env.authorization(for: try #require(operation)),
+          now: env.now
+        )
+      case .denial:
+        let claim = try #require(operation)
+        _ = try env.learning.authorizeAndStartOperation(
+          env.authorization(
+            for: claim,
+            carrier: CarrierAuthorization(
+              sourceDigest: claim.key.sourceDigest,
+              digest: CarrierDigest(rawValue: "denied"),
+              isPermitted: false
+            )
+          ),
+          now: env.now
+        )
+      case .bootClaimed, .bootStarted:
+        _ = try env.learning.reconcileOperationsAtBoot(now: env.now)
+      }
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+
+    switch fault {
+    case .claim:
+      #expect(try env.countRows(in: "learning_operations") == 0)
+    case .start, .denial, .bootClaimed:
+      #expect(try env.operationState(try #require(operation).id) == .claimed)
+    case .bootStarted:
+      #expect(try env.operationState(try #require(operation).id) == .started)
+    }
+  }
+
+  @Test(arguments: AssignmentIdentityCorruption.allCases)
+  func recomputeRequiresTheFivePartAssignmentIdentity(
+    _ corruption: AssignmentIdentityCorruption
+  ) throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    try env.apply(corruption, runId: sealed.runId)
+
+    // when / then
+    #expect {
+      _ = try env.learning.recomputeAssignment(runId: sealed.runId, now: env.now)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+  }
+
+  @Test(arguments: EvaluationCorruption.allCases)
+  func succeededEvaluatorRequiresOneExactEvaluation(
+    _ corruption: EvaluationCorruption
+  ) throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let claim = try env.startedOperation(env.evaluatorKey(for: sealed))
+    _ = try env.learning.finishOperation(env.result(for: claim.id), now: env.now)
+    try env.apply(corruption, runId: sealed.runId)
+
+    // when / then
+    #expect {
+      _ = try env.learning.recomputeAssignment(runId: sealed.runId, now: env.now)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+  }
+
+  @Test func relevantFeedbackRefreshesRevisionAndTimestampEvenWhenOutcomeStaysPositive() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: sealed))
+    _ = try env.learning.finishOperation(env.result(for: operation.id), now: env.now)
+    let before = try #require(try env.assignment(runId: sealed.runId))
+    let digest = try #require(before.resolvedEvidence?.evaluationDigest)
+    let target = env.evaluationFeedbackTarget(
+      digest: digest,
+      signal: .evaluationConfirm
+    )
+    try env.learning.createTargets([target], chunks: [], now: env.now)
+    let feedbackAt = env.now.addingTimeInterval(7)
+
+    // when
+    let result = try env.learning.consumeAndAppendEvent(
+      env.feedbackTap(target, updateId: 11),
+      now: feedbackAt
+    )
+
+    // then — owner confirmation changes provenance, even though positive remains positive.
+    guard case .recorded = result else {
+      Issue.record("expected recorded confirmation")
+      return
+    }
+    let after = try #require(try env.assignment(runId: sealed.runId))
+    #expect(after.resolvedEvidence?.outcome == .positive)
+    #expect(after.resolvedEvidence?.ownerConfirmed == true)
+    #expect(after.resolvedEvidence?.effectiveFeedbackRevision == FeedbackRevision(1))
+    #expect(before.resolvedAt == env.now)
+    #expect(after.resolvedAt == feedbackAt)
+  }
+
+  @Test func unrelatedFeedbackDoesNotRewriteAResolvedAssignmentCache() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: sealed))
+    _ = try env.learning.finishOperation(env.result(for: operation.id), now: env.now)
+    let before = try env.assignmentCacheSnapshot(runId: sealed.runId)
+    _ = try env.appendFeedback(
+      subjectKind: .run,
+      subjectDigest: "999999",
+      signal: .resultUseful
+    )
+
+    // when
+    let recomputed = try env.learning.recomputeAssignment(
+      runId: sealed.runId,
+      now: env.now.addingTimeInterval(20)
+    )
+    let after = try env.assignmentCacheSnapshot(runId: sealed.runId)
+
+    // then — a job-wide revision alone is not a reason to rewrite unrelated provenance.
+    guard case .unchanged(let assignment) = recomputed else {
+      Issue.record("expected unchanged assignment")
+      return
+    }
+    #expect(after == before)
+    #expect(assignment.resolvedEvidence?.effectiveFeedbackRevision == FeedbackRevision(0))
+    #expect(try env.currentLearningState().feedbackRevision == FeedbackRevision(1))
+  }
+
+  @Test func terminallyIneligibleEvidenceIgnoresResultFeedbackAsQualityEvidence() throws {
+    // given
+    let env = try trialEnvironment()
+    let evidence = try env.ineligibleSealedEvidence()
+
+    // when
+    try env.recordRunFeedback(
+      runId: evidence.runId,
+      signal: .resultUseful,
+      updateId: 12
+    )
+
+    // then — feedback cannot convert a technical exclusion into positive support.
+    let assignment = try #require(try env.assignment(runId: evidence.runId))
+    #expect(assignment.resolvedEvidence?.outcome == .neutral)
+    #expect(assignment.resolvedEvidence?.evaluationRequired == false)
+  }
+
+  @Test func disputeWithdrawsOnlyEvaluationDependentSupport() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: sealed))
+    _ = try env.learning.finishOperation(
+      env.result(
+        for: operation.id,
+        evaluation: env.verdict(outcome: .reusableIssue, issueCodes: ["wrong_fact"])
+      ),
+      now: env.now
+    )
+    let evaluated = try #require(try env.assignment(runId: sealed.runId))
+    let digest = try #require(evaluated.resolvedEvidence?.evaluationDigest)
+    let dispute = env.evaluationFeedbackTarget(digest: digest, signal: .evaluationDispute)
+    let useful = env.runFeedbackTarget(runId: sealed.runId, signal: .resultUseful)
+    try env.learning.createTargets([dispute, useful], chunks: [], now: env.now)
+
+    // when — first remove evaluator support, then add independent run-result support.
+    _ = try env.learning.consumeAndAppendEvent(
+      env.feedbackTap(dispute, updateId: 13),
+      now: env.now.addingTimeInterval(1)
+    )
+    let disputed = try #require(try env.assignment(runId: sealed.runId))
+    _ = try env.learning.consumeAndAppendEvent(
+      env.feedbackTap(useful, updateId: 14),
+      now: env.now.addingTimeInterval(2)
+    )
+
+    // then
+    #expect(disputed.resolvedEvidence?.outcome == .neutral)
+    #expect(disputed.resolvedEvidence?.evaluationRequired == true)
+    #expect(disputed.resolvedEvidence?.hardVetoes == [.ownerDependencyRejected])
+    let independent = try #require(try env.assignment(runId: sealed.runId))
+    #expect(independent.resolvedEvidence?.outcome == .positive)
+    #expect(independent.resolvedEvidence?.evaluationRequired == false)
+    #expect(independent.resolvedEvidence?.hardVetoes.isEmpty == true)
+  }
+
+  @Test func runCorrectionRecomputesInsideTheChallengeTransaction() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: sealed))
+    _ = try env.learning.finishOperation(env.result(for: operation.id), now: env.now)
+    let target = env.runFeedbackTarget(runId: sealed.runId, signal: .resultCorrection)
+    try env.learning.createTargets([target], chunks: [], now: env.now)
+    let opened = try env.learning.consumeAndOpenChallenge(
+      env.feedbackTap(target, updateId: 16),
+      prompt: env.challengePrompt(target),
+      now: env.now
+    )
+    guard case .challengeOpened(let challenge) = opened else {
+      Issue.record("expected correction challenge")
+      return
+    }
+    let correctedAt = env.now.addingTimeInterval(1)
+
+    // when
+    _ = try env.learning.consumeChallenge(
+      id: challenge.id,
+      payload: "Use the corrected source.",
+      now: correctedAt
+    )
+
+    // then — appending only the event leaves the cached positive assignment unchanged.
+    let assignment = try #require(try env.assignment(runId: sealed.runId))
+    #expect(assignment.resolvedEvidence?.outcome == .negative)
+    #expect(assignment.resolvedEvidence?.correctionEventDigest != nil)
+    #expect(assignment.resolvedEvidence?.effectiveFeedbackRevision == FeedbackRevision(1))
+    #expect(assignment.resolvedAt == correctedAt)
+  }
+
+  @Test func sameEpochLateResultRefreshesCacheWithoutReopeningTerminalTrial() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: sealed))
+    let trial = try #require(try env.learning.openTrial(jobId: env.jobId))
+    let reject = env.candidateFeedbackTarget(
+      digest: trial.candidateDigest,
+      signal: .candidateReject
+    )
+    try env.learning.createTargets([reject], chunks: [], now: env.now)
+    _ = try env.learning.consumeAndAppendEvent(
+      env.feedbackTap(reject, updateId: 15),
+      now: env.now.addingTimeInterval(1)
+    )
+    let terminalState = try env.currentLearningState()
+    #expect(try env.trialState(trialId: trial.trialId) == .fellBack)
+
+    // when
+    _ = try env.learning.finishOperation(
+      env.result(for: operation.id),
+      now: env.now.addingTimeInterval(2)
+    )
+
+    // then — the current-epoch product may repair history but cannot apply Task 17 transitions.
+    let refreshed = try #require(try env.assignment(runId: sealed.runId))
+    #expect(refreshed.resolvedEvidence?.outcome == .positive)
+    #expect(try env.trialState(trialId: trial.trialId) == .fellBack)
+    #expect(try env.currentLearningState() == terminalState)
+  }
+
+  @Test func publicRecomputeDistinguishesMissingStaleAndFutureAssignments() throws {
+    // given
+    let missing = try trialEnvironment()
+    let stale = try trialEnvironment()
+    let staleRun = try stale.settledBoundRun()
+    try stale.advanceJobEpoch()
+    let future = try trialEnvironment()
+    let futureRun = try future.settledBoundRun()
+    try future.queue.write { db in
+      try db.execute(
+        sql: "UPDATE job_learning_state SET learning_epoch = 0 WHERE job_id = ?",
+        arguments: [future.jobId]
+      )
+    }
+
+    // when / then
+    #expect(
+      try missing.learning.recomputeAssignment(runId: 999_999, now: missing.now) == .notAssigned
+    )
+    #expect(try stale.learning.recomputeAssignment(runId: staleRun, now: stale.now) == .stale)
+    #expect {
+      _ = try future.learning.recomputeAssignment(runId: futureRun, now: future.now)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+  }
+
+  @Test func liveTrialIdentitiesAreStrictSortedAndRejectMultiplicity() throws {
+    // given — insert the larger job first so row-id order differs from the public sort order.
+    let env = try BoundRunEnvironment.make()
+    let secondJob = try env.jobs.create(
+      NewScheduledJob(
+        ownerChatId: 777,
+        label: "second trial",
+        prompt: "Summarize the second archive",
+        recurrence: nil,
+        timezone: "Europe/Berlin",
+        nextOccurrence: env.now
+      ),
+      now: env.now
+    )
+    let second = try env.installTrial(jobId: secondJob.id)
+    let first = try env.installTrial(jobId: env.jobId)
+
+    // when
+    let identities = try env.learning.liveTrialIdentities()
+
+    // then
+    #expect(identities == [first, second])
+
+    // given — v13 normally prevents this; removing the index exposes the defensive scan.
+    try env.insertDuplicateLiveTrial(jobId: env.jobId)
+
+    // when / then — choosing the first row would starve one live trial indefinitely.
+    #expect {
+      _ = try env.learning.liveTrialIdentities()
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+  }
+
+  @Test func liveTrialIdentitiesRejectUnreadableAuthoritativeSource() throws {
+    // given
+    let env = try trialEnvironment()
+    try env.queue.write { db in
+      try db.execute(sql: "UPDATE learning_candidates SET base_revision = 99")
+    }
+
+    // when / then — validating only four scalar columns would enqueue this corrupt trial.
+    #expect {
+      _ = try env.learning.liveTrialIdentities()
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+  }
+
+  @Test(arguments: TrialSnapshotCorruption.allCases)
+  func trialSnapshotRejectsCountAndForeignAssignmentMismatch(
+    _ corruption: TrialSnapshotCorruption
+  ) throws {
+    // given
+    let env = try trialEnvironment()
+    let runId = try env.settledBoundRun()
+    let identity = try #require(try env.learning.liveTrialIdentities().first)
+    try env.apply(corruption, runId: runId, trialId: identity.trialId)
+
+    // when / then
+    #expect {
+      _ = try env.learning.reconcileTrial(identity, now: env.now)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+  }
+
+  @Test func repeatedReconciliationPreservesResolvedTimestampAndReturnsStaleAfterEpochChange()
+    throws
+  {
+    // given
+    let env = try trialEnvironment()
+    let evidence = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: evidence))
+    _ = try env.learning.finishOperation(env.result(for: operation.id), now: env.now)
+    let identity = try #require(try env.learning.liveTrialIdentities().first)
+    let resolvedAt = try env.assignment(runId: evidence.runId)?.resolvedAt
+
+    // when
+    let first = try env.learning.reconcileTrial(identity, now: env.now.addingTimeInterval(20))
+    let second = try env.learning.reconcileTrial(identity, now: env.now.addingTimeInterval(40))
+
+    // then — identical projection work writes neither a new timestamp nor another drain.
+    guard
+      case .reconciled(let firstPass) = first,
+      case .reconciled(let secondPass) = second
+    else {
+      Issue.record("expected two live reconciliation results")
+      return
+    }
+    #expect(firstPass.didDrain == false)
+    #expect(secondPass.didDrain == false)
+    #expect(try env.assignment(runId: evidence.runId)?.resolvedAt == resolvedAt)
+
+    // when
+    try env.advanceJobEpoch()
+
+    // then
+    #expect(try env.learning.reconcileTrial(identity, now: env.now) == .stale)
+  }
+
+  @Test func evidenceRecomputeFailureRollsBackReceiptVersionsAndCache() throws {
+    // given
+    let env = try trialEnvironment()
+    let runId = try env.settledBoundRun()
+    try env.corruptAssignmentGeneration(runId: runId)
+    let versionsBefore = try env.sealingVersionSnapshot(runId: runId)
+
+    // when
+    #expect {
+      _ = try env.learning.sealEvidence(runId: runId, now: env.now)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+
+    // then — a post-commit hook would leave an authoritative receipt behind a rejected cache.
+    #expect(try env.learning.evidence(runId: runId) == nil)
+    #expect(try env.assignmentState(runId: runId) == .created)
+    #expect(try env.sealingVersionSnapshot(runId: runId) == versionsBefore)
+  }
+
+  @Test func recomputeFailureRollsBackOperationUsageEvaluationAndCache() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: sealed))
+    try env.corruptAssignmentGeneration(runId: sealed.runId)
+
+    // when
+    #expect {
+      _ = try env.learning.finishOperation(env.result(for: operation.id), now: env.now)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+
+    // then — evaluation and spend cannot commit ahead of the exact assignment projection.
+    #expect(try env.operationState(operation.id) == .started)
+    #expect(try env.learningUsage(operationId: operation.id).isEmpty)
+    #expect(try env.learning.evaluation(runId: sealed.runId) == nil)
+    #expect(try env.assignmentState(runId: sealed.runId) == .learningOutcomeUnresolved)
+  }
+
+  @Test func feedbackRecomputeFailureRollsBackTargetRevisionEventAndCache() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: sealed))
+    _ = try env.learning.finishOperation(env.result(for: operation.id), now: env.now)
+    let target = env.runFeedbackTarget(runId: sealed.runId, signal: .resultNotUseful)
+    try env.learning.createTargets([target], chunks: [], now: env.now)
+    try env.corruptAssignmentGeneration(runId: sealed.runId)
+    let cacheBefore = try env.assignmentCacheSnapshot(runId: sealed.runId)
+
+    // when
+    #expect {
+      _ = try env.learning.consumeAndAppendEvent(
+        env.feedbackTap(target, updateId: 7),
+        now: env.now.addingTimeInterval(1)
+      )
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+
+    // then — target consumption and owner history are in the same transaction as projection.
+    #expect(try env.learning.feedbackTarget(nonce: target.nonce)?.consumedAt == nil)
+    #expect(try env.currentLearningState().feedbackRevision == FeedbackRevision(0))
+    #expect(try env.feedbackEventCount() == 0)
+    #expect(try env.assignmentCacheSnapshot(runId: sealed.runId) == cacheBefore)
+  }
+
+  @Test func correctionRecomputeFailureRollsBackChallengeRevisionEventAndAudit() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: sealed))
+    _ = try env.learning.finishOperation(env.result(for: operation.id), now: env.now)
+    let target = env.runFeedbackTarget(runId: sealed.runId, signal: .resultCorrection)
+    try env.learning.createTargets([target], chunks: [], now: env.now)
+    let opened = try env.learning.consumeAndOpenChallenge(
+      env.feedbackTap(target, updateId: 8),
+      prompt: env.challengePrompt(target),
+      now: env.now
+    )
+    guard case .challengeOpened(let challenge) = opened else {
+      Issue.record("expected correction challenge")
+      return
+    }
+    let auditCount = try env.learningAuditCount()
+    try env.corruptAssignmentGeneration(runId: sealed.runId)
+
+    // when
+    #expect {
+      _ = try env.learning.consumeChallenge(
+        id: challenge.id,
+        payload: "Use the corrected source.",
+        now: env.now.addingTimeInterval(1)
+      )
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+
+    // then — challenge payload, consumption, event, revision and audit roll back together.
+    let live = try env.learning.liveChallenge(ownerUserId: 42, chatId: 777)
+    #expect(live?.id == challenge.id)
+    #expect(live?.consumedAt == nil)
+    #expect(try env.currentLearningState().feedbackRevision == FeedbackRevision(0))
+    #expect(try env.feedbackEventCount() == 0)
+    #expect(try env.learningAuditCount() == auditCount)
+  }
+
+  @Test func evaluationAndFeedbackWritersConvergeInBothCommitOrders() throws {
+    // given
+    let evaluationFirst = try trialEnvironment()
+    let firstEvidence = try evaluationFirst.sealedTrialEvidence()
+    let firstOperation = try evaluationFirst.startedOperation(
+      evaluationFirst.evaluatorKey(for: firstEvidence)
+    )
+    _ = try evaluationFirst.learning.finishOperation(
+      evaluationFirst.result(for: firstOperation.id),
+      now: evaluationFirst.now
+    )
+    try evaluationFirst.recordRunFeedback(
+      runId: firstEvidence.runId,
+      signal: .resultNotUseful,
+      updateId: 9
+    )
+
+    let feedbackFirst = try trialEnvironment()
+    let secondEvidence = try feedbackFirst.sealedTrialEvidence()
+    try feedbackFirst.recordRunFeedback(
+      runId: secondEvidence.runId,
+      signal: .resultNotUseful,
+      updateId: 10
+    )
+    let secondOperation = try feedbackFirst.startedOperation(
+      feedbackFirst.evaluatorKey(for: secondEvidence)
+    )
+
+    // when
+    _ = try feedbackFirst.learning.finishOperation(
+      feedbackFirst.result(for: secondOperation.id),
+      now: feedbackFirst.now
+    )
+    let first = try #require(try evaluationFirst.assignment(runId: firstEvidence.runId))
+    let second = try #require(try feedbackFirst.assignment(runId: secondEvidence.runId))
+
+    // then — projecting outside either writer makes the last commit order observable.
+    #expect(first.resolvedEvidence?.outcome == .negative)
+    #expect(second.resolvedEvidence?.outcome == .negative)
+    #expect(first.resolvedEvidence?.issueCodes == second.resolvedEvidence?.issueCodes)
+    #expect(
+      first.resolvedEvidence?.evaluationRequired == second.resolvedEvidence?.evaluationRequired
+    )
+    #expect(first.resolvedEvidence?.effectiveFeedbackRevision == FeedbackRevision(1))
+    #expect(second.resolvedEvidence?.effectiveFeedbackRevision == FeedbackRevision(1))
+  }
+}
+
+// MARK: - Trial Fixture
+
+private struct SealingVersionSnapshot: Equatable {
+  let evidenceSchemaVersion: Int?
+  let classifierVersion: String?
+}
+
+private struct AssignmentCacheSnapshot: Equatable {
+  let values: [DatabaseValue]
+}
+
+enum AssignmentIdentityCorruption: CaseIterable {
+  case assignmentJob
+  case assignmentEpoch
+  case assignmentGeneration
+  case bindingTrial
+  case bindingGeneration
+  case bindingStableDigest
+  case bindingEffectiveDigest
+}
+
+enum EvaluationCorruption: CaseIterable {
+  case missing
+  case duplicate
+  case digest
+  case job
+  case epoch
+  case evidence
+  case outcome
+  case issueCodes
+  case rubric
+  case prompt
+  case schema
+  case compatibility
+  case createdAt
+}
+
+enum TrialSnapshotCorruption: CaseIterable {
+  case count
+  case assignmentJob
+}
+
+enum OperationProjectionFault: CaseIterable {
+  case claim
+  case start
+  case denial
+  case bootClaimed
+  case bootStarted
+}
+
+private func trialEnvironment() throws -> BoundRunEnvironment {
+  let env = try BoundRunEnvironment.make()
+  try env.installTrial()
+  return env
+}
+
+extension BoundRunEnvironment {
+  func installTrial() throws {
+    _ = try installTrial(jobId: jobId)
+  }
+
+  @discardableResult
+  func installTrial(jobId: Int64) throws -> LearningTrialIdentity {
+    let state = try learning.armJob(jobId: jobId, now: now)
+    let base = LessonSet.empty(jobId: jobId)
+    let replacement = try LessonSet.canonical(
+      jobId: jobId,
+      lessons: ["Check the archive before answering"]
+    )
+    let manifest = CandidateSourceManifest(
+      origin: .reflection,
+      algorithm: .v1,
+      jobId: jobId,
+      epoch: state.epoch,
+      triggerDigest: TriggerDigest(rawValue: SHA256Digest.hex("trial-trigger-\(jobId)")),
+      triggerReason: .ownerCorrection,
+      qualifyingIssueCodes: [],
+      operationId: LearningOperationID(rawValue: "trial-fixture-operation"),
+      carrierDigest: CarrierDigest(rawValue: SHA256Digest.hex("trial-carrier-\(jobId)")),
+      resultDigest: ReflectionResultDigest(rawValue: SHA256Digest.hex("trial-result-\(jobId)")),
+      baseDigest: base.digest,
+      baseRevision: state.stableRevision,
+      feedbackRevision: state.feedbackRevision,
+      evidence: [],
+      evaluations: [],
+      feedback: [],
+      predecessorCandidate: nil,
+      predecessorFeedback: nil
+    )
+    let artifact = try CandidateArtifact(replacement: replacement, manifest: manifest)
+    return try queue.write { db in
+      try ScheduledLearningStoreGRDB.recordCandidateArtifact(db, artifact: artifact, now: now)
+      try db.execute(
+        sql: """
+          INSERT INTO learning_trials(job_id, learning_epoch, base_digest, candidate_digest,
+            generation, admitted_at, assignment_deadline, decision_deadline, max_assignments,
+            consumed_assignments, cohort_cutoff, state, algorithm)
+          VALUES (?, ?, ?, ?, 1, ?, ?, ?, 3, 0, ?, ?, ?)
+          """,
+        arguments: [
+          jobId,
+          state.epoch.value,
+          base.digest.rawValue,
+          artifact.digest.rawValue,
+          EpochSecondCodec.epoch(now),
+          EpochSecondCodec.epoch(now.addingTimeInterval(TrialAdmissionPolicy.assignmentWindow)),
+          EpochSecondCodec.epoch(now.addingTimeInterval(TrialAdmissionPolicy.decisionWindow)),
+          EpochSecondCodec.epoch(now),
+          LearningTrialState.open.rawValue,
+          LearningAlgorithm.v1.rawValue,
+        ]
+      )
+      let trialId = db.lastInsertedRowID
+      try db.execute(
+        sql: "UPDATE job_learning_state SET open_trial_id = ? WHERE job_id = ?",
+        arguments: [trialId, jobId]
+      )
+      try ScheduledLearningStoreGRDB.insertDecision(
+        db,
+        kind: AdmissionReceipt.kind,
+        jobId: jobId,
+        epoch: state.epoch,
+        inputs: AdmissionDecisionInputs(candidateDigest: artifact.digest),
+        result: AdmissionReceipt(
+          candidateDigest: artifact.digest,
+          replacementDigest: replacement.digest,
+          trialId: trialId,
+          generation: 1
+        ),
+        algorithm: .v1,
+        now: now
+      )
+      return LearningTrialIdentity(
+        trialId: trialId,
+        jobId: jobId,
+        epoch: state.epoch,
+        generation: 1
+      )
+    }
+  }
+
+  func seal(runId: Int64) throws -> SealedEvidence {
+    _ = try learning.sealEvidence(runId: runId, now: now)
+    return try #require(try learning.evidence(runId: runId))
+  }
+
+  func sealedTrialEvidence() throws -> SealedEvidence {
+    try seal(runId: settledBoundRun())
+  }
+
+  func assignmentState(runId: Int64) throws -> TrialAssignmentState? {
+    try queue.read { db in
+      let raw = try String.fetchOne(
+        db,
+        sql: "SELECT state FROM trial_assignments WHERE run_id = ?",
+        arguments: [runId]
+      )
+      return raw.flatMap(TrialAssignmentState.init(rawValue:))
+    }
+  }
+
+  func assignment(runId: Int64) throws -> TrialAssignment? {
+    switch try learning.recomputeAssignment(runId: runId, now: now) {
+    case .notAssigned, .stale:
+      return nil
+    case .unchanged(let assignment), .updated(let assignment):
+      return assignment
+    }
+  }
+
+  func runFeedbackTarget(runId: Int64, signal: OwnerSignal) -> NewFeedbackTarget {
+    NewFeedbackTarget(
+      nonce: "run-\(runId)-\(signal.rawValue)",
+      jobId: jobId,
+      epoch: LearningEpoch(1),
+      subjectKind: .run,
+      subjectDigest: String(runId),
+      allowedActions: [signal],
+      ownerUserId: 42,
+      chatId: 777,
+      expiresAt: now.addingTimeInterval(3_600)
+    )
+  }
+
+  func evaluationFeedbackTarget(
+    digest: EvaluationDigest,
+    signal: OwnerSignal
+  ) -> NewFeedbackTarget {
+    feedbackTarget(
+      nonce: "evaluation-\(signal.rawValue)",
+      kind: .evaluation,
+      digest: digest.rawValue,
+      signal: signal
+    )
+  }
+
+  func candidateFeedbackTarget(
+    digest: CandidateDigest,
+    signal: OwnerSignal
+  ) -> NewFeedbackTarget {
+    feedbackTarget(
+      nonce: "candidate-\(signal.rawValue)",
+      kind: .candidate,
+      digest: digest.rawValue,
+      signal: signal
+    )
+  }
+
+  func feedbackTap(_ target: NewFeedbackTarget, updateId: Int64) -> FeedbackTap {
+    FeedbackTap(
+      nonce: target.nonce,
+      signal: target.allowedActions[0],
+      ownerUserId: target.ownerUserId,
+      chatId: target.chatId,
+      transportUpdateId: updateId
+    )
+  }
+
+  func challengePrompt(_ target: NewFeedbackTarget) -> [LearningNoticeChunk] {
+    let payload = "Reply with the correction."
+    return [
+      LearningNoticeChunk(
+        subjectDigest: FeedbackChallengeDeliveryIdentity.digest(targetNonce: target.nonce),
+        ordinal: 0,
+        chatId: target.chatId,
+        payload: payload,
+        payloadHash: ContentHash.fnv1a(payload)
+      )
+    ]
+  }
+
+  func recordRunFeedback(
+    runId: Int64,
+    signal: OwnerSignal,
+    updateId: Int64
+  ) throws {
+    let target = runFeedbackTarget(runId: runId, signal: signal)
+    try learning.createTargets([target], chunks: [], now: now)
+    guard
+      case .recorded = try learning.consumeAndAppendEvent(
+        feedbackTap(target, updateId: updateId),
+        now: now.addingTimeInterval(1)
+      )
+    else {
+      throw StoreError.unexpected("fixture feedback was not recorded")
+    }
+  }
+
+  func corruptAssignmentGeneration(runId: Int64) throws {
+    try queue.write { db in
+      try db.execute(
+        sql:
+          "UPDATE trial_assignments SET trial_generation = trial_generation + 1 WHERE run_id = ?",
+        arguments: [runId]
+      )
+    }
+  }
+
+  func resetAssignmentCache(
+    runId: Int64,
+    state: TrialAssignmentState
+  ) throws {
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          UPDATE trial_assignments
+          SET state = ?, outcome = NULL, issue_codes = NULL, evaluation_digest = NULL,
+            evaluation_required = 1, effective_feedback_revision = NULL, resolved_at = NULL
+          WHERE run_id = ?
+          """,
+        arguments: [state.rawValue, runId]
+      )
+    }
+  }
+
+  func apply(
+    _ corruption: AssignmentIdentityCorruption,
+    runId: Int64
+  ) throws {
+    let mutation: String
+    switch corruption {
+    case .assignmentJob:
+      mutation = "UPDATE trial_assignments SET job_id = job_id + 1 WHERE run_id = ?"
+    case .assignmentEpoch:
+      mutation = "UPDATE trial_assignments SET learning_epoch = learning_epoch + 1 WHERE run_id = ?"
+    case .assignmentGeneration:
+      mutation =
+        "UPDATE trial_assignments SET trial_generation = trial_generation + 1 WHERE run_id = ?"
+    case .bindingTrial:
+      mutation = "UPDATE run_learning_bindings SET trial_id = trial_id + 1 WHERE run_id = ?"
+    case .bindingGeneration:
+      mutation =
+        "UPDATE run_learning_bindings SET trial_generation = trial_generation + 1 WHERE run_id = ?"
+    case .bindingStableDigest:
+      mutation =
+        "UPDATE run_learning_bindings SET stable_digest = effective_digest WHERE run_id = ?"
+    case .bindingEffectiveDigest:
+      mutation =
+        "UPDATE run_learning_bindings SET effective_digest = stable_digest WHERE run_id = ?"
+    }
+    try queue.write { db in
+      try db.execute(sql: mutation, arguments: [runId])
+    }
+  }
+
+  func apply(
+    _ corruption: EvaluationCorruption,
+    runId: Int64
+  ) throws {
+    try queue.write { db in
+      switch corruption {
+      case .missing:
+        try db.execute(
+          sql: "DELETE FROM learning_evaluations WHERE run_id = ?",
+          arguments: [runId]
+        )
+      case .duplicate:
+        try db.execute(
+          sql: """
+            INSERT INTO learning_evaluations(evaluation_digest, job_id, learning_epoch, run_id,
+              evidence_digest, outcome, issue_codes, rubric_version, evaluator_prompt_version,
+              evaluator_schema_version, compatibility_digest, created_at)
+            SELECT ?, job_id, learning_epoch, run_id, evidence_digest, outcome, issue_codes,
+              rubric_version, evaluator_prompt_version, evaluator_schema_version,
+              compatibility_digest, created_at
+            FROM learning_evaluations WHERE run_id = ?
+            """,
+          arguments: [String(repeating: "f", count: 64), runId]
+        )
+      case .digest:
+        try updateEvaluation(
+          db,
+          runId: runId,
+          column: "evaluation_digest",
+          value: String(repeating: "f", count: 64)
+        )
+      case .job:
+        try updateEvaluation(db, runId: runId, column: "job_id", value: 999)
+      case .epoch:
+        try updateEvaluation(db, runId: runId, column: "learning_epoch", value: 999)
+      case .evidence:
+        try updateEvaluation(
+          db,
+          runId: runId,
+          column: "evidence_digest",
+          value: String(repeating: "f", count: 64)
+        )
+      case .outcome:
+        try updateEvaluation(db, runId: runId, column: "outcome", value: "unknown")
+      case .issueCodes:
+        try updateEvaluation(db, runId: runId, column: "issue_codes", value: "[\"z\",\"a\"]")
+      case .rubric:
+        try updateEvaluation(db, runId: runId, column: "rubric_version", value: "999")
+      case .prompt:
+        try updateEvaluation(
+          db,
+          runId: runId,
+          column: "evaluator_prompt_version",
+          value: "999"
+        )
+      case .schema:
+        try updateEvaluation(
+          db,
+          runId: runId,
+          column: "evaluator_schema_version",
+          value: "999"
+        )
+      case .compatibility:
+        try updateEvaluation(
+          db,
+          runId: runId,
+          column: "compatibility_digest",
+          value: String(repeating: "f", count: 64)
+        )
+      case .createdAt:
+        try db.execute(
+          sql: "UPDATE learning_evaluations SET created_at = X'00' WHERE run_id = ?",
+          arguments: [runId]
+        )
+      }
+    }
+  }
+
+  func apply(
+    _ corruption: TrialSnapshotCorruption,
+    runId: Int64,
+    trialId: Int64
+  ) throws {
+    try queue.write { db in
+      switch corruption {
+      case .count:
+        try db.execute(
+          sql: "UPDATE learning_trials SET consumed_assignments = 2 WHERE trial_id = ?",
+          arguments: [trialId]
+        )
+      case .assignmentJob:
+        try db.execute(
+          sql: "UPDATE trial_assignments SET job_id = job_id + 1 WHERE run_id = ?",
+          arguments: [runId]
+        )
+      }
+    }
+  }
+
+  func insertDuplicateLiveTrial(jobId: Int64) throws {
+    try queue.write { db in
+      try db.execute(sql: "DROP INDEX idx_learning_trials_live_job")
+      try db.execute(
+        sql: """
+          INSERT INTO learning_trials(job_id, learning_epoch, base_digest, candidate_digest,
+            generation, admitted_at, assignment_deadline, decision_deadline, max_assignments,
+            consumed_assignments, cohort_cutoff, state, close_reason, algorithm)
+          SELECT job_id, learning_epoch, base_digest, candidate_digest, generation + 1,
+            admitted_at, assignment_deadline, decision_deadline, max_assignments, 0,
+            cohort_cutoff, state, close_reason, algorithm
+          FROM learning_trials WHERE job_id = ?
+          """,
+        arguments: [jobId]
+      )
+    }
+  }
+
+  func trialState(trialId: Int64) throws -> LearningTrialState? {
+    try queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT state FROM learning_trials WHERE trial_id = ?",
+        arguments: [trialId]
+      ).flatMap(LearningTrialState.init(rawValue:))
+    }
+  }
+
+  fileprivate func sealingVersionSnapshot(runId: Int64) throws -> SealingVersionSnapshot {
+    try queue.read { db in
+      guard
+        let row = try Row.fetchOne(
+          db,
+          sql: """
+            SELECT evidence_schema_version, classifier_version
+            FROM run_compatibility WHERE run_id = ?
+            """,
+          arguments: [runId]
+        )
+      else {
+        throw StoreError.unexpected("fixture compatibility is missing")
+      }
+      return SealingVersionSnapshot(
+        evidenceSchemaVersion: row["evidence_schema_version"],
+        classifierVersion: row["classifier_version"]
+      )
+    }
+  }
+
+  fileprivate func assignmentCacheSnapshot(runId: Int64) throws -> AssignmentCacheSnapshot {
+    let columns = [
+      "run_id", "trial_id", "job_id", "learning_epoch", "trial_generation", "assigned_at",
+      "state", "outcome", "issue_codes", "evaluation_digest", "evaluation_required",
+      "effective_feedback_revision", "resolved_at",
+    ]
+    return try queue.read { db in
+      guard
+        let row = try Row.fetchOne(
+          db,
+          sql: "SELECT * FROM trial_assignments WHERE run_id = ?",
+          arguments: [runId]
+        )
+      else {
+        throw StoreError.unexpected("fixture assignment is missing")
+      }
+      return AssignmentCacheSnapshot(
+        values: columns.map { column in
+          row[column] as DatabaseValue
+        }
+      )
+    }
+  }
+
+  func feedbackEventCount() throws -> Int {
+    try queue.read { db in
+      try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM feedback_events") ?? -1
+    }
+  }
+
+  func learningAuditCount() throws -> Int {
+    try queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM audit_events WHERE action = ?",
+        arguments: [AuditAction.learningFeedback.rawValue]
+      ) ?? -1
+    }
+  }
+
+  private func feedbackTarget(
+    nonce: String,
+    kind: FeedbackSubjectKind,
+    digest: String,
+    signal: OwnerSignal
+  ) -> NewFeedbackTarget {
+    NewFeedbackTarget(
+      nonce: nonce,
+      jobId: jobId,
+      epoch: LearningEpoch(1),
+      subjectKind: kind,
+      subjectDigest: digest,
+      allowedActions: [signal],
+      ownerUserId: 42,
+      chatId: 777,
+      expiresAt: now.addingTimeInterval(3_600)
+    )
+  }
+
+  private func updateEvaluation(
+    _ db: Database,
+    runId: Int64,
+    column: String,
+    value: (any DatabaseValueConvertible)?
+  ) throws {
+    try db.execute(
+      sql: "UPDATE learning_evaluations SET \(column) = ? WHERE run_id = ?",
+      arguments: [value, runId]
+    )
+  }
+}

--- a/Tests/ClawDataTests/Stores/Learning/TrialAssignmentResolutionTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/TrialAssignmentResolutionTests.swift
@@ -332,8 +332,9 @@ import Testing
     let env = try trialEnvironment()
     let sealed = try env.sealedTrialEvidence()
     try env.apply(corruption, runId: sealed.runId)
+    let cacheBefore = try env.assignmentCacheSnapshot(runId: sealed.runId)
 
-    // when / then
+    // when / then — removing any binding or assignment identity predicate admits its own case.
     #expect {
       _ = try env.learning.recomputeAssignment(runId: sealed.runId, now: env.now)
     } throws: { error in
@@ -342,6 +343,48 @@ import Testing
       }
       return true
     }
+    #expect(try env.assignmentCacheSnapshot(runId: sealed.runId) == cacheBefore)
+  }
+
+  @Test(arguments: LiveTrialStateDrift.allCases)
+  func recomputeRejectsSameEpochLiveTrialStateDrift(_ drift: LiveTrialStateDrift) throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    try env.apply(drift)
+    let cacheBefore = try env.assignmentCacheSnapshot(runId: sealed.runId)
+
+    // when / then — omitting the current-state strict decode accepts same-epoch live drift.
+    #expect {
+      _ = try env.learning.recomputeAssignment(runId: sealed.runId, now: env.now)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+    #expect(try env.assignmentCacheSnapshot(runId: sealed.runId) == cacheBefore)
+  }
+
+  @Test(arguments: LiveTrialStateDrift.allCases)
+  func reconcileRejectsSameEpochLiveTrialStateDrift(_ drift: LiveTrialStateDrift) throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let identity = try #require(try env.learning.liveTrialIdentities().first)
+    try env.apply(drift)
+    let cacheBefore = try env.assignmentCacheSnapshot(runId: sealed.runId)
+
+    // when / then — omitting reconciliation's strict current-state decode accepts live drift.
+    #expect {
+      _ = try env.learning.reconcileTrial(identity, now: env.now)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+    #expect(try env.assignmentCacheSnapshot(runId: sealed.runId) == cacheBefore)
   }
 
   @Test(arguments: EvaluationCorruption.allCases)
@@ -364,6 +407,107 @@ import Testing
       }
       return true
     }
+  }
+
+  @Test(arguments: EvaluatorSourceCorruption.allCases)
+  func evaluatorSourceRequiresOneConsistentOperationAndEvaluationState(
+    _ corruption: EvaluatorSourceCorruption
+  ) throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: sealed))
+    _ = try env.learning.finishOperation(env.result(for: operation.id), now: env.now)
+    try env.resetAssignmentCache(runId: sealed.runId, state: .primaryRunSettled)
+    try env.apply(corruption, operationId: operation.id, runId: sealed.runId)
+    let cacheBefore = try env.assignmentCacheSnapshot(runId: sealed.runId)
+
+    // when / then — removing independent evaluation counting or state-shape validation admits
+    // the matching impossible source combination.
+    #expect {
+      _ = try env.learning.recomputeAssignment(runId: sealed.runId, now: env.now)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+    #expect(try env.assignmentCacheSnapshot(runId: sealed.runId) == cacheBefore)
+  }
+
+  @Test func supersededEvaluatorAttemptMustBeInterrupted() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let first = try env.startedOperation(env.evaluatorKey(for: sealed))
+    _ = try env.learning.reconcileOperationsAtBoot(now: env.now)
+    let second = try env.startedOperation(env.evaluatorKey(for: sealed))
+    _ = try env.learning.finishOperation(env.result(for: second.id), now: env.now)
+    try env.resetAssignmentCache(runId: sealed.runId, state: .primaryRunSettled)
+    try env.replaceInterruptedOperationWithFailed(first.id)
+    let cacheBefore = try env.assignmentCacheSnapshot(runId: sealed.runId)
+
+    // when / then — accepting a non-interrupted predecessor loses the retry lineage invariant.
+    #expect {
+      _ = try env.learning.recomputeAssignment(runId: sealed.runId, now: env.now)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+    #expect(try env.assignmentCacheSnapshot(runId: sealed.runId) == cacheBefore)
+  }
+
+  @Test(arguments: EvidenceReceiptCorruption.allCases)
+  func evidenceReceiptCorruptionFailsBeforeAssignmentCacheRepair(
+    _ corruption: EvidenceReceiptCorruption
+  ) throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    try env.apply(corruption, runId: sealed.runId)
+    let cacheBefore = try env.assignmentCacheSnapshot(runId: sealed.runId)
+
+    // when / then — removing receipt shape, canonical-payload, or digest validation admits the
+    // matching corruption through both public readers.
+    #expect {
+      _ = try env.learning.evidence(runId: sealed.runId)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+    #expect {
+      _ = try env.learning.recomputeAssignment(runId: sealed.runId, now: env.now)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+    #expect(try env.assignmentCacheSnapshot(runId: sealed.runId) == cacheBefore)
+  }
+
+  @Test func eligibleReceiptMayLoseItsPayloadAfterRetention() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    try env.removeEvidencePayload(runId: sealed.runId)
+
+    // when
+    let retained = try #require(try env.learning.evidence(runId: sealed.runId))
+    let recomputed = try env.learning.recomputeAssignment(runId: sealed.runId, now: env.now)
+
+    // then — requiring payload bytes for every eligible receipt breaks compact retention.
+    #expect(retained.eligibility == .eligibleTaskEvidence)
+    #expect(retained.payload == nil)
+    guard case .unchanged(let assignment) = recomputed else {
+      Issue.record("expected unchanged retained assignment")
+      return
+    }
+    #expect(assignment.state == .primaryRunSettled)
   }
 
   @Test func relevantFeedbackRefreshesRevisionAndTimestampEvenWhenOutcomeStaysPositive() throws {
@@ -428,6 +572,54 @@ import Testing
     #expect(after == before)
     #expect(assignment.resolvedEvidence?.effectiveFeedbackRevision == FeedbackRevision(0))
     #expect(try env.currentLearningState().feedbackRevision == FeedbackRevision(1))
+  }
+
+  @Test func assignmentCacheCannotNameAFutureFeedbackRevision() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: sealed))
+    _ = try env.learning.finishOperation(env.result(for: operation.id), now: env.now)
+    try env.setAssignmentFeedbackRevision(runId: sealed.runId, revision: 99)
+    let cacheBefore = try env.assignmentCacheSnapshot(runId: sealed.runId)
+
+    // when / then — removing the cached-revision upper bound manufactures future provenance.
+    #expect {
+      _ = try env.learning.recomputeAssignment(runId: sealed.runId, now: env.now)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+    #expect(try env.assignmentCacheSnapshot(runId: sealed.runId) == cacheBefore)
+  }
+
+  @Test func assignmentProjectionCannotConsumeAFutureFeedbackEvent() throws {
+    // given
+    let env = try trialEnvironment()
+    let sealed = try env.sealedTrialEvidence()
+    let operation = try env.startedOperation(env.evaluatorKey(for: sealed))
+    _ = try env.learning.finishOperation(env.result(for: operation.id), now: env.now)
+    try env.recordRunFeedback(
+      runId: sealed.runId,
+      signal: .resultNotUseful,
+      updateId: 18
+    )
+    try env.setCurrentFeedbackRevision(0)
+    try env.resetAssignmentCache(runId: sealed.runId, state: .primaryRunSettled)
+    let cacheBefore = try env.assignmentCacheSnapshot(runId: sealed.runId)
+
+    // when / then — removing the source-revision upper bound consumes a future event.
+    #expect {
+      _ = try env.learning.recomputeAssignment(runId: sealed.runId, now: env.now)
+    } throws: { error in
+      guard case StoreError.unexpected = error else {
+        return false
+      }
+      return true
+    }
+    #expect(try env.assignmentCacheSnapshot(runId: sealed.runId) == cacheBefore)
   }
 
   @Test func terminallyIneligibleEvidenceIgnoresResultFeedbackAsQualityEvidence() throws {
@@ -540,14 +732,20 @@ import Testing
     #expect(try env.trialState(trialId: trial.trialId) == .fellBack)
 
     // when
+    let finishedAt = env.now.addingTimeInterval(2)
     _ = try env.learning.finishOperation(
       env.result(for: operation.id),
-      now: env.now.addingTimeInterval(2)
+      now: finishedAt
     )
 
     // then — the current-epoch product may repair history but cannot apply Task 17 transitions.
-    let refreshed = try #require(try env.assignment(runId: sealed.runId))
-    #expect(refreshed.resolvedEvidence?.outcome == .positive)
+    let refreshed = try env.rawResolvedAssignment(runId: sealed.runId)
+    #expect(refreshed.state == .learningOutcomeResolved)
+    #expect(refreshed.outcome == .positive)
+    #expect(refreshed.evaluationDigest == refreshed.sourceEvaluationDigest)
+    #expect(refreshed.evaluationDigest != nil)
+    #expect(refreshed.feedbackRevision == terminalState.feedbackRevision)
+    #expect(refreshed.resolvedAt == finishedAt)
     #expect(try env.trialState(trialId: trial.trialId) == .fellBack)
     #expect(try env.currentLearningState() == terminalState)
   }
@@ -872,14 +1070,30 @@ private struct AssignmentCacheSnapshot: Equatable {
   let values: [DatabaseValue]
 }
 
+private struct RawResolvedAssignment {
+  let state: TrialAssignmentState
+  let outcome: TrialOutcomeKind
+  let evaluationDigest: EvaluationDigest?
+  let sourceEvaluationDigest: EvaluationDigest?
+  let feedbackRevision: FeedbackRevision
+  let resolvedAt: Date
+}
+
 enum AssignmentIdentityCorruption: CaseIterable {
   case assignmentJob
   case assignmentEpoch
   case assignmentGeneration
+  case bindingJob
+  case bindingEpoch
   case bindingTrial
   case bindingGeneration
   case bindingStableDigest
   case bindingEffectiveDigest
+}
+
+enum LiveTrialStateDrift: CaseIterable {
+  case stableDigest
+  case stableRevision
 }
 
 enum EvaluationCorruption: CaseIterable {
@@ -891,11 +1105,61 @@ enum EvaluationCorruption: CaseIterable {
   case evidence
   case outcome
   case issueCodes
+  case duplicateIssueCode
   case rubric
   case prompt
   case schema
   case compatibility
   case createdAt
+}
+
+enum EvidenceReceiptCorruption: CaseIterable {
+  case ineligibleWithPayload
+  case eligibleWithExclusion
+  case exclusionWithWrongEligibility
+  case unknownExclusion
+  case payloadStorageClass
+  case malformedPayload
+  case noncanonicalPayload
+  case payloadSchema
+  case payloadDigest
+  case compactDigest
+}
+
+enum EvaluatorSourceCorruption: CaseIterable {
+  case orphanEvaluation
+  case startedWithEvaluation
+  case failedWithEvaluation
+  case pendingFailure
+  case claimedCallIdentity
+  case startedMissingCarrier
+  case startedMissingRoute
+  case startedMissingProviderCall
+  case startedNegativeTokens
+  case startedNegativeCost
+  case startedClosedReservation
+  case succeededFailure
+  case succeededMissingCarrier
+  case succeededMissingRoute
+  case succeededMissingProviderCall
+  case succeededNonzeroTokens
+  case succeededNonzeroCost
+  case succeededMissingReservation
+  case succeededOpenReservation
+  case failedMissingFailure
+  case failedWrongFailure
+  case failedNoCallWrongFailure
+  case failedNoCallCallIdentity
+  case interruptedFailure
+  case interruptedOpenReservation
+  case unknownFailure
+  case job
+  case epoch
+  case phase
+  case sourceDigest
+  case keyDigest
+  case attemptGeneration
+  case supersedes
 }
 
 enum TrialSnapshotCorruption: CaseIterable {
@@ -1136,10 +1400,63 @@ extension BoundRunEnvironment {
     }
   }
 
+  func setAssignmentFeedbackRevision(runId: Int64, revision: Int64) throws {
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          UPDATE trial_assignments SET effective_feedback_revision = ? WHERE run_id = ?
+          """,
+        arguments: [revision, runId]
+      )
+    }
+  }
+
+  func setCurrentFeedbackRevision(_ revision: Int64) throws {
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE job_learning_state SET feedback_revision = ? WHERE job_id = ?",
+        arguments: [revision, jobId]
+      )
+    }
+  }
+
   func apply(
     _ corruption: AssignmentIdentityCorruption,
     runId: Int64
   ) throws {
+    if case .bindingJob = corruption {
+      let otherJob = try jobs.create(
+        NewScheduledJob(
+          ownerChatId: 777,
+          label: "foreign binding",
+          prompt: "Read a different archive",
+          recurrence: nil,
+          timezone: "Europe/Berlin",
+          nextOccurrence: now
+        ),
+        now: now
+      )
+      try queue.write { db in
+        try db.execute(
+          sql: """
+            INSERT INTO lesson_sets(job_id, digest, schema_version, canonical_bytes, source,
+              created_at)
+            SELECT ?, lesson_sets.digest, lesson_sets.schema_version, lesson_sets.canonical_bytes,
+              lesson_sets.source, lesson_sets.created_at
+            FROM lesson_sets
+            JOIN run_learning_bindings ON run_learning_bindings.effective_digest = lesson_sets.digest
+              AND run_learning_bindings.job_id = lesson_sets.job_id
+            WHERE run_learning_bindings.run_id = ?
+            """,
+          arguments: [otherJob.id, runId]
+        )
+        try db.execute(
+          sql: "UPDATE run_learning_bindings SET job_id = ? WHERE run_id = ?",
+          arguments: [otherJob.id, runId]
+        )
+      }
+      return
+    }
     let mutation: String
     switch corruption {
     case .assignmentJob:
@@ -1149,6 +1466,11 @@ extension BoundRunEnvironment {
     case .assignmentGeneration:
       mutation =
         "UPDATE trial_assignments SET trial_generation = trial_generation + 1 WHERE run_id = ?"
+    case .bindingJob:
+      preconditionFailure("binding job corruption returns after creating its referenced job")
+    case .bindingEpoch:
+      mutation =
+        "UPDATE run_learning_bindings SET learning_epoch = learning_epoch + 1 WHERE run_id = ?"
     case .bindingTrial:
       mutation = "UPDATE run_learning_bindings SET trial_id = trial_id + 1 WHERE run_id = ?"
     case .bindingGeneration:
@@ -1163,6 +1485,31 @@ extension BoundRunEnvironment {
     }
     try queue.write { db in
       try db.execute(sql: mutation, arguments: [runId])
+    }
+  }
+
+  func apply(_ drift: LiveTrialStateDrift) throws {
+    try queue.write { db in
+      switch drift {
+      case .stableDigest:
+        try db.execute(
+          sql: """
+            UPDATE job_learning_state
+            SET stable_lesson_set_digest = (
+              SELECT replacement_digest FROM learning_candidates WHERE job_id = ?
+            )
+            WHERE job_id = ?
+            """,
+          arguments: [jobId, jobId]
+        )
+      case .stableRevision:
+        try db.execute(
+          sql: """
+            UPDATE job_learning_state SET stable_revision = stable_revision + 1 WHERE job_id = ?
+            """,
+          arguments: [jobId]
+        )
+      }
     }
   }
 
@@ -1212,6 +1559,13 @@ extension BoundRunEnvironment {
         try updateEvaluation(db, runId: runId, column: "outcome", value: "unknown")
       case .issueCodes:
         try updateEvaluation(db, runId: runId, column: "issue_codes", value: "[\"z\",\"a\"]")
+      case .duplicateIssueCode:
+        try updateEvaluation(
+          db,
+          runId: runId,
+          column: "issue_codes",
+          value: "[\"duplicate\",\"duplicate\"]"
+        )
       case .rubric:
         try updateEvaluation(db, runId: runId, column: "rubric_version", value: "999")
       case .prompt:
@@ -1241,6 +1595,348 @@ extension BoundRunEnvironment {
           arguments: [runId]
         )
       }
+    }
+  }
+
+  func apply(
+    _ corruption: EvidenceReceiptCorruption,
+    runId: Int64
+  ) throws {
+    try queue.write { db in
+      switch corruption {
+      case .ineligibleWithPayload:
+        try db.execute(
+          sql: "UPDATE learning_evidence SET eligibility = ? WHERE run_id = ?",
+          arguments: [LearningEligibility.transientInfrastructureFailure.rawValue, runId]
+        )
+      case .eligibleWithExclusion:
+        try db.execute(
+          sql: "UPDATE learning_evidence SET exclusion_reason = ? WHERE run_id = ?",
+          arguments: [EvidenceExclusion.staleEpoch.rawValue, runId]
+        )
+      case .exclusionWithWrongEligibility:
+        let eligibility = LearningEligibility.transientInfrastructureFailure
+        let digest = SHA256Digest.hex(
+          "\(EvidenceLimits.schemaVersion):\(runId):\(eligibility.rawValue)"
+        )
+        try db.execute(
+          sql: """
+            UPDATE learning_evidence
+            SET payload = NULL, eligibility = ?, exclusion_reason = ?, evidence_digest = ?
+            WHERE run_id = ?
+            """,
+          arguments: [eligibility.rawValue, EvidenceExclusion.staleEpoch.rawValue, digest, runId]
+        )
+      case .unknownExclusion:
+        try db.execute(
+          sql: "UPDATE learning_evidence SET exclusion_reason = ? WHERE run_id = ?",
+          arguments: ["unknown", runId]
+        )
+      case .payloadStorageClass:
+        try db.execute(
+          sql: "UPDATE learning_evidence SET payload = ? WHERE run_id = ?",
+          arguments: ["not-a-blob", runId]
+        )
+      case .malformedPayload:
+        try replaceEvidencePayload(db, runId: runId, with: Data("{}".utf8))
+      case .noncanonicalPayload:
+        var bytes = try evidencePayloadBytes(db, runId: runId)
+        bytes.append(0x20)
+        try replaceEvidencePayload(db, runId: runId, with: bytes)
+      case .payloadSchema:
+        let bytes = try evidencePayloadBytes(db, runId: runId)
+        guard
+          let json = String(data: bytes, encoding: .utf8),
+          json.contains(EvidenceLimits.schemaVersion)
+        else {
+          throw StoreError.unexpected("fixture evidence payload is unreadable")
+        }
+        let changed = json.replacingOccurrences(
+          of: EvidenceLimits.schemaVersion,
+          with: "evidence/v2"
+        )
+        try replaceEvidencePayload(db, runId: runId, with: Data(changed.utf8))
+      case .payloadDigest:
+        try db.execute(
+          sql: "UPDATE learning_evidence SET evidence_digest = ? WHERE run_id = ?",
+          arguments: [String(repeating: "f", count: 64), runId]
+        )
+      case .compactDigest:
+        try db.execute(
+          sql: """
+            UPDATE learning_evidence
+            SET payload = NULL, eligibility = ?, exclusion_reason = NULL
+            WHERE run_id = ?
+            """,
+          arguments: [LearningEligibility.insufficientEvidence.rawValue, runId]
+        )
+      }
+    }
+  }
+
+  func apply(
+    _ corruption: EvaluatorSourceCorruption,
+    operationId: LearningOperationID,
+    runId: Int64
+  ) throws {
+    try queue.write { db in
+      switch corruption {
+      case .orphanEvaluation:
+        try db.execute(
+          sql: "DELETE FROM learning_operations WHERE operation_id = ?",
+          arguments: [operationId.rawValue]
+        )
+      case .startedWithEvaluation:
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: [
+            "state": LearningOperationState.started.rawValue,
+            "reservation_state": LearningReservationState.open.rawValue,
+            "reserved_tokens": 1,
+            "reserved_cost_usd": 1.0,
+          ]
+        )
+      case .failedWithEvaluation:
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: [
+            "state": LearningOperationState.failed.rawValue,
+            "failure_code": LearningOperationFailure.providerTerminal.rawValue,
+          ]
+        )
+      case .pendingFailure:
+        try makeNoCallOperation(
+          db,
+          id: operationId,
+          runId: runId,
+          state: .pending,
+          failure: .budgetDenied,
+          retainEvaluation: false
+        )
+      case .claimedCallIdentity:
+        try db.execute(
+          sql: "DELETE FROM learning_evaluations WHERE run_id = ?",
+          arguments: [runId]
+        )
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: ["state": LearningOperationState.claimed.rawValue]
+        )
+      case .startedMissingCarrier:
+        try db.execute(
+          sql: "DELETE FROM learning_evaluations WHERE run_id = ?",
+          arguments: [runId]
+        )
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: [
+            "state": LearningOperationState.started.rawValue,
+            "carrier_digest": nil,
+            "reservation_state": LearningReservationState.open.rawValue,
+          ]
+        )
+      case .startedMissingRoute:
+        try makeStartedOperationCorruption(
+          db,
+          id: operationId,
+          runId: runId,
+          assignments: ["route": nil]
+        )
+      case .startedMissingProviderCall:
+        try makeStartedOperationCorruption(
+          db,
+          id: operationId,
+          runId: runId,
+          assignments: ["provider_call_id": nil]
+        )
+      case .startedNegativeTokens:
+        try makeStartedOperationCorruption(
+          db,
+          id: operationId,
+          runId: runId,
+          assignments: ["reserved_tokens": -1]
+        )
+      case .startedNegativeCost:
+        try makeStartedOperationCorruption(
+          db,
+          id: operationId,
+          runId: runId,
+          assignments: ["reserved_cost_usd": -1.0]
+        )
+      case .startedClosedReservation:
+        try db.execute(
+          sql: "DELETE FROM learning_evaluations WHERE run_id = ?",
+          arguments: [runId]
+        )
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: ["state": LearningOperationState.started.rawValue]
+        )
+      case .succeededFailure:
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: ["failure_code": LearningOperationFailure.providerTerminal.rawValue]
+        )
+      case .succeededMissingCarrier:
+        try updateOperation(db, id: operationId, assignments: ["carrier_digest": nil])
+      case .succeededMissingRoute:
+        try updateOperation(db, id: operationId, assignments: ["route": nil])
+      case .succeededMissingProviderCall:
+        try updateOperation(db, id: operationId, assignments: ["provider_call_id": nil])
+      case .succeededNonzeroTokens:
+        try updateOperation(db, id: operationId, assignments: ["reserved_tokens": 1])
+      case .succeededNonzeroCost:
+        try updateOperation(db, id: operationId, assignments: ["reserved_cost_usd": 1.0])
+      case .succeededMissingReservation:
+        try updateOperation(db, id: operationId, assignments: ["reservation_state": nil])
+      case .succeededOpenReservation:
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: ["reservation_state": LearningReservationState.open.rawValue]
+        )
+      case .failedMissingFailure:
+        try db.execute(
+          sql: "DELETE FROM learning_evaluations WHERE run_id = ?",
+          arguments: [runId]
+        )
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: [
+            "state": LearningOperationState.failed.rawValue,
+            "failure_code": nil,
+          ]
+        )
+      case .failedWrongFailure:
+        try db.execute(
+          sql: "DELETE FROM learning_evaluations WHERE run_id = ?",
+          arguments: [runId]
+        )
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: [
+            "state": LearningOperationState.failed.rawValue,
+            "failure_code": LearningOperationFailure.budgetDenied.rawValue,
+          ]
+        )
+      case .failedNoCallWrongFailure:
+        try makeNoCallOperation(
+          db,
+          id: operationId,
+          runId: runId,
+          state: .failedNoCall,
+          failure: .providerTerminal,
+          retainEvaluation: false
+        )
+      case .failedNoCallCallIdentity:
+        try db.execute(
+          sql: "DELETE FROM learning_evaluations WHERE run_id = ?",
+          arguments: [runId]
+        )
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: [
+            "state": LearningOperationState.failedNoCall.rawValue,
+            "failure_code": LearningOperationFailure.budgetDenied.rawValue,
+          ]
+        )
+      case .interruptedFailure:
+        try db.execute(
+          sql: "DELETE FROM learning_evaluations WHERE run_id = ?",
+          arguments: [runId]
+        )
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: [
+            "state": LearningOperationState.interruptedUnknown.rawValue,
+            "failure_code": LearningOperationFailure.providerTerminal.rawValue,
+          ]
+        )
+      case .interruptedOpenReservation:
+        try db.execute(
+          sql: "DELETE FROM learning_evaluations WHERE run_id = ?",
+          arguments: [runId]
+        )
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: [
+            "state": LearningOperationState.interruptedUnknown.rawValue,
+            "reservation_state": LearningReservationState.open.rawValue,
+          ]
+        )
+      case .unknownFailure:
+        try db.execute(
+          sql: "DELETE FROM learning_evaluations WHERE run_id = ?",
+          arguments: [runId]
+        )
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: [
+            "state": LearningOperationState.failed.rawValue,
+            "failure_code": "unknown",
+          ]
+        )
+      case .job:
+        try updateOperation(db, id: operationId, assignments: ["job_id": jobId + 1])
+      case .epoch:
+        try updateOperation(db, id: operationId, assignments: ["learning_epoch": 2])
+      case .phase:
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: ["phase": LearningPhase.reflector.rawValue]
+        )
+      case .sourceDigest:
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: ["source_digest": String(repeating: "f", count: 64)]
+        )
+      case .keyDigest:
+        try updateOperation(
+          db,
+          id: operationId,
+          assignments: ["key_digest": String(repeating: "f", count: 64)]
+        )
+      case .attemptGeneration:
+        try updateOperation(db, id: operationId, assignments: ["attempt_generation": 2])
+      case .supersedes:
+        try updateOperation(db, id: operationId, assignments: ["supersedes": operationId.rawValue])
+      }
+    }
+  }
+
+  func replaceInterruptedOperationWithFailed(_ id: LearningOperationID) throws {
+    try queue.write { db in
+      try updateOperation(
+        db,
+        id: id,
+        assignments: [
+          "state": LearningOperationState.failed.rawValue,
+          "failure_code": LearningOperationFailure.providerTerminal.rawValue,
+        ]
+      )
+    }
+  }
+
+  func removeEvidencePayload(runId: Int64) throws {
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE learning_evidence SET payload = NULL WHERE run_id = ?",
+        arguments: [runId]
+      )
     }
   }
 
@@ -1338,6 +2034,54 @@ extension BoundRunEnvironment {
     }
   }
 
+  fileprivate func rawResolvedAssignment(runId: Int64) throws -> RawResolvedAssignment {
+    try queue.read { db in
+      guard
+        let row = try Row.fetchOne(
+          db,
+          sql: """
+            SELECT assignment.state, assignment.outcome, assignment.evaluation_digest,
+              assignment.effective_feedback_revision, assignment.resolved_at,
+              evaluation.evaluation_digest AS source_evaluation_digest
+            FROM trial_assignments AS assignment
+            LEFT JOIN learning_evaluations AS evaluation ON evaluation.run_id = assignment.run_id
+            WHERE assignment.run_id = ?
+            """,
+          arguments: [runId]
+        ),
+        let stateRaw = SQLiteStoredValue.string(in: row, column: "state"),
+        let state = TrialAssignmentState(rawValue: stateRaw),
+        let outcomeRaw = SQLiteStoredValue.string(in: row, column: "outcome"),
+        let outcome = TrialOutcomeKind(rawValue: outcomeRaw),
+        let evaluationRaw = SQLiteStoredValue.nullableString(
+          in: row,
+          column: "evaluation_digest"
+        ),
+        let sourceRaw = SQLiteStoredValue.nullableString(
+          in: row,
+          column: "source_evaluation_digest"
+        ),
+        let feedbackRaw = SQLiteStoredValue.int64(
+          in: row,
+          column: "effective_feedback_revision"
+        ),
+        feedbackRaw >= 0,
+        let resolvedRaw = SQLiteStoredValue.int64(in: row, column: "resolved_at"),
+        let resolvedAt = EpochSecondCodec.date(fromEpoch: resolvedRaw)
+      else {
+        throw StoreError.unexpected("fixture assignment cache is not resolved")
+      }
+      return RawResolvedAssignment(
+        state: state,
+        outcome: outcome,
+        evaluationDigest: evaluationRaw.value.map(EvaluationDigest.init(rawValue:)),
+        sourceEvaluationDigest: sourceRaw.value.map(EvaluationDigest.init(rawValue:)),
+        feedbackRevision: FeedbackRevision(feedbackRaw),
+        resolvedAt: resolvedAt
+      )
+    }
+  }
+
   func feedbackEventCount() throws -> Int {
     try queue.read { db in
       try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM feedback_events") ?? -1
@@ -1382,6 +2126,96 @@ extension BoundRunEnvironment {
     try db.execute(
       sql: "UPDATE learning_evaluations SET \(column) = ? WHERE run_id = ?",
       arguments: [value, runId]
+    )
+  }
+
+  private func evidencePayloadBytes(_ db: Database, runId: Int64) throws -> Data {
+    guard
+      let bytes = try Data.fetchOne(
+        db,
+        sql: "SELECT payload FROM learning_evidence WHERE run_id = ?",
+        arguments: [runId]
+      )
+    else {
+      throw StoreError.unexpected("fixture evidence payload is missing")
+    }
+    return bytes
+  }
+
+  private func replaceEvidencePayload(
+    _ db: Database,
+    runId: Int64,
+    with bytes: Data
+  ) throws {
+    try db.execute(
+      sql: "UPDATE learning_evidence SET payload = ?, evidence_digest = ? WHERE run_id = ?",
+      arguments: [bytes, SHA256Digest.hex(bytes), runId]
+    )
+  }
+
+  private func makeNoCallOperation(
+    _ db: Database,
+    id: LearningOperationID,
+    runId: Int64,
+    state: LearningOperationState,
+    failure: LearningOperationFailure,
+    retainEvaluation: Bool
+  ) throws {
+    if retainEvaluation == false {
+      try db.execute(
+        sql: "DELETE FROM learning_evaluations WHERE run_id = ?",
+        arguments: [runId]
+      )
+    }
+    try updateOperation(
+      db,
+      id: id,
+      assignments: [
+        "state": state.rawValue,
+        "failure_code": failure.rawValue,
+        "carrier_digest": nil,
+        "route": nil,
+        "provider_call_id": nil,
+        "reserved_tokens": 0,
+        "reserved_cost_usd": 0.0,
+        "reservation_state": LearningReservationState.closed.rawValue,
+      ]
+    )
+  }
+
+  private func makeStartedOperationCorruption(
+    _ db: Database,
+    id: LearningOperationID,
+    runId: Int64,
+    assignments: [String: (any DatabaseValueConvertible)?]
+  ) throws {
+    try db.execute(
+      sql: "DELETE FROM learning_evaluations WHERE run_id = ?",
+      arguments: [runId]
+    )
+    var source = assignments
+    source["state"] = LearningOperationState.started.rawValue
+    source["reservation_state"] =
+      source["reservation_state"] ?? LearningReservationState.open.rawValue
+    try updateOperation(db, id: id, assignments: source)
+  }
+
+  private func updateOperation(
+    _ db: Database,
+    id: LearningOperationID,
+    assignments: [String: (any DatabaseValueConvertible)?]
+  ) throws {
+    let ordered = assignments.sorted { left, right in
+      left.key < right.key
+    }
+    let columns = ordered.map { assignment in
+      "\(assignment.key) = ?"
+    }.joined(separator: ", ")
+    var arguments = StatementArguments(ordered.map(\.value))
+    arguments += [id.rawValue]
+    try db.execute(
+      sql: "UPDATE learning_operations SET \(columns) WHERE operation_id = ?",
+      arguments: arguments
     )
   }
 }

--- a/Tests/ClawDataTests/Stores/Learning/TrialSerializationTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/TrialSerializationTests.swift
@@ -1,0 +1,231 @@
+import ClawCore
+import ClawTestSupport
+import Dispatch
+import Foundation
+import GRDB
+import Synchronization
+import Testing
+
+@testable import ClawData
+
+@Suite struct TrialSerializationTests {
+  @Test func recomputeThenResetCommitsOnlyTheSerializedOldEpochProjection() async throws {
+    // given
+    let gate = SQLiteTransactionGate()
+    let fixture = try pooledTrialEnvironment(prefix: "claw-trial-recompute-reset", gate: gate)
+    defer {
+      gate.release()
+      try? FileManager.default.removeItem(atPath: fixture.path)
+    }
+    try fixture.env.installTrial()
+    let evidence = try fixture.env.sealedTrialEvidence()
+    try fixture.env.resetAssignmentCache(runId: evidence.runId, state: .created)
+    try await fixture.env.queue.write { db in
+      try db.execute(
+        sql: """
+          CREATE TRIGGER hold_task16_recompute
+          BEFORE UPDATE OF state ON trial_assignments
+          WHEN OLD.run_id = \(evidence.runId)
+          BEGIN SELECT task16_hold(); END
+          """
+      )
+    }
+    let learning = fixture.env.learning
+    let jobId = fixture.env.jobId
+    let now = fixture.env.now
+
+    // when
+    let recomputationTask = Task.detached {
+      try learning.recomputeAssignment(runId: evidence.runId, now: now)
+    }
+    await gate.entered.wait()
+    let resetTask = Task.detached {
+      try learning.applyReset(updateId: 9_160, jobId: jobId, now: now.addingTimeInterval(1))
+    }
+    gate.release()
+    let recomputation = try await recomputationTask.value
+    let reset = try await resetTask.value
+
+    // then — moving the projection after its writer transaction would let it cross the reset epoch.
+    guard case .updated(let assignment) = recomputation else {
+      Issue.record("expected the first serialized writer to refresh the old-epoch cache")
+      return
+    }
+    guard case .applied(let receipt)? = reset.outcome else {
+      Issue.record("expected reset to apply after recomputation")
+      return
+    }
+    #expect(assignment.state == .primaryRunSettled)
+    #expect(receipt.result.newEpoch == LearningEpoch(2))
+    #expect(try fixture.env.currentLearningState().epoch == LearningEpoch(2))
+    #expect(try fixture.env.assignmentState(runId: evidence.runId) == .primaryRunSettled)
+    #expect(try fixture.env.trialState() == .closed)
+  }
+
+  @Test func resetThenRecomputeRejectsTheOldEpochWithoutWritingItsCache() async throws {
+    // given
+    let gate = SQLiteTransactionGate()
+    let fixture = try pooledTrialEnvironment(prefix: "claw-trial-reset-recompute", gate: gate)
+    defer {
+      gate.release()
+      try? FileManager.default.removeItem(atPath: fixture.path)
+    }
+    try fixture.env.installTrial()
+    let evidence = try fixture.env.sealedTrialEvidence()
+    try fixture.env.resetAssignmentCache(runId: evidence.runId, state: .created)
+    try await fixture.env.queue.write { db in
+      try db.execute(
+        sql: """
+          CREATE TRIGGER hold_task16_reset
+          BEFORE UPDATE OF learning_epoch ON job_learning_state
+          WHEN OLD.job_id = \(fixture.env.jobId)
+          BEGIN SELECT task16_hold(); END
+          """
+      )
+    }
+    let learning = fixture.env.learning
+    let jobId = fixture.env.jobId
+    let now = fixture.env.now
+
+    // when
+    let resetTask = Task.detached {
+      try learning.applyReset(updateId: 9_161, jobId: jobId, now: now.addingTimeInterval(1))
+    }
+    await gate.entered.wait()
+    let recomputationTask = Task.detached {
+      try learning.recomputeAssignment(runId: evidence.runId, now: now.addingTimeInterval(2))
+    }
+    gate.release()
+    let reset = try await resetTask.value
+    let recomputation = try await recomputationTask.value
+
+    // then — removing the current-epoch fence lets an old assignment overwrite cache after reset.
+    guard case .applied(let receipt)? = reset.outcome else {
+      Issue.record("expected reset to win the serialized writer order")
+      return
+    }
+    #expect(receipt.result.newEpoch == LearningEpoch(2))
+    #expect(recomputation == .stale)
+    #expect(try fixture.env.assignmentState(runId: evidence.runId) == .created)
+    #expect(try fixture.env.trialState() == .closed)
+  }
+
+  @Test func admissionQueuedBehindTheThirdFireStillSeesOneLiveDrainingTrial() async throws {
+    // given
+    let gate = SQLiteTransactionGate()
+    let fixture = try pooledTrialEnvironment(prefix: "claw-trial-admission-drain", gate: gate)
+    defer {
+      gate.release()
+      try? FileManager.default.removeItem(atPath: fixture.path)
+    }
+    let admission = AdmissionStoreFixture(path: fixture.path, env: fixture.env)
+    let candidate = try admission.persistedCandidate()
+    try fixture.env.installTrial()
+    try fixture.env.makeRepeatable()
+    _ = try fixture.env.settledBoundRun()
+    _ = try fixture.env.settledBoundRun()
+    try await fixture.env.queue.write { db in
+      try db.execute(
+        sql: """
+          CREATE TRIGGER hold_task16_third_fire
+          BEFORE UPDATE OF consumed_assignments ON learning_trials
+          WHEN NEW.consumed_assignments = 3
+          BEGIN SELECT task16_hold(); END
+          """
+      )
+    }
+    let env = fixture.env
+
+    // when
+    let fireTask = Task.detached {
+      try env.pendingBoundRun()
+    }
+    await gate.entered.wait()
+    let admissionTask = Task.detached {
+      try env.learning.admitCandidate(
+        digest: candidate.digest,
+        redactor: SecretRedactor(secretValues: []),
+        now: env.now.addingTimeInterval(1)
+      )
+    }
+    gate.release()
+    _ = try await fireTask.value
+    let outcome = try await admissionTask.value
+
+    // then — an open-only lookup or index can admit a second experiment after the drain commits.
+    #expect(outcome == .rejected(.trialAlreadyLive))
+    #expect(try env.trialState() == .draining)
+    #expect(try env.liveTrialCount() == 1)
+  }
+}
+
+private struct PooledTrialEnvironment {
+  let path: String
+  let env: BoundRunEnvironment
+}
+
+private func pooledTrialEnvironment(
+  prefix: String,
+  gate: SQLiteTransactionGate
+) throws -> PooledTrialEnvironment {
+  let path = makeTempDatabasePath(prefix: prefix)
+  var configuration = ClawDatabase.makeConfiguration()
+  configuration.prepareDatabase { db in
+    db.add(
+      function: DatabaseFunction("task16_hold", argumentCount: 0) { _ in
+        gate.hold()
+        return 0
+      }
+    )
+  }
+  let pool = try DatabasePool(path: path, configuration: configuration)
+  return PooledTrialEnvironment(path: path, env: try BoundRunEnvironment.make(writer: pool))
+}
+
+private final class SQLiteTransactionGate: @unchecked Sendable {
+  let entered = AsyncGate()
+
+  private let semaphore = DispatchSemaphore(value: 0)
+  private let released = Mutex(false)
+
+  func hold() {
+    entered.open()
+    semaphore.wait()
+  }
+
+  func release() {
+    let shouldSignal = released.withLock { state in
+      guard state == false else {
+        return false
+      }
+      state = true
+      return true
+    }
+    if shouldSignal {
+      semaphore.signal()
+    }
+  }
+}
+
+private extension BoundRunEnvironment {
+  func trialState() throws -> LearningTrialState? {
+    try queue.read { db in
+      let raw = try String.fetchOne(
+        db,
+        sql: "SELECT state FROM learning_trials WHERE job_id = ? ORDER BY trial_id LIMIT 1",
+        arguments: [jobId]
+      )
+      return raw.flatMap(LearningTrialState.init(rawValue:))
+    }
+  }
+
+  func liveTrialCount() throws -> Int {
+    try queue.read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM learning_trials WHERE state IN (?, ?)",
+        arguments: [LearningTrialState.open.rawValue, LearningTrialState.draining.rawValue]
+      ) ?? -1
+    }
+  }
+}

--- a/Tests/ClawDataTests/Stores/Learning/TrialSerializationTests.swift
+++ b/Tests/ClawDataTests/Stores/Learning/TrialSerializationTests.swift
@@ -35,11 +35,11 @@ import Testing
     let now = fixture.env.now
 
     // when
-    let recomputationTask = Task.detached {
+    let recomputationTask = databaseTask {
       try learning.recomputeAssignment(runId: evidence.runId, now: now)
     }
     await gate.entered.wait()
-    let resetTask = Task.detached {
+    let resetTask = databaseTask {
       try learning.applyReset(updateId: 9_160, jobId: jobId, now: now.addingTimeInterval(1))
     }
     gate.release()
@@ -88,11 +88,11 @@ import Testing
     let now = fixture.env.now
 
     // when
-    let resetTask = Task.detached {
+    let resetTask = databaseTask {
       try learning.applyReset(updateId: 9_161, jobId: jobId, now: now.addingTimeInterval(1))
     }
     await gate.entered.wait()
-    let recomputationTask = Task.detached {
+    let recomputationTask = databaseTask {
       try learning.recomputeAssignment(runId: evidence.runId, now: now.addingTimeInterval(2))
     }
     gate.release()
@@ -137,11 +137,11 @@ import Testing
     let env = fixture.env
 
     // when
-    let fireTask = Task.detached {
+    let fireTask = databaseTask {
       try env.pendingBoundRun()
     }
     await gate.entered.wait()
-    let admissionTask = Task.detached {
+    let admissionTask = databaseTask {
       try env.learning.admitCandidate(
         digest: candidate.digest,
         redactor: SecretRedactor(secretValues: []),
@@ -162,6 +162,18 @@ import Testing
 private struct PooledTrialEnvironment {
   let path: String
   let env: BoundRunEnvironment
+}
+
+private func databaseTask<Value: Sendable>(
+  _ operation: @escaping @Sendable () throws -> Value
+) -> Task<Value, any Error> {
+  Task {
+    try await withCheckedThrowingContinuation { continuation in
+      DispatchQueue.global().async {
+        continuation.resume(with: Result(catching: operation))
+      }
+    }
+  }
 }
 
 private func pooledTrialEnvironment(

--- a/Tests/ClawGatewayTests/Learning/EvaluationRunEnvironment.swift
+++ b/Tests/ClawGatewayTests/Learning/EvaluationRunEnvironment.swift
@@ -341,6 +341,14 @@ final class RecordingLearningStore: ScheduledLearningStore, @unchecked Sendable 
     try base.learningView(jobId: jobId)
   }
 
+  func applyReset(
+    updateId: Int64,
+    jobId: Int64,
+    now: Date
+  ) throws(StoreError) -> ConfirmedLearningResetResult {
+    try base.applyReset(updateId: updateId, jobId: jobId, now: now)
+  }
+
   func createTargets(
     _ targets: [NewFeedbackTarget],
     chunks: [LearningNoticeChunk],

--- a/Tests/ClawGatewayTests/Learning/EvaluationRunEnvironment.swift
+++ b/Tests/ClawGatewayTests/Learning/EvaluationRunEnvironment.swift
@@ -302,28 +302,58 @@ private extension EvaluationRunEnvironment {
 /// `Sendable` wrappers that lean on GRDB's own serialization — and an actor cannot satisfy a
 /// synchronous requirement.
 final class RecordingLearningStore: ScheduledLearningStore, @unchecked Sendable {
+  struct ServiceBehavior: Sendable {
+    let identities: [LearningTrialIdentity]?
+    let trialResults: [Int64: TrialReconciliationResult]
+    let failingTrialIds: Set<Int64>
+    let failEnumeration: Bool
+    let unsealedRunIds: [Int64]?
+    let handledSealRunIds: Set<Int64>
+
+    init(
+      identities: [LearningTrialIdentity]? = nil,
+      trialResults: [Int64: TrialReconciliationResult] = [:],
+      failingTrialIds: Set<Int64> = [],
+      failEnumeration: Bool = false,
+      unsealedRunIds: [Int64]? = nil,
+      handledSealRunIds: Set<Int64> = []
+    ) {
+      self.identities = identities
+      self.trialResults = trialResults
+      self.failingTrialIds = failingTrialIds
+      self.failEnumeration = failEnumeration
+      self.unsealedRunIds = unsealedRunIds
+      self.handledSealRunIds = handledSealRunIds
+    }
+  }
+
   private let lock = NSLock()
   private let base: ScheduledLearningStoreGRDB
   private let supersedes: Bool
   private let admissionFails: Bool
   private let recordsReviewCommits: Bool
   private let failingReviewCandidate: CandidateDigest?
+  private let serviceBehavior: ServiceBehavior
   private var presented: [LearningAuthorization] = []
   private var reviewSubjects: Set<String> = []
   private var admissions = 0
+  private var recordedServiceCalls: [String] = []
+  private var bootReconciliationFails = false
 
   init(
     base: ScheduledLearningStoreGRDB,
     supersedes: Bool = false,
     admissionFails: Bool = false,
     recordsReviewCommits: Bool = false,
-    failingReviewCandidate: CandidateDigest? = nil
+    failingReviewCandidate: CandidateDigest? = nil,
+    serviceBehavior: ServiceBehavior = ServiceBehavior()
   ) {
     self.base = base
     self.supersedes = supersedes
     self.admissionFails = admissionFails
     self.recordsReviewCommits = recordsReviewCommits
     self.failingReviewCandidate = failingReviewCandidate
+    self.serviceBehavior = serviceBehavior
   }
 
   /// Every authorization the runner presented, in order.
@@ -335,6 +365,19 @@ final class RecordingLearningStore: ScheduledLearningStore, @unchecked Sendable 
 
   var admissionAttempts: Int {
     lock.withLock { admissions }
+  }
+
+  var serviceCalls: [String] {
+    lock.withLock { recordedServiceCalls }
+  }
+
+  var failBootReconciliation: Bool {
+    get { lock.withLock { bootReconciliationFails } }
+    set { lock.withLock { bootReconciliationFails = newValue } }
+  }
+
+  func clearServiceCalls() {
+    lock.withLock { recordedServiceCalls.removeAll() }
   }
 
   func learningView(jobId: Int64?) throws(StoreError) -> [JobLearningView] {
@@ -464,6 +507,38 @@ final class RecordingLearningStore: ScheduledLearningStore, @unchecked Sendable 
     try base.openTrial(jobId: jobId)
   }
 
+  func recomputeAssignment(
+    runId: Int64,
+    now: Date
+  ) throws(StoreError) -> AssignmentRecomputation {
+    try base.recomputeAssignment(runId: runId, now: now)
+  }
+
+  func liveTrialIdentities() throws(StoreError) -> [LearningTrialIdentity] {
+    recordServiceCall("live")
+    if serviceBehavior.failEnumeration {
+      throw .unexpected("injected live-trial enumeration failure")
+    }
+    if let identities = serviceBehavior.identities {
+      return identities
+    }
+    return try base.liveTrialIdentities()
+  }
+
+  func reconcileTrial(
+    _ identity: LearningTrialIdentity,
+    now: Date
+  ) throws(StoreError) -> TrialReconciliationResult {
+    recordServiceCall("trial:\(identity.trialId)")
+    if serviceBehavior.failingTrialIds.contains(identity.trialId) {
+      throw .unexpected("injected trial reconciliation failure")
+    }
+    if let result = serviceBehavior.trialResults[identity.trialId] {
+      return result
+    }
+    return try base.reconcileTrial(identity, now: now)
+  }
+
   func settlement(runId: Int64) throws(StoreError) -> RunSettlement? {
     try base.settlement(runId: runId)
   }
@@ -482,12 +557,20 @@ final class RecordingLearningStore: ScheduledLearningStore, @unchecked Sendable 
   }
 
   func unsealed(limit: Int) throws(StoreError) -> [Int64] {
-    try base.unsealed(limit: limit)
+    recordServiceCall("unsealed")
+    if let runIds = serviceBehavior.unsealedRunIds {
+      return runIds
+    }
+    return try base.unsealed(limit: limit)
   }
 
   @discardableResult
   func sealEvidence(runId: Int64, now: Date) throws(StoreError) -> SealOutcome {
-    try base.sealEvidence(runId: runId, now: now)
+    recordServiceCall("seal:\(runId)")
+    if serviceBehavior.handledSealRunIds.contains(runId) {
+      return .alreadySealed
+    }
+    return try base.sealEvidence(runId: runId, now: now)
   }
 
   func evidence(runId: Int64) throws(StoreError) -> SealedEvidence? {
@@ -524,6 +607,16 @@ final class RecordingLearningStore: ScheduledLearningStore, @unchecked Sendable 
 
   @discardableResult
   func reconcileOperationsAtBoot(now: Date) throws(StoreError) -> OperationReconciliation {
-    try base.reconcileOperationsAtBoot(now: now)
+    recordServiceCall("operations")
+    if failBootReconciliation {
+      throw .unexpected("injected operation reconciliation failure")
+    }
+    return try base.reconcileOperationsAtBoot(now: now)
+  }
+}
+
+private extension RecordingLearningStore {
+  func recordServiceCall(_ call: String) {
+    lock.withLock { recordedServiceCalls.append(call) }
   }
 }

--- a/Tests/ClawGatewayTests/Learning/EvaluationRunEnvironment.swift
+++ b/Tests/ClawGatewayTests/Learning/EvaluationRunEnvironment.swift
@@ -337,6 +337,10 @@ final class RecordingLearningStore: ScheduledLearningStore, @unchecked Sendable 
     lock.withLock { admissions }
   }
 
+  func learningView(jobId: Int64?) throws(StoreError) -> [JobLearningView] {
+    try base.learningView(jobId: jobId)
+  }
+
   func createTargets(
     _ targets: [NewFeedbackTarget],
     chunks: [LearningNoticeChunk],

--- a/Tests/ClawGatewayTests/Learning/EvaluationRunEnvironment.swift
+++ b/Tests/ClawGatewayTests/Learning/EvaluationRunEnvironment.swift
@@ -380,6 +380,37 @@ final class RecordingLearningStore: ScheduledLearningStore, @unchecked Sendable 
     lock.withLock { recordedServiceCalls.removeAll() }
   }
 
+  func applyTrialDecision(
+    _ decision: TrialDecision,
+    trial: LearningTrial,
+    feedbackRevision: FeedbackRevision,
+    now: Date
+  ) throws(StoreError) -> DecisionReceipt? {
+    try base.applyTrialDecision(
+      decision,
+      trial: trial,
+      feedbackRevision: feedbackRevision,
+      now: now
+    )
+  }
+
+  func rollback(_ trigger: RollbackTrigger, now: Date) throws(StoreError) -> DecisionReceipt? {
+    try base.rollback(trigger, now: now)
+  }
+
+  func commitPromotionReply(
+    updateId: Int64,
+    target: NewFeedbackTarget,
+    chunks: [LearningNoticeChunk],
+    now: Date
+  ) throws(StoreError) -> PromotionReplyOutcome {
+    try base.commitPromotionReply(updateId: updateId, target: target, chunks: chunks, now: now)
+  }
+
+  func currentPromotion(jobId: Int64) throws(StoreError) -> DecisionReceipt? {
+    try base.currentPromotion(jobId: jobId)
+  }
+
   func learningView(jobId: Int64?) throws(StoreError) -> [JobLearningView] {
     try base.learningView(jobId: jobId)
   }

--- a/Tests/ClawGatewayTests/Learning/LearningSurfaceTests.swift
+++ b/Tests/ClawGatewayTests/Learning/LearningSurfaceTests.swift
@@ -1,0 +1,128 @@
+import ClawCore
+import Foundation
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct LearningSurfaceTests {
+  @Test func detailKeepsDistinctIdentitiesAndBothDeadlines() throws {
+    // given
+    let view = try learningDetailView()
+    let assignmentDeadline = Date(timeIntervalSince1970: 1_782_086_400)
+    let decisionDeadline = Date(timeIntervalSince1970: 1_782_172_800)
+
+    // when
+    let rendered = LearningSurface.render([.readable(view)])
+
+    // then — swapping digest fields or dropping the second deadline loses distinct stored facts.
+    #expect(rendered.contains("candidate digest: \(Self.candidate.rawValue)"))
+    #expect(rendered.contains("trial base digest: \(Self.base.rawValue)"))
+    #expect(
+      rendered.contains("replacement digest: \(view.liveTrial?.replacementDigest.rawValue ?? "")")
+    )
+    #expect(rendered.contains(assignmentDeadline.wallClockMinute(in: Self.zone)))
+    #expect(rendered.contains(decisionDeadline.wallClockMinute(in: Self.zone)))
+    #expect(rendered.contains("assignments: 1 of 3"))
+    #expect(rendered.contains("assignment outcomes: 1 unresolved"))
+    #expect(rendered.contains("decision result trial: 41"))
+    #expect(rendered.contains("decision result generation: 2"))
+    #expect(rendered.contains("  1. Keep facts exact."))
+    #expect(rendered.contains("  2. Preserve order."))
+  }
+
+  @Test func unreadableAndUnarmedStatesDoNotInventLearningFacts() {
+    // given
+    let identity = LearningJobIdentity(
+      jobId: 8,
+      label: "unarmed",
+      status: .paused,
+      timezone: "Europe/Berlin"
+    )
+    let unreadable = UnreadableLearningJob(jobId: 9, validatedLabel: nil)
+
+    // when
+    let unarmedText = LearningSurface.render([.unarmed(identity)])
+    let unreadableText = LearningSurface.render([.unreadable(unreadable)])
+
+    // then — rendering either as a canonical empty stable state would invent an epoch and lessons.
+    #expect(unarmedText.contains("learning state: not created"))
+    #expect(unarmedText.contains("learning epoch") == false)
+    #expect(unreadableText.contains("learning state: unreadable"))
+    #expect(unreadableText.contains("unknown label"))
+  }
+
+  @Test func listPreservesStoreOrderAndKeepsUnreadableRowsVisible() throws {
+    // given
+    let readable = try learningDetailView()
+    let unreadable = UnreadableLearningJob(jobId: 72, validatedLabel: "damaged")
+
+    // when
+    let rendered = LearningSurface.render(
+      [.readable(readable), .unreadable(unreadable)],
+      style: .list
+    )
+
+    // then — filtering semantic corruption hides an armed job from the owner.
+    let lines = rendered.split(separator: "\n")
+    #expect(lines.first?.hasPrefix("7 · digest") == true)
+    #expect(lines.last?.hasPrefix("72 · damaged · learning state unreadable") == true)
+  }
+}
+
+private extension LearningSurfaceTests {
+  static let base = LessonSetDigest(rawValue: String(repeating: "a", count: 64))
+  static let candidate = CandidateDigest(rawValue: String(repeating: "b", count: 64))
+  static let replacement = LessonSetDigest(rawValue: String(repeating: "c", count: 64))
+  static let zone = TimeZone(identifier: "Europe/Berlin") ?? .gmt
+
+  func learningDetailView() throws -> ReadableJobLearningView {
+    let lessons = try LessonSet.canonical(
+      jobId: 7,
+      lessons: ["Keep facts exact.", "Preserve order."]
+    )
+    let trial = LearningTrialView(
+      trialId: 41,
+      epoch: LearningEpoch(3),
+      generation: 2,
+      state: .draining,
+      candidateDigest: Self.candidate,
+      baseDigest: Self.base,
+      baseRevision: StableRevision(6),
+      replacementDigest: Self.replacement,
+      counts: LearningTrialCounts(consumed: 1, maximum: 3, unresolved: 1),
+      assignmentDeadline: Date(timeIntervalSince1970: 1_782_086_400),
+      decisionDeadline: Date(timeIntervalSince1970: 1_782_172_800)
+    )
+    let receipt = AdmissionReceipt(
+      candidateDigest: Self.candidate,
+      replacementDigest: Self.replacement,
+      trialId: 41,
+      generation: 2
+    )
+    let decision = LearningDecisionView(
+      decisionId: 13,
+      jobId: 7,
+      epoch: LearningEpoch(3),
+      algorithm: .v1,
+      decidedAt: Date(timeIntervalSince1970: 1_782_000_600),
+      detail: .candidateAdmission(
+        inputs: AdmissionDecisionInputs(candidateDigest: Self.candidate),
+        result: receipt
+      )
+    )
+    return ReadableJobLearningView(
+      job: LearningJobIdentity(
+        jobId: 7,
+        label: "digest",
+        status: .active,
+        timezone: Self.zone.identifier
+      ),
+      epoch: LearningEpoch(3),
+      stableRevision: StableRevision(6),
+      stableLessons: lessons,
+      liveTrial: trial,
+      lastDecision: decision,
+      warnings: [.trialPointerMismatch]
+    )
+  }
+}

--- a/Tests/ClawGatewayTests/Learning/LearningSurfaceTests.swift
+++ b/Tests/ClawGatewayTests/Learning/LearningSurfaceTests.swift
@@ -22,8 +22,10 @@ import Testing
     )
     #expect(rendered.contains(assignmentDeadline.wallClockMinute(in: Self.zone)))
     #expect(rendered.contains(decisionDeadline.wallClockMinute(in: Self.zone)))
-    #expect(rendered.contains("assignments: 1 of 3"))
-    #expect(rendered.contains("assignment outcomes: 1 unresolved"))
+    #expect(rendered.contains("assignments: 10 of 12"))
+    #expect(
+      rendered.contains("assignment outcomes: 1 positive, 2 negative, 3 neutral, 4 unresolved")
+    )
     #expect(rendered.contains("decision result trial: 41"))
     #expect(rendered.contains("decision result generation: 2"))
     #expect(rendered.contains("  1. Keep facts exact."))
@@ -35,6 +37,9 @@ import Testing
 
     // then — omitting warnings from the compact projection hides a known integrity mismatch.
     #expect(listed.contains("warning"))
+    #expect(
+      listed.contains("assignment outcomes: 1 positive, 2 negative, 3 neutral, 4 unresolved")
+    )
   }
 
   @Test func unreadableAndUnarmedStatesDoNotInventLearningFacts() {
@@ -171,7 +176,14 @@ private extension LearningSurfaceTests {
       baseDigest: Self.base,
       baseRevision: StableRevision(6),
       replacementDigest: Self.replacement,
-      counts: LearningTrialCounts(consumed: 1, maximum: 3, unresolved: 1),
+      counts: LearningTrialCounts(
+        consumed: 10,
+        maximum: 12,
+        positive: 1,
+        negative: 2,
+        neutral: 3,
+        unresolved: 4
+      ),
       assignmentDeadline: Date(timeIntervalSince1970: 1_782_086_400),
       decisionDeadline: Date(timeIntervalSince1970: 1_782_172_800)
     )

--- a/Tests/ClawGatewayTests/Learning/LearningSurfaceTests.swift
+++ b/Tests/ClawGatewayTests/Learning/LearningSurfaceTests.swift
@@ -74,6 +74,81 @@ import Testing
     #expect(lines.first?.hasPrefix("7 · digest") == true)
     #expect(lines.last?.hasPrefix("72 · damaged · learning state unreadable") == true)
   }
+
+  @Test func resetDecisionRendersOnlySafeBarrierFactsAndCounts() {
+    // given
+    let empty = LessonSet.empty(jobId: 7)
+    let inputs = LearningResetDecisionInputs(
+      oldEpoch: LearningEpoch(3),
+      oldStableDigest: Self.base,
+      oldStableRevision: StableRevision(6),
+      feedbackRevisionAtCut: FeedbackRevision(9),
+      priorOpenTrialId: 41
+    )
+    let result = LearningResetDecisionResult(
+      newEpoch: LearningEpoch(4),
+      emptyStableDigest: empty.digest,
+      newStableRevision: StableRevision(7),
+      closedTrials: [
+        ResetTrialIdentity(
+          trialId: 41,
+          jobId: 7,
+          epoch: LearningEpoch(3),
+          generation: 2,
+          baseDigest: Self.base,
+          candidateDigest: Self.candidate,
+          algorithm: .v1
+        )
+      ],
+      invalidatedTargetCount: 5,
+      invalidatedChallengeCount: 2,
+      staleNoCallOperationIds: [LearningOperationID(rawValue: "opaque-stale-id")],
+      inFlightOperationIds: [LearningOperationID(rawValue: "opaque-flight-id")]
+    )
+    let view = ReadableJobLearningView(
+      job: LearningJobIdentity(
+        jobId: 7,
+        label: "digest",
+        status: .active,
+        timezone: Self.zone.identifier
+      ),
+      epoch: result.newEpoch,
+      stableRevision: result.newStableRevision,
+      stableLessons: empty,
+      liveTrial: nil,
+      lastDecision: LearningDecisionView(
+        decisionId: 14,
+        jobId: 7,
+        epoch: result.newEpoch,
+        algorithm: .v1,
+        decidedAt: Date(timeIntervalSince1970: 1_782_000_600),
+        detail: .learningReset(inputs: inputs, result: result)
+      ),
+      warnings: []
+    )
+
+    // when
+    let rendered = LearningSurface.render([.readable(view)])
+
+    // then — rendering raw receipt identities would expose opaque operation ids without adding
+    // owner value; the category counts and epoch transition are the useful safe projection.
+    #expect(rendered.contains("decision kind: \(ResetReceipt.kind)"))
+    #expect(rendered.contains("reset old epoch: 3"))
+    #expect(rendered.contains("reset new epoch: 4"))
+    #expect(rendered.contains("reset old stable digest: \(Self.base.rawValue)"))
+    #expect(rendered.contains("reset empty stable digest: \(empty.digest.rawValue)"))
+    #expect(rendered.contains("reset old stable revision: 6"))
+    #expect(rendered.contains("reset new stable revision: 7"))
+    #expect(rendered.contains("reset feedback revision: 9"))
+    #expect(rendered.contains("reset prior live trial: 41"))
+    #expect(rendered.contains("reset closed trials: 1"))
+    #expect(rendered.contains("reset invalidated targets: 5"))
+    #expect(rendered.contains("reset invalidated challenges: 2"))
+    #expect(rendered.contains("reset abandoned calls: 1"))
+    #expect(rendered.contains("reset in-flight calls: 1"))
+    #expect(rendered.contains("opaque-stale-id") == false)
+    #expect(rendered.contains("opaque-flight-id") == false)
+  }
 }
 
 private extension LearningSurfaceTests {

--- a/Tests/ClawGatewayTests/Learning/LearningSurfaceTests.swift
+++ b/Tests/ClawGatewayTests/Learning/LearningSurfaceTests.swift
@@ -28,6 +28,13 @@ import Testing
     #expect(rendered.contains("decision result generation: 2"))
     #expect(rendered.contains("  1. Keep facts exact."))
     #expect(rendered.contains("  2. Preserve order."))
+    #expect(rendered.contains("warning: stored trial pointer does not match the live trial"))
+
+    // when
+    let listed = LearningSurface.render([.readable(view)], style: .list)
+
+    // then — omitting warnings from the compact projection hides a known integrity mismatch.
+    #expect(listed.contains("warning"))
   }
 
   @Test func unreadableAndUnarmedStatesDoNotInventLearningFacts() {

--- a/Tests/ClawGatewayTests/Learning/TrialSweepTests.swift
+++ b/Tests/ClawGatewayTests/Learning/TrialSweepTests.swift
@@ -1,0 +1,278 @@
+import ClawCore
+import ClawTestSupport
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+@testable import ClawGateway
+
+@Suite struct TrialSweepTests {
+  @Test func periodicSweepDrainsPausedTrialAndReturnsDeadlineRecommendation() async throws {
+    // given
+    let fixture = try TrialSweepFixture.make()
+    let service = ScheduledLearningService(
+      store: fixture.learning,
+      logger: TestLog.silent
+    )
+
+    // when
+    let first = await service.reconcileTrials(now: fixture.assignmentDeadline)
+    let second = await service.reconcileTrials(now: fixture.assignmentDeadline)
+
+    // then — a future fire is not required to close exposure, and retry does not drain twice.
+    #expect(first.count == 1)
+    #expect(first.first?.identity == fixture.identity)
+    #expect(first.first?.didDrain == true)
+    #expect(first.first?.decision == .fallback(reason: .insufficientSupport))
+    #expect(second.count == 1)
+    #expect(second.first?.didDrain == false)
+    #expect(second.first?.decision == .fallback(reason: .insufficientSupport))
+    #expect(try fixture.trialState() == .draining)
+  }
+
+  @Test func periodicAndBootPassesKeepExactSealingAndOperationOrder() async throws {
+    // given
+    let base = try emptyStore()
+    let identity = trialIdentity(id: 11, jobId: 4)
+    let reconciliation = TrialReconciliation(
+      identity: identity,
+      didDrain: false,
+      assignments: [],
+      decision: .wait
+    )
+    let behavior = RecordingLearningStore.ServiceBehavior(
+      identities: [identity],
+      trialResults: [identity.trialId: .reconciled(reconciliation)],
+      unsealedRunIds: [91],
+      handledSealRunIds: [91]
+    )
+    let recording = RecordingLearningStore(base: base, serviceBehavior: behavior)
+    let service = ScheduledLearningService(store: recording, logger: TestLog.silent)
+
+    // when
+    await service.sweep(now: Date(timeIntervalSince1970: 10))
+
+    // then — enumerating before sealing can reconcile a source snapshot the same pass changes.
+    #expect(recording.serviceCalls == ["unsealed", "seal:91", "live", "trial:11"])
+
+    // when
+    recording.clearServiceCalls()
+    recording.failBootReconciliation = true
+    await service.reconcileAtBoot(now: Date(timeIntervalSince1970: 11))
+
+    // then — operation failure is isolated; boot still seals before using the same trial pass.
+    #expect(
+      recording.serviceCalls
+        == ["operations", "unsealed", "seal:91", "live", "trial:11"]
+    )
+  }
+
+  @Test func oneTrialFailureDoesNotBlockLaterTrialsAndStaleIsDropped() async throws {
+    // given
+    let base = try emptyStore()
+    let first = trialIdentity(id: 21, jobId: 5)
+    let stale = trialIdentity(id: 22, jobId: 6)
+    let last = trialIdentity(id: 23, jobId: 7)
+    let expected = TrialReconciliation(
+      identity: last,
+      didDrain: false,
+      assignments: [],
+      decision: .wait
+    )
+    let behavior = RecordingLearningStore.ServiceBehavior(
+      identities: [first, stale, last],
+      trialResults: [
+        stale.trialId: .stale,
+        last.trialId: .reconciled(expected),
+      ],
+      failingTrialIds: [first.trialId]
+    )
+    let recording = RecordingLearningStore(base: base, serviceBehavior: behavior)
+    let service = ScheduledLearningService(store: recording, logger: TestLog.silent)
+
+    // when
+    let results = await service.reconcileTrials(now: Date(timeIntervalSince1970: 12))
+
+    // then — aborting on the first mapped error loses the healthy later trial.
+    #expect(results == [expected])
+    #expect(recording.serviceCalls == ["live", "trial:21", "trial:22", "trial:23"])
+  }
+
+  @Test func trialEnumerationFailureReturnsEmptyWithoutAttemptingAnIdentity() async throws {
+    // given
+    let recording = RecordingLearningStore(
+      base: try emptyStore(),
+      serviceBehavior: RecordingLearningStore.ServiceBehavior(failEnumeration: true)
+    )
+    let service = ScheduledLearningService(store: recording, logger: TestLog.silent)
+
+    // when
+    let results = await service.reconcileTrials(now: Date(timeIntervalSince1970: 13))
+
+    // then — guessed identities after an unreadable live set could cross job or epoch boundaries.
+    #expect(results.isEmpty)
+    #expect(recording.serviceCalls == ["live"])
+  }
+}
+
+// MARK: - Fixtures
+
+private extension TrialSweepTests {
+  func emptyStore() throws -> ScheduledLearningStoreGRDB {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    return ScheduledLearningStoreGRDB(writer: queue)
+  }
+
+  func trialIdentity(id: Int64, jobId: Int64) -> LearningTrialIdentity {
+    LearningTrialIdentity(
+      trialId: id,
+      jobId: jobId,
+      epoch: LearningEpoch(1),
+      generation: 1
+    )
+  }
+}
+
+private struct TrialSweepFixture {
+  let queue: DatabaseQueue
+  let learning: ScheduledLearningStoreGRDB
+  let identity: LearningTrialIdentity
+  let assignmentDeadline: Date
+
+  static func make() throws -> TrialSweepFixture {
+    let queue = try ClawDatabase.makeInMemoryQueue()
+    try ClawDatabase.migrate(queue)
+    let jobs = ScheduledJobStoreGRDB(writer: queue, learningEnabled: true)
+    let deadline = Date(timeIntervalSince1970: 1_782_086_400)
+    let admittedAt = deadline.addingTimeInterval(-TrialAdmissionPolicy.assignmentWindow)
+    let job = try jobs.create(
+      NewScheduledJob(
+        ownerChatId: 777,
+        label: "paused trial",
+        prompt: "Summarize the archive",
+        recurrence: nil,
+        timezone: "Europe/Berlin",
+        nextOccurrence: admittedAt
+      ),
+      now: admittedAt
+    )
+    let learning = ScheduledLearningStoreGRDB(writer: queue)
+    let state = try learning.armJob(jobId: job.id, now: admittedAt)
+    let identity = try installTrial(
+      queue: queue,
+      state: state,
+      admittedAt: admittedAt
+    )
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE scheduled_jobs SET status = ? WHERE id = ?",
+        arguments: [ScheduledJobStatus.paused.rawValue, job.id]
+      )
+    }
+    return TrialSweepFixture(
+      queue: queue,
+      learning: learning,
+      identity: identity,
+      assignmentDeadline: deadline
+    )
+  }
+
+  func trialState() throws -> LearningTrialState? {
+    try queue.read { db in
+      try String.fetchOne(
+        db,
+        sql: "SELECT state FROM learning_trials WHERE trial_id = ?",
+        arguments: [identity.trialId]
+      ).flatMap(LearningTrialState.init(rawValue:))
+    }
+  }
+}
+
+private extension TrialSweepFixture {
+  static func installTrial(
+    queue: DatabaseQueue,
+    state: JobLearningState,
+    admittedAt: Date
+  ) throws -> LearningTrialIdentity {
+    let replacement = try LessonSet.canonical(
+      jobId: state.jobId,
+      lessons: ["Check the archive before answering."]
+    )
+    let manifest = CandidateSourceManifest(
+      origin: .reflection,
+      algorithm: .v1,
+      jobId: state.jobId,
+      epoch: state.epoch,
+      triggerDigest: TriggerDigest(rawValue: SHA256Digest.hex("sweep-trigger")),
+      triggerReason: .ownerCorrection,
+      qualifyingIssueCodes: [],
+      operationId: LearningOperationID(rawValue: "sweep-operation"),
+      carrierDigest: CarrierDigest(rawValue: SHA256Digest.hex("sweep-carrier")),
+      resultDigest: ReflectionResultDigest(rawValue: SHA256Digest.hex("sweep-result")),
+      baseDigest: state.stableDigest,
+      baseRevision: state.stableRevision,
+      feedbackRevision: state.feedbackRevision,
+      evidence: [],
+      evaluations: [],
+      feedback: [],
+      predecessorCandidate: nil,
+      predecessorFeedback: nil
+    )
+    let artifact = try CandidateArtifact(replacement: replacement, manifest: manifest)
+    return try queue.write { db in
+      try ScheduledLearningStoreGRDB.recordCandidateArtifact(
+        db,
+        artifact: artifact,
+        now: admittedAt
+      )
+      try db.execute(
+        sql: """
+          INSERT INTO learning_trials(job_id, learning_epoch, base_digest, candidate_digest,
+            generation, admitted_at, assignment_deadline, decision_deadline, max_assignments,
+            consumed_assignments, cohort_cutoff, state, algorithm)
+          VALUES (?, ?, ?, ?, 1, ?, ?, ?, 3, 0, ?, ?, ?)
+          """,
+        arguments: [
+          state.jobId,
+          state.epoch.value,
+          state.stableDigest.rawValue,
+          artifact.digest.rawValue,
+          EpochSecondCodec.epoch(admittedAt),
+          EpochSecondCodec.epoch(
+            admittedAt.addingTimeInterval(TrialAdmissionPolicy.assignmentWindow)
+          ),
+          EpochSecondCodec.epoch(
+            admittedAt.addingTimeInterval(TrialAdmissionPolicy.decisionWindow)
+          ),
+          EpochSecondCodec.epoch(admittedAt),
+          LearningTrialState.open.rawValue,
+          LearningAlgorithm.v1.rawValue,
+        ]
+      )
+      let identity = LearningTrialIdentity(
+        trialId: db.lastInsertedRowID,
+        jobId: state.jobId,
+        epoch: state.epoch,
+        generation: 1
+      )
+      try ScheduledLearningStoreGRDB.insertDecision(
+        db,
+        kind: AdmissionReceipt.kind,
+        jobId: state.jobId,
+        epoch: state.epoch,
+        inputs: AdmissionDecisionInputs(candidateDigest: artifact.digest),
+        result: AdmissionReceipt(
+          candidateDigest: artifact.digest,
+          replacementDigest: replacement.digest,
+          trialId: identity.trialId,
+          generation: identity.generation
+        ),
+        algorithm: .v1,
+        now: admittedAt
+      )
+      return identity
+    }
+  }
+}

--- a/Tests/ClawGatewayTests/Routing/LearningPromotionRoutingTests.swift
+++ b/Tests/ClawGatewayTests/Routing/LearningPromotionRoutingTests.swift
@@ -1,0 +1,116 @@
+import ClawCore
+import ClawTestSupport
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawData
+@testable import ClawGateway
+
+@Suite struct LearningPromotionRoutingTests {
+  @Test func currentPromotionReplyUsesOutboxAndPokesAfterCommit() async throws {
+    // given
+    let signal = OutboxSignal()
+    let harness = try LearningRoutingTests.Harness.make(outboxSignal: signal)
+    let job = try harness.createJob(label: "current promotion")
+    let promotionId = try harness.seedCurrentPromotion(jobId: job.id)
+
+    // when
+    let outcome = await harness.router.handle(
+      rawUpdate: textUpdate(id: 980, from: 42, text: "/learning \(job.id)")
+    )
+    signal.finish()
+    var notifications = signal.notifications.makeAsyncIterator()
+    let poked = await notifications.next() != nil
+
+    // then
+    #expect(outcome == .processed)
+    #expect(poked)
+    #expect(await harness.transport.sent.isEmpty)
+    let rows = try harness.queue.read { db in
+      try Row.fetchAll(
+        db,
+        sql: "SELECT payload, reply_markup FROM outbound_deliveries ORDER BY step_index"
+      )
+    }
+    let last = try #require(rows.last)
+    let markup = try #require(last["reply_markup"] as String?)
+    let button = try #require(try FeedbackKeyboard.parseMarkup(markup).first?.first)
+    #expect(button.action == .promotionRollback)
+    let target = try #require(try harness.learning.feedbackTarget(nonce: button.nonce))
+    #expect(target.subjectDigest == String(promotionId))
+    #expect(target.ownerUserId == 42)
+    #expect(target.chatId == 42)
+    #expect((last["payload"] as String).contains(LearningDecisionResult.stale.rawValue))
+  }
+}
+
+private extension LearningRoutingTests.Harness {
+  func seedCurrentPromotion(jobId: Int64) throws -> Int64 {
+    let state = try learning.armJob(jobId: jobId, now: now)
+    let trial = LearningTrial(
+      identity: LearningTrialIdentity(trialId: 1, jobId: jobId, epoch: state.epoch, generation: 1),
+      baseDigest: LessonSetDigest(rawValue: SHA256Digest.hex("retained predecessor")),
+      baseRevision: StableRevision(0),
+      candidateDigest: CandidateDigest(rawValue: SHA256Digest.hex("empty replacement candidate")),
+      replacementDigest: state.stableDigest,
+      algorithm: .v1,
+      admittedAt: now,
+      cohortCutoff: now,
+      maxAssignments: TrialAdmissionPolicy.maximumAssignments,
+      consumedAssignments: 2,
+      assignmentDeadline: now.addingTimeInterval(TrialAdmissionPolicy.assignmentWindow),
+      decisionDeadline: now.addingTimeInterval(TrialAdmissionPolicy.decisionWindow),
+      state: .promoted,
+      hardVetoes: []
+    )
+    let inputs = TrialDecisionInputs(trial: trial, feedbackRevision: state.feedbackRevision)
+    return try queue.write { db in
+      try db.execute(
+        sql: "UPDATE job_learning_state SET stable_revision = 1 WHERE job_id = ?",
+        arguments: [jobId]
+      )
+      let promoted = LearningDecisionRecord(
+        result: .promoted,
+        reason: LearningDecisionResult.promoted.rawValue,
+        cohort: [],
+        stableRevision: StableRevision(1)
+      )
+      try insertDecisionProjection(db, inputs: inputs, record: promoted, kind: .trial)
+      let promotionId = db.lastInsertedRowID
+      let stale = LearningDecisionRecord(
+        result: .stale,
+        reason: LearningDecisionResult.stale.rawValue,
+        cohort: [],
+        stableRevision: StableRevision(1),
+        rollbackTrigger: .adapter(
+          promotionId: promotionId,
+          adapterId: "unfrozen",
+          outcome: .regression
+        )
+      )
+      try insertDecisionProjection(db, inputs: inputs, record: stale, kind: .rollback)
+      return promotionId
+    }
+  }
+
+  func insertDecisionProjection(
+    _ db: Database,
+    inputs: TrialDecisionInputs,
+    record: LearningDecisionRecord,
+    kind: LearningDecisionKind
+  ) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO learning_decisions(kind, job_id, learning_epoch, inputs, result, algorithm, decided_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+      arguments: [
+        kind.rawValue, inputs.identity.jobId, inputs.identity.epoch.value,
+        try ScheduledLearningStoreGRDB.canonicalDecisionJSON(inputs),
+        try ScheduledLearningStoreGRDB.canonicalDecisionJSON(record), LearningAlgorithm.v1.rawValue,
+        EpochSecondCodec.epoch(now),
+      ]
+    )
+  }
+}

--- a/Tests/ClawGatewayTests/Routing/LearningRoutingTests.swift
+++ b/Tests/ClawGatewayTests/Routing/LearningRoutingTests.swift
@@ -34,7 +34,7 @@ import Testing
     #expect(await harness.dispatcher.calls.isEmpty)
   }
 
-  @Test func disabledServiceStillReadsAndResetDoesNotDispatch() async throws {
+  @Test func disabledServiceStillReadsAndResetRequiresOwnerConfirmation() async throws {
     // given — no ScheduledLearningService is passed to the router.
     let harness = try Harness.make()
     let job = try harness.createJob(label: "retained state")
@@ -52,16 +52,175 @@ import Testing
       rawUpdate: textUpdate(id: 3, from: 42, text: "/learning reset")
     )
 
-    // then — gating the view on the optional service hides retained state; reset must stay canned.
+    // then — gating this provider-free path on the optional worker would strand retained state.
     #expect(detail == .processed)
     #expect(validReset == .processed)
     #expect(invalidReset == .processed)
     let texts = await harness.transport.sent.map(\.text)
     #expect(texts[0].contains("Schedule \(job.id) · retained state"))
-    #expect(texts[1] == CommandReplies.learningResetUnavailable)
+    let prompt = texts[1]
+    #expect(prompt.contains("Reset its learning?"))
+    #expect(prompt.contains("new learning epoch with an empty stable lesson set"))
+    #expect(prompt.contains("close every live trial"))
+    #expect(prompt.contains("invalidate pending feedback targets and challenges"))
+    #expect(prompt.contains("learning calls that have not started"))
+    #expect(prompt.contains("Calls already in flight may finish, but only their usage is retained"))
+    #expect(prompt.contains("Existing runs keep the lessons they were pinned to"))
+    #expect(prompt.contains("learning history is retained"))
+    #expect(prompt.contains("exact current effects are resolved when you confirm"))
     #expect(texts[2] == CommandReplies.learningUsage)
     #expect(await harness.dispatcher.calls.isEmpty)
     #expect(try harness.learningRows() == rowsBefore)
+
+    // when
+    let confirmed = await harness.router.handle(rawUpdate: textUpdate(id: 4, from: 42, text: "yes"))
+
+    // then — only the fused confirmation update raises the barrier.
+    #expect(confirmed == .processed)
+    #expect(try harness.learningEpoch(jobId: job.id) == LearningEpoch(2))
+    #expect((await harness.transport.sent.last?.text)?.contains("Learning reset applied") == true)
+    #expect(await harness.dispatcher.calls.isEmpty)
+  }
+
+  @Test func missingAndUnarmedResetDoNotReplaceAnExistingConfirmation() async throws {
+    // given
+    let harness = try Harness.make()
+    let armed = try harness.createJob(label: "armed")
+    _ = try harness.learning.armJob(jobId: armed.id, now: harness.now)
+    let unarmed = try harness.createJob(label: "unarmed")
+    _ = await harness.router.handle(
+      rawUpdate: textUpdate(id: 10, from: 42, text: "/learning reset \(armed.id)")
+    )
+    let sessionId = try harness.ownerSessionId()
+    let parked = await harness.pendingConfirmations.pending(sessionId: sessionId)
+
+    // when
+    _ = await harness.router.handle(
+      rawUpdate: textUpdate(id: 11, from: 42, text: "/learning reset \(unarmed.id)")
+    )
+    let afterUnarmed = await harness.pendingConfirmations.pending(sessionId: sessionId)
+    _ = await harness.router.handle(
+      rawUpdate: textUpdate(id: 12, from: 42, text: "/learning reset 99999")
+    )
+    let afterMissing = await harness.pendingConfirmations.pending(sessionId: sessionId)
+
+    // then — parking before the one-snapshot boundary would displace a valid pending reset.
+    #expect(parked == .learningReset(jobId: armed.id))
+    #expect(afterUnarmed == parked)
+    #expect(afterMissing == parked)
+    let texts = await harness.transport.sent.map(\.text)
+    #expect(texts[1].contains("learning state: not created"))
+    #expect(texts[2] == "No schedule with id 99999. See /schedule list.")
+  }
+
+  @Test func unreadableStateCanStillBeWithdrawnThroughReset() async throws {
+    // given
+    let harness = try Harness.make(secretValues: ["secret-label"])
+    let job = try harness.createJob(label: "secret-label")
+    _ = try harness.learning.armJob(jobId: job.id, now: harness.now)
+    try harness.insertUnreadableCurrentDecision(jobId: job.id)
+    #expect(try harness.learning.learningView(jobId: job.id).isOnlyUnreadable)
+
+    // when
+    let parked = await harness.router.handle(
+      rawUpdate: textUpdate(id: 20, from: 42, text: "/learning reset \(job.id)")
+    )
+    let confirmed = await harness.router.handle(
+      rawUpdate: textUpdate(id: 21, from: 42, text: "yes")
+    )
+
+    // then — requiring a readable prior decision prevents the owner from fencing damaged state.
+    #expect(parked == .processed)
+    #expect(confirmed == .processed)
+    let prompt = await harness.transport.sent.first?.text
+    #expect(prompt?.contains(SecretRedactor.replacement) == true)
+    #expect(prompt?.contains("secret-label") == false)
+    #expect(try harness.learningEpoch(jobId: job.id) == LearningEpoch(2))
+    #expect(try harness.learning.learningView(jobId: job.id).onlyReadable != nil)
+  }
+
+  @Test func redeliveredOldYesDoesNotClearANewerResetSlot() async throws {
+    // given
+    let harness = try Harness.make()
+    let first = try harness.createJob(label: "first")
+    let second = try harness.createJob(label: "second")
+    _ = try harness.learning.armJob(jobId: first.id, now: harness.now)
+    _ = try harness.learning.armJob(jobId: second.id, now: harness.now)
+    _ = await harness.router.handle(
+      rawUpdate: textUpdate(id: 30, from: 42, text: "/learning reset \(first.id)")
+    )
+    let oldYes = textUpdate(id: 31, from: 42, text: "yes")
+    _ = await harness.router.handle(rawUpdate: oldYes)
+    _ = await harness.router.handle(
+      rawUpdate: textUpdate(id: 32, from: 42, text: "/learning reset \(second.id)")
+    )
+    let sessionId = try harness.ownerSessionId()
+
+    // when
+    let replay = await harness.router.handle(rawUpdate: oldYes)
+
+    // then — clearing before the fused claim result lets a stale delivery erase newer intent.
+    #expect(replay == .skipped)
+    #expect(try harness.learningEpoch(jobId: second.id) == LearningEpoch(1))
+    #expect(
+      await harness.pendingConfirmations.pending(sessionId: sessionId)
+        == .learningReset(jobId: second.id)
+    )
+  }
+
+  @Test(arguments: ResetConfirmationRace.allCases)
+  func confirmationResolvesTheCurrentResetOutcome(_ race: ResetConfirmationRace) async throws {
+    // given
+    let harness = try Harness.make()
+    let job = try harness.createJob(label: "resolution race")
+    _ = try harness.learning.armJob(jobId: job.id, now: harness.now)
+    _ = await harness.router.handle(
+      rawUpdate: textUpdate(id: 35, from: 42, text: "/learning reset \(job.id)")
+    )
+    switch race {
+    case .alreadyReset:
+      _ = try harness.learning.applyReset(updateId: 3_500, jobId: job.id, now: harness.now)
+    case .unarmed:
+      try await harness.queue.write { db in
+        try db.execute(sql: "DELETE FROM job_learning_state WHERE job_id = ?", arguments: [job.id])
+      }
+    case .notFound:
+      try await harness.queue.write { db in
+        try db.execute(sql: "DELETE FROM job_learning_state WHERE job_id = ?", arguments: [job.id])
+        try db.execute(sql: "DELETE FROM scheduled_jobs WHERE id = ?", arguments: [job.id])
+      }
+    }
+
+    // when
+    let outcome = await harness.router.handle(rawUpdate: textUpdate(id: 36, from: 42, text: "yes"))
+
+    // then — resolving the preview snapshot instead of the confirmation-time outcome reports a
+    // reset that did not occur, or hides a reset another serialized writer already completed.
+    #expect(outcome == .processed)
+    #expect(await harness.transport.sent.last?.text == race.expectedReply(jobId: job.id))
+  }
+
+  @Test func resetCommitFailureClaimsAndClearsWithNothingChanged() async throws {
+    // given
+    let harness = try Harness.make()
+    let job = try harness.createJob(label: "rollback")
+    _ = try harness.learning.armJob(jobId: job.id, now: harness.now)
+    _ = await harness.router.handle(
+      rawUpdate: textUpdate(id: 40, from: 42, text: "/learning reset \(job.id)")
+    )
+    try harness.failResetAudit()
+    let sessionId = try harness.ownerSessionId()
+
+    // when
+    let outcome = await harness.router.handle(
+      rawUpdate: textUpdate(id: 41, from: 42, text: "yes")
+    )
+
+    // then — acknowledging success or keeping a terminally failed slot misstates the rollback.
+    #expect(outcome == .processed)
+    #expect(try harness.learningEpoch(jobId: job.id) == LearningEpoch(1))
+    #expect(await harness.pendingConfirmations.pending(sessionId: sessionId) == nil)
+    #expect(await harness.transport.sent.last?.text == LearningReplies.resetFailed)
   }
 
   @Test func redactsThenSplitsPlainTextWithoutLoss() async throws {
@@ -132,6 +291,7 @@ private extension LearningRoutingTests {
     let dispatcher: FakeTurnRunner
     let jobs: ScheduledJobStoreGRDB
     let learning: ScheduledLearningStoreGRDB
+    let pendingConfirmations: PendingConfirmationRegistry
     let now = Date(timeIntervalSince1970: 1_782_000_600)
 
     static func make(
@@ -146,13 +306,14 @@ private extension LearningRoutingTests {
       let dispatcher = FakeTurnRunner()
       let jobs = ScheduledJobStoreGRDB(writer: queue, learningEnabled: false)
       let learning = ScheduledLearningStoreGRDB(writer: queue)
+      let pendingConfirmations = PendingConfirmationRegistry()
       let router = MessageRouter(
         processed: ProcessedUpdateStoreGRDB(writer: queue),
         sessionMessages: SessionMessageStoreGRDB(writer: queue),
         commands: CommandStoreGRDB(writer: queue),
         memory: MemoryStoreGRDB(writer: queue),
         memoryCommands: MemoryCommandStoreGRDB(writer: queue),
-        pendingConfirmations: PendingConfirmationRegistry(),
+        pendingConfirmations: pendingConfirmations,
         botIdentity: BotIdentity(id: 900, username: "claw_bot"),
         accessControl: AccessControl(allowlist: allowlist, groupChats: groupChats),
         delivery: transport,
@@ -172,7 +333,8 @@ private extension LearningRoutingTests {
         transport: transport,
         dispatcher: dispatcher,
         jobs: jobs,
-        learning: learning
+        learning: learning,
+        pendingConfirmations: pendingConfirmations
       )
     }
 
@@ -195,5 +357,83 @@ private extension LearningRoutingTests {
         try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM job_learning_state") ?? -1
       }
     }
+
+    func learningEpoch(jobId: Int64) throws -> LearningEpoch? {
+      try queue.read { db in
+        try Int64.fetchOne(
+          db,
+          sql: "SELECT learning_epoch FROM job_learning_state WHERE job_id = ?",
+          arguments: [jobId]
+        ).map(LearningEpoch.init)
+      }
+    }
+
+    func ownerSessionId() throws -> Int64 {
+      let sessionId = try SessionMessageStoreGRDB(writer: queue).findSession(
+        sessionKey: SessionKey.telegramDM(chatId: 42)
+      )
+      guard let sessionId else {
+        throw StoreError.unexpected("owner session is missing")
+      }
+      return sessionId
+    }
+
+    func insertUnreadableCurrentDecision(jobId: Int64) throws {
+      try queue.write { db in
+        try db.execute(
+          sql: """
+            INSERT INTO learning_decisions(kind, job_id, learning_epoch, inputs, result,
+              algorithm, decided_at)
+            VALUES ('unknown', ?, 1, '{}', '{}', ?, ?)
+            """,
+          arguments: [jobId, LearningAlgorithm.v1.rawValue, now]
+        )
+      }
+    }
+
+    func failResetAudit() throws {
+      try queue.write { db in
+        try db.execute(
+          sql: """
+            CREATE TRIGGER fail_reset_audit BEFORE INSERT ON audit_events
+            WHEN NEW.action = '\(AuditAction.learningReset.rawValue)'
+            BEGIN SELECT RAISE(ABORT, 'forced reset audit failure'); END
+            """
+        )
+      }
+    }
+  }
+}
+
+enum ResetConfirmationRace: CaseIterable {
+  case alreadyReset
+  case unarmed
+  case notFound
+
+  func expectedReply(jobId: Int64) -> String {
+    switch self {
+    case .alreadyReset:
+      "Learning for schedule \(jobId) was already reset at epoch 2."
+    case .unarmed:
+      "Schedule \(jobId) has no learning state to reset."
+    case .notFound:
+      "No schedule with id \(jobId). Nothing was reset."
+    }
+  }
+}
+
+private extension Array where Element == JobLearningView {
+  var onlyReadable: ReadableJobLearningView? {
+    guard count == 1, case .readable(let view) = self[0] else {
+      return nil
+    }
+    return view
+  }
+
+  var isOnlyUnreadable: Bool {
+    guard count == 1, case .unreadable = self[0] else {
+      return false
+    }
+    return true
   }
 }

--- a/Tests/ClawGatewayTests/Routing/LearningRoutingTests.swift
+++ b/Tests/ClawGatewayTests/Routing/LearningRoutingTests.swift
@@ -80,14 +80,18 @@ import Testing
     let expected = SecretRedactor(secretValues: ["x"]).redact(raw)
 
     // when
-    let outcome = await harness.router.handle(
-      rawUpdate: textUpdate(id: 1, from: 42, text: "/learning")
-    )
+    let update = textUpdate(id: 1, from: 42, text: "/learning")
+    let outcome = await harness.router.handle(rawUpdate: update)
+    let firstBatch = await harness.transport.sent.map(\.text)
+    let replay = await harness.router.handle(rawUpdate: update)
 
-    // then — rich-limit, split-before-redact, truncation, or reordering breaks this equality.
+    // then — rich-limit, split-before-redact, truncation, reordering, or a chunk-path claim
+    // bypass breaks these equalities; the nearest duplicate test reaches only the one-message path.
     #expect(outcome == .processed)
+    #expect(replay == .skipped)
     let chunks = await harness.transport.sent.map(\.text)
     #expect(chunks.count > 1)
+    #expect(chunks == firstBatch)
     #expect(
       chunks.allSatisfy { chunk in
         chunk.count <= TelegramMessageLimits.maxPlainMessageCharacters
@@ -95,6 +99,27 @@ import Testing
     )
     #expect(chunks.joined() == expected)
     #expect(chunks.joined().contains("x") == false)
+    #expect(await harness.dispatcher.calls.isEmpty)
+  }
+
+  @Test func chunkClaimFailureRetriesWithoutDelivery() async throws {
+    // given
+    let harness = try Harness.make()
+    let job = try harness.createJob(label: "claim failure")
+    _ = try harness.learning.armJob(jobId: job.id, now: harness.now)
+    try await harness.queue.write { db in
+      try db.drop(table: "processed_updates")
+    }
+
+    // when
+    let outcome = await harness.router.handle(
+      rawUpdate: textUpdate(id: 1, from: 42, text: "/learning")
+    )
+
+    // then — sending before the multipart ownership claim leaks a reply for a retryable update;
+    // the nearest claim-failure tests exercise other sender branches.
+    #expect(outcome == .transientFailure)
+    #expect(await harness.transport.sent.isEmpty)
     #expect(await harness.dispatcher.calls.isEmpty)
   }
 }

--- a/Tests/ClawGatewayTests/Routing/LearningRoutingTests.swift
+++ b/Tests/ClawGatewayTests/Routing/LearningRoutingTests.swift
@@ -1,0 +1,174 @@
+import ClawAgent
+import ClawCore
+import ClawData
+import ClawTestSupport
+import Foundation
+import GRDB
+import Testing
+
+@testable import ClawGateway
+
+@Suite struct LearningRoutingTests {
+  @Test func groupRefusesBeforeRead() async throws {
+    // given
+    let harness = try Harness.make(groupChats: [-1_001])
+    try await harness.queue.write { db in
+      try db.execute(sql: "DROP TABLE job_learning_state")
+    }
+
+    // when
+    let outcome = await harness.router.handle(
+      rawUpdate: textUpdate(
+        id: 1,
+        from: 42,
+        chat: -1_001,
+        text: "/learning",
+        chatKind: .supergroup,
+        messageThreadId: 7
+      )
+    )
+
+    // then — making a read-only report room-safe reaches the deliberately broken reader.
+    #expect(outcome == .processed)
+    #expect(await harness.transport.sent.map(\.text) == [CommandReplies.directOnly])
+    #expect(await harness.dispatcher.calls.isEmpty)
+  }
+
+  @Test func disabledServiceStillReadsAndResetDoesNotDispatch() async throws {
+    // given — no ScheduledLearningService is passed to the router.
+    let harness = try Harness.make()
+    let job = try harness.createJob(label: "retained state")
+    _ = try harness.learning.armJob(jobId: job.id, now: harness.now)
+    let rowsBefore = try harness.learningRows()
+
+    // when
+    let detail = await harness.router.handle(
+      rawUpdate: textUpdate(id: 1, from: 42, text: "/learning \(job.id)")
+    )
+    let validReset = await harness.router.handle(
+      rawUpdate: textUpdate(id: 2, from: 42, text: "/learning reset \(job.id)")
+    )
+    let invalidReset = await harness.router.handle(
+      rawUpdate: textUpdate(id: 3, from: 42, text: "/learning reset")
+    )
+
+    // then — gating the view on the optional service hides retained state; reset must stay canned.
+    #expect(detail == .processed)
+    #expect(validReset == .processed)
+    #expect(invalidReset == .processed)
+    let texts = await harness.transport.sent.map(\.text)
+    #expect(texts[0].contains("Schedule \(job.id) · retained state"))
+    #expect(texts[1] == CommandReplies.learningResetUnavailable)
+    #expect(texts[2] == CommandReplies.learningUsage)
+    #expect(await harness.dispatcher.calls.isEmpty)
+    #expect(try harness.learningRows() == rowsBefore)
+  }
+
+  @Test func redactsThenSplitsPlainTextWithoutLoss() async throws {
+    // given
+    let harness = try Harness.make(secretValues: ["x"])
+    for index in 0..<40 {
+      let job = try harness.createJob(
+        label: "\(String(repeating: "x", count: 55))\(index)"
+      )
+      _ = try harness.learning.armJob(jobId: job.id, now: harness.now)
+    }
+    let raw = LearningSurface.render(
+      try harness.learning.learningView(jobId: nil),
+      style: .list
+    )
+    let expected = SecretRedactor(secretValues: ["x"]).redact(raw)
+
+    // when
+    let outcome = await harness.router.handle(
+      rawUpdate: textUpdate(id: 1, from: 42, text: "/learning")
+    )
+
+    // then — rich-limit, split-before-redact, truncation, or reordering breaks this equality.
+    #expect(outcome == .processed)
+    let chunks = await harness.transport.sent.map(\.text)
+    #expect(chunks.count > 1)
+    #expect(
+      chunks.allSatisfy { chunk in
+        chunk.count <= TelegramMessageLimits.maxPlainMessageCharacters
+      }
+    )
+    #expect(chunks.joined() == expected)
+    #expect(chunks.joined().contains("x") == false)
+    #expect(await harness.dispatcher.calls.isEmpty)
+  }
+}
+
+private extension LearningRoutingTests {
+  struct Harness {
+    let queue: DatabaseQueue
+    let router: MessageRouter
+    let transport: RecordingTransport
+    let dispatcher: FakeTurnRunner
+    let jobs: ScheduledJobStoreGRDB
+    let learning: ScheduledLearningStoreGRDB
+    let now = Date(timeIntervalSince1970: 1_782_000_600)
+
+    static func make(
+      groupChats: Set<Int64> = [],
+      secretValues: [String] = []
+    ) throws -> Harness {
+      let queue = try ClawDatabase.makeInMemoryQueue()
+      try ClawDatabase.migrate(queue)
+      let allowlist = AllowlistStoreGRDB(writer: queue)
+      try allowlist.seedAllowlist(userIds: [42])
+      let transport = RecordingTransport()
+      let dispatcher = FakeTurnRunner()
+      let jobs = ScheduledJobStoreGRDB(writer: queue, learningEnabled: false)
+      let learning = ScheduledLearningStoreGRDB(writer: queue)
+      let router = MessageRouter(
+        processed: ProcessedUpdateStoreGRDB(writer: queue),
+        sessionMessages: SessionMessageStoreGRDB(writer: queue),
+        commands: CommandStoreGRDB(writer: queue),
+        memory: MemoryStoreGRDB(writer: queue),
+        memoryCommands: MemoryCommandStoreGRDB(writer: queue),
+        pendingConfirmations: PendingConfirmationRegistry(),
+        botIdentity: BotIdentity(id: 900, username: "claw_bot"),
+        accessControl: AccessControl(allowlist: allowlist, groupChats: groupChats),
+        delivery: transport,
+        turnRunner: dispatcher,
+        imageCache: ImageCache(),
+        lanes: SessionLaneRegistry(),
+        schedule: makeIdleScheduleSurface(writer: queue),
+        learningStore: learning,
+        learningRedactor: SecretRedactor(secretValues: secretValues),
+        coordinator: ApprovalCoordinator(),
+        doctor: StubDoctorReporter(),
+        logger: TestLog.silent
+      )
+      return Harness(
+        queue: queue,
+        router: router,
+        transport: transport,
+        dispatcher: dispatcher,
+        jobs: jobs,
+        learning: learning
+      )
+    }
+
+    func createJob(label: String) throws -> ScheduledJob {
+      try jobs.create(
+        NewScheduledJob(
+          ownerChatId: 42,
+          label: label,
+          prompt: "Summarize",
+          recurrence: nil,
+          timezone: "Europe/Berlin",
+          nextOccurrence: now
+        ),
+        now: now
+      )
+    }
+
+    func learningRows() throws -> Int {
+      try queue.read { db in
+        try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM job_learning_state") ?? -1
+      }
+    }
+  }
+}

--- a/Tests/ClawGatewayTests/Routing/LearningRoutingTests.swift
+++ b/Tests/ClawGatewayTests/Routing/LearningRoutingTests.swift
@@ -283,7 +283,7 @@ import Testing
   }
 }
 
-private extension LearningRoutingTests {
+extension LearningRoutingTests {
   struct Harness {
     let queue: DatabaseQueue
     let router: MessageRouter
@@ -296,7 +296,8 @@ private extension LearningRoutingTests {
 
     static func make(
       groupChats: Set<Int64> = [],
-      secretValues: [String] = []
+      secretValues: [String] = [],
+      outboxSignal: OutboxSignal? = nil
     ) throws -> Harness {
       let queue = try ClawDatabase.makeInMemoryQueue()
       try ClawDatabase.migrate(queue)
@@ -323,6 +324,7 @@ private extension LearningRoutingTests {
         schedule: makeIdleScheduleSurface(writer: queue),
         learningStore: learning,
         learningRedactor: SecretRedactor(secretValues: secretValues),
+        learningOutboxSignal: outboxSignal,
         coordinator: ApprovalCoordinator(),
         doctor: StubDoctorReporter(),
         logger: TestLog.silent

--- a/Tests/ClawGatewayTests/Routing/ScheduleInteractionTests.swift
+++ b/Tests/ClawGatewayTests/Routing/ScheduleInteractionTests.swift
@@ -242,6 +242,7 @@ import Testing
     let reply = try #require(await harness.transport.sent.last?.text)
     #expect(reply == CommandReplies.help)
     #expect(reply.contains("/skills"))
+    #expect(reply.contains("/learning"))
   }
 
   @Test func strangersGetNoHelp() async throws {

--- a/Tests/ClawGatewayTests/Routing/TopicReplyRoutingTests.swift
+++ b/Tests/ClawGatewayTests/Routing/TopicReplyRoutingTests.swift
@@ -38,6 +38,8 @@ import Testing
     #expect(outcome == .processed)
     let sent = try #require(await harness.transport.sent.first)
     #expect(sent.text == CommandReplies.help(mode: .group))
+    #expect(sent.text.contains("/learning") == false)
+    #expect(sent.text.contains("learning state live in my owner's direct chat"))
     #expect(
       sent.target
         == DeliveryTarget(

--- a/Tests/ClawGatewayTests/Turn/PinnedLessonTests.swift
+++ b/Tests/ClawGatewayTests/Turn/PinnedLessonTests.swift
@@ -446,6 +446,14 @@ private struct UnresolvableLessonSets: ScheduledLearningStore {
     try base.learningView(jobId: jobId)
   }
 
+  func applyReset(
+    updateId: Int64,
+    jobId: Int64,
+    now: Date
+  ) throws(StoreError) -> ConfirmedLearningResetResult {
+    try base.applyReset(updateId: updateId, jobId: jobId, now: now)
+  }
+
   func admitCandidate(
     digest: CandidateDigest,
     redactor: SecretRedactor,

--- a/Tests/ClawGatewayTests/Turn/PinnedLessonTests.swift
+++ b/Tests/ClawGatewayTests/Turn/PinnedLessonTests.swift
@@ -442,6 +442,10 @@ private extension FeedbackTarget {
 private struct UnresolvableLessonSets: ScheduledLearningStore {
   let base: ScheduledLearningStoreGRDB
 
+  func learningView(jobId: Int64?) throws(StoreError) -> [JobLearningView] {
+    try base.learningView(jobId: jobId)
+  }
+
   func admitCandidate(
     digest: CandidateDigest,
     redactor: SecretRedactor,

--- a/Tests/ClawGatewayTests/Turn/PinnedLessonTests.swift
+++ b/Tests/ClawGatewayTests/Turn/PinnedLessonTests.swift
@@ -442,6 +442,37 @@ private extension FeedbackTarget {
 private struct UnresolvableLessonSets: ScheduledLearningStore {
   let base: ScheduledLearningStoreGRDB
 
+  func applyTrialDecision(
+    _ decision: TrialDecision,
+    trial: LearningTrial,
+    feedbackRevision: FeedbackRevision,
+    now: Date
+  ) throws(StoreError) -> DecisionReceipt? {
+    try base.applyTrialDecision(
+      decision,
+      trial: trial,
+      feedbackRevision: feedbackRevision,
+      now: now
+    )
+  }
+
+  func rollback(_ trigger: RollbackTrigger, now: Date) throws(StoreError) -> DecisionReceipt? {
+    try base.rollback(trigger, now: now)
+  }
+
+  func commitPromotionReply(
+    updateId: Int64,
+    target: NewFeedbackTarget,
+    chunks: [LearningNoticeChunk],
+    now: Date
+  ) throws(StoreError) -> PromotionReplyOutcome {
+    try base.commitPromotionReply(updateId: updateId, target: target, chunks: chunks, now: now)
+  }
+
+  func currentPromotion(jobId: Int64) throws(StoreError) -> DecisionReceipt? {
+    try base.currentPromotion(jobId: jobId)
+  }
+
   func learningView(jobId: Int64?) throws(StoreError) -> [JobLearningView] {
     try base.learningView(jobId: jobId)
   }

--- a/Tests/ClawGatewayTests/Turn/PinnedLessonTests.swift
+++ b/Tests/ClawGatewayTests/Turn/PinnedLessonTests.swift
@@ -543,6 +543,24 @@ private struct UnresolvableLessonSets: ScheduledLearningStore {
     try base.openTrial(jobId: jobId)
   }
 
+  func recomputeAssignment(
+    runId: Int64,
+    now: Date
+  ) throws(StoreError) -> AssignmentRecomputation {
+    try base.recomputeAssignment(runId: runId, now: now)
+  }
+
+  func liveTrialIdentities() throws(StoreError) -> [LearningTrialIdentity] {
+    try base.liveTrialIdentities()
+  }
+
+  func reconcileTrial(
+    _ identity: LearningTrialIdentity,
+    now: Date
+  ) throws(StoreError) -> TrialReconciliationResult {
+    try base.reconcileTrial(identity, now: now)
+  }
+
   func settlement(runId: Int64) throws(StoreError) -> RunSettlement? {
     try base.settlement(runId: runId)
   }

--- a/Tests/ClawdCompositionTests/BotMenuCommandsTests.swift
+++ b/Tests/ClawdCompositionTests/BotMenuCommandsTests.swift
@@ -18,4 +18,19 @@ import Testing
     #expect(skills.description.contains("accepted"))
     #expect(skills.description.contains("rejected"))
   }
+
+  @Test func registeredCatalogIncludesTheLearningView() throws {
+    // given
+    let catalog = DaemonBuilder.botMenuCommands
+
+    // when
+    let learning = try #require(
+      catalog.first { command in
+        command.command == "learning"
+      }
+    )
+
+    // then — omitting registration hides a routed owner command from Telegram's picker.
+    #expect(learning.description.contains("learning"))
+  }
 }

--- a/Tests/ClawdCompositionTests/LearningCompositionTests.swift
+++ b/Tests/ClawdCompositionTests/LearningCompositionTests.swift
@@ -58,6 +58,60 @@ import Testing
     #expect(builder.makePinnedLessonStore() == nil)
   }
 
+  @Test func theDisarmedRootStillComposesTheRedactedLearningReader() async throws {
+    // given — retained learning state exists although the optional worker service is disabled.
+    let response = HTTPResult(
+      statusCode: 200,
+      headers: [:],
+      body: Data(#"{"ok":true,"result":{"message_id":7,"chat":{"id":777}}}"#.utf8)
+    )
+    let http = ScriptedHTTPExecutor([.ok(response)])
+    let builder = try LearningComposition.makeBuilder(learningEnabled: false, http: http)
+    try builder.stores.allowlist.seedAllowlist(userIds: [777])
+    let now = Date(timeIntervalSince1970: 1_782_000_600)
+    let job = try LearningComposition.createJob(builder, now: now, label: "tg-token")
+    _ = try builder.stores.learning.armJob(jobId: job.id, now: now)
+    let router = builder.makeIntakeRouter(
+      coordination: DaemonBuilder.TurnCoordination(),
+      turnRunner: IdleCompositionTurns(),
+      imageCache: ImageCache(),
+      scheduleSurface: LearningComposition.scheduleSurface(builder),
+      approvalCallbacks: nil,
+      doctor: IdleCompositionDoctor(),
+      learning: nil
+    )
+
+    // when
+    let outcome = await router.handle(
+      rawUpdate: RawUpdate(
+        updateId: 70,
+        message: RawMessage(
+          messageId: 70,
+          fromUserId: 777,
+          chatId: 777,
+          text: "/learning \(job.id)",
+          caption: nil,
+          mediaKind: nil,
+          chatKind: .private,
+          chatTitle: nil,
+          messageThreadId: nil,
+          senderDisplayName: nil
+        ),
+        editedMessage: nil
+      )
+    )
+
+    // then — omitting the independent store/redactor injection hides state or leaks root secrets.
+    #expect(outcome == .processed)
+    #expect(builder.makeLearningService() == nil)
+    let call = try #require(await http.recorded.first)
+    let body = try #require(JSONSerialization.jsonObject(with: call.body) as? [String: Any])
+    let text = try #require(body["text"] as? String)
+    #expect(text.contains("Schedule \(job.id)"))
+    #expect(text.contains(SecretRedactor.replacement))
+    #expect(text.contains("tg-token") == false)
+  }
+
   @Test func feedbackRouterIsComposedOnlyWhileLearningIsArmed() async throws {
     // given — each real root owns a live target, but only one has the learning feature armed
     for learningEnabled in [true, false] {
@@ -277,7 +331,10 @@ private enum LearningComposition {
     tool(name: "web_fetch", risk: .ask),
   ]
 
-  static func makeBuilder(learningEnabled: Bool) throws -> DaemonBuilder {
+  static func makeBuilder(
+    learningEnabled: Bool,
+    http: ScriptedHTTPExecutor = ScriptedHTTPExecutor([])
+  ) throws -> DaemonBuilder {
     var environment = [
       AppConfig.EnvKey.stateRoot: NSTemporaryDirectory() + "clawd-learn-" + UUID().uuidString,
       AppConfig.EnvKey.llmModel: CompositionAcceptance.qualifiedModel,
@@ -286,7 +343,7 @@ private enum LearningComposition {
       environment[AppConfig.EnvKey.learningEnabled] = "true"
     }
     return try CompositionAcceptance.makeBuilder(
-      http: ScriptedHTTPExecutor([]),
+      http: http,
       config: try AppConfig.load(environment: environment)
     )
   }
@@ -303,11 +360,15 @@ private enum LearningComposition {
     return fired.runId
   }
 
-  static func createJob(_ builder: DaemonBuilder, now: Date) throws -> ScheduledJob {
+  static func createJob(
+    _ builder: DaemonBuilder,
+    now: Date,
+    label: String = "digest"
+  ) throws -> ScheduledJob {
     try builder.stores.scheduledJobs.create(
       NewScheduledJob(
         ownerChatId: 777,
-        label: "digest",
+        label: label,
         prompt: "Summarize my unread items",
         recurrence: nil,
         timezone: "Europe/Berlin",

--- a/Tests/ClawdCompositionTests/LearningCompositionTests.swift
+++ b/Tests/ClawdCompositionTests/LearningCompositionTests.swift
@@ -13,7 +13,8 @@ import Testing
 /// `TurnRunner` hop is tested against a double, so without this suite the real closure never runs.
 @Suite struct LearningCompositionTests {
   @Test func theArmedRootFreezesTheSurfaceABoundRunRanOn() throws {
-    // given — a real builder over real stores, learning armed, and one bound run from its own fire
+    // given — a real builder over real stores, learning armed, and one bound run from its own
+    // fire
     let builder = try LearningComposition.makeBuilder(learningEnabled: true)
     let runId = try LearningComposition.fireBoundRun(builder)
     let freeze = builder.makeLearningSurfaceFreeze(
@@ -58,14 +59,14 @@ import Testing
     #expect(builder.makePinnedLessonStore() == nil)
   }
 
-  @Test func theDisarmedRootStillComposesTheRedactedLearningReader() async throws {
+  @Test func theDisarmedRootStillComposesTheRedactedLearningReaderAndReset() async throws {
     // given — retained learning state exists although the optional worker service is disabled.
     let response = HTTPResult(
       statusCode: 200,
       headers: [:],
       body: Data(#"{"ok":true,"result":{"message_id":7,"chat":{"id":777}}}"#.utf8)
     )
-    let http = ScriptedHTTPExecutor([.ok(response)])
+    let http = ScriptedHTTPExecutor([.ok(response), .ok(response), .ok(response)])
     let builder = try LearningComposition.makeBuilder(learningEnabled: false, http: http)
     try builder.stores.allowlist.seedAllowlist(userIds: [777])
     let now = Date(timeIntervalSince1970: 1_782_000_600)
@@ -100,16 +101,67 @@ import Testing
         editedMessage: nil
       )
     )
+    let resetPrompt = await router.handle(
+      rawUpdate: RawUpdate(
+        updateId: 71,
+        message: RawMessage(
+          messageId: 71,
+          fromUserId: 777,
+          chatId: 777,
+          text: "/learning reset \(job.id)",
+          caption: nil,
+          mediaKind: nil,
+          chatKind: .private,
+          chatTitle: nil,
+          messageThreadId: nil,
+          senderDisplayName: nil
+        ),
+        editedMessage: nil
+      )
+    )
+    let reset = await router.handle(
+      rawUpdate: RawUpdate(
+        updateId: 72,
+        message: RawMessage(
+          messageId: 72,
+          fromUserId: 777,
+          chatId: 777,
+          text: "yes",
+          caption: nil,
+          mediaKind: nil,
+          chatKind: .private,
+          chatTitle: nil,
+          messageThreadId: nil,
+          senderDisplayName: nil
+        ),
+        editedMessage: nil
+      )
+    )
 
     // then — omitting the independent store/redactor injection hides state or leaks root secrets.
     #expect(outcome == .processed)
+    #expect(resetPrompt == .processed)
+    #expect(reset == .processed)
     #expect(builder.makeLearningService() == nil)
-    let call = try #require(await http.recorded.first)
+    let calls = await http.recorded
+    let call = try #require(calls.first)
     let body = try #require(JSONSerialization.jsonObject(with: call.body) as? [String: Any])
     let text = try #require(body["text"] as? String)
     #expect(text.contains("Schedule \(job.id)"))
     #expect(text.contains(SecretRedactor.replacement))
     #expect(text.contains("tg-token") == false)
+    let promptBody = try #require(
+      JSONSerialization.jsonObject(with: calls[1].body) as? [String: Any]
+    )
+    let prompt = try #require(promptBody["text"] as? String)
+    #expect(prompt.contains(SecretRedactor.replacement))
+    #expect(prompt.contains("tg-token") == false)
+    let view = try #require(try builder.stores.learning.learningView(jobId: job.id).first)
+    guard case .readable(let readable) = view else {
+      Issue.record("expected reset learning state")
+      return
+    }
+    #expect(readable.epoch == LearningEpoch(2))
   }
 
   @Test func feedbackRouterIsComposedOnlyWhileLearningIsArmed() async throws {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -810,6 +810,60 @@ The accepted reasoning is the deployment, not a mitigation: a **supervised, one-
 - **Per-fire context isolation.** The fire transaction resets the session's context window (`window_start_message_id` → the pre-fire high-water mark, taint/private-data cleared — `/new` semantics) before inserting the trigger row, so every fire that runs starts on a fresh transcript of its persistent `sched:job:<id>` (or `sched:heartbeat`) session. That reset is session-global, so a fire into a session that already has a live run (PENDING/RUNNING/AWAITING_APPROVAL — e.g. one parked on an approval) is **skipped entirely** rather than run: resetting would advance the shared `window_start_message_id` past the live run's own rows and empty its context on resume (silent data loss). A skip resets nothing and inserts no trigger/run — the occurrence is dropped misfire-style with the schedule still advancing, audited as `job_overlap_skipped` (jobs) or `heartbeat_skipped` with the overlap reason (heartbeat). Prior fires stay durable (audit, FTS, interactive recall) but never replay into a proactive run's context, and proactive turns assemble under the dedicated proactive prompt with recall omitted (§9.2) — a fired task can never read as a "please arm a schedule" chat message, and one bad fire cannot poison the next.
 - `getUpdates` recovery is pinned: socket read timeout = long-poll timeout + 10 s; backoff-reconnect on timeout/network error. Scheduler-side gap recovery is lateness-based (§6.3's catch-up table) — no wake detection. Doctor exposes `last_tick_at`.
 
+### 14.1 Scheduled learning terminal decisions
+
+The generic learning loop follows the accepted
+[production design](superpowers/specs/2026-09-02-generic-production-learning-loop-design.md)
+and the fixed `scheduled-learning/v1`
+[algorithm](research/170-generic-scheduled-task-learning-algorithm.md). `ClawCore` owns its
+protocols and value types; `ScheduledLearningStoreGRDB` commits its transitions through
+`writeMapping`. The workflow coordinator consumes store recommendations separately from the
+terminal transaction.
+
+`applyTrialDecision(_:trial:feedbackRevision:now:)` captures the reviewed trial identity,
+candidate and replacement digests, base digest and revision, algorithm, and current feedback
+revision. In one transaction it checks the repeatable non-cancelled job, epoch and generation,
+all reviewed identities, stable base and feedback revision, then projects the entire assigned
+cohort from authoritative evidence, evaluator operations and effective owner signals. Promotion
+requires at least two distinct positive runs, zero negatives or hard vetoes, and resolution of
+all assigned runs. It revalidates the candidate's immutable provenance and effective source
+edges. Trial feedback may advance the reviewed revision without changing an unrelated candidate
+source edge. Production freezes no deterministic adapter, so it requires no deterministic receipt.
+
+The transaction writes a canonical terminal receipt, compare-and-swaps the stable pointer and
+revision, and closes the exact trial. The receipt keeps the complete cohort, including every
+positive run, its evaluation dependency, effective feedback revision, correction digest and owner
+confirmation. Activation and evidence remain separate: promotion is heuristic, while the receipt
+reports owner-confirmed support. A repeated exact terminal request returns its original receipt.
+An unresolved cohort produces no terminal receipt until a policy deadline or veto permits fallback.
+Fallback leaves the stable pointer untouched. Stale reviewed predicates record a stale decision;
+only the matching live trial may close. Candidate-edit predecessor closure, candidate rejection,
+and disputes of required candidate-source evaluations use the same terminal receipt helper within
+their existing feedback/edit transaction.
+
+`rollback(_:now:)` names one promotion receipt. It restores that promotion's direct retained base
+only if both the current stable digest and revision still identify the promotion in the same epoch.
+Owner triggers reference a durable, effective authenticated `candidate_reject` or
+`promotion_rollback` event on the exact candidate or promotion subject. Support-withdrawal triggers
+reference an effective owner not-useful, correction or evaluation-dispute event affecting one of
+the receipt's positive runs; the store reprojects only that fixed positive set and rolls back when
+fewer than two valid supports remain. A later active-run heuristic issue cannot supply this trigger.
+Trusted safety receipts bind the promotion and a security, secret-leakage, corruption or invariant
+failure. Adapter critical/regression triggers remain inert because production freezes no adapter.
+Stale triggers record a stale receipt and leave state unchanged. A successful rollback also closes
+a live successor trial with a stale receipt because that trial depended on the withdrawn base.
+Rollback keeps the epoch and
+advances the stable revision; owner reset remains its separate epoch-raising transaction. A closed
+or rolled-back replacement cannot open another trial against the same base and algorithm.
+
+The owner view decodes terminal receipts as well as admission, reflection and reset receipts.
+`currentPromotion(jobId:)` finds the exact active promotion independently of the last decision.
+For `/learning <jobId>`, `commitPromotionReply` rechecks that promotion, claims the transport update,
+and writes the exact promotion feedback target and all command-reply outbox chunks in one
+transaction. Only the final chunk carries the rollback button. The gateway pokes `OutboxSignal`
+after commit. A stale promotion exposes no new target. Callback-driven progression belongs to the
+workflow coordinator; the feedback boundary still authenticates, consumes and records the request.
+
 ## 15. Configuration & secrets
 
 - **Environment variables are the active configuration surface; `config.toml` remains future work.** The typed `AppConfig` is loaded from the environment/`.env` today; the structured-file behavior described below is the intended shape once that file lands, not a shipped surface. **A provider-qualified `CLAW_LLM_MODEL` value (`openai-chatgpt/<model>`) is the only configuration selector the subscription route adds** — there is deliberately **no per-provider environment namespace**. The model value carries the route selector, provider-owned OAuth state lives in the credential store, and fixed protocol details are implementation constants (§8.3), so ad-hoc `CLAW_CHATGPT_*` variables would only duplicate the structure that structured configuration will supply; they are **deferred with `config.toml`**, not merely unimplemented. When it lands, the registry deserializes provider-specific blocks into the same resolved route (§8.1) without changing any downstream seam.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -258,6 +258,18 @@ exactly one allowlisted owner), then it works through `HEARTBEAT.md` up to
 `CLAW_HEARTBEAT_MAX_PER_DAY` times a day, every `CLAW_HEARTBEAT_INTERVAL_MINUTES`
 minutes, staying silent during `CLAW_HEARTBEAT_QUIET_HOURS` (default `22:00-09:00`).
 
+### Inspect scheduled learning
+
+Send `/learning` to list jobs with retained learning state, or `/learning <jobId>` to inspect
+lessons, trial assignments and the last decision. Promotion receipts show the runs that supplied
+support and distinguish heuristic activation from owner-confirmed evidence.
+
+A detail reply for a current promotion carries **Roll back promotion** on its final message.
+That button records an authenticated request for that exact promotion. The learning coordinator
+applies rollback only while the promotion remains current. Rollback restores its direct prior
+lesson set and keeps the learning epoch. `/learning reset <jobId>` asks you to confirm a new epoch
+with an empty set and invalidates pending feedback controls.
+
 ## Voice messages (macOS 26)
 
 On by default, on-device, off on other platforms. `CLAW_VOICE_LOCALES` takes a


### PR DESCRIPTION
The owner can now inspect and reset learning state. Bounded trial cohorts are reconciled from authoritative evidence and feedback, then promotion, fallback and rollback update the stable lesson pointer with compare-and-swap checks.

Part **4 of 5** of the split of #181, implementing #178 on top of #166. Review and merge in the order below; this PR targets `feature/learning-03-candidates`. The complete production workflow is delivered by part 5.

## Stack

| Order | PR |
| --- | --- |
| 1 | [Capture immutable lessons and settled run evidence](https://github.com/ivan-magda/swift-claw/pull/192) |
| 2 | [Evaluate runs and collect authenticated owner feedback](https://github.com/ivan-magda/swift-claw/pull/193) |
| 3 | [Reflect bounded candidates and admit them for review](https://github.com/ivan-magda/swift-claw/pull/194) |
| 4 | [Add owner controls, bounded trials and terminal decisions](https://github.com/ivan-magda/swift-claw/pull/195) |
| 5 | [Wire the production learning workflow and organize its modules](https://github.com/ivan-magda/swift-claw/pull/181) |

## Scope and review guide

- Expose /learning inspection and strict receipt decoding.
- Add the owner-confirmed reset barrier, epoch invalidation and reset receipt validation.
- Reconcile trial assignments and validate candidate/source provenance, cohort outcomes and deadlines.
- Commit promotion, fallback and rollback receipts with exact stable identity and feedback revision checks.

Review owner inspection/reset separately from trial reconciliation, then trace promotion and rollback transactions. Focus on epoch, stable revision, support withdrawal and stale-request behavior.

## Split integrity

Move the existing TrialSerializationTests cooperative-pool deadlock fix and its one-thread CI filter into this part, where those tests first appear. Preserve the earlier fixture API; the later fixture cleanup stays in part 5.

Original feature commits are retained through `9e7dede66310da3defb0e606779974653af8ce30`. This partition adds no new tests or product behavior. An independent static review checked test placement, backport dependencies and partition-induced redundancy.

## Validation

Checked the exact tree at `bd3f07977785292ae27e04ba317802e37a64acbf` locally on macOS:

- `scripts/lint.sh --fix`: no additional formatting changes; diff inspected.
- `scripts/lint.sh`: `lint: ok` (existing non-fatal warnings remain).
- `swift build`: `Build complete!`.
- `timeout 600 swift test`: **3474 tests in 438 suites passed**.
- Page benchmark `scripts/lint.sh`: passed; `scripts/test.sh`: **70 tests, OK**.
- `LIBDISPATCH_COOPERATIVE_POOL_STRICT=1 timeout 120 swift test --filter TrialSerializationTests`: passed.

GitHub CI is tracked separately; these results are local, not a claim of completed remote CI.
