### PR TITLE
refactor: narrow module-owned public declarations

### DIFF
--- a/Sources/ClawAgent/Context/BudgetFitter.swift
+++ b/Sources/ClawAgent/Context/BudgetFitter.swift
@@ -1,12 +1,12 @@
 import ClawCore
 import Foundation
 
-public struct SectionUnit: Sendable, Equatable {
-  public let id: String
-  public let content: String
-  public let canTruncate: Bool
+struct SectionUnit: Sendable, Equatable {
+  let id: String
+  let content: String
+  let canTruncate: Bool
 
-  public init(id: String = "", content: String, canTruncate: Bool) {
+  init(id: String = "", content: String, canTruncate: Bool) {
     self.id = id
     self.content = content
     self.canTruncate = canTruncate
@@ -15,7 +15,7 @@ public struct SectionUnit: Sendable, Equatable {
 
 /// How a row announces the units the budget dropped. The row owns the wording so the fitter stays
 /// row-agnostic, and the rendered line is cost-accounted inside the row's cap like any other unit.
-public enum DropMarker: Sendable, Equatable {
+enum DropMarker: Sendable, Equatable {
   case none
   case showingCount(noun: String)
 
@@ -29,16 +29,16 @@ public enum DropMarker: Sendable, Equatable {
   }
 }
 
-public struct FittableSection: Sendable, Equatable, Identifiable {
-  public let id: ContextRowID
-  public let tier: ContextTier
-  public let priority: ContextPriority
-  public let truncatable: Bool
-  public let cap: Int?
-  public let dropMarker: DropMarker
-  public let units: [SectionUnit]
+struct FittableSection: Sendable, Equatable, Identifiable {
+  let id: ContextRowID
+  let tier: ContextTier
+  let priority: ContextPriority
+  let truncatable: Bool
+  let cap: Int?
+  let dropMarker: DropMarker
+  let units: [SectionUnit]
 
-  public init(
+  init(
     id: ContextRowID,
     tier: ContextTier,
     priority: ContextPriority,
@@ -57,16 +57,16 @@ public struct FittableSection: Sendable, Equatable, Identifiable {
   }
 }
 
-public struct FittedSection: Sendable, Equatable, Identifiable {
-  public let id: ContextRowID
-  public let tier: ContextTier
-  public let priority: ContextPriority
-  public let truncatable: Bool
-  public let cap: Int?
-  public let units: [SectionUnit]
-  public let droppedUnitIDs: [String]
+struct FittedSection: Sendable, Equatable, Identifiable {
+  let id: ContextRowID
+  let tier: ContextTier
+  let priority: ContextPriority
+  let truncatable: Bool
+  let cap: Int?
+  let units: [SectionUnit]
+  let droppedUnitIDs: [String]
 
-  public var content: String {
+  var content: String {
     renderUnits(units)
   }
 
@@ -81,15 +81,15 @@ public struct FittedSection: Sendable, Equatable, Identifiable {
   }
 }
 
-public enum BudgetFitterError: Error, Equatable {
+enum BudgetFitterError: Error, Equatable {
   case nonTruncatableRowsExceedInputCap(required: Int, cap: Int)
 }
 
-public enum BudgetFitter {
-  public static let truncationMarker = TextTruncation.marker
-  public static let dropMarkerUnitID = "drop-marker"
+enum BudgetFitter {
+  static let truncationMarker = TextTruncation.marker
+  static let dropMarkerUnitID = "drop-marker"
 
-  public static func fitWithUnits(
+  static func fitWithUnits(
     _ sections: [FittableSection],
     budget: ContextBudget
   ) throws -> [FittedSection] {
@@ -254,7 +254,7 @@ public enum BudgetFitter {
   /// What the truncatable rows have left to share: the input cap less whatever the fixed rows
   /// render to. The assembler pre-scales each truncatable cap against this before handing the
   /// sections over, so both sides have to read one formula or the caps stop matching the squeeze.
-  public static func residual(for sections: [FittableSection], budget: ContextBudget) -> Int {
+  static func residual(for sections: [FittableSection], budget: ContextBudget) -> Int {
     residual(required: requiredGraphemes(sections), budget: budget)
   }
 

--- a/Sources/ClawAgent/Context/ContextRowPolicy.swift
+++ b/Sources/ClawAgent/Context/ContextRowPolicy.swift
@@ -6,7 +6,7 @@ extension ContextRowID {
   /// carry no cap, and neither does the lessons row — its content is already capped at three
   /// lessons and 1536 bytes when the set is built. The four truncatable rows are scaled against
   /// whatever the fixed sections left.
-  public func resolve(in budget: ContextBudget, residualGraphemes: Int?) -> Int? {
+  func resolve(in budget: ContextBudget, residualGraphemes: Int?) -> Int? {
     switch self {
     case .policy, .systemWorkspace, .tools, .metadata, .lessons:
       nil
@@ -60,27 +60,15 @@ extension ContextRowID {
   }
 }
 
-public struct RowSpec: Sendable, Equatable, Identifiable {
-  public let id: ContextRowID
-  public let tier: ContextTier
-  public let priority: ContextPriority
-  public let truncatable: Bool
-
-  public init(
-    id: ContextRowID,
-    tier: ContextTier,
-    priority: ContextPriority,
-    truncatable: Bool
-  ) {
-    self.id = id
-    self.tier = tier
-    self.priority = priority
-    self.truncatable = truncatable
-  }
+struct RowSpec: Sendable, Equatable, Identifiable {
+  let id: ContextRowID
+  let tier: ContextTier
+  let priority: ContextPriority
+  let truncatable: Bool
 }
 
-public enum ContextRowPolicy {
-  public static let specs: [RowSpec] = [
+enum ContextRowPolicy {
+  static let specs: [RowSpec] = [
     RowSpec(
       id: .policy,
       tier: .system,

--- a/Sources/ClawAgent/Context/HistoryHygiene.swift
+++ b/Sources/ClawAgent/Context/HistoryHygiene.swift
@@ -5,8 +5,8 @@ import Foundation
 /// any anchor whose observations are incomplete, so a malformed history (crash, partial commit)
 /// can never become a wire-protocol 400. The LOAD seam already bounds windows by conversational
 /// rows; no-orphan holds only because BOTH seams enforce it.
-public enum HistoryHygiene {
-  public static func sanitize(_ history: [StoredMessage]) -> [StoredMessage] {
+enum HistoryHygiene {
+  static func sanitize(_ history: [StoredMessage]) -> [StoredMessage] {
     var sanitized: [StoredMessage] = []
     var index = 0
 

--- a/Sources/ClawAgent/Context/MemoryRanker.swift
+++ b/Sources/ClawAgent/Context/MemoryRanker.swift
@@ -1,8 +1,8 @@
 import ClawCore
 import Foundation
 
-public enum MemoryRanker {
-  public static func rank(
+enum MemoryRanker {
+  static func rank(
     items: [MemoryItem],
     excludeSensitive: Bool,
     cap: Int

--- a/Sources/ClawAppleSpeech/AppleSpeechTranscriber.swift
+++ b/Sources/ClawAppleSpeech/AppleSpeechTranscriber.swift
@@ -13,17 +13,17 @@ import Foundation
   /// `SpeechTranscriber` model where the locale is supported and falls back to
   /// `DictationTranscriber` (the older system-dictation model, e.g. for `ru-RU`) elsewhere.
   @available(macOS 26.0, *)
-  public actor AppleSpeechTranscriber: VoiceTranscribing {
+  actor AppleSpeechTranscriber: VoiceTranscribing {
     private let localeIdentifiers: [String]
 
     private let maxAudioDurationSeconds: Int?
 
-    public init(localeIdentifiers: [String], maxAudioDurationSeconds: Int? = nil) {
+    init(localeIdentifiers: [String], maxAudioDurationSeconds: Int? = nil) {
       self.localeIdentifiers = localeIdentifiers
       self.maxAudioDurationSeconds = maxAudioDurationSeconds
     }
 
-    public func transcribe(
+    func transcribe(
       audioFileAt url: URL
     ) async throws(VoiceTranscriptionError) -> String {
       let lanes = await Self.resolveLanes(for: localeIdentifiers)

--- a/Sources/ClawAuth/Catalog/ChatGPTModelCatalog.swift
+++ b/Sources/ClawAuth/Catalog/ChatGPTModelCatalog.swift
@@ -25,7 +25,7 @@ public struct ChatGPTCatalogModel: Sendable, Equatable {
 /// print the assignment for the owner to set by hand — so the type names one outcome rather than a
 /// taxonomy nobody branches on. What it must never be is a login failure: the credential is already
 /// stored and valid by the time anything asks what models exist.
-public enum ChatGPTCatalogFailure: Error, Sendable, Equatable {
+enum ChatGPTCatalogFailure: Error, Sendable, Equatable {
   case unavailable(detail: String)
 }
 

--- a/Sources/ClawAuth/Catalog/ChatGPTModelPicker.swift
+++ b/Sources/ClawAuth/Catalog/ChatGPTModelPicker.swift
@@ -3,29 +3,29 @@ import Foundation
 
 /// What a model choice is and where it came from. The origin is what lets the command explain a
 /// default it picked without asking.
-public enum ChatGPTModelChoiceOrigin: Sendable, Equatable {
+enum ChatGPTModelChoiceOrigin: Sendable, Equatable {
   case configuredDefault
   case firstReturnedDefault
   case owner
 }
 
-public struct ChatGPTModelChoice: Sendable, Equatable {
-  public let slug: String
-  public let origin: ChatGPTModelChoiceOrigin
+struct ChatGPTModelChoice: Sendable, Equatable {
+  let slug: String
+  let origin: ChatGPTModelChoiceOrigin
 
-  public init(slug: String, origin: ChatGPTModelChoiceOrigin) {
+  init(slug: String, origin: ChatGPTModelChoiceOrigin) {
     self.slug = slug
     self.origin = origin
   }
 
   /// The exact line an owner may paste. The variable is the one configuration reads and the prefix
   /// is the route's own, so a chosen model resolves back to the provider it came from.
-  public var assignment: String {
+  var assignment: String {
     "\(AppConfig.EnvKey.llmModel)=\(ChatGPTProviderMetadata.modelPrefix)\(slug)"
   }
 }
 
-public enum ChatGPTModelPickerOutcome: Sendable, Equatable {
+enum ChatGPTModelPickerOutcome: Sendable, Equatable {
   case chose(ChatGPTModelChoice)
   /// The owner named a row the numbered list does not have. The caller asks again; nothing here
   /// decides how many times it may.
@@ -36,14 +36,14 @@ public enum ChatGPTModelPickerOutcome: Sendable, Equatable {
 /// Picks a model from a catalog. A pure function of what it is handed: it reads no terminal, no
 /// configuration, and no clock, so the same arguments always name the same model — which is what
 /// makes the default a non-interactive run takes provably the one a terminal would have offered.
-public enum ChatGPTModelPicker {
+enum ChatGPTModelPicker {
   /// - Parameters:
   ///   - configuredSuffix: the ChatGPT model already configured, if any. Honored only while the
   ///     catalog still offers it: a default naming a model the vendor has withdrawn would be a
   ///     suggestion that cannot work.
   ///   - chosenIndex: the row an owner named, numbered from one as the printed list is. Ignored
   ///     without a terminal, where no prompt ran and so no answer can have come back.
-  public static func select(
+  static func select(
     catalog: [ChatGPTCatalogModel],
     configuredSuffix: String?,
     isInteractive: Bool,

--- a/Sources/ClawAuth/Commands/AuthMutationCoordinator.swift
+++ b/Sources/ClawAuth/Commands/AuthMutationCoordinator.swift
@@ -52,10 +52,10 @@ public protocol AuthMutationLocking: Sendable {
 
 // MARK: - Coordinator
 
-public struct AuthMutationCoordinator: Sendable {
+struct AuthMutationCoordinator: Sendable {
   private let lock: any AuthMutationLocking
 
-  public init(lock: any AuthMutationLocking) {
+  init(lock: any AuthMutationLocking) {
     self.lock = lock
   }
 

--- a/Sources/ClawAuth/Presentation/AuthCommandResultMapper.swift
+++ b/Sources/ClawAuth/Presentation/AuthCommandResultMapper.swift
@@ -58,13 +58,13 @@ public struct AuthCommandResult: Sendable, Equatable {
 /// It exists so the table is in one place and can be read as a table. Scattering these decisions
 /// through the workflow would make "does a broken envelope really exit 11?" a question answered by
 /// tracing control flow.
-public enum AuthCommandResultMapper {
-  public static let cancelled = AuthCommandResult(
+enum AuthCommandResultMapper {
+  static let cancelled = AuthCommandResult(
     exit: .cancelled,
     events: [.error("Cancelled. The stored credential is unchanged.")]
   )
 
-  public static func result(for failure: AuthMutationLockFailure) -> AuthCommandResult {
+  static func result(for failure: AuthMutationLockFailure) -> AuthCommandResult {
     switch failure {
     case .held:
       return AuthCommandResult(
@@ -90,7 +90,7 @@ public enum AuthCommandResultMapper {
   /// ordinary command failure on an error no case happens to name would be the one mistake that
   /// matters here: it would tell a supervisor to try again on a condition that will never fix
   /// itself.
-  public static func runtimeSecretResult(for error: any Error) -> AuthCommandResult {
+  static func runtimeSecretResult(for error: any Error) -> AuthCommandResult {
     let named = error as? SecretStoreError
     let cause =
       if let named {
@@ -110,21 +110,21 @@ public enum AuthCommandResultMapper {
 
   /// Worded for a read and a write alike: login saves through this seam, status and logout read
   /// through it, and a lead that named one of those would be wrong for the other two.
-  public static func result(for error: LLMCredentialStoreError) -> AuthCommandResult {
+  static func result(for error: LLMCredentialStoreError) -> AuthCommandResult {
     AuthCommandResult(
       exit: .secretLoadFailure,
       events: [.error("The stored credential could not be accessed: \(describe(error)).")]
     )
   }
 
-  public static func credentialStoreResult(for error: any Error) -> AuthCommandResult {
+  static func credentialStoreResult(for error: any Error) -> AuthCommandResult {
     guard let named = error as? LLMCredentialStoreError else {
       return unexpected()
     }
     return result(for: named)
   }
 
-  public static func result(for failure: ChatGPTOAuthFailure) -> AuthCommandResult {
+  static func result(for failure: ChatGPTOAuthFailure) -> AuthCommandResult {
     AuthCommandResult(
       exit: .commandFailure,
       events: [.error("Login failed: \(describe(failure)).")]
@@ -134,7 +134,7 @@ public enum AuthCommandResultMapper {
   /// A failure no seam named. It is an ordinary command failure, and it says nothing about the error
   /// it came from: an unrecognized value is exactly the one whose description nobody has checked for
   /// a token. Every command shares it, so it names none of them.
-  public static func unexpected() -> AuthCommandResult {
+  static func unexpected() -> AuthCommandResult {
     AuthCommandResult(
       exit: .commandFailure,
       events: [.error("The command failed for an unexpected reason.")]

--- a/Sources/ClawCore/Domain/Bot/PositiveInt64.swift
+++ b/Sources/ClawCore/Domain/Bot/PositiveInt64.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public enum PositiveInt64 {
-  public static func parse(_ raw: String) -> Int64? {
+enum PositiveInt64 {
+  static func parse(_ raw: String) -> Int64? {
     let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
 
     guard let value = Int64(trimmed), value > 0 else {

--- a/Sources/ClawCore/Domain/Learning/LessonSet.swift
+++ b/Sources/ClawCore/Domain/Learning/LessonSet.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-public enum LessonSetLimits {
-  public static let maxLessons = 3
-  public static let maxLessonBytes = 512
-  public static let maxSetBytes = 1_536
+enum LessonSetLimits {
+  static let maxLessons = 3
+  static let maxLessonBytes = 512
+  static let maxSetBytes = 1_536
 }
 
 public enum LessonSetError: Error, Sendable, Equatable {

--- a/Sources/ClawCore/Domain/Memory/MemoryWriteRequest.swift
+++ b/Sources/ClawCore/Domain/Memory/MemoryWriteRequest.swift
@@ -14,7 +14,7 @@ public enum MemoryWriteWarning: Sendable, Equatable {
   }
 }
 
-public enum MemoryWriteBuildError: Error, Sendable, Equatable {
+enum MemoryWriteBuildError: Error, Sendable, Equatable {
   case emptyAfterNormalization
 }
 

--- a/Sources/ClawCore/Transport/BoundedAsyncChannel.swift
+++ b/Sources/ClawCore/Transport/BoundedAsyncChannel.swift
@@ -26,7 +26,7 @@ public enum BoundedAsyncChannelError: Error, Sendable, Equatable {
 /// The consumer owns teardown. Abandoning the iteration — `break`ing out of a `for try await`
 /// without cancelling the consuming task — strands every parked producer forever, so such a
 /// consumer must call `finish()`. Cancelling the consumer instead unwinds the producers correctly.
-public struct BoundedAsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
+struct BoundedAsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
   private let storage: Storage
 
   /// - Parameter capacity: the greatest total weight the buffer may hold. Must be positive.
@@ -34,7 +34,7 @@ public struct BoundedAsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
   ///   the channel's lock, and must not return a negative weight. An element's weight is floored at
   ///   one: every element holds a buffer slot whatever its payload costs, so the channel bounds
   ///   element count even for a stream that weighs nothing.
-  public init(
+  init(
     capacity: Int,
     weight: @escaping @Sendable (Element) -> Int = { _ in 1 }
   ) {
@@ -47,31 +47,31 @@ public struct BoundedAsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
   /// - Throws: `CancellationError` if the calling task is cancelled first — the element is not
   ///   queued; `BoundedAsyncChannelError.channelFinished` if the channel is already closed; or a
   ///   weight rejection for an element this channel could never admit.
-  public func send(_ element: Element) async throws {
+  func send(_ element: Element) async throws {
     try await storage.send(element)
   }
 
   /// Ends the sequence once every already-accepted element has been read. Later calls are ignored:
   /// the first termination wins.
-  public func finish() {
+  func finish() {
     storage.close(with: .finished)
   }
 
   /// Ends the sequence with `error`, delivered after every already-accepted element. Later calls are
   /// ignored.
-  public func finish(throwing error: any Error) {
+  func finish(throwing error: any Error) {
     storage.close(with: .failed(error))
   }
 
-  public func makeAsyncIterator() -> Iterator {
+  func makeAsyncIterator() -> Iterator {
     Iterator(storage: storage, hasClaim: storage.claimIterator())
   }
 
-  public struct Iterator: AsyncIteratorProtocol {
+  struct Iterator: AsyncIteratorProtocol {
     fileprivate let storage: Storage
     fileprivate let hasClaim: Bool
 
-    public mutating func next() async throws -> Element? {
+    mutating func next() async throws -> Element? {
       guard hasClaim else {
         throw BoundedAsyncChannelError.multipleIterators
       }

--- a/Sources/ClawGateway/Coder/CoderCompletionReport.swift
+++ b/Sources/ClawGateway/Coder/CoderCompletionReport.swift
@@ -1,13 +1,13 @@
 import ClawCore
 
-public struct CoderCompletionReport: Sendable {
+struct CoderCompletionReport: Sendable {
   private let redact: @Sendable (String) -> String
 
-  public init(redact: @escaping @Sendable (String) -> String) {
+  init(redact: @escaping @Sendable (String) -> String) {
     self.redact = redact
   }
 
-  public func chunks(job: CoderJob, result: CoderResult) -> [OutboxChunk] {
+  func chunks(job: CoderJob, result: CoderResult) -> [OutboxChunk] {
     var blocks = ["## Coder · \(redact(result.state.rawValue))", field("Summary", result.summary)]
 
     if job.ownership != .none && job.ownership != .stopped {

--- a/Sources/ClawGateway/Learning/LearningSurface.swift
+++ b/Sources/ClawGateway/Learning/LearningSurface.swift
@@ -2,15 +2,15 @@ import ClawCore
 import Foundation
 
 /// Pure owner-facing rendering for the typed learning snapshot.
-public enum LearningSurface {
-  public static let emptyList = "No scheduled jobs have learning state yet."
+enum LearningSurface {
+  static let emptyList = "No scheduled jobs have learning state yet."
 
-  public enum Style: Sendable {
+  enum Style: Sendable {
     case list
     case detail
   }
 
-  public static func render(_ views: [JobLearningView], style: Style = .detail) -> String {
+  static func render(_ views: [JobLearningView], style: Style = .detail) -> String {
     switch style {
     case .list:
       return renderList(views)

--- a/Sources/ClawGateway/Response/ApprovalKeyboard.swift
+++ b/Sources/ClawGateway/Response/ApprovalKeyboard.swift
@@ -4,20 +4,20 @@
 /// clock, no randomness) so the outbox row it lands in is reproducible; `parse` is STRICT — only
 /// "apr:<nonce>:y" / "apr:<nonce>:n" survive, so a malformed or forged shape is dropped before the
 /// auth chain ever runs.
-public enum ApprovalKeyboard {
-  public static let approveVerdict = "y"
-  public static let denyVerdict = "n"
+enum ApprovalKeyboard {
+  static let approveVerdict = "y"
+  static let denyVerdict = "n"
 
   private static let prefix = "apr"
 
-  public static func callbackData(nonce: String, verdict: String) -> String {
+  static func callbackData(nonce: String, verdict: String) -> String {
     "\(prefix):\(nonce):\(verdict)"
   }
 
   /// Deterministic by construction: a fixed (sorted) key order, no whitespace, no Date or random.
   /// The nonce is base64url (`[A-Za-z0-9-_]`) and the verdicts/labels are ASCII, so nothing here
   /// needs JSON escaping. The client decodes this String to an object for the request body.
-  public static func markup(nonce: String) -> String {
+  static func markup(nonce: String) -> String {
     let approve = callbackData(nonce: nonce, verdict: approveVerdict)
     let deny = callbackData(nonce: nonce, verdict: denyVerdict)
     return #"""
@@ -28,7 +28,7 @@ public enum ApprovalKeyboard {
       """#
   }
 
-  public static func parse(_ callbackData: String) -> (nonce: String, approve: Bool)? {
+  static func parse(_ callbackData: String) -> (nonce: String, approve: Bool)? {
     let parts =
       callbackData
       .split(separator: ":", omittingEmptySubsequences: false)

--- a/Sources/ClawGateway/Response/CommandReplies.swift
+++ b/Sources/ClawGateway/Response/CommandReplies.swift
@@ -1,24 +1,24 @@
 import ClawCore
 
-public enum CommandReplies {
-  public static let stopped = "Stopped."
-  public static let nothingToStop = "Nothing to stop."
-  public static let freshConversation =
+enum CommandReplies {
+  static let stopped = "Stopped."
+  static let nothingToStop = "Nothing to stop."
+  static let freshConversation =
     "Started a fresh conversation — earlier context cleared."
 
   /// Refusal for the owner-scoped command families in a shared room. It names the private state so
   /// the attendee learns the rule, not just this one rejection.
-  public static let directOnly =
+  static let directOnly =
     "Not here — memory, schedules, and learning state live in my owner's direct chat."
 
-  public static let learningUsage = "Usage: /learning reset <id>. See /learning"
-  public static let learningUnavailable = "Learning status is unavailable. Try again."
+  static let learningUsage = "Usage: /learning reset <id>. See /learning"
+  static let learningUnavailable = "Learning status is unavailable. Try again."
 
   /// The owner manual, including the parked-entry interaction rules (stated verbatim as
   /// owner-visible text): slash commands bypass confirmation resolution entirely; only the
   /// next plain text resolves a parked entry; /new clears it; another gated command displaces it;
   /// /stop and /new act on the interactive session only.
-  public static let help = """
+  static let help = """
     Commands:
     /schedule <text>: create a schedule (I confirm before it arms)
     /schedule list: list schedules

--- a/Sources/ClawGateway/Response/MemoryReplies.swift
+++ b/Sources/ClawGateway/Response/MemoryReplies.swift
@@ -3,47 +3,47 @@ import Foundation
 
 /// Owner-facing copy for `/remember` and `/memory`: terse, mobile-first, provenance on the line.
 /// Pure rendering - no store or transport knowledge.
-public enum MemoryReplies {
+enum MemoryReplies {
   /// A screenful on mobile; the review list never tries to show everything.
-  public static let reviewListLimit = 20
+  static let reviewListLimit = 20
 
   static let snippetCapGraphemes = 60
 
-  public static var rememberUsage: String {
+  static var rememberUsage: String {
     "Usage: /remember [\(kindNames):] <text>"
   }
 
-  public static var memoryUsage: String {
+  static var memoryUsage: String {
     "Usage: /memory [\(kindNames)] | /memory show <id> | /memory delete <id>"
   }
 
-  public static let nothingToSave = "No savable text."
-  public static let cancelled = "Cancelled."
+  static let nothingToSave = "No savable text."
+  static let cancelled = "Cancelled."
 
   /// Terminal owner-write failure copy: the pending intent was cleared; re-issue.
-  public static let saveFailed =
+  static let saveFailed =
     "Couldn't save it. Nothing was written. Run /remember again."
-  public static let deleteFailed =
+  static let deleteFailed =
     "Couldn't delete it. Nothing changed. Run /memory delete <id> again."
 
   /// `id` is nil only if a `MemoryCommandStore` violates its newlyClaimed-implies-item contract;
   /// the ack degrades instead of crashing the router.
-  public static func saved(id: Int64?) -> String {
+  static func saved(id: Int64?) -> String {
     if let id {
       return "Saved memory \(id)."
     }
     return "Saved."
   }
 
-  public static func deleted(id: Int64) -> String {
+  static func deleted(id: Int64) -> String {
     "Deleted memory \(id)."
   }
 
-  public static func notFound(id: Int64) -> String {
+  static func notFound(id: Int64) -> String {
     "No memory with id \(id)."
   }
 
-  public static func emptyReview(kind: MemoryKind?) -> String {
+  static func emptyReview(kind: MemoryKind?) -> String {
     if let kind {
       return "No \(kind.rawValue) memories yet."
     }
@@ -52,7 +52,7 @@ public enum MemoryReplies {
 
   /// Grouped by kind (declaration order), each line `id · «short text» · source · date · ⚠`.
   /// Items keep the store's most-recent-first order within their group.
-  public static func reviewList(items: [MemoryItem]) -> String {
+  static func reviewList(items: [MemoryItem]) -> String {
     let limitedItems = Array(items.prefix(reviewListLimit))
     var lines: [String] = []
 
@@ -72,7 +72,7 @@ public enum MemoryReplies {
   }
 
   /// Full text and full provenance: kind, source, session, created, sensitivity.
-  public static func showItem(_ item: MemoryItem) -> String {
+  static func showItem(_ item: MemoryItem) -> String {
     let sessionText = item.sessionId.map(String.init) ?? "none"
     let lines = [
       "Memory \(item.id): \(item.kind.rawValue)",
@@ -84,7 +84,7 @@ public enum MemoryReplies {
     return lines.joined(separator: "\n")
   }
 
-  public static func deleteConfirmPrompt(item: MemoryItem) -> String {
+  static func deleteConfirmPrompt(item: MemoryItem) -> String {
     let lines = [
       "Delete memory \(item.id)?",
       "«\(item.text)»",

--- a/Sources/ClawGateway/Response/ScheduleReplies.swift
+++ b/Sources/ClawGateway/Response/ScheduleReplies.swift
@@ -4,14 +4,14 @@ import Foundation
 /// Owner-facing copy for the scheduling surface: the confirm prompt shows the parked draft
 /// VERBATIM and never model-truncated, and every fire time is rendered in the job's own
 /// timezone. Pure rendering — no store or transport knowledge.
-public enum ScheduleReplies {
+enum ScheduleReplies {
   /// The confirm prompt previews the next 3 fire times.
-  public static let confirmPreviewCount = 3
+  static let confirmPreviewCount = 3
 
   static let exampleLine =
     "Example: /schedule every weekday at 07:00, summarize my unread items"
 
-  public static var parseFailed: String {
+  static var parseFailed: String {
     "I couldn't turn that into a schedule. \(exampleLine)"
   }
 
@@ -20,23 +20,23 @@ public enum ScheduleReplies {
   // auth sentence names the exact recovery command, while access and quota deliberately do not.
 
   /// A `/schedule` parse that could not reach a usable model (terminal reject, brownout, deadline).
-  public static var providerUnavailable: String { Degradation.providerUnavailable }
+  static var providerUnavailable: String { Degradation.providerUnavailable }
 
   /// The credential is gone or refused; names `clawd auth login` as the exact recovery.
-  public static var authenticationRequired: String { Degradation.authenticationRequired }
+  static var authenticationRequired: String { Degradation.authenticationRequired }
 
   /// The plan/account cannot use the requested route or model; does not tell the owner to log in.
-  public static var accessDenied: String { Degradation.accessDenied }
+  static var accessDenied: String { Degradation.accessDenied }
 
   /// A clean throttle; says to retry after the provider's hint or the plan reset, never to log in.
-  public static func quotaLimited(retryAfterSeconds: Int?) -> String {
+  static func quotaLimited(retryAfterSeconds: Int?) -> String {
     Degradation.quotaLimited(retryAfterSeconds: retryAfterSeconds)
   }
 
   /// The owner reply for a `/schedule` parse that failed at the provider. Typed failures earn their
   /// own actionable guidance; every other result falls back to the generic unavailable copy (the
   /// router only routes provider-failure results here, so the fallback is never reached in practice).
-  public static func providerFailure(_ result: ScheduleDraftParseResult) -> String {
+  static func providerFailure(_ result: ScheduleDraftParseResult) -> String {
     switch result {
     case .authenticationRequired:
       return authenticationRequired
@@ -49,19 +49,19 @@ public enum ScheduleReplies {
     }
   }
 
-  public static var emptyList: String {
+  static var emptyList: String {
     "No schedules yet. \(exampleLine)"
   }
 
   /// Terminal arm failure: the pending intent was cleared; re-issue.
-  public static let armFailed =
+  static let armFailed =
     "Couldn't arm the schedule. Nothing was created. Run /schedule again."
 
   /// A parked one-shot confirmed after its instant already passed — nothing left to arm.
-  public static let armExpired =
+  static let armExpired =
     "That schedule's time has already passed. Send /schedule again to set a new one."
 
-  public static func confirmPrompt(schedule: ValidatedSchedule, nextFires: [Date]) -> String {
+  static func confirmPrompt(schedule: ValidatedSchedule, nextFires: [Date]) -> String {
     var lines = [
       "Arm this schedule?",
       "label: «\(schedule.label)»",
@@ -81,7 +81,7 @@ public enum ScheduleReplies {
 
   /// `job` is nil only if a `ScheduleCommandStore` violates its newlyClaimed-implies-job
   /// contract; the ack degrades instead of crashing the router (the MemoryReplies.saved pattern).
-  public static func armed(job: ScheduledJob?) -> String {
+  static func armed(job: ScheduledJob?) -> String {
     guard let job else {
       return "Armed."
     }
@@ -95,7 +95,7 @@ public enum ScheduleReplies {
   }
 
   /// One `/schedule list` row: `id · label · status · recurrence-in-words · tz · next fire`.
-  public static func listLines(_ rows: [(job: ScheduledJob, nextFire: Date?)]) -> String {
+  static func listLines(_ rows: [(job: ScheduledJob, nextFire: Date?)]) -> String {
     rows.map { row in
       let fire =
         row.nextFire.map { date in
@@ -108,23 +108,23 @@ public enum ScheduleReplies {
     }.joined(separator: "\n")
   }
 
-  public static func notFound(id: Int64) -> String {
+  static func notFound(id: Int64) -> String {
     "No schedule with id \(id). See /schedule list."
   }
 
   /// Terminal verb failure after the update was already claimed: nothing changed; re-issue.
-  public static let verbFailed = "Couldn't update the schedule. Nothing changed. Try again."
+  static let verbFailed = "Couldn't update the schedule. Nothing changed. Try again."
 
-  public static let pauseUsage = "Usage: /pause <id>. See /schedule list"
-  public static let resumeUsage = "Usage: /resume <id>. See /schedule list"
-  public static let runNowUsage = "Usage: /runnow <id>. See /schedule list"
-  public static let cancelUsage = "Usage: /cancel <id>. See /schedule list"
+  static let pauseUsage = "Usage: /pause <id>. See /schedule list"
+  static let resumeUsage = "Usage: /resume <id>. See /schedule list"
+  static let runNowUsage = "Usage: /runnow <id>. See /schedule list"
+  static let cancelUsage = "Usage: /cancel <id>. See /schedule list"
 
-  public static func paused(job: ScheduledJob) -> String {
+  static func paused(job: ScheduledJob) -> String {
     "Paused schedule \(job.id) · «\(job.label)». Resume with /resume \(job.id)."
   }
 
-  public static func resumed(job: ScheduledJob) -> String {
+  static func resumed(job: ScheduledJob) -> String {
     guard let next = job.nextOccurrence else {
       return "Resumed schedule \(job.id) · «\(job.label)». Nothing left to fire."
     }
@@ -134,19 +134,19 @@ public enum ScheduleReplies {
       """
   }
 
-  public static func cancelled(job: ScheduledJob) -> String {
+  static func cancelled(job: ScheduledJob) -> String {
     """
     Cancelled schedule \(job.id) · «\(job.label)». It will not fire again; \
     an in-flight run finishes on its own.
     """
   }
 
-  public static func runningNow(id: Int64) -> String {
+  static func runningNow(id: Int64) -> String {
     "Running schedule \(id) now. You'll get the result like any scheduled delivery."
   }
 
   /// `/runnow` on a job whose previous run hasn't finished: the fire is skipped, not failed.
-  public static func alreadyRunning(id: Int64) -> String {
+  static func alreadyRunning(id: Int64) -> String {
     "Schedule \(id) already has a run in progress. Wait for it to finish, then try again."
   }
 

--- a/Sources/ClawGateway/Response/ToolApprovalPrompt.swift
+++ b/Sources/ClawGateway/Response/ToolApprovalPrompt.swift
@@ -5,19 +5,19 @@ import Foundation
 /// authored HERE, never by the model, and the fully-resolved canonical target is never
 /// truncated. Delivery-only: joined into the outbox payload, never stored as assistant history.
 /// Exhaustive over `ApprovalReason` — a new approval kind cannot compile without owner-facing copy.
-public enum ToolApprovalPrompt {
+enum ToolApprovalPrompt {
   /// Everything the durable-approval prompt renders. The banners are decided by the suspend
   /// commit from the originating turn's taint state and the target's identity; the
   /// renderer stays a pure function of its input.
-  public struct Input: Sendable, Equatable {
-    public let recorded: RecordedToolAction
+  struct Input: Sendable, Equatable {
+    let recorded: RecordedToolAction
     /// The originating turn ingested untrusted content (TAINT banner).
-    public let taintBanner: Bool
+    let taintBanner: Bool
     /// The canonical target is a file that steers a later turn (privileged-file banner).
-    public let privilegedFileBanner: Bool
-    public let isGroup: Bool
+    let privilegedFileBanner: Bool
+    let isGroup: Bool
 
-    public init(
+    init(
       recorded: RecordedToolAction,
       taintBanner: Bool,
       privilegedFileBanner: Bool,
@@ -34,7 +34,7 @@ public enum ToolApprovalPrompt {
   /// fully-resolved target, blast radius, the privileged-file banner, the tool-authored
   /// secret-redacted preview, and scan warnings — assembled in a fixed order so the owner can
   /// judge risk at a glance.
-  public static func text(for input: Input) -> String {
+  static func text(for input: Input) -> String {
     if input.recorded.reason == .coderSubmit {
       return coderText(for: input)
     }
@@ -73,7 +73,7 @@ public enum ToolApprovalPrompt {
   /// outbox. The inline keyboard rides the FINAL chunk — the one ending with the tap instruction —
   /// and the suspend commit stamps `approval_id` onto exactly that keyboard-carrying chunk
   /// (`enqueuePromptChunks`), so button disarm keeps working across a split.
-  public static func chunks(for input: Input, chatId: Int64, nonce: String) -> [OutboxChunk] {
+  static func chunks(for input: Input, chatId: Int64, nonce: String) -> [OutboxChunk] {
     let prompt = text(for: input)
     let parts =
       input.recorded.reason == .coderSubmit

--- a/Sources/ClawGateway/Routing/AddressingResolver.swift
+++ b/Sources/ClawGateway/Routing/AddressingResolver.swift
@@ -8,14 +8,14 @@ import Foundation
 /// the text or a photo caption, a slash command it recognizes, or a reply to something it said
 /// itself. Everything else is overheard, not asked. Without a known identity nothing in a group is
 /// addressed, so a daemon that somehow ran without one stays quiet instead of answering everyone.
-public struct AddressingResolver: Sendable {
+struct AddressingResolver: Sendable {
   private let identity: BotIdentity?
 
-  public init(identity: BotIdentity?) {
+  init(identity: BotIdentity?) {
     self.identity = identity
   }
 
-  public func isAddressed(_ message: IncomingMessage, mode: ChatMode) -> Bool {
+  func isAddressed(_ message: IncomingMessage, mode: ChatMode) -> Bool {
     switch mode {
     case .direct:
       return true

--- a/Sources/ClawGateway/Services/ImageMessageService.swift
+++ b/Sources/ClawGateway/Services/ImageMessageService.swift
@@ -31,7 +31,7 @@ public enum ImageMessageFailure: Error, Sendable, Equatable {
   }
 }
 
-public protocol ImageMessageHandling: Sendable {
+package protocol ImageMessageHandling: Sendable {
   func materialize(_ attachment: PhotoAttachment) async -> Result<ImagePart, ImageMessageFailure>
 }
 

--- a/Sources/ClawGateway/Services/Learning/LearningNotices.swift
+++ b/Sources/ClawGateway/Services/Learning/LearningNotices.swift
@@ -1,7 +1,7 @@
 import ClawCore
 import Foundation
 
-public enum LearningReviewError: Error, Sendable, Equatable {
+enum LearningReviewError: Error, Sendable, Equatable {
   case invalidCandidate
   case nonceGenerationFailed
 }

--- a/Sources/ClawGateway/Services/Learning/LearningWorkflow.swift
+++ b/Sources/ClawGateway/Services/Learning/LearningWorkflow.swift
@@ -2,7 +2,7 @@ import ClawCore
 import Foundation
 import Logging
 
-public enum WorkflowStep: Hashable, Sendable {
+enum WorkflowStep: Hashable, Sendable {
   case reflection(TriggerDigest)
   case candidate(CandidateDigest)
   case control(Int64)
@@ -11,14 +11,13 @@ public enum WorkflowStep: Hashable, Sendable {
 }
 
 /// An invocation's reviewed work identity; durable ownership belongs to the underlying transaction.
-public struct WorkflowClaim: Sendable {
-  public let step: WorkflowStep
-  public init(step: WorkflowStep) { self.step = step }
+struct WorkflowClaim: Sendable {
+  let step: WorkflowStep
 }
 
 /// Advances durable transitions to a wait state, using store CAS claims rather than process locks.
 public struct LearningWorkflow: Sendable {
-  public static let maxTransitionsPerInvocation = 64
+  static let maxTransitionsPerInvocation = 64
   let store: any LearningWorkflowStore
   private let jobs: any ScheduledJobStore
   private let runner: LearningOperationRunner

--- a/Sources/ClawLLM/ChatGPT/ChatGPTResponsesProvider.swift
+++ b/Sources/ClawLLM/ChatGPT/ChatGPTResponsesProvider.swift
@@ -13,7 +13,7 @@ import Logging
 /// this adapter owns. `complete` and `stream` differ only in where visible deltas go: they build the
 /// same plan and run the same engine, so their terminal reply, usage, tool calls, replay state, and
 /// retry count are identical on the same wire.
-public struct ChatGPTResponsesProvider: LLMProvider, Sendable {
+struct ChatGPTResponsesProvider: LLMProvider, Sendable {
   private let engine: ChatGPTResponsesAttemptEngine
   private let codec: ChatGPTProviderStateCodec
   private let encoder = ChatGPTResponsesRequestEncoder()
@@ -31,7 +31,7 @@ public struct ChatGPTResponsesProvider: LLMProvider, Sendable {
   ///   derives instead of matching against randomness.
   /// - Parameter treatsQuotaAsTerminal: set only when a fallback route exists, so a 429 fails onto it
   ///   immediately instead of burning the turn deadline retrying a subscription quota wall.
-  public init(
+  init(
     http: any HTTPStreaming,
     credentials: any LLMCredentialSource,
     credentialProfileID: UUID?,
@@ -61,8 +61,7 @@ public struct ChatGPTResponsesProvider: LLMProvider, Sendable {
     )
   }
 
-  /// The designated init, internal so a test can silence or capture logs without widening the
-  /// public surface past the pinned signature above.
+  /// Accepts a logger so tests can silence or capture diagnostics.
   init(
     http: any HTTPStreaming,
     credentials: any LLMCredentialSource,
@@ -95,7 +94,7 @@ public struct ChatGPTResponsesProvider: LLMProvider, Sendable {
     )
   }
 
-  public func complete(request: ChatRequest) async throws -> ChatResponse {
+  func complete(request: ChatRequest) async throws -> ChatResponse {
     switch makePlan(for: request) {
     case .failure(let cause):
       // Nothing reached the wire, so the accounting is `notStarted` — carried on the failure rather
@@ -116,7 +115,7 @@ public struct ChatGPTResponsesProvider: LLMProvider, Sendable {
     }
   }
 
-  public func stream(request: ChatRequest) -> LLMEventStream {
+  func stream(request: ChatRequest) -> LLMEventStream {
     let planResult = makePlan(for: request)
     let engine = engine
     return LLMEventStream.make { sink in

--- a/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
+++ b/Sources/ClawLLM/Provider/OpenAICompatibleProvider.swift
@@ -8,7 +8,7 @@ import Logging
 ///
 /// It owns the wire, never the credential: authorization arrives per request from an injected
 /// source, and the only header that source may contribute is `Authorization`.
-public struct OpenAICompatibleProvider: LLMProvider {
+struct OpenAICompatibleProvider: LLMProvider {
   private let config: LLMConfig
   /// The resolved endpoint the route selected. Kept as its own value rather than pulled back out of
   /// the route on every call: this adapter owns the wire URL and applies its own single-slash path
@@ -28,7 +28,7 @@ public struct OpenAICompatibleProvider: LLMProvider {
   /// per-turn correlation lives in `AgentRuntime`, so the `LLMProvider` contract stays unchanged.
   private let logger: Logger
 
-  public init(
+  init(
     config: LLMConfig,
     endpoint: String,
     maxTokensField: MaxTokensField,
@@ -53,7 +53,7 @@ public struct OpenAICompatibleProvider: LLMProvider {
     self.logger = logger
   }
 
-  public func complete(request: ChatRequest) async throws -> ChatResponse {
+  func complete(request: ChatRequest) async throws -> ChatResponse {
     let body = try encode(request: request)
     let url = chatCompletionsURL()
     let exposure = ProviderAttemptExposure()
@@ -149,7 +149,7 @@ public struct OpenAICompatibleProvider: LLMProvider {
     }
   }
 
-  public func stream(request: ChatRequest) -> LLMEventStream {
+  func stream(request: ChatRequest) -> LLMEventStream {
     LLMEventStream.make { sink in
       await infer(request: request, into: sink)
     }

--- a/Sources/ClawLLM/Provider/SSEParser.swift
+++ b/Sources/ClawLLM/Provider/SSEParser.swift
@@ -1,7 +1,7 @@
 import ClawCore
 import Foundation
 
-public enum SSEParserError: Error, Sendable, Equatable {
+enum SSEParserError: Error, Sendable, Equatable {
   case eventTooLarge
   case bufferedStreamTooLarge
   case accumulatedContentTooLarge
@@ -9,7 +9,7 @@ public enum SSEParserError: Error, Sendable, Equatable {
   case malformedJSON(String)
 }
 
-public struct SSEParser: Sendable {
+struct SSEParser: Sendable {
   private let maxEventBytes: Int
   private let maxBufferedBytes: Int
   private let maxAccumulatedContentBytes: Int
@@ -30,7 +30,7 @@ public struct SSEParser: Sendable {
 
   private var toolCallAccumulators: [Int: ToolCallAccumulator] = [:]
 
-  public init(
+  init(
     maxEventBytes: Int = LLMStreamLimits.maxEventBytes,
     maxBufferedBytes: Int = LLMStreamLimits.maxBufferedBytes,
     maxAccumulatedContentBytes: Int = LLMStreamLimits.maxAccumulatedContentBytes,
@@ -43,7 +43,7 @@ public struct SSEParser: Sendable {
     self.providerCost = fallbackProviderCost
   }
 
-  public mutating func push(_ data: Data) throws -> [StreamEvent] {
+  mutating func push(_ data: Data) throws -> [StreamEvent] {
     guard !finished else {
       return []
     }
@@ -76,7 +76,7 @@ public struct SSEParser: Sendable {
     return events
   }
 
-  public mutating func finish() throws -> StreamEvent? {
+  mutating func finish() throws -> StreamEvent? {
     guard !finished else {
       return nil
     }

--- a/Sources/ClawMCP/Catalog/MCPSchemaNormalizer.swift
+++ b/Sources/ClawMCP/Catalog/MCPSchemaNormalizer.swift
@@ -11,7 +11,7 @@ import ClawCore
 /// The pass is pure and position-aware: it recurses only into values that are schemas, so a property
 /// literally named `definitions` keeps its name — rewriting a user-facing property into a meta
 /// keyword is worse than the malformed schema it was meant to fix.
-public enum MCPSchemaNormalizer {
+enum MCPSchemaNormalizer {
   /// The parameter schema a tool gets when the server's is not one. Object with no properties is
   /// what "this tool takes no arguments" looks like, which is the only reading left.
   static let emptyObjectSchema = JSONValue.object([
@@ -19,7 +19,7 @@ public enum MCPSchemaNormalizer {
     Keyword.properties: .object([:]),
   ])
 
-  public static func normalize(_ schema: JSONValue) -> JSONValue {
+  static func normalize(_ schema: JSONValue) -> JSONValue {
     var promotions: [ReferencePromotion] = []
     let normalized = normalizeSchema(schema, path: [], promotions: &promotions)
     let referenced = rewriteReferences(normalized, promotions: promotions)

--- a/Sources/ClawMCP/Catalog/MCPToolNamer.swift
+++ b/Sources/ClawMCP/Catalog/MCPToolNamer.swift
@@ -21,16 +21,16 @@ public struct MCPToolCoordinate: Sendable, Equatable, Hashable {
 ///
 /// Names are assigned across the whole declared set in one pass, in config order, so a server added
 /// at the end of the file cannot silently rename an earlier server's tools.
-public enum MCPToolNamer {
-  public static let prefix = "mcp__"
-  public static let separator = "__"
+enum MCPToolNamer {
+  static let prefix = "mcp__"
+  static let separator = "__"
   /// Caps the server fragment so one verbose server name cannot crowd out every tool name behind it.
-  public static let serverFragmentLimit = 30
-  public static let nameLimit = 64
+  static let serverFragmentLimit = 30
+  static let nameLimit = 64
 
   /// The local name for each coordinate, positionally: the caller pairs by index, which is the same
   /// order-preservation the one-pass assignment already rests on.
-  public static func assign(_ coordinates: [MCPToolCoordinate]) -> [String] {
+  static func assign(_ coordinates: [MCPToolCoordinate]) -> [String] {
     var taken: Set<String> = []
     var assigned: [String] = []
     assigned.reserveCapacity(coordinates.count)

--- a/Sources/ClawMCP/Errors/MCPSessionError.swift
+++ b/Sources/ClawMCP/Errors/MCPSessionError.swift
@@ -2,7 +2,7 @@
 ///
 /// Like `MCPTransportError`, every case is safe to render — none quotes the server's body — so a
 /// doctor row or a skip reason built from one carries our words, not a third party's.
-public enum MCPSessionError: Error, Sendable, Equatable {
+enum MCPSessionError: Error, Sendable, Equatable {
   /// The call outlived the whole budget a tool call is allowed (connect plus request).
   case callTimedOut(seconds: Int)
   /// A handshake or tool-list exchange outlived its phase-specific connect/request budget. The HTTP
@@ -19,7 +19,7 @@ public enum MCPSessionError: Error, Sendable, Equatable {
 extension MCPSessionError {
   /// Discovery failures precede a tool invocation. A call deadline can expire after handoff, so the
   /// remote side effect remains unknown.
-  public var callExecutionDisposition: MCPCallExecutionDisposition {
+  var callExecutionDisposition: MCPCallExecutionDisposition {
     switch self {
     case .callTimedOut:
       return .mayHaveExecuted
@@ -30,7 +30,7 @@ extension MCPSessionError {
 }
 
 extension MCPSessionError: CustomStringConvertible {
-  public var description: String {
+  var description: String {
     switch self {
     case .callTimedOut(let seconds):
       return "MCP call exceeded its \(seconds)s budget"

--- a/Sources/ClawMCP/Errors/MCPTransportError.swift
+++ b/Sources/ClawMCP/Errors/MCPTransportError.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Whether a failed MCP call could have run on the remote server. This is separate from HTTP
 /// transmission: a session-expired request reached the server, but the server rejected it before the
 /// tool ran.
-public enum MCPCallExecutionDisposition: Sendable, Equatable {
+enum MCPCallExecutionDisposition: Sendable, Equatable {
   case definitelyNotExecuted
   case mayHaveExecuted
 }
@@ -14,7 +14,7 @@ public enum MCPCallExecutionDisposition: Sendable, Equatable {
 /// Every case is safe to render. Nothing quotes the server's body, and the one case that carries a
 /// server-supplied string renders it only through `mediaTypeDescription`, so a failure can be logged
 /// or shown to the owner without carrying remote text into a place that reads as our own words.
-public enum MCPTransportError: Error, Sendable, Equatable {
+enum MCPTransportError: Error, Sendable, Equatable {
   /// A send arrived before `connect()`, or after `disconnect()` spent the instance.
   case notConnected
   /// The server no longer knows the session id we replayed; a fresh transport must re-initialize.
@@ -31,7 +31,7 @@ public enum MCPTransportError: Error, Sendable, Equatable {
   case requestFailed(HTTPTransportFailure)
 
   /// The side-effect disposition the session retry classifier and owner-facing observation share.
-  public var callExecutionDisposition: MCPCallExecutionDisposition {
+  var callExecutionDisposition: MCPCallExecutionDisposition {
     switch self {
     case .notConnected, .sessionExpired:
       return .definitelyNotExecuted
@@ -46,7 +46,7 @@ public enum MCPTransportError: Error, Sendable, Equatable {
 }
 
 extension MCPTransportError: CustomStringConvertible {
-  public var description: String {
+  var description: String {
     switch self {
     case .notConnected:
       return "MCP transport is not connected"

--- a/Sources/ClawMCP/Transport/MCPServerSession.swift
+++ b/Sources/ClawMCP/Transport/MCPServerSession.swift
@@ -5,15 +5,15 @@ import MCP
 
 /// Pinned bounds on what one server may contribute at discovery, sized for a personal daemon.
 /// An implementer changing one changes it here.
-public enum MCPDiscoveryLimits {
-  public static let maxPages = 16
-  public static let maxTools = 512
-  public static let maxCatalogBytes = 2 * 1024 * 1024
+enum MCPDiscoveryLimits {
+  static let maxPages = 16
+  static let maxTools = 512
+  static let maxCatalogBytes = 2 * 1024 * 1024
   /// Aggregate provider-input allowance for MCP definitions across all admitted servers. The rest of
   /// the run's input cap remains available to built-ins and messages.
-  public static let maxProviderDefinitionTokens = 25_000
+  static let maxProviderDefinitionTokens = 25_000
   /// How many servers are contacted at once. Discovery order stays config order regardless.
-  public static let connectConcurrency = 4
+  static let connectConcurrency = 4
 }
 
 /// Builds the transport a session speaks over.

--- a/Sources/ClawMCP/Transport/MCPStreamableHTTPTransport.swift
+++ b/Sources/ClawMCP/Transport/MCPStreamableHTTPTransport.swift
@@ -5,17 +5,17 @@ import MCP
 
 /// Pinned bounds for one Streamable HTTP exchange, sized for a personal daemon talking to a handful
 /// of servers. An implementer changing one changes it here.
-public enum MCPTransportLimits {
+enum MCPTransportLimits {
   /// The most one JSON-RPC message may weigh: a whole JSON response, or a single SSE event still
   /// waiting for its blank line. A stream may run far longer than this — the bound is per message,
   /// not per transfer.
-  public static let maxMessageBytes = 4 * 1024 * 1024
+  static let maxMessageBytes = 4 * 1024 * 1024
   /// Complete protocol messages waiting for the SDK's receive loop. The HTTP body channel has its
   /// own byte bound; this closes the second queue after framing has split that body into messages.
-  public static let maxBufferedMessages = 16
+  static let maxBufferedMessages = 16
   /// Cancellation is advisory and local continuation cleanup has already won. Do not let a server
   /// that ignores the notice consume another full request budget while the caller is timing out.
-  public static let cancellationTimeout: Duration = .seconds(1)
+  static let cancellationTimeout: Duration = .seconds(1)
 }
 
 /// The MCP Streamable HTTP transport, spoken over swift-claw's own HTTP seam.
@@ -34,8 +34,8 @@ public enum MCPTransportLimits {
 ///
 /// The instance is single-use: `disconnect()` finishes the receive stream, and an `AsyncThrowingStream`
 /// that has finished cannot be reopened. Reconnecting means building a new transport.
-public actor MCPStreamableHTTPTransport: Transport {
-  nonisolated public let logger: Logger
+actor MCPStreamableHTTPTransport: Transport {
+  nonisolated let logger: Logger
 
   private let endpoint: String
   private var baseHeaders: [String: String]
@@ -52,7 +52,7 @@ public actor MCPStreamableHTTPTransport: Transport {
   private let messages: AsyncThrowingStream<Data, any Error>
   private let messageContinuation: AsyncThrowingStream<Data, any Error>.Continuation
 
-  public init(
+  init(
     server: MCPServerConfig,
     token: String? = nil,
     http: any HTTPExecuting & HTTPStreaming,
@@ -76,7 +76,7 @@ public actor MCPStreamableHTTPTransport: Transport {
 
   /// Marks the transport usable. Streamable HTTP has no connection of its own — the initialize POST
   /// the SDK sends next is what reaches the server.
-  public func connect() async throws {
+  func connect() async throws {
     switch lifecycle {
     case .connected:
       return
@@ -90,7 +90,7 @@ public actor MCPStreamableHTTPTransport: Transport {
   /// Ends the receive stream, then tells the server the session is over. The order matters: the
   /// SDK's message loop is parked on our stream and is awaited by `Client.disconnect`, so finishing
   /// first means a slow teardown request cannot hold up a shutdown.
-  public func disconnect() async {
+  func disconnect() async {
     switch lifecycle {
     case .idle, .disconnected:
       return
@@ -108,7 +108,7 @@ public actor MCPStreamableHTTPTransport: Transport {
     await deleteSession(session)
   }
 
-  public func send(_ data: Data) async throws {
+  func send(_ data: Data) async throws {
     guard lifecycle == .connected else {
       throw MCPTransportError.notConnected
     }
@@ -127,7 +127,7 @@ public actor MCPStreamableHTTPTransport: Transport {
     handshakeCompleted = true
   }
 
-  public func receive() -> AsyncThrowingStream<Data, any Error> {
+  func receive() -> AsyncThrowingStream<Data, any Error> {
     messages
   }
 }

--- a/Sources/ClawMCP/Utilities/MCPValueBridge.swift
+++ b/Sources/ClawMCP/Utilities/MCPValueBridge.swift
@@ -7,8 +7,8 @@ import MCP
 /// Both describe the same JSON, but the SDK splits integers from doubles and folds data-URL strings
 /// into a case of their own. Bridging structurally rather than round-tripping through an encoder
 /// keeps the pass total — nothing here can throw on a schema we are about to advertise.
-public enum MCPValueBridge {
-  public static func jsonValue(_ value: Value) -> JSONValue {
+enum MCPValueBridge {
+  static func jsonValue(_ value: Value) -> JSONValue {
     switch value {
     case .null:
       return .null
@@ -30,7 +30,7 @@ public enum MCPValueBridge {
     }
   }
 
-  public static func value(_ json: JSONValue) -> Value {
+  static func value(_ json: JSONValue) -> Value {
     switch json {
     case .null:
       return .null

--- a/Sources/ClawTools/Policy/CanonicalURL.swift
+++ b/Sources/ClawTools/Policy/CanonicalURL.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum CanonicalURLError: Error, Sendable, Equatable {
+enum CanonicalURLError: Error, Sendable, Equatable {
   case unparseable
   case unsupportedScheme(String)
   case nonASCIIHost
@@ -11,8 +11,8 @@ public enum CanonicalURLError: Error, Sendable, Equatable {
 /// The canonical form — ONE algorithm serving both the owner's approval display and the
 /// approval's exact-match target, plus the full pre-dispatch URL policy (scheme/port/userinfo/
 /// IDN), so a URL can never win approval at gate time and then be refused at dispatch time.
-public enum CanonicalURL {
-  public static func canonicalize(_ raw: String) -> Result<String, CanonicalURLError> {
+enum CanonicalURL {
+  static func canonicalize(_ raw: String) -> Result<String, CanonicalURLError> {
     guard
       let components = URLComponents(string: raw),
       let rawScheme = components.scheme

--- a/Sources/ClawTools/Search/ExaSearchProvider.swift
+++ b/Sources/ClawTools/Search/ExaSearchProvider.swift
@@ -1,7 +1,7 @@
 import ClawCore
 import Foundation
 
-public enum SearchError: Error, Sendable, Equatable {
+enum SearchError: Error, Sendable, Equatable {
   case terminal(status: Int, message: String)
   case retryable(status: Int, message: String)
   case transport(String)

--- a/Sources/ClawTools/Text/HTMLTextExtractor.swift
+++ b/Sources/ClawTools/Text/HTMLTextExtractor.swift
@@ -8,8 +8,8 @@ import Foundation
 /// O(n) here; the old lazy `<script>…[\s\S]*?…</script>` / `\s*\n\s*` regexes were O(n²) on the same
 /// input and pinned a CPU core for minutes, with no way for the tool timeout to interrupt the
 /// synchronous work. Malicious servers are in scope, so this path must not blow up.
-public enum HTMLTextExtractor {
-  public static func extractText(fromHTML html: String) -> String {
+enum HTMLTextExtractor {
+  static func extractText(fromHTML html: String) -> String {
     let stripped = stripMarkup(html)
     let decoded = decodeEntities(stripped)
     return collapseWhitespace(decoded)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -115,6 +115,12 @@ Enabled compatible Coder contributes tools at the daemon root; the sole names ar
 `CoderToolNames.submit` (`coder_submit`), `.status` (`coder_status`), and `.cancel` (`coder_cancel`).
 No provider registry, second backend, ACP session manager or generic process module is introduced.
 
+Module-owned helpers stay `internal`; implementation details needed by sibling targets use
+`package`. The type table includes implementation details as well as exported contracts.
+For example, `BoundedAsyncChannel` is internal to `ClawCore`, behind the public
+`HTTPStreamExchange` and `LLMEventStream` seams; its error remains visible to the HTTP adapter.
+Concrete LLM providers are internal to `ClawLLM`, constructed through `ProviderStackFactory`.
+
 The experimental laboratory lives in the separate
 [`swift-claw-evals`](https://github.com/ivan-magda/swift-claw-evals) repository. It owns
 `ClawEvaluation`, `claw-eval`, benchmark corpora, Python reference implementations, freeze tooling


### PR DESCRIPTION
## What changed and why

Narrow module-owned helpers and their dependent types so they no longer appear as exported contracts. This covers all 163 declarations reported in #204 plus related members and dependent types: 215 declarations across eight modules.

Use internal access except for `ImageMessageHandling`, which needs package access through the router's composition initializer. Preserve public composition and domain seams, and document the access boundaries in `docs/ARCHITECTURE.md` §3. Runtime behavior is unchanged.

## Related issue

Closes #204.

## Validation

- `scripts/lint.sh` — `lint: ok` (existing warnings).
- `swift build` — passed.
- `swift test` — 3,449 tests in 439 suites passed.
- Periphery with `--retain-files 'Tests/**/*.swift' --retain-codable-properties`, using the freshly built index — zero redundant-public findings.
- Independent access-boundary review and rebase review — no actionable findings.
- Test-intent map and test redundancy review: N/A; no test changes.

## Checklist

- [x] Followed [CONTRIBUTING.md](https://github.com/ivan-magda/swift-claw/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/ivan-magda/swift-claw/blob/main/CODE_OF_CONDUCT.md).
- N/A — Behavior coverage: access-control refactor with unchanged runtime behavior and tests.
- [x] Architecture and contract changes are reflected in [docs/ARCHITECTURE.md](https://github.com/ivan-magda/swift-claw/blob/main/docs/ARCHITECTURE.md).
- N/A — Public guides: no user-visible changes.
