### PR TITLE
docs: complete GitHub community standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Report a reproducible problem with swift-claw.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Please search existing issues first.
+        For suspected vulnerabilities, use [private vulnerability reporting](https://github.com/ivan-magda/swift-claw/security/advisories/new) as described in [SECURITY.md](https://github.com/ivan-magda/swift-claw/blob/main/SECURITY.md).
+        Review everything before posting: remove credentials, tokens, private messages, personal identifiers, and sensitive paths. Do not attach your environment file or state directory.
+        Our [Code of Conduct](https://github.com/ivan-magda/swift-claw/blob/main/CODE_OF_CONDUCT.md) applies here.
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: Release tag or source commit. If available, include the output of clawd --version.
+      placeholder: Release tag or git commit SHA
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS version, CPU architecture, and install method. Include Swift version if building from source.
+      placeholder: macOS or Linux version; arm64 or x86_64; install script, release binary, or source build
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Give the smallest example that triggers the problem, including relevant commands or Telegram actions.
+      placeholder: |
+        1. Configure ...
+        2. Run or send ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead? Include error text and how often it occurs.
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Doctor output
+      description: Paste clawd doctor --json output after reviewing it for private information. It redacts secrets. If doctor cannot run, explain why.
+      render: text
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Optional redacted log excerpts, screenshots, relevant provider/model or feature settings, and the last working version.

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,0 +1,34 @@
+name: Feature request
+description: Propose an improvement with a concrete use case.
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues and check the [product scope](https://github.com/ivan-magda/swift-claw/blob/main/docs/PRD.md) first.
+        swift-claw is a single-maintainer personal assistant. Discuss the approach in the issue before building a nontrivial change; see [CONTRIBUTING.md](https://github.com/ivan-magda/swift-claw/blob/main/CONTRIBUTING.md).
+        Keep examples free of credentials and private data. Our [Code of Conduct](https://github.com/ivan-magda/swift-claw/blob/main/CODE_OF_CONDUCT.md) applies here.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to accomplish, and what makes it difficult today?
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Proposed behavior
+      description: Describe the result you want, with an example of how you would use it.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional workarounds or other approaches you have tried or considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Optional examples, related issues, or constraints that help explain the request.

--- a/.github/ISSUE_TEMPLATE/03-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/03-documentation.yml
@@ -1,0 +1,29 @@
+name: Documentation improvement
+description: Report missing, confusing, or incorrect documentation.
+labels: [documentation]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues first. Small typo or broken-link fixes can go straight to a pull request.
+        For exploitable behavior or exposed secrets, follow [SECURITY.md](https://github.com/ivan-magda/swift-claw/blob/main/SECURITY.md) instead of posting publicly.
+        Keep examples free of credentials and private data. Our [Code of Conduct](https://github.com/ivan-magda/swift-claw/blob/main/CODE_OF_CONDUCT.md) applies here.
+  - type: textarea
+    id: location
+    attributes:
+      label: Affected documentation
+      description: Link to the page and section, or describe where you expected to find the information. Include the release or commit if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What needs improvement?
+      description: Explain what is missing, confusing, or incorrect and what you were trying to do.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested correction
+      description: Optional wording, examples, or references that would help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability privately
+    url: https://github.com/ivan-magda/swift-claw/security/advisories/new
+    about: Follow SECURITY.md; do not disclose exploitable behavior in a public issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## What changed and why
+
+<!-- Describe the problem and resulting behavior. Include a before/after example if useful. -->
+
+## Related issue
+
+<!-- Link the issue with the agreed approach. Trivial fixes can skip an issue; say why. -->
+
+## Validation
+
+<!--
+List the checks you ran and their results. Explain any checks you did not run.
+For Swift changes: scripts/lint.sh, then swift build, then swift test.
+For documentation-only changes: check affected links, examples, and template syntax as applicable.
+
+For test changes, include or link the test-intent map from docs/TESTING.md:
+Risk | Production branch or seam | Nearest existing test | Unique mutant | Primary test
+Record the pre-commit redundancy pass. Cross-cutting test changes need an independent
+review of test value and redundancy.
+-->
+
+## Checklist
+
+<!-- Check applicable items; mark others N/A with a short reason. -->
+
+- [ ] I followed [CONTRIBUTING.md](https://github.com/ivan-magda/swift-claw/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/ivan-magda/swift-claw/blob/main/CODE_OF_CONDUCT.md).
+- [ ] Behavior changes have appropriate coverage following [docs/TESTING.md](https://github.com/ivan-magda/swift-claw/blob/main/docs/TESTING.md).
+- [ ] Architecture or contract changes are reflected in [docs/ARCHITECTURE.md](https://github.com/ivan-magda/swift-claw/blob/main/docs/ARCHITECTURE.md).
+- [ ] User-visible changes are reflected in every affected public guide (README, Getting Started, Install, Customization, and deploy).
+
+<!-- Report vulnerabilities privately using SECURITY.md. Remove credentials and private data from the diff, logs, and screenshots. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [ivan.magda@outlook.com](mailto:ivan.magda@outlook.com) (received by the project maintainer, Ivan Magda). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 Thanks for your interest in swift-claw.
 
+Please follow our [Code of Conduct](CODE_OF_CONDUCT.md) in project spaces. It also
+explains how to report unacceptable behavior privately.
+
 ## Open an issue first
 
 Please open an issue and agree on the approach before sending a pull request.
@@ -9,8 +12,14 @@ swift-claw is a single-maintainer project with a normative spec; a short issue
 discussion saves you from building something that can't merge. Small fixes
 (typos, broken links, obvious one-liners) can skip straight to a PR.
 
-For bug reports, include your platform, the output of `clawd doctor --json`
-(it redacts secrets), and steps to reproduce.
+Use the [issue chooser](https://github.com/ivan-magda/swift-claw/issues/new/choose)
+for bug reports, feature requests, and documentation improvements. Blank issues remain
+available for questions and other project work.
+
+For bug reports, include your version, platform, steps to reproduce, and the output of
+`clawd doctor --json` when available (or explain why it cannot run). Doctor redacts
+secrets, but review diagnostics and log excerpts for private information before posting.
+Never attach credentials, environment files, private conversations, or your state directory.
 
 For vulnerabilities, never open a public issue. Follow [SECURITY.md](SECURITY.md).
 
@@ -62,8 +71,9 @@ Day-to-day commands, including how to run the daemon locally, live in
 ## What a pull request needs
 
 - A linked issue with an agreed approach (except trivial fixes).
-- `scripts/lint.sh` and `swift test` green. CI runs the tests on macOS and Linux, and the
-  lint gate on Linux.
+- For Swift changes, `scripts/lint.sh`, then `swift build`, then `swift test` green.
+  CI runs the tests on macOS and Linux, and the lint gate on Linux. For documentation-only
+  changes, check affected links, examples, and template syntax as applicable.
 - Tests for behavior changes, structured as Given-When-Then
   (`// given` / `// when` / `// then`). [docs/TESTING.md](docs/TESTING.md) is
   the rubric for what earns a test.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Contributions are welcome. Open an issue to discuss what you have in mind before
 sending a pull request; [CONTRIBUTING.md](CONTRIBUTING.md) has the details and the
 lint/test gate.
 
+Please follow our [Code of Conduct](CODE_OF_CONDUCT.md) when participating in the project.
+
 ## License
 
 [MIT](LICENSE) © Ivan Magda


### PR DESCRIPTION
GitHub's community profile is missing a code of conduct, issue templates, and a pull request template. Add Contributor Covenant 2.1 with a private reporting contact, YAML forms for bugs, feature requests, and documentation improvements, and a PR template aligned with the repository's contribution and test guidance.

Keep blank issues available for questions and maintenance work, and route vulnerabilities to the existing private reporting channel. Link the new conduct policy and issue chooser from the contributor documentation. The maintainer requested this community-standards work directly; there is no separate tracking issue.

Validation:

- Parsed all four YAML files and checked form metadata, existing labels, field types, unique IDs, and required-field types. Verified all three forms in GitHub's native preview.
- Verified all 11 repository file links in the new templates and all six external links (HTTP 200), and compared the conduct policy against canonical Contributor Covenant 2.1 (only the reporting contact differs).
- Ran `scripts/lint.sh --fix`: no Swift formatting changes. Ran `scripts/lint.sh`: `lint: ok`, with existing warnings in unchanged files.
- Ran `git diff --check` and independent content review; corrected the review's wording finding.
- Did not run local `swift build` or `swift test`: this changes only community documentation and GitHub templates. The regular PR CI runs remain enabled.
