### PR TITLE
build: remove obsolete EventSource trait workaround

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,15 +13,6 @@ let package = Package(
     .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.11.0"),
     .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.2"),
     .package(url: "https://github.com/modelcontextprotocol/swift-sdk", from: "0.12.1"),
-    // Transitive through the MCP SDK. Declared here only to switch its "AsyncHTTPClient"
-    // trait on: the trait is off by default, yet the module is visible in our build (we
-    // depend on AsyncHTTPClient directly), so its `canImport` guard compiles code against
-    // a dependency the target never declared and the module search path breaks.
-    .package(
-      url: "https://github.com/mattt/eventsource.git",
-      from: "1.4.1",
-      traits: ["AsyncHTTPClient"]
-    ),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.14.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),


### PR DESCRIPTION
## What changed and why

Remove the direct EventSource dependency and its obsolete AsyncHTTPClient trait workaround. EventSource 1.5.1, adopted in #200, includes [the upstream fix](https://github.com/mattt/EventSource/pull/19) that gates the backend on the enabled trait instead of `canImport`.

EventSource remains a transitive MCP SDK dependency pinned to 1.5.1. The application's own MCP transport is unchanged.

## Related issue

Follow-up to #200. This small manifest cleanup does not need a separate issue.

## Validation

- `scripts/lint.sh --fix`, diff review, then `scripts/lint.sh`: passed (`lint: ok`; existing warnings).
- `swift build`: passed on macOS arm64 with Swift 6.3.3.
- `swift test`: 3449 tests in 439 suites passed. Opt-in live speech and container suites were skipped.
- A clean build also passed with EventSource's `AsyncHTTPClient` trait disabled; checked the compiler flags to verify that path was exercised.
- `Package.resolved` is unchanged. The diff only removes nine lines from `Package.swift`.

## Checklist

- [x] Followed CONTRIBUTING.md and the Code of Conduct.
- [x] Validated the build change through clean compilation and the existing test suite. No new runtime behavior or test diff.
- N/A — no architecture or contract changes.
- N/A — no user-visible changes requiring public guide updates.
